### PR TITLE
Add application layer project with MediatR use cases

### DIFF
--- a/Veriado.Application/Abstractions/IClock.cs
+++ b/Veriado.Application/Abstractions/IClock.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace Veriado.Application.Abstractions;
+
+/// <summary>
+/// Provides access to wall-clock time in UTC.
+/// </summary>
+public interface IClock
+{
+    /// <summary>
+    /// Gets the current UTC timestamp.
+    /// </summary>
+    DateTimeOffset UtcNow { get; }
+}

--- a/Veriado.Application/Abstractions/IEventPublisher.cs
+++ b/Veriado.Application/Abstractions/IEventPublisher.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Veriado.Domain.Primitives;
+
+namespace Veriado.Application.Abstractions;
+
+/// <summary>
+/// Defines a publisher capable of dispatching domain events raised by aggregates.
+/// </summary>
+public interface IEventPublisher
+{
+    /// <summary>
+    /// Publishes a single domain event.
+    /// </summary>
+    /// <param name="domainEvent">The domain event to publish.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    Task PublishAsync(IDomainEvent domainEvent, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Publishes a collection of domain events.
+    /// </summary>
+    /// <param name="domainEvents">The events to publish.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    Task PublishAsync(IEnumerable<IDomainEvent> domainEvents, CancellationToken cancellationToken);
+}

--- a/Veriado.Application/Abstractions/IFileReadRepository.cs
+++ b/Veriado.Application/Abstractions/IFileReadRepository.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Veriado.Application.Common;
+using Veriado.Domain.Metadata;
+
+namespace Veriado.Application.Abstractions;
+
+/// <summary>
+/// Provides read-optimized access to file projections for query scenarios.
+/// </summary>
+public interface IFileReadRepository
+{
+    Task<FileDetailReadModel?> GetDetailAsync(Guid id, CancellationToken cancellationToken);
+
+    Task<Page<FileListItemReadModel>> ListAsync(PageRequest request, CancellationToken cancellationToken);
+
+    Task<IReadOnlyList<FileListItemReadModel>> ListExpiringAsync(DateTimeOffset validUntilUtc, CancellationToken cancellationToken);
+}
+
+public sealed record FileListItemReadModel(
+    Guid Id,
+    string Name,
+    string Extension,
+    string Mime,
+    string Author,
+    long SizeBytes,
+    int Version,
+    bool IsReadOnly,
+    DateTimeOffset CreatedUtc,
+    DateTimeOffset LastModifiedUtc,
+    DateTimeOffset? ValidUntilUtc);
+
+public sealed record FileDocumentValidityReadModel(
+    DateTimeOffset IssuedAtUtc,
+    DateTimeOffset ValidUntilUtc,
+    bool HasPhysicalCopy,
+    bool HasElectronicCopy);
+
+public sealed record FileDetailReadModel(
+    Guid Id,
+    string Name,
+    string Extension,
+    string Mime,
+    string Author,
+    long SizeBytes,
+    int Version,
+    bool IsReadOnly,
+    DateTimeOffset CreatedUtc,
+    DateTimeOffset LastModifiedUtc,
+    FileDocumentValidityReadModel? Validity,
+    FileSystemMetadata SystemMetadata,
+    IReadOnlyDictionary<string, string?> ExtendedMetadata);

--- a/Veriado.Application/Abstractions/IFileRepository.cs
+++ b/Veriado.Application/Abstractions/IFileRepository.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Veriado.Domain.Files;
+
+namespace Veriado.Application.Abstractions;
+
+/// <summary>
+/// Defines write-oriented persistence operations for <see cref="FileEntity"/> aggregates.
+/// </summary>
+public interface IFileRepository
+{
+    /// <summary>
+    /// Gets a file aggregate by its identifier.
+    /// </summary>
+    /// <param name="id">The file identifier.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The aggregate or <see langword="null"/> if not found.</returns>
+    Task<FileEntity?> GetAsync(Guid id, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Gets a collection of file aggregates by their identifiers.
+    /// </summary>
+    /// <param name="ids">The file identifiers to retrieve.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The collection of aggregates found for the provided identifiers.</returns>
+    Task<IReadOnlyList<FileEntity>> GetManyAsync(IReadOnlyCollection<Guid> ids, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Streams all file aggregates.
+    /// </summary>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>An asynchronous sequence of files.</returns>
+    IAsyncEnumerable<FileEntity> StreamAllAsync(CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Adds a new file aggregate to the store.
+    /// </summary>
+    /// <param name="file">The aggregate to add.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    Task AddAsync(FileEntity file, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Persists changes to an existing aggregate.
+    /// </summary>
+    /// <param name="file">The aggregate to update.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    Task UpdateAsync(FileEntity file, CancellationToken cancellationToken);
+}

--- a/Veriado.Application/Abstractions/IRequestContext.cs
+++ b/Veriado.Application/Abstractions/IRequestContext.cs
@@ -1,0 +1,24 @@
+using System;
+
+namespace Veriado.Application.Abstractions;
+
+/// <summary>
+/// Provides contextual information about the current request being processed by the application layer.
+/// </summary>
+public interface IRequestContext
+{
+    /// <summary>
+    /// Gets the idempotency request identifier, if supplied by the caller.
+    /// </summary>
+    Guid? RequestId { get; }
+
+    /// <summary>
+    /// Gets the identifier of the authenticated user, if any.
+    /// </summary>
+    string? UserId { get; }
+
+    /// <summary>
+    /// Gets an optional correlation identifier that can be used for tracing.
+    /// </summary>
+    string? CorrelationId { get; }
+}

--- a/Veriado.Application/Abstractions/ISearchIndexer.cs
+++ b/Veriado.Application/Abstractions/ISearchIndexer.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Veriado.Domain.Search;
+
+namespace Veriado.Application.Abstractions;
+
+/// <summary>
+/// Provides operations for projecting file aggregates into the search index.
+/// </summary>
+public interface ISearchIndexer
+{
+    /// <summary>
+    /// Indexes or updates the provided search document.
+    /// </summary>
+    /// <param name="document">The document to index.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    Task IndexAsync(SearchDocument document, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Removes the search document associated with the file identifier.
+    /// </summary>
+    /// <param name="fileId">The identifier of the file to remove from the index.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    Task RemoveAsync(Guid fileId, CancellationToken cancellationToken);
+}

--- a/Veriado.Application/Abstractions/ISearchQueryService.cs
+++ b/Veriado.Application/Abstractions/ISearchQueryService.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Veriado.Application.Abstractions;
+
+/// <summary>
+/// Executes search queries against the indexed document corpus.
+/// </summary>
+public interface ISearchQueryService
+{
+    /// <summary>
+    /// Executes a search query and returns ranked hits.
+    /// </summary>
+    /// <param name="query">The textual query to execute.</param>
+    /// <param name="limit">Optional maximum number of hits to return.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The ranked collection of search hits.</returns>
+    Task<IReadOnlyList<SearchHit>> SearchAsync(string query, int? limit, CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// Represents a single search hit returned by the search infrastructure.
+/// </summary>
+/// <param name="FileId">The identifier of the matching file.</param>
+/// <param name="Title">The indexed title.</param>
+/// <param name="Mime">The MIME type of the file.</param>
+/// <param name="Snippet">An optional snippet highlighting the match.</param>
+/// <param name="Score">The relevance score.</param>
+/// <param name="LastModifiedUtc">The last modification timestamp in UTC.</param>
+public sealed record SearchHit(
+    Guid FileId,
+    string Title,
+    string Mime,
+    string? Snippet,
+    double Score,
+    DateTimeOffset LastModifiedUtc);

--- a/Veriado.Application/Abstractions/ITextExtractor.cs
+++ b/Veriado.Application/Abstractions/ITextExtractor.cs
@@ -1,0 +1,19 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Veriado.Domain.Files;
+
+namespace Veriado.Application.Abstractions;
+
+/// <summary>
+/// Extracts textual content from file aggregates for indexing purposes.
+/// </summary>
+public interface ITextExtractor
+{
+    /// <summary>
+    /// Extracts text from the provided file aggregate.
+    /// </summary>
+    /// <param name="file">The file aggregate.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The extracted text or <see langword="null"/> when none could be produced.</returns>
+    Task<string?> ExtractTextAsync(FileEntity file, CancellationToken cancellationToken);
+}

--- a/Veriado.Application/Common/Paging.cs
+++ b/Veriado.Application/Common/Paging.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Collections.Generic;
+
+namespace Veriado.Application.Common;
+
+/// <summary>
+/// Represents a request for a page of results.
+/// </summary>
+public sealed class PageRequest
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PageRequest"/> class.
+    /// </summary>
+    /// <param name="pageNumber">The 1-based page number.</param>
+    /// <param name="pageSize">The size of the page.</param>
+    public PageRequest(int pageNumber, int pageSize)
+    {
+        if (pageNumber <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(pageNumber), pageNumber, "Page number must be positive.");
+        }
+
+        if (pageSize <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "Page size must be positive.");
+        }
+
+        PageNumber = pageNumber;
+        PageSize = pageSize;
+    }
+
+    /// <summary>
+    /// Gets the 1-based page number.
+    /// </summary>
+    public int PageNumber { get; }
+
+    /// <summary>
+    /// Gets the page size.
+    /// </summary>
+    public int PageSize { get; }
+
+    /// <summary>
+    /// Gets the number of records to skip.
+    /// </summary>
+    public int Skip => (PageNumber - 1) * PageSize;
+}
+
+/// <summary>
+/// Represents a materialized page of items returned by a query.
+/// </summary>
+/// <typeparam name="T">The type of item in the page.</typeparam>
+/// <param name="Items">The items in the page.</param>
+/// <param name="PageNumber">The current page number.</param>
+/// <param name="PageSize">The size of the page.</param>
+/// <param name="TotalCount">The total number of items across all pages.</param>
+public sealed record Page<T>(
+    IReadOnlyList<T> Items,
+    int PageNumber,
+    int PageSize,
+    int TotalCount)
+{
+    /// <summary>
+    /// Gets the total number of pages based on the page size and total count.
+    /// </summary>
+    public int TotalPages => PageSize == 0
+        ? 0
+        : (int)Math.Ceiling(TotalCount / (double)PageSize);
+}

--- a/Veriado.Application/Common/Policies/ImportPolicy.cs
+++ b/Veriado.Application/Common/Policies/ImportPolicy.cs
@@ -1,0 +1,40 @@
+using System;
+
+namespace Veriado.Application.Common.Policies;
+
+/// <summary>
+/// Defines the configuration used when importing new file content into the system.
+/// </summary>
+public sealed class ImportPolicy
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ImportPolicy"/> class.
+    /// </summary>
+    /// <param name="maxContentLengthBytes">The optional maximum length of file content in bytes.</param>
+    public ImportPolicy(int? maxContentLengthBytes = null)
+    {
+        if (maxContentLengthBytes.HasValue && maxContentLengthBytes.Value <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(maxContentLengthBytes), maxContentLengthBytes.Value, "Maximum content length must be greater than zero.");
+        }
+
+        MaxContentLengthBytes = maxContentLengthBytes;
+    }
+
+    /// <summary>
+    /// Gets the optional maximum allowed content length in bytes.
+    /// </summary>
+    public int? MaxContentLengthBytes { get; }
+
+    /// <summary>
+    /// Throws when the provided length exceeds the allowed limit.
+    /// </summary>
+    /// <param name="length">The length to validate.</param>
+    public void EnsureWithinLimit(long length)
+    {
+        if (MaxContentLengthBytes.HasValue && length > MaxContentLengthBytes.Value)
+        {
+            throw new ArgumentOutOfRangeException(nameof(length), length, "File content exceeds the configured maximum size.");
+        }
+    }
+}

--- a/Veriado.Application/Common/Policies/ValidityReminderPolicy.cs
+++ b/Veriado.Application/Common/Policies/ValidityReminderPolicy.cs
@@ -1,0 +1,28 @@
+using System;
+
+namespace Veriado.Application.Common.Policies;
+
+/// <summary>
+/// Describes how far in advance validity reminders should be issued for expiring documents.
+/// </summary>
+public sealed class ValidityReminderPolicy
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ValidityReminderPolicy"/> class.
+    /// </summary>
+    /// <param name="reminderLeadTime">The lead time before expiration at which documents should be surfaced.</param>
+    public ValidityReminderPolicy(TimeSpan reminderLeadTime)
+    {
+        if (reminderLeadTime < TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(nameof(reminderLeadTime), reminderLeadTime, "Reminder lead time must be non-negative.");
+        }
+
+        ReminderLeadTime = reminderLeadTime;
+    }
+
+    /// <summary>
+    /// Gets the lead time before expiration when documents should be surfaced.
+    /// </summary>
+    public TimeSpan ReminderLeadTime { get; }
+}

--- a/Veriado.Application/Common/Results.cs
+++ b/Veriado.Application/Common/Results.cs
@@ -1,0 +1,220 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Veriado.Application.Common;
+
+/// <summary>
+/// Represents the result of an application-layer operation.
+/// </summary>
+/// <typeparam name="T">The type of value returned on success.</typeparam>
+public readonly struct AppResult<T>
+{
+    private readonly T? _value;
+    private readonly AppError? _error;
+
+    private AppResult(bool isSuccess, T? value, AppError? error)
+    {
+        IsSuccess = isSuccess;
+        _value = value;
+        _error = error;
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether the operation succeeded.
+    /// </summary>
+    public bool IsSuccess { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether the operation failed.
+    /// </summary>
+    public bool IsFailure => !IsSuccess;
+
+    /// <summary>
+    /// Gets the value produced by the operation when it succeeded.
+    /// </summary>
+    public T Value => IsSuccess
+        ? _value!
+        : throw new InvalidOperationException("Cannot access the value of a failed result.");
+
+    /// <summary>
+    /// Gets the application error for failed results.
+    /// </summary>
+    public AppError Error => IsFailure
+        ? _error!
+        : throw new InvalidOperationException("Cannot access the error of a successful result.");
+
+    /// <summary>
+    /// Tries to get the value and returns a boolean indicating whether it is present.
+    /// </summary>
+    /// <param name="value">When the operation succeeds, contains the result value.</param>
+    /// <returns><see langword="true"/> when the operation succeeded; otherwise <see langword="false"/>.</returns>
+    public bool TryGetValue([MaybeNullWhen(false)] out T value)
+    {
+        value = IsSuccess ? _value : default;
+        return IsSuccess;
+    }
+
+    /// <summary>
+    /// Creates a successful result.
+    /// </summary>
+    /// <param name="value">The value of the operation.</param>
+    /// <returns>The successful result.</returns>
+    public static AppResult<T> Success(T value) => new(true, value, null);
+
+    /// <summary>
+    /// Creates a failed result with the specified application error.
+    /// </summary>
+    /// <param name="error">The application error.</param>
+    /// <returns>The failure result.</returns>
+    public static AppResult<T> Failure(AppError error)
+    {
+        ArgumentNullException.ThrowIfNull(error);
+        return new AppResult<T>(false, default, error);
+    }
+
+    /// <summary>
+    /// Creates a validation failure result with the provided error messages.
+    /// </summary>
+    /// <param name="errors">The validation error messages.</param>
+    /// <returns>The failure result.</returns>
+    public static AppResult<T> Validation(IReadOnlyCollection<string> errors)
+    {
+        ArgumentNullException.ThrowIfNull(errors);
+        return Failure(AppError.Validation("Validation failed.", errors));
+    }
+
+    /// <summary>
+    /// Creates a conflict result with the provided message.
+    /// </summary>
+    /// <param name="message">The error message.</param>
+    /// <returns>The failure result.</returns>
+    public static AppResult<T> Conflict(string message) => Failure(AppError.Conflict(message));
+
+    /// <summary>
+    /// Creates a not-found result with the provided message.
+    /// </summary>
+    /// <param name="message">The error message.</param>
+    /// <returns>The failure result.</returns>
+    public static AppResult<T> NotFound(string message) => Failure(AppError.NotFound(message));
+
+    /// <summary>
+    /// Creates a forbidden result with the provided message.
+    /// </summary>
+    /// <param name="message">The error message.</param>
+    /// <returns>The failure result.</returns>
+    public static AppResult<T> Forbidden(string message) => Failure(AppError.Forbidden(message));
+
+    /// <summary>
+    /// Creates a result indicating that the payload was too large.
+    /// </summary>
+    /// <param name="message">The error message.</param>
+    /// <returns>The failure result.</returns>
+    public static AppResult<T> TooLarge(string message) => Failure(AppError.TooLarge(message));
+
+    /// <summary>
+    /// Creates an unexpected failure result.
+    /// </summary>
+    /// <param name="message">The error message.</param>
+    /// <returns>The failure result.</returns>
+    public static AppResult<T> Unexpected(string message) => Failure(AppError.Unexpected(message));
+
+    /// <summary>
+    /// Converts an exception raised by the domain or infrastructure into an application result.
+    /// </summary>
+    /// <param name="exception">The exception to convert.</param>
+    /// <param name="defaultMessage">An optional override message.</param>
+    /// <returns>The failure result.</returns>
+    public static AppResult<T> FromException(Exception exception, string? defaultMessage = null)
+    {
+        ArgumentNullException.ThrowIfNull(exception);
+        return exception switch
+        {
+            ArgumentException or ArgumentNullException or ArgumentOutOfRangeException
+                => Failure(AppError.Validation(defaultMessage ?? exception.Message, new[] { exception.Message })),
+            InvalidOperationException
+                => Failure(AppError.Conflict(defaultMessage ?? exception.Message)),
+            _ => Failure(AppError.Unexpected(defaultMessage ?? "An unexpected error occurred.")),
+        };
+    }
+
+    /// <inheritdoc />
+    public override string ToString() => IsSuccess
+        ? $"Success({Value})"
+        : $"Failure({Error.Code}: {Error.Message})";
+}
+
+/// <summary>
+/// Represents an application error with a standardized error code.
+/// </summary>
+/// <param name="Code">The error code.</param>
+/// <param name="Message">The human-readable error message.</param>
+/// <param name="Details">Optional detailed messages.</param>
+public sealed record AppError(ErrorCode Code, string Message, IReadOnlyCollection<string>? Details = null)
+{
+    /// <summary>
+    /// Creates a not-found error.
+    /// </summary>
+    public static AppError NotFound(string message) => new(ErrorCode.NotFound, message);
+
+    /// <summary>
+    /// Creates a conflict error.
+    /// </summary>
+    public static AppError Conflict(string message) => new(ErrorCode.Conflict, message);
+
+    /// <summary>
+    /// Creates a validation error.
+    /// </summary>
+    public static AppError Validation(string message, IReadOnlyCollection<string>? details = null) => new(ErrorCode.Validation, message, details);
+
+    /// <summary>
+    /// Creates a forbidden error.
+    /// </summary>
+    public static AppError Forbidden(string message) => new(ErrorCode.Forbidden, message);
+
+    /// <summary>
+    /// Creates a payload-too-large error.
+    /// </summary>
+    public static AppError TooLarge(string message) => new(ErrorCode.TooLarge, message);
+
+    /// <summary>
+    /// Creates an unexpected error.
+    /// </summary>
+    public static AppError Unexpected(string message) => new(ErrorCode.Unexpected, message);
+}
+
+/// <summary>
+/// Enumerates standardized error codes used by the application layer.
+/// </summary>
+public enum ErrorCode
+{
+    /// <summary>
+    /// Represents a missing resource.
+    /// </summary>
+    NotFound,
+
+    /// <summary>
+    /// Represents a conflict or concurrency violation.
+    /// </summary>
+    Conflict,
+
+    /// <summary>
+    /// Represents validation errors.
+    /// </summary>
+    Validation,
+
+    /// <summary>
+    /// Represents lack of authorization to perform an operation.
+    /// </summary>
+    Forbidden,
+
+    /// <summary>
+    /// Represents that the payload exceeds allowed limits.
+    /// </summary>
+    TooLarge,
+
+    /// <summary>
+    /// Represents an unexpected failure.
+    /// </summary>
+    Unexpected,
+}

--- a/Veriado.Application/Common/Validation.cs
+++ b/Veriado.Application/Common/Validation.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Veriado.Application.Common;
+
+/// <summary>
+/// Provides guard helper methods for validating arguments.
+/// </summary>
+public static class Guard
+{
+    /// <summary>
+    /// Ensures that the provided value is not <see langword="null"/>.
+    /// </summary>
+    public static T AgainstNull<T>(T? value, string parameterName)
+        where T : class
+    {
+        return value ?? throw new ArgumentNullException(parameterName);
+    }
+
+    /// <summary>
+    /// Ensures that the provided string is not null, empty or whitespace.
+    /// </summary>
+    public static string AgainstNullOrWhiteSpace(string? value, string parameterName)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            throw new ArgumentException("Value cannot be null or whitespace.", parameterName);
+        }
+
+        return value.Trim();
+    }
+
+    /// <summary>
+    /// Ensures that the provided integer value is greater than or equal to the minimum.
+    /// </summary>
+    public static int AgainstLessThan(int value, int minimum, string parameterName)
+    {
+        if (value < minimum)
+        {
+            throw new ArgumentOutOfRangeException(parameterName, value, $"Value must be greater than or equal to {minimum}.");
+        }
+
+        return value;
+    }
+
+    /// <summary>
+    /// Ensures that the provided long value is within range.
+    /// </summary>
+    public static long AgainstNegative(long value, string parameterName)
+    {
+        if (value < 0)
+        {
+            throw new ArgumentOutOfRangeException(parameterName, value, "Value must be non-negative.");
+        }
+
+        return value;
+    }
+}
+
+/// <summary>
+/// Defines a validator that can validate requests before they reach the handler.
+/// </summary>
+/// <typeparam name="TRequest">The type of request to validate.</typeparam>
+public interface IRequestValidator<in TRequest>
+{
+    /// <summary>
+    /// Validates the provided request.
+    /// </summary>
+    /// <param name="request">The request to validate.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The collection of validation error messages. An empty collection indicates success.</returns>
+    Task<IReadOnlyCollection<string>> ValidateAsync(TRequest request, CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// Represents validation errors produced by <see cref="IRequestValidator{TRequest}"/> implementations.
+/// </summary>
+public sealed class ValidationException : Exception
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ValidationException"/> class.
+    /// </summary>
+    /// <param name="errors">The validation error messages.</param>
+    public ValidationException(IReadOnlyCollection<string> errors)
+        : base("One or more validation errors occurred.")
+    {
+        Errors = errors;
+    }
+
+    /// <summary>
+    /// Gets the validation error messages.
+    /// </summary>
+    public IReadOnlyCollection<string> Errors { get; }
+}

--- a/Veriado.Application/DTO/FileDetailDto.cs
+++ b/Veriado.Application/DTO/FileDetailDto.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Generic;
+using Veriado.Domain.Metadata;
+
+namespace Veriado.Application.DTO;
+
+/// <summary>
+/// Represents the detailed projection of a file, including extended metadata.
+/// </summary>
+/// <param name="File">The core file projection.</param>
+/// <param name="SystemMetadata">The file system metadata snapshot.</param>
+/// <param name="ExtendedMetadata">Extended metadata values indexed by property key string.</param>
+/// <param name="Title">The resolved document title.</param>
+/// <param name="Subject">The resolved document subject.</param>
+/// <param name="Company">The resolved company metadata value.</param>
+/// <param name="Manager">The resolved manager metadata value.</param>
+/// <param name="Comments">The resolved comments metadata value.</param>
+public sealed record FileDetailDto(
+    FileDto File,
+    FileSystemMetadataDto SystemMetadata,
+    IReadOnlyDictionary<string, string?> ExtendedMetadata,
+    string? Title,
+    string? Subject,
+    string? Company,
+    string? Manager,
+    string? Comments);
+
+/// <summary>
+/// Represents the file system metadata snapshot for a file.
+/// </summary>
+/// <param name="Attributes">The file attribute flags.</param>
+/// <param name="CreatedUtc">The creation timestamp.</param>
+/// <param name="LastWriteUtc">The last write timestamp.</param>
+/// <param name="LastAccessUtc">The last access timestamp.</param>
+/// <param name="OwnerSid">The owner security identifier.</param>
+/// <param name="HardLinkCount">The hard link count.</param>
+/// <param name="AlternateDataStreamCount">The alternate data stream count.</param>
+public sealed record FileSystemMetadataDto(
+    FileAttributesFlags Attributes,
+    DateTimeOffset CreatedUtc,
+    DateTimeOffset LastWriteUtc,
+    DateTimeOffset LastAccessUtc,
+    string? OwnerSid,
+    uint? HardLinkCount,
+    uint? AlternateDataStreamCount);

--- a/Veriado.Application/DTO/FileDto.cs
+++ b/Veriado.Application/DTO/FileDto.cs
@@ -1,0 +1,43 @@
+using System;
+
+namespace Veriado.Application.DTO;
+
+/// <summary>
+/// Represents the canonical projection of a file used by command handlers.
+/// </summary>
+/// <param name="Id">The file identifier.</param>
+/// <param name="Name">The file name without extension.</param>
+/// <param name="Extension">The file extension.</param>
+/// <param name="Mime">The MIME type.</param>
+/// <param name="Author">The document author.</param>
+/// <param name="SizeBytes">The file size in bytes.</param>
+/// <param name="Version">The file version number.</param>
+/// <param name="IsReadOnly">Indicates whether the file is read-only.</param>
+/// <param name="CreatedUtc">The creation timestamp.</param>
+/// <param name="LastModifiedUtc">The last modification timestamp.</param>
+/// <param name="Validity">Optional document validity information.</param>
+public sealed record FileDto(
+    Guid Id,
+    string Name,
+    string Extension,
+    string Mime,
+    string Author,
+    long SizeBytes,
+    int Version,
+    bool IsReadOnly,
+    DateTimeOffset CreatedUtc,
+    DateTimeOffset LastModifiedUtc,
+    FileValidityDto? Validity);
+
+/// <summary>
+/// Represents the validity state of a document.
+/// </summary>
+/// <param name="IssuedAtUtc">The issuance timestamp.</param>
+/// <param name="ValidUntilUtc">The expiration timestamp.</param>
+/// <param name="HasPhysicalCopy">Whether a physical copy exists.</param>
+/// <param name="HasElectronicCopy">Whether an electronic copy exists.</param>
+public sealed record FileValidityDto(
+    DateTimeOffset IssuedAtUtc,
+    DateTimeOffset ValidUntilUtc,
+    bool HasPhysicalCopy,
+    bool HasElectronicCopy);

--- a/Veriado.Application/DTO/FileListItemDto.cs
+++ b/Veriado.Application/DTO/FileListItemDto.cs
@@ -1,0 +1,30 @@
+using System;
+
+namespace Veriado.Application.DTO;
+
+/// <summary>
+/// Represents a file projection optimized for list screens.
+/// </summary>
+/// <param name="Id">The file identifier.</param>
+/// <param name="Name">The file name without extension.</param>
+/// <param name="Extension">The file extension.</param>
+/// <param name="Mime">The MIME type.</param>
+/// <param name="Author">The document author.</param>
+/// <param name="SizeBytes">The file size in bytes.</param>
+/// <param name="Version">The file version number.</param>
+/// <param name="IsReadOnly">Indicates whether the file is read-only.</param>
+/// <param name="CreatedUtc">The creation timestamp.</param>
+/// <param name="LastModifiedUtc">The last modification timestamp.</param>
+/// <param name="ValidUntilUtc">The optional validity expiration timestamp.</param>
+public sealed record FileListItemDto(
+    Guid Id,
+    string Name,
+    string Extension,
+    string Mime,
+    string Author,
+    long SizeBytes,
+    int Version,
+    bool IsReadOnly,
+    DateTimeOffset CreatedUtc,
+    DateTimeOffset LastModifiedUtc,
+    DateTimeOffset? ValidUntilUtc);

--- a/Veriado.Application/DTO/SearchHitDto.cs
+++ b/Veriado.Application/DTO/SearchHitDto.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace Veriado.Application.DTO;
+
+/// <summary>
+/// Represents a single hit returned by the search subsystem.
+/// </summary>
+/// <param name="FileId">The identifier of the matching file.</param>
+/// <param name="Title">The display title of the hit.</param>
+/// <param name="Mime">The MIME type of the file.</param>
+/// <param name="Snippet">The optional snippet that matched the query.</param>
+/// <param name="Score">The relevance score.</param>
+/// <param name="LastModifiedUtc">The last modification timestamp.</param>
+public sealed record SearchHitDto(
+    Guid FileId,
+    string Title,
+    string Mime,
+    string? Snippet,
+    double Score,
+    DateTimeOffset LastModifiedUtc);

--- a/Veriado.Application/DependencyInjection/ApplicationServicesExtensions.cs
+++ b/Veriado.Application/DependencyInjection/ApplicationServicesExtensions.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Veriado.Application.Common;
+using Veriado.Application.Common.Policies;
+using Veriado.Application.Pipeline;
+using Veriado.Application.Pipeline.Idempotency;
+
+namespace Veriado.Application.DependencyInjection;
+
+/// <summary>
+/// Provides extension methods to register the application layer services.
+/// </summary>
+public static class ApplicationServicesExtensions
+{
+    /// <summary>
+    /// Registers MediatR handlers, pipeline behaviors and supporting services.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="configure">Optional configuration callback.</param>
+    /// <returns>The same service collection for chaining.</returns>
+    public static IServiceCollection AddApplication(this IServiceCollection services, Action<ApplicationOptions>? configure = null)
+    {
+        var assembly = Assembly.GetExecutingAssembly();
+        var options = new ApplicationOptions();
+        configure?.Invoke(options);
+
+        services.AddMediatR(cfg => cfg.RegisterServicesFromAssembly(assembly));
+
+        RegisterValidators(services, assembly);
+
+        services.TryAddSingleton(new ImportPolicy(options.MaxContentLengthBytes));
+        services.TryAddSingleton(new ValidityReminderPolicy(options.ValidityReminderLeadTime));
+
+        services.AddTransient(typeof(IPipelineBehavior<,>), typeof(LoggingBehavior<,>));
+        services.AddTransient(typeof(IPipelineBehavior<,>), typeof(IdempotencyBehavior<,>));
+        services.AddTransient(typeof(IPipelineBehavior<,>), typeof(ValidationBehavior<,>));
+
+        return services;
+    }
+
+    private static void RegisterValidators(IServiceCollection services, Assembly assembly)
+    {
+        var validatorInterface = typeof(IRequestValidator<>);
+        foreach (var type in assembly.GetTypes())
+        {
+            if (type.IsAbstract || type.IsInterface)
+            {
+                continue;
+            }
+
+            var validatorInterfaces = type.GetInterfaces().Where(i => i.IsGenericType && i.GetGenericTypeDefinition() == validatorInterface);
+            foreach (var serviceType in validatorInterfaces)
+            {
+                services.AddTransient(serviceType, type);
+            }
+        }
+    }
+}
+
+/// <summary>
+/// Options used to configure application layer services.
+/// </summary>
+public sealed class ApplicationOptions
+{
+    /// <summary>
+    /// Gets or sets the optional maximum file content size in bytes accepted by commands.
+    /// </summary>
+    public int? MaxContentLengthBytes { get; set; }
+
+    /// <summary>
+    /// Gets or sets the lead time before expiration used for reminder queries.
+    /// </summary>
+    public TimeSpan ValidityReminderLeadTime { get; set; } = TimeSpan.FromDays(30);
+}

--- a/Veriado.Application/Mapping/DomainToDto.cs
+++ b/Veriado.Application/Mapping/DomainToDto.cs
@@ -1,0 +1,229 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Reflection;
+using Veriado.Application.Abstractions;
+using Veriado.Application.DTO;
+using Veriado.Domain.Files;
+using Veriado.Domain.Metadata;
+
+namespace Veriado.Application.Mapping;
+
+/// <summary>
+/// Provides mapping helpers between domain entities/read models and DTOs.
+/// </summary>
+public static class DomainToDto
+{
+    private static readonly FieldInfo MetadataValueField = typeof(MetadataValue)
+        .GetField("_value", BindingFlags.Instance | BindingFlags.NonPublic)!;
+
+    /// <summary>
+    /// Maps a <see cref="FileEntity"/> aggregate to a <see cref="FileDto"/>.
+    /// </summary>
+    /// <param name="file">The domain aggregate.</param>
+    /// <returns>The mapped DTO.</returns>
+    public static FileDto ToFileDto(FileEntity file)
+    {
+        ArgumentNullException.ThrowIfNull(file);
+        return new FileDto(
+            file.Id,
+            file.Name.Value,
+            file.Extension.Value,
+            file.Mime.Value,
+            file.Author,
+            file.Size.Value,
+            file.Version,
+            file.IsReadOnly,
+            file.CreatedUtc.Value,
+            file.LastModifiedUtc.Value,
+            ToValidityDto(file.Validity));
+    }
+
+    /// <summary>
+    /// Maps a read model to a <see cref="FileDto"/>.
+    /// </summary>
+    public static FileDto ToFileDto(FileDetailReadModel detail)
+    {
+        ArgumentNullException.ThrowIfNull(detail);
+        return new FileDto(
+            detail.Id,
+            detail.Name,
+            detail.Extension,
+            detail.Mime,
+            detail.Author,
+            detail.SizeBytes,
+            detail.Version,
+            detail.IsReadOnly,
+            detail.CreatedUtc,
+            detail.LastModifiedUtc,
+            ToValidityDto(detail.Validity));
+    }
+
+    /// <summary>
+    /// Maps a read model to a <see cref="FileListItemDto"/>.
+    /// </summary>
+    public static FileListItemDto ToListItemDto(FileListItemReadModel model)
+    {
+        ArgumentNullException.ThrowIfNull(model);
+        return new FileListItemDto(
+            model.Id,
+            model.Name,
+            model.Extension,
+            model.Mime,
+            model.Author,
+            model.SizeBytes,
+            model.Version,
+            model.IsReadOnly,
+            model.CreatedUtc,
+            model.LastModifiedUtc,
+            model.ValidUntilUtc);
+    }
+
+    /// <summary>
+    /// Maps a <see cref="FileEntity"/> to a <see cref="FileDetailDto"/>.
+    /// </summary>
+    public static FileDetailDto ToDetailDto(FileEntity file)
+    {
+        ArgumentNullException.ThrowIfNull(file);
+        var metadata = ConvertMetadataDictionary(file.ExtendedMetadata);
+        return new FileDetailDto(
+            ToFileDto(file),
+            ToMetadataDto(file.SystemMetadata),
+            metadata,
+            file.GetTitle(),
+            file.GetSubject(),
+            file.GetCompany(),
+            file.GetManager(),
+            file.GetComments());
+    }
+
+    /// <summary>
+    /// Maps a <see cref="FileDetailReadModel"/> to a <see cref="FileDetailDto"/>.
+    /// </summary>
+    public static FileDetailDto ToDetailDto(FileDetailReadModel detail)
+    {
+        ArgumentNullException.ThrowIfNull(detail);
+        var metadata = detail.ExtendedMetadata is null
+            ? new Dictionary<string, string?>(StringComparer.Ordinal)
+            : new Dictionary<string, string?>(detail.ExtendedMetadata, StringComparer.Ordinal);
+        var title = GetMetadataValue(metadata, WindowsPropertyIds.Title);
+        var subject = GetMetadataValue(metadata, WindowsPropertyIds.Subject);
+        var company = GetMetadataValue(metadata, WindowsPropertyIds.Company);
+        var manager = GetMetadataValue(metadata, WindowsPropertyIds.Manager);
+        var comments = GetMetadataValue(metadata, WindowsPropertyIds.Comments);
+        return new FileDetailDto(
+            ToFileDto(detail),
+            ToMetadataDto(detail.SystemMetadata),
+            metadata,
+            title,
+            subject,
+            company,
+            manager,
+            comments);
+    }
+
+    /// <summary>
+    /// Maps a search hit projection to its DTO.
+    /// </summary>
+    public static SearchHitDto ToSearchHitDto(SearchHit hit)
+    {
+        ArgumentNullException.ThrowIfNull(hit);
+        return new SearchHitDto(hit.FileId, hit.Title, hit.Mime, hit.Snippet, hit.Score, hit.LastModifiedUtc);
+    }
+
+    private static FileSystemMetadataDto ToMetadataDto(FileSystemMetadata metadata)
+    {
+        return new FileSystemMetadataDto(
+            metadata.Attributes,
+            metadata.CreatedUtc.Value,
+            metadata.LastWriteUtc.Value,
+            metadata.LastAccessUtc.Value,
+            metadata.OwnerSid,
+            metadata.HardLinkCount,
+            metadata.AlternateDataStreamCount);
+    }
+
+    private static FileValidityDto? ToValidityDto(FileDocumentValidityEntity? validity)
+    {
+        if (validity is null)
+        {
+            return null;
+        }
+
+        return new FileValidityDto(
+            validity.IssuedAt.Value,
+            validity.ValidUntil.Value,
+            validity.HasPhysicalCopy,
+            validity.HasElectronicCopy);
+    }
+
+    private static FileValidityDto? ToValidityDto(FileDocumentValidityReadModel? validity)
+    {
+        if (validity is null)
+        {
+            return null;
+        }
+
+        return new FileValidityDto(
+            validity.IssuedAtUtc,
+            validity.ValidUntilUtc,
+            validity.HasPhysicalCopy,
+            validity.HasElectronicCopy);
+    }
+
+    private static IReadOnlyDictionary<string, string?> ConvertMetadataDictionary(ExtendedMetadata metadata)
+    {
+        var dictionary = new Dictionary<string, string?>(StringComparer.Ordinal);
+        foreach (var pair in metadata.AsEnumerable())
+        {
+            var key = pair.Key.ToString();
+            dictionary[key] = FormatMetadataValue(pair.Value);
+        }
+
+        return dictionary;
+    }
+
+    private static string? GetMetadataValue(IReadOnlyDictionary<string, string?> metadata, PropertyKey key)
+    {
+        return metadata.TryGetValue(key.ToString(), out var value) ? value : null;
+    }
+
+    private static string? FormatMetadataValue(MetadataValue value)
+    {
+        if (value.TryGetString(out var single))
+        {
+            return single;
+        }
+
+        if (value.TryGetStringArray(out var array) && array is not null)
+        {
+            return string.Join(", ", array);
+        }
+
+        if (value.TryGetGuid(out var guid))
+        {
+            return guid.ToString("D", CultureInfo.InvariantCulture);
+        }
+
+        if (value.TryGetFileTime(out var fileTime))
+        {
+            return fileTime.ToString("O", CultureInfo.InvariantCulture);
+        }
+
+        if (value.TryGetBinary(out var binary) && binary is not null)
+        {
+            return Convert.ToBase64String(binary);
+        }
+
+        var raw = MetadataValueField.GetValue(value);
+        return raw switch
+        {
+            null => null,
+            bool boolean => boolean.ToString(CultureInfo.InvariantCulture),
+            int number => number.ToString(CultureInfo.InvariantCulture),
+            uint unsigned => unsigned.ToString(CultureInfo.InvariantCulture),
+            double dbl => dbl.ToString(CultureInfo.InvariantCulture),
+            _ => raw.ToString(),
+        };
+    }
+}

--- a/Veriado.Application/Pipeline/Idempotency/IIdempotencyStore.cs
+++ b/Veriado.Application/Pipeline/Idempotency/IIdempotencyStore.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Veriado.Application.Pipeline.Idempotency;
+
+/// <summary>
+/// Provides persistence for idempotency request processing.
+/// </summary>
+public interface IIdempotencyStore
+{
+    /// <summary>
+    /// Attempts to register a request identifier for processing.
+    /// </summary>
+    /// <param name="requestId">The request identifier.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns><see langword="true"/> if the request may proceed; otherwise <see langword="false"/>.</returns>
+    Task<bool> TryRegisterAsync(Guid requestId, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Marks a previously registered request as successfully processed.
+    /// </summary>
+    /// <param name="requestId">The request identifier.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    Task MarkProcessedAsync(Guid requestId, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Releases a previously registered request after a failure, allowing retries.
+    /// </summary>
+    /// <param name="requestId">The request identifier.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    Task MarkFailedAsync(Guid requestId, CancellationToken cancellationToken);
+}

--- a/Veriado.Application/Pipeline/Idempotency/IdempotencyBehavior.cs
+++ b/Veriado.Application/Pipeline/Idempotency/IdempotencyBehavior.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using Veriado.Application.Abstractions;
+using Veriado.Application.Common;
+
+namespace Veriado.Application.Pipeline.Idempotency;
+
+/// <summary>
+/// Prevents duplicate processing of commands by leveraging the request context.
+/// </summary>
+public sealed class IdempotencyBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
+    where TRequest : notnull
+{
+    private readonly IRequestContext _requestContext;
+    private readonly IIdempotencyStore _store;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="IdempotencyBehavior{TRequest, TResponse}"/> class.
+    /// </summary>
+    public IdempotencyBehavior(IRequestContext requestContext, IIdempotencyStore store)
+    {
+        _requestContext = requestContext;
+        _store = store;
+    }
+
+    /// <inheritdoc />
+    public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken cancellationToken)
+    {
+        var requestId = _requestContext.RequestId;
+        if (!requestId.HasValue)
+        {
+            return await next();
+        }
+
+        if (!await _store.TryRegisterAsync(requestId.Value, cancellationToken))
+        {
+            if (TryCreateDuplicateResponse(out var duplicate))
+            {
+                return duplicate;
+            }
+
+            throw new InvalidOperationException($"Duplicate request '{requestId}' detected.");
+        }
+
+        try
+        {
+            var response = await next();
+            await _store.MarkProcessedAsync(requestId.Value, cancellationToken);
+            return response;
+        }
+        catch
+        {
+            await _store.MarkFailedAsync(requestId.Value, cancellationToken);
+            throw;
+        }
+    }
+
+    private static bool TryCreateDuplicateResponse(out TResponse response)
+    {
+        if (typeof(TResponse).IsGenericType && typeof(TResponse).GetGenericTypeDefinition() == typeof(AppResult<>))
+        {
+            var argument = typeof(TResponse).GenericTypeArguments[0];
+            var method = typeof(AppResult<>).MakeGenericType(argument).GetMethod(
+                "Conflict",
+                BindingFlags.Public | BindingFlags.Static,
+                binder: null,
+                types: new[] { typeof(string) },
+                modifiers: null);
+            if (method is not null)
+            {
+                response = (TResponse)method.Invoke(null, new object[] { "The request has already been processed." })!;
+                return true;
+            }
+        }
+
+        response = default!;
+        return false;
+    }
+}

--- a/Veriado.Application/Pipeline/LoggingBehavior.cs
+++ b/Veriado.Application/Pipeline/LoggingBehavior.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using Veriado.Application.Abstractions;
+
+namespace Veriado.Application.Pipeline;
+
+/// <summary>
+/// Logs request handling lifecycle events.
+/// </summary>
+public sealed class LoggingBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
+    where TRequest : notnull
+{
+    private readonly ILogger<LoggingBehavior<TRequest, TResponse>> _logger;
+    private readonly IRequestContext _requestContext;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="LoggingBehavior{TRequest, TResponse}"/> class.
+    /// </summary>
+    public LoggingBehavior(ILogger<LoggingBehavior<TRequest, TResponse>> logger, IRequestContext requestContext)
+    {
+        _logger = logger;
+        _requestContext = requestContext;
+    }
+
+    /// <inheritdoc />
+    public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken cancellationToken)
+    {
+        var requestName = typeof(TRequest).Name;
+        var requestId = _requestContext.RequestId;
+        _logger.LogInformation("Handling {RequestName} (RequestId: {RequestId})", requestName, requestId);
+
+        var stopwatch = Stopwatch.StartNew();
+        try
+        {
+            var response = await next();
+            stopwatch.Stop();
+            _logger.LogInformation(
+                "Handled {RequestName} in {ElapsedMilliseconds} ms",
+                requestName,
+                stopwatch.Elapsed.TotalMilliseconds);
+            return response;
+        }
+        catch (Exception ex)
+        {
+            stopwatch.Stop();
+            _logger.LogError(ex, "Exception handling {RequestName} after {ElapsedMilliseconds} ms", requestName, stopwatch.Elapsed.TotalMilliseconds);
+            throw;
+        }
+    }
+}

--- a/Veriado.Application/Pipeline/ValidationBehavior.cs
+++ b/Veriado.Application/Pipeline/ValidationBehavior.cs
@@ -1,0 +1,80 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using Veriado.Application.Common;
+
+namespace Veriado.Application.Pipeline;
+
+/// <summary>
+/// Executes registered validators prior to invoking the request handler.
+/// </summary>
+public sealed class ValidationBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
+    where TRequest : notnull
+{
+    private readonly IEnumerable<IRequestValidator<TRequest>> _validators;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ValidationBehavior{TRequest, TResponse}"/> class.
+    /// </summary>
+    public ValidationBehavior(IEnumerable<IRequestValidator<TRequest>> validators)
+    {
+        _validators = validators;
+    }
+
+    /// <inheritdoc />
+    public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken cancellationToken)
+    {
+        if (!_validators.Any())
+        {
+            return await next();
+        }
+
+        var errors = new List<string>();
+        foreach (var validator in _validators)
+        {
+            var result = await validator.ValidateAsync(request, cancellationToken);
+            if (result.Count > 0)
+            {
+                errors.AddRange(result);
+            }
+        }
+
+        if (errors.Count == 0)
+        {
+            return await next();
+        }
+
+        var readOnly = errors.AsReadOnly();
+        if (TryCreateValidationResponse(readOnly, out var response))
+        {
+            return response;
+        }
+
+        throw new ValidationException(readOnly);
+    }
+
+    private static bool TryCreateValidationResponse(IReadOnlyCollection<string> errors, out TResponse response)
+    {
+        if (typeof(TResponse).IsGenericType && typeof(TResponse).GetGenericTypeDefinition() == typeof(AppResult<>))
+        {
+            var argument = typeof(TResponse).GenericTypeArguments[0];
+            var method = typeof(AppResult<>).MakeGenericType(argument).GetMethod(
+                "Validation",
+                BindingFlags.Public | BindingFlags.Static,
+                binder: null,
+                types: new[] { typeof(IReadOnlyCollection<string>) },
+                modifiers: null);
+            if (method is not null)
+            {
+                response = (TResponse)method.Invoke(null, new object[] { errors })!;
+                return true;
+            }
+        }
+
+        response = default!;
+        return false;
+    }
+}

--- a/Veriado.Application/ThirdParty/LICENSE.Apache-2.0.MediatR.txt
+++ b/Veriado.Application/ThirdParty/LICENSE.Apache-2.0.MediatR.txt
@@ -1,0 +1,201 @@
+This license applies to the "MediatR" library by Jimmy Bogard.
+The following is the complete text of the Apache License, Version 2.0.
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/Veriado.Application/ThirdParty/THIRD-PARTY-NOTICES.md
+++ b/Veriado.Application/ThirdParty/THIRD-PARTY-NOTICES.md
@@ -1,0 +1,11 @@
+# Third-Party Notices
+
+This project makes use of the MediatR library to provide mediator-based request/response handling.
+
+- **Component**: MediatR
+- **Author**: Jimmy Bogard
+- **Source**: <https://github.com/jbogard/MediatR>
+- **License**: Apache License, Version 2.0
+
+MediatR is redistributed under the terms of the Apache License, Version 2.0. A copy of the license is provided in
+`LICENSE.Apache-2.0.MediatR.txt`. No changes have been made to the original project.

--- a/Veriado.Application/UseCases/Files/ApplySystemMetadata/ApplySystemMetadataCommand.cs
+++ b/Veriado.Application/UseCases/Files/ApplySystemMetadata/ApplySystemMetadataCommand.cs
@@ -1,0 +1,28 @@
+using System;
+using MediatR;
+using Veriado.Application.Common;
+using Veriado.Application.DTO;
+using Veriado.Domain.Metadata;
+
+namespace Veriado.Application.UseCases.Files.ApplySystemMetadata;
+
+/// <summary>
+/// Command to apply a system metadata snapshot to a file.
+/// </summary>
+/// <param name="FileId">The file identifier.</param>
+/// <param name="Attributes">The file attribute flags.</param>
+/// <param name="CreatedUtc">The creation timestamp.</param>
+/// <param name="LastWriteUtc">The last write timestamp.</param>
+/// <param name="LastAccessUtc">The last access timestamp.</param>
+/// <param name="OwnerSid">The owner security identifier.</param>
+/// <param name="HardLinkCount">The hard link count.</param>
+/// <param name="AlternateDataStreamCount">The ADS count.</param>
+public sealed record ApplySystemMetadataCommand(
+    Guid FileId,
+    FileAttributesFlags Attributes,
+    DateTimeOffset CreatedUtc,
+    DateTimeOffset LastWriteUtc,
+    DateTimeOffset LastAccessUtc,
+    string? OwnerSid,
+    uint? HardLinkCount,
+    uint? AlternateDataStreamCount) : IRequest<AppResult<FileDto>>;

--- a/Veriado.Application/UseCases/Files/ApplySystemMetadata/ApplySystemMetadataHandler.cs
+++ b/Veriado.Application/UseCases/Files/ApplySystemMetadata/ApplySystemMetadataHandler.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using Veriado.Application.Abstractions;
+using Veriado.Application.Common;
+using Veriado.Application.DTO;
+using Veriado.Application.Mapping;
+using Veriado.Domain.Files;
+using Veriado.Domain.Metadata;
+using Veriado.Domain.ValueObjects;
+
+namespace Veriado.Application.UseCases.Files.ApplySystemMetadata;
+
+/// <summary>
+/// Handles applying system metadata snapshots to files.
+/// </summary>
+public sealed class ApplySystemMetadataHandler : IRequestHandler<ApplySystemMetadataCommand, AppResult<FileDto>>
+{
+    private readonly IFileRepository _repository;
+    private readonly IEventPublisher _eventPublisher;
+    private readonly ISearchIndexer _searchIndexer;
+    private readonly IClock _clock;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ApplySystemMetadataHandler"/> class.
+    /// </summary>
+    public ApplySystemMetadataHandler(
+        IFileRepository repository,
+        IEventPublisher eventPublisher,
+        ISearchIndexer searchIndexer,
+        IClock clock)
+    {
+        _repository = repository;
+        _eventPublisher = eventPublisher;
+        _searchIndexer = searchIndexer;
+        _clock = clock;
+    }
+
+    /// <inheritdoc />
+    public async Task<AppResult<FileDto>> Handle(ApplySystemMetadataCommand request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var file = await _repository.GetAsync(request.FileId, cancellationToken);
+            if (file is null)
+            {
+                return AppResult<FileDto>.NotFound($"File '{request.FileId}' was not found.");
+            }
+
+            var metadata = new FileSystemMetadata(
+                request.Attributes,
+                UtcTimestamp.From(request.CreatedUtc),
+                UtcTimestamp.From(request.LastWriteUtc),
+                UtcTimestamp.From(request.LastAccessUtc),
+                request.OwnerSid,
+                request.HardLinkCount,
+                request.AlternateDataStreamCount);
+
+            file.ApplySystemMetadata(metadata);
+            await PersistAsync(file, cancellationToken);
+            return AppResult<FileDto>.Success(DomainToDto.ToFileDto(file));
+        }
+        catch (Exception ex) when (ex is ArgumentException or ArgumentOutOfRangeException)
+        {
+            return AppResult<FileDto>.FromException(ex);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return AppResult<FileDto>.FromException(ex);
+        }
+        catch (Exception ex)
+        {
+            return AppResult<FileDto>.FromException(ex, "Failed to apply system metadata.");
+        }
+    }
+
+    private async Task PersistAsync(FileEntity file, CancellationToken cancellationToken)
+    {
+        await PublishDomainEventsAsync(file, cancellationToken);
+        await IndexAndUpdateAsync(file, cancellationToken);
+    }
+
+    private async Task IndexAndUpdateAsync(FileEntity file, CancellationToken cancellationToken)
+    {
+        var document = file.ToSearchDocument();
+        await _searchIndexer.IndexAsync(document, cancellationToken);
+        file.ConfirmIndexed(file.SearchIndex.SchemaVersion, _clock.UtcNow);
+        await _repository.UpdateAsync(file, cancellationToken);
+    }
+
+    private async Task PublishDomainEventsAsync(FileEntity file, CancellationToken cancellationToken)
+    {
+        if (file.DomainEvents.Count == 0)
+        {
+            return;
+        }
+
+        await _eventPublisher.PublishAsync(file.DomainEvents, cancellationToken);
+        file.ClearDomainEvents();
+    }
+}

--- a/Veriado.Application/UseCases/Files/ClearFileValidity/ClearFileValidityCommand.cs
+++ b/Veriado.Application/UseCases/Files/ClearFileValidity/ClearFileValidityCommand.cs
@@ -1,0 +1,12 @@
+using System;
+using MediatR;
+using Veriado.Application.Common;
+using Veriado.Application.DTO;
+
+namespace Veriado.Application.UseCases.Files.ClearFileValidity;
+
+/// <summary>
+/// Command to clear validity information from a file.
+/// </summary>
+/// <param name="FileId">The file identifier.</param>
+public sealed record ClearFileValidityCommand(Guid FileId) : IRequest<AppResult<FileDto>>;

--- a/Veriado.Application/UseCases/Files/ClearFileValidity/ClearFileValidityHandler.cs
+++ b/Veriado.Application/UseCases/Files/ClearFileValidity/ClearFileValidityHandler.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using Veriado.Application.Abstractions;
+using Veriado.Application.Common;
+using Veriado.Application.DTO;
+using Veriado.Application.Mapping;
+using Veriado.Domain.Files;
+
+namespace Veriado.Application.UseCases.Files.ClearFileValidity;
+
+/// <summary>
+/// Handles clearing document validity from files.
+/// </summary>
+public sealed class ClearFileValidityHandler : IRequestHandler<ClearFileValidityCommand, AppResult<FileDto>>
+{
+    private readonly IFileRepository _repository;
+    private readonly IEventPublisher _eventPublisher;
+    private readonly ISearchIndexer _searchIndexer;
+    private readonly IClock _clock;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ClearFileValidityHandler"/> class.
+    /// </summary>
+    public ClearFileValidityHandler(
+        IFileRepository repository,
+        IEventPublisher eventPublisher,
+        ISearchIndexer searchIndexer,
+        IClock clock)
+    {
+        _repository = repository;
+        _eventPublisher = eventPublisher;
+        _searchIndexer = searchIndexer;
+        _clock = clock;
+    }
+
+    /// <inheritdoc />
+    public async Task<AppResult<FileDto>> Handle(ClearFileValidityCommand request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var file = await _repository.GetAsync(request.FileId, cancellationToken);
+            if (file is null)
+            {
+                return AppResult<FileDto>.NotFound($"File '{request.FileId}' was not found.");
+            }
+
+            file.ClearValidity();
+            await PersistAsync(file, cancellationToken);
+            return AppResult<FileDto>.Success(DomainToDto.ToFileDto(file));
+        }
+        catch (InvalidOperationException ex)
+        {
+            return AppResult<FileDto>.FromException(ex);
+        }
+        catch (Exception ex)
+        {
+            return AppResult<FileDto>.FromException(ex, "Failed to clear file validity.");
+        }
+    }
+
+    private async Task PersistAsync(FileEntity file, CancellationToken cancellationToken)
+    {
+        await PublishDomainEventsAsync(file, cancellationToken);
+        await IndexAndUpdateAsync(file, cancellationToken);
+    }
+
+    private async Task IndexAndUpdateAsync(FileEntity file, CancellationToken cancellationToken)
+    {
+        var document = file.ToSearchDocument();
+        await _searchIndexer.IndexAsync(document, cancellationToken);
+        file.ConfirmIndexed(file.SearchIndex.SchemaVersion, _clock.UtcNow);
+        await _repository.UpdateAsync(file, cancellationToken);
+    }
+
+    private async Task PublishDomainEventsAsync(FileEntity file, CancellationToken cancellationToken)
+    {
+        if (file.DomainEvents.Count == 0)
+        {
+            return;
+        }
+
+        await _eventPublisher.PublishAsync(file.DomainEvents, cancellationToken);
+        file.ClearDomainEvents();
+    }
+}

--- a/Veriado.Application/UseCases/Files/CreateFile/CreateFileCommand.cs
+++ b/Veriado.Application/UseCases/Files/CreateFile/CreateFileCommand.cs
@@ -1,0 +1,20 @@
+using System;
+using MediatR;
+using Veriado.Application.Common;
+
+namespace Veriado.Application.UseCases.Files.CreateFile;
+
+/// <summary>
+/// Command used to create a new file aggregate with content.
+/// </summary>
+/// <param name="Name">The file name without extension.</param>
+/// <param name="Extension">The file extension.</param>
+/// <param name="Mime">The MIME type.</param>
+/// <param name="Author">The document author.</param>
+/// <param name="Content">The binary content of the file.</param>
+public sealed record CreateFileCommand(
+    string Name,
+    string Extension,
+    string Mime,
+    string Author,
+    byte[] Content) : IRequest<AppResult<Guid>>;

--- a/Veriado.Application/UseCases/Files/CreateFile/CreateFileHandler.cs
+++ b/Veriado.Application/UseCases/Files/CreateFile/CreateFileHandler.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using Veriado.Application.Abstractions;
+using Veriado.Application.Common;
+using Veriado.Application.Common.Policies;
+using Veriado.Domain.Files;
+using Veriado.Domain.ValueObjects;
+
+namespace Veriado.Application.UseCases.Files.CreateFile;
+
+/// <summary>
+/// Handles creation of new file aggregates.
+/// </summary>
+public sealed class CreateFileHandler : IRequestHandler<CreateFileCommand, AppResult<Guid>>
+{
+    private readonly IFileRepository _repository;
+    private readonly IEventPublisher _eventPublisher;
+    private readonly ISearchIndexer _searchIndexer;
+    private readonly ITextExtractor _textExtractor;
+    private readonly ImportPolicy _importPolicy;
+    private readonly IClock _clock;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CreateFileHandler"/> class.
+    /// </summary>
+    public CreateFileHandler(
+        IFileRepository repository,
+        IEventPublisher eventPublisher,
+        ISearchIndexer searchIndexer,
+        ITextExtractor textExtractor,
+        ImportPolicy importPolicy,
+        IClock clock)
+    {
+        _repository = repository;
+        _eventPublisher = eventPublisher;
+        _searchIndexer = searchIndexer;
+        _textExtractor = textExtractor;
+        _importPolicy = importPolicy;
+        _clock = clock;
+    }
+
+    /// <inheritdoc />
+    public async Task<AppResult<Guid>> Handle(CreateFileCommand request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            Guard.AgainstNull(request.Content, nameof(request.Content));
+            _importPolicy.EnsureWithinLimit(request.Content.LongLength);
+
+            var name = FileName.From(request.Name);
+            var extension = FileExtension.From(request.Extension);
+            var mime = MimeType.From(request.Mime);
+            var file = FileEntity.CreateNew(name, extension, mime, request.Author, request.Content, _importPolicy.MaxContentLengthBytes);
+
+            await PersistAsync(file, isNew: true, extractContent: true, cancellationToken);
+            return AppResult<Guid>.Success(file.Id);
+        }
+        catch (Exception ex) when (ex is ArgumentException or ArgumentOutOfRangeException)
+        {
+            return AppResult<Guid>.FromException(ex);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return AppResult<Guid>.FromException(ex);
+        }
+        catch (Exception ex)
+        {
+            return AppResult<Guid>.FromException(ex, "Failed to create the file.");
+        }
+    }
+
+    private async Task PersistAsync(FileEntity file, bool isNew, bool extractContent, CancellationToken cancellationToken)
+    {
+        if (isNew)
+        {
+            await _repository.AddAsync(file, cancellationToken);
+        }
+
+        await PublishDomainEventsAsync(file, cancellationToken);
+        await IndexAndUpdateAsync(file, extractContent, cancellationToken);
+    }
+
+    private async Task IndexAndUpdateAsync(FileEntity file, bool extractContent, CancellationToken cancellationToken)
+    {
+        var text = extractContent ? await _textExtractor.ExtractTextAsync(file, cancellationToken) : null;
+        var document = file.ToSearchDocument(text);
+        await _searchIndexer.IndexAsync(document, cancellationToken);
+        file.ConfirmIndexed(file.SearchIndex.SchemaVersion, _clock.UtcNow);
+        await _repository.UpdateAsync(file, cancellationToken);
+    }
+
+    private async Task PublishDomainEventsAsync(FileEntity file, CancellationToken cancellationToken)
+    {
+        if (file.DomainEvents.Count == 0)
+        {
+            return;
+        }
+
+        await _eventPublisher.PublishAsync(file.DomainEvents, cancellationToken);
+        file.ClearDomainEvents();
+    }
+}

--- a/Veriado.Application/UseCases/Files/RenameFile/RenameFileCommand.cs
+++ b/Veriado.Application/UseCases/Files/RenameFile/RenameFileCommand.cs
@@ -1,0 +1,13 @@
+using System;
+using MediatR;
+using Veriado.Application.Common;
+using Veriado.Application.DTO;
+
+namespace Veriado.Application.UseCases.Files.RenameFile;
+
+/// <summary>
+/// Command for renaming a file aggregate.
+/// </summary>
+/// <param name="FileId">The file identifier.</param>
+/// <param name="Name">The new file name without extension.</param>
+public sealed record RenameFileCommand(Guid FileId, string Name) : IRequest<AppResult<FileDto>>;

--- a/Veriado.Application/UseCases/Files/RenameFile/RenameFileHandler.cs
+++ b/Veriado.Application/UseCases/Files/RenameFile/RenameFileHandler.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using Veriado.Application.Abstractions;
+using Veriado.Application.Common;
+using Veriado.Application.DTO;
+using Veriado.Application.Mapping;
+using Veriado.Domain.Files;
+using Veriado.Domain.ValueObjects;
+
+namespace Veriado.Application.UseCases.Files.RenameFile;
+
+/// <summary>
+/// Handles renaming file aggregates.
+/// </summary>
+public sealed class RenameFileHandler : IRequestHandler<RenameFileCommand, AppResult<FileDto>>
+{
+    private readonly IFileRepository _repository;
+    private readonly IEventPublisher _eventPublisher;
+    private readonly ISearchIndexer _searchIndexer;
+    private readonly IClock _clock;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RenameFileHandler"/> class.
+    /// </summary>
+    public RenameFileHandler(
+        IFileRepository repository,
+        IEventPublisher eventPublisher,
+        ISearchIndexer searchIndexer,
+        IClock clock)
+    {
+        _repository = repository;
+        _eventPublisher = eventPublisher;
+        _searchIndexer = searchIndexer;
+        _clock = clock;
+    }
+
+    /// <inheritdoc />
+    public async Task<AppResult<FileDto>> Handle(RenameFileCommand request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var file = await _repository.GetAsync(request.FileId, cancellationToken);
+            if (file is null)
+            {
+                return AppResult<FileDto>.NotFound($"File '{request.FileId}' was not found.");
+            }
+
+            var newName = FileName.From(request.Name);
+            file.Rename(newName);
+            await PersistAsync(file, cancellationToken);
+            return AppResult<FileDto>.Success(DomainToDto.ToFileDto(file));
+        }
+        catch (Exception ex) when (ex is ArgumentException or ArgumentOutOfRangeException)
+        {
+            return AppResult<FileDto>.FromException(ex);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return AppResult<FileDto>.FromException(ex);
+        }
+        catch (Exception ex)
+        {
+            return AppResult<FileDto>.FromException(ex, "Failed to rename file.");
+        }
+    }
+
+    private async Task PersistAsync(FileEntity file, CancellationToken cancellationToken)
+    {
+        await PublishDomainEventsAsync(file, cancellationToken);
+        await IndexAndUpdateAsync(file, cancellationToken);
+    }
+
+    private async Task IndexAndUpdateAsync(FileEntity file, CancellationToken cancellationToken)
+    {
+        var document = file.ToSearchDocument();
+        await _searchIndexer.IndexAsync(document, cancellationToken);
+        file.ConfirmIndexed(file.SearchIndex.SchemaVersion, _clock.UtcNow);
+        await _repository.UpdateAsync(file, cancellationToken);
+    }
+
+    private async Task PublishDomainEventsAsync(FileEntity file, CancellationToken cancellationToken)
+    {
+        if (file.DomainEvents.Count == 0)
+        {
+            return;
+        }
+
+        await _eventPublisher.PublishAsync(file.DomainEvents, cancellationToken);
+        file.ClearDomainEvents();
+    }
+}

--- a/Veriado.Application/UseCases/Files/ReplaceFileContent/ReplaceFileContentCommand.cs
+++ b/Veriado.Application/UseCases/Files/ReplaceFileContent/ReplaceFileContentCommand.cs
@@ -1,0 +1,13 @@
+using System;
+using MediatR;
+using Veriado.Application.Common;
+using Veriado.Application.DTO;
+
+namespace Veriado.Application.UseCases.Files.ReplaceFileContent;
+
+/// <summary>
+/// Command that replaces the binary content of an existing file.
+/// </summary>
+/// <param name="FileId">The identifier of the file to update.</param>
+/// <param name="Content">The new binary content.</param>
+public sealed record ReplaceFileContentCommand(Guid FileId, byte[] Content) : IRequest<AppResult<FileDto>>;

--- a/Veriado.Application/UseCases/Files/ReplaceFileContent/ReplaceFileContentHandler.cs
+++ b/Veriado.Application/UseCases/Files/ReplaceFileContent/ReplaceFileContentHandler.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using Veriado.Application.Abstractions;
+using Veriado.Application.Common;
+using Veriado.Application.Common.Policies;
+using Veriado.Application.DTO;
+using Veriado.Application.Mapping;
+using Veriado.Domain.Files;
+
+namespace Veriado.Application.UseCases.Files.ReplaceFileContent;
+
+/// <summary>
+/// Handles replacing file content while ensuring search index synchronization.
+/// </summary>
+public sealed class ReplaceFileContentHandler : IRequestHandler<ReplaceFileContentCommand, AppResult<FileDto>>
+{
+    private readonly IFileRepository _repository;
+    private readonly IEventPublisher _eventPublisher;
+    private readonly ISearchIndexer _searchIndexer;
+    private readonly ITextExtractor _textExtractor;
+    private readonly ImportPolicy _importPolicy;
+    private readonly IClock _clock;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ReplaceFileContentHandler"/> class.
+    /// </summary>
+    public ReplaceFileContentHandler(
+        IFileRepository repository,
+        IEventPublisher eventPublisher,
+        ISearchIndexer searchIndexer,
+        ITextExtractor textExtractor,
+        ImportPolicy importPolicy,
+        IClock clock)
+    {
+        _repository = repository;
+        _eventPublisher = eventPublisher;
+        _searchIndexer = searchIndexer;
+        _textExtractor = textExtractor;
+        _importPolicy = importPolicy;
+        _clock = clock;
+    }
+
+    /// <inheritdoc />
+    public async Task<AppResult<FileDto>> Handle(ReplaceFileContentCommand request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            Guard.AgainstNull(request.Content, nameof(request.Content));
+            _importPolicy.EnsureWithinLimit(request.Content.LongLength);
+
+            var file = await _repository.GetAsync(request.FileId, cancellationToken);
+            if (file is null)
+            {
+                return AppResult<FileDto>.NotFound($"File '{request.FileId}' was not found.");
+            }
+
+            file.ReplaceContent(request.Content, _importPolicy.MaxContentLengthBytes);
+            await PersistAsync(file, extractContent: true, cancellationToken);
+            return AppResult<FileDto>.Success(DomainToDto.ToFileDto(file));
+        }
+        catch (Exception ex) when (ex is ArgumentException or ArgumentOutOfRangeException)
+        {
+            return AppResult<FileDto>.FromException(ex);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return AppResult<FileDto>.FromException(ex);
+        }
+        catch (Exception ex)
+        {
+            return AppResult<FileDto>.FromException(ex, "Failed to replace file content.");
+        }
+    }
+
+    private async Task PersistAsync(FileEntity file, bool extractContent, CancellationToken cancellationToken)
+    {
+        await PublishDomainEventsAsync(file, cancellationToken);
+        await IndexAndUpdateAsync(file, extractContent, cancellationToken);
+    }
+
+    private async Task IndexAndUpdateAsync(FileEntity file, bool extractContent, CancellationToken cancellationToken)
+    {
+        var text = extractContent ? await _textExtractor.ExtractTextAsync(file, cancellationToken) : null;
+        var document = file.ToSearchDocument(text);
+        await _searchIndexer.IndexAsync(document, cancellationToken);
+        file.ConfirmIndexed(file.SearchIndex.SchemaVersion, _clock.UtcNow);
+        await _repository.UpdateAsync(file, cancellationToken);
+    }
+
+    private async Task PublishDomainEventsAsync(FileEntity file, CancellationToken cancellationToken)
+    {
+        if (file.DomainEvents.Count == 0)
+        {
+            return;
+        }
+
+        await _eventPublisher.PublishAsync(file.DomainEvents, cancellationToken);
+        file.ClearDomainEvents();
+    }
+}

--- a/Veriado.Application/UseCases/Files/SetExtendedMetadata/SetExtendedMetadataCommand.cs
+++ b/Veriado.Application/UseCases/Files/SetExtendedMetadata/SetExtendedMetadataCommand.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Collections.Generic;
+using MediatR;
+using Veriado.Application.Common;
+using Veriado.Application.DTO;
+
+namespace Veriado.Application.UseCases.Files.SetExtendedMetadata;
+
+/// <summary>
+/// Command to set extended metadata values on a file.
+/// </summary>
+/// <param name="FileId">The file identifier.</param>
+/// <param name="Entries">The metadata entries to upsert or remove.</param>
+public sealed record SetExtendedMetadataCommand(Guid FileId, IReadOnlyCollection<ExtendedMetadataEntry> Entries) : IRequest<AppResult<FileDto>>;
+
+/// <summary>
+/// Represents a single extended metadata operation.
+/// </summary>
+/// <param name="FormatId">The property set format identifier.</param>
+/// <param name="PropertyId">The property identifier.</param>
+/// <param name="Value">The value to set, or <see langword="null"/> to remove.</param>
+public sealed record ExtendedMetadataEntry(Guid FormatId, int PropertyId, string? Value);

--- a/Veriado.Application/UseCases/Files/SetExtendedMetadata/SetExtendedMetadataHandler.cs
+++ b/Veriado.Application/UseCases/Files/SetExtendedMetadata/SetExtendedMetadataHandler.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using Veriado.Application.Abstractions;
+using Veriado.Application.Common;
+using Veriado.Application.DTO;
+using Veriado.Application.Mapping;
+using Veriado.Domain.Files;
+using Veriado.Domain.Metadata;
+
+namespace Veriado.Application.UseCases.Files.SetExtendedMetadata;
+
+/// <summary>
+/// Handles setting extended metadata values for files.
+/// </summary>
+public sealed class SetExtendedMetadataHandler : IRequestHandler<SetExtendedMetadataCommand, AppResult<FileDto>>
+{
+    private readonly IFileRepository _repository;
+    private readonly IEventPublisher _eventPublisher;
+    private readonly ISearchIndexer _searchIndexer;
+    private readonly IClock _clock;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SetExtendedMetadataHandler"/> class.
+    /// </summary>
+    public SetExtendedMetadataHandler(
+        IFileRepository repository,
+        IEventPublisher eventPublisher,
+        ISearchIndexer searchIndexer,
+        IClock clock)
+    {
+        _repository = repository;
+        _eventPublisher = eventPublisher;
+        _searchIndexer = searchIndexer;
+        _clock = clock;
+    }
+
+    /// <inheritdoc />
+    public async Task<AppResult<FileDto>> Handle(SetExtendedMetadataCommand request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            if (request.Entries is null || request.Entries.Count == 0)
+            {
+                return AppResult<FileDto>.Validation(new[] { "At least one metadata entry must be provided." });
+            }
+
+            var file = await _repository.GetAsync(request.FileId, cancellationToken);
+            if (file is null)
+            {
+                return AppResult<FileDto>.NotFound($"File '{request.FileId}' was not found.");
+            }
+
+            file.SetExtendedMetadata(builder =>
+            {
+                foreach (var entry in request.Entries)
+                {
+                    var key = new PropertyKey(entry.FormatId, entry.PropertyId);
+                    if (string.IsNullOrWhiteSpace(entry.Value))
+                    {
+                        builder.Remove(key);
+                    }
+                    else
+                    {
+                        builder.Set(key, MetadataValue.FromString(entry.Value));
+                    }
+                }
+            });
+
+            await PersistAsync(file, cancellationToken);
+            return AppResult<FileDto>.Success(DomainToDto.ToFileDto(file));
+        }
+        catch (Exception ex) when (ex is ArgumentException or ArgumentOutOfRangeException)
+        {
+            return AppResult<FileDto>.FromException(ex);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return AppResult<FileDto>.FromException(ex);
+        }
+        catch (Exception ex)
+        {
+            return AppResult<FileDto>.FromException(ex, "Failed to set extended metadata.");
+        }
+    }
+
+    private async Task PersistAsync(FileEntity file, CancellationToken cancellationToken)
+    {
+        await PublishDomainEventsAsync(file, cancellationToken);
+        await IndexAndUpdateAsync(file, cancellationToken);
+    }
+
+    private async Task IndexAndUpdateAsync(FileEntity file, CancellationToken cancellationToken)
+    {
+        var document = file.ToSearchDocument();
+        await _searchIndexer.IndexAsync(document, cancellationToken);
+        file.ConfirmIndexed(file.SearchIndex.SchemaVersion, _clock.UtcNow);
+        await _repository.UpdateAsync(file, cancellationToken);
+    }
+
+    private async Task PublishDomainEventsAsync(FileEntity file, CancellationToken cancellationToken)
+    {
+        if (file.DomainEvents.Count == 0)
+        {
+            return;
+        }
+
+        await _eventPublisher.PublishAsync(file.DomainEvents, cancellationToken);
+        file.ClearDomainEvents();
+    }
+}

--- a/Veriado.Application/UseCases/Files/SetFileReadOnly/SetFileReadOnlyCommand.cs
+++ b/Veriado.Application/UseCases/Files/SetFileReadOnly/SetFileReadOnlyCommand.cs
@@ -1,0 +1,13 @@
+using System;
+using MediatR;
+using Veriado.Application.Common;
+using Veriado.Application.DTO;
+
+namespace Veriado.Application.UseCases.Files.SetFileReadOnly;
+
+/// <summary>
+/// Command for toggling the read-only status of a file.
+/// </summary>
+/// <param name="FileId">The file identifier.</param>
+/// <param name="IsReadOnly">The desired read-only status.</param>
+public sealed record SetFileReadOnlyCommand(Guid FileId, bool IsReadOnly) : IRequest<AppResult<FileDto>>;

--- a/Veriado.Application/UseCases/Files/SetFileReadOnly/SetFileReadOnlyHandler.cs
+++ b/Veriado.Application/UseCases/Files/SetFileReadOnly/SetFileReadOnlyHandler.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using Veriado.Application.Abstractions;
+using Veriado.Application.Common;
+using Veriado.Application.DTO;
+using Veriado.Application.Mapping;
+using Veriado.Domain.Files;
+
+namespace Veriado.Application.UseCases.Files.SetFileReadOnly;
+
+/// <summary>
+/// Handles toggling the read-only status of a file aggregate.
+/// </summary>
+public sealed class SetFileReadOnlyHandler : IRequestHandler<SetFileReadOnlyCommand, AppResult<FileDto>>
+{
+    private readonly IFileRepository _repository;
+    private readonly IEventPublisher _eventPublisher;
+    private readonly ISearchIndexer _searchIndexer;
+    private readonly IClock _clock;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SetFileReadOnlyHandler"/> class.
+    /// </summary>
+    public SetFileReadOnlyHandler(
+        IFileRepository repository,
+        IEventPublisher eventPublisher,
+        ISearchIndexer searchIndexer,
+        IClock clock)
+    {
+        _repository = repository;
+        _eventPublisher = eventPublisher;
+        _searchIndexer = searchIndexer;
+        _clock = clock;
+    }
+
+    /// <inheritdoc />
+    public async Task<AppResult<FileDto>> Handle(SetFileReadOnlyCommand request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var file = await _repository.GetAsync(request.FileId, cancellationToken);
+            if (file is null)
+            {
+                return AppResult<FileDto>.NotFound($"File '{request.FileId}' was not found.");
+            }
+
+            file.SetReadOnly(request.IsReadOnly);
+            await PersistAsync(file, cancellationToken);
+            return AppResult<FileDto>.Success(DomainToDto.ToFileDto(file));
+        }
+        catch (InvalidOperationException ex)
+        {
+            return AppResult<FileDto>.FromException(ex);
+        }
+        catch (Exception ex)
+        {
+            return AppResult<FileDto>.FromException(ex, "Failed to change the read-only status.");
+        }
+    }
+
+    private async Task PersistAsync(FileEntity file, CancellationToken cancellationToken)
+    {
+        await PublishDomainEventsAsync(file, cancellationToken);
+        await IndexAndUpdateAsync(file, cancellationToken);
+    }
+
+    private async Task IndexAndUpdateAsync(FileEntity file, CancellationToken cancellationToken)
+    {
+        var document = file.ToSearchDocument();
+        await _searchIndexer.IndexAsync(document, cancellationToken);
+        file.ConfirmIndexed(file.SearchIndex.SchemaVersion, _clock.UtcNow);
+        await _repository.UpdateAsync(file, cancellationToken);
+    }
+
+    private async Task PublishDomainEventsAsync(FileEntity file, CancellationToken cancellationToken)
+    {
+        if (file.DomainEvents.Count == 0)
+        {
+            return;
+        }
+
+        await _eventPublisher.PublishAsync(file.DomainEvents, cancellationToken);
+        file.ClearDomainEvents();
+    }
+}

--- a/Veriado.Application/UseCases/Files/SetFileValidity/SetFileValidityCommand.cs
+++ b/Veriado.Application/UseCases/Files/SetFileValidity/SetFileValidityCommand.cs
@@ -1,0 +1,21 @@
+using System;
+using MediatR;
+using Veriado.Application.Common;
+using Veriado.Application.DTO;
+
+namespace Veriado.Application.UseCases.Files.SetFileValidity;
+
+/// <summary>
+/// Command to set or update document validity information for a file.
+/// </summary>
+/// <param name="FileId">The file identifier.</param>
+/// <param name="IssuedAtUtc">The timestamp when the document was issued.</param>
+/// <param name="ValidUntilUtc">The timestamp when the document expires.</param>
+/// <param name="HasPhysicalCopy">Indicates whether a physical copy exists.</param>
+/// <param name="HasElectronicCopy">Indicates whether an electronic copy exists.</param>
+public sealed record SetFileValidityCommand(
+    Guid FileId,
+    DateTimeOffset IssuedAtUtc,
+    DateTimeOffset ValidUntilUtc,
+    bool HasPhysicalCopy,
+    bool HasElectronicCopy) : IRequest<AppResult<FileDto>>;

--- a/Veriado.Application/UseCases/Files/SetFileValidity/SetFileValidityHandler.cs
+++ b/Veriado.Application/UseCases/Files/SetFileValidity/SetFileValidityHandler.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using Veriado.Application.Abstractions;
+using Veriado.Application.Common;
+using Veriado.Application.DTO;
+using Veriado.Application.Mapping;
+using Veriado.Domain.Files;
+using Veriado.Domain.ValueObjects;
+
+namespace Veriado.Application.UseCases.Files.SetFileValidity;
+
+/// <summary>
+/// Handles updates to document validity metadata for files.
+/// </summary>
+public sealed class SetFileValidityHandler : IRequestHandler<SetFileValidityCommand, AppResult<FileDto>>
+{
+    private readonly IFileRepository _repository;
+    private readonly IEventPublisher _eventPublisher;
+    private readonly ISearchIndexer _searchIndexer;
+    private readonly IClock _clock;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SetFileValidityHandler"/> class.
+    /// </summary>
+    public SetFileValidityHandler(
+        IFileRepository repository,
+        IEventPublisher eventPublisher,
+        ISearchIndexer searchIndexer,
+        IClock clock)
+    {
+        _repository = repository;
+        _eventPublisher = eventPublisher;
+        _searchIndexer = searchIndexer;
+        _clock = clock;
+    }
+
+    /// <inheritdoc />
+    public async Task<AppResult<FileDto>> Handle(SetFileValidityCommand request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var file = await _repository.GetAsync(request.FileId, cancellationToken);
+            if (file is null)
+            {
+                return AppResult<FileDto>.NotFound($"File '{request.FileId}' was not found.");
+            }
+
+            var issued = UtcTimestamp.From(request.IssuedAtUtc);
+            var validUntil = UtcTimestamp.From(request.ValidUntilUtc);
+            file.SetValidity(issued, validUntil, request.HasPhysicalCopy, request.HasElectronicCopy);
+            await PersistAsync(file, cancellationToken);
+            return AppResult<FileDto>.Success(DomainToDto.ToFileDto(file));
+        }
+        catch (Exception ex) when (ex is ArgumentException or ArgumentOutOfRangeException)
+        {
+            return AppResult<FileDto>.FromException(ex);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return AppResult<FileDto>.FromException(ex);
+        }
+        catch (Exception ex)
+        {
+            return AppResult<FileDto>.FromException(ex, "Failed to update file validity.");
+        }
+    }
+
+    private async Task PersistAsync(FileEntity file, CancellationToken cancellationToken)
+    {
+        await PublishDomainEventsAsync(file, cancellationToken);
+        await IndexAndUpdateAsync(file, cancellationToken);
+    }
+
+    private async Task IndexAndUpdateAsync(FileEntity file, CancellationToken cancellationToken)
+    {
+        var document = file.ToSearchDocument();
+        await _searchIndexer.IndexAsync(document, cancellationToken);
+        file.ConfirmIndexed(file.SearchIndex.SchemaVersion, _clock.UtcNow);
+        await _repository.UpdateAsync(file, cancellationToken);
+    }
+
+    private async Task PublishDomainEventsAsync(FileEntity file, CancellationToken cancellationToken)
+    {
+        if (file.DomainEvents.Count == 0)
+        {
+            return;
+        }
+
+        await _eventPublisher.PublishAsync(file.DomainEvents, cancellationToken);
+        file.ClearDomainEvents();
+    }
+}

--- a/Veriado.Application/UseCases/Files/UpdateFileMetadata/UpdateFileMetadataCommand.cs
+++ b/Veriado.Application/UseCases/Files/UpdateFileMetadata/UpdateFileMetadataCommand.cs
@@ -1,0 +1,14 @@
+using System;
+using MediatR;
+using Veriado.Application.Common;
+using Veriado.Application.DTO;
+
+namespace Veriado.Application.UseCases.Files.UpdateFileMetadata;
+
+/// <summary>
+/// Command to update the core metadata of a file such as MIME type and author.
+/// </summary>
+/// <param name="FileId">The identifier of the file.</param>
+/// <param name="Mime">The optional new MIME type.</param>
+/// <param name="Author">The optional new author.</param>
+public sealed record UpdateFileMetadataCommand(Guid FileId, string? Mime, string? Author) : IRequest<AppResult<FileDto>>;

--- a/Veriado.Application/UseCases/Files/UpdateFileMetadata/UpdateFileMetadataHandler.cs
+++ b/Veriado.Application/UseCases/Files/UpdateFileMetadata/UpdateFileMetadataHandler.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using Veriado.Application.Abstractions;
+using Veriado.Application.Common;
+using Veriado.Application.DTO;
+using Veriado.Application.Mapping;
+using Veriado.Domain.Files;
+using Veriado.Domain.ValueObjects;
+
+namespace Veriado.Application.UseCases.Files.UpdateFileMetadata;
+
+/// <summary>
+/// Handles updates of core file metadata.
+/// </summary>
+public sealed class UpdateFileMetadataHandler : IRequestHandler<UpdateFileMetadataCommand, AppResult<FileDto>>
+{
+    private readonly IFileRepository _repository;
+    private readonly IEventPublisher _eventPublisher;
+    private readonly ISearchIndexer _searchIndexer;
+    private readonly IClock _clock;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="UpdateFileMetadataHandler"/> class.
+    /// </summary>
+    public UpdateFileMetadataHandler(
+        IFileRepository repository,
+        IEventPublisher eventPublisher,
+        ISearchIndexer searchIndexer,
+        IClock clock)
+    {
+        _repository = repository;
+        _eventPublisher = eventPublisher;
+        _searchIndexer = searchIndexer;
+        _clock = clock;
+    }
+
+    /// <inheritdoc />
+    public async Task<AppResult<FileDto>> Handle(UpdateFileMetadataCommand request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var file = await _repository.GetAsync(request.FileId, cancellationToken);
+            if (file is null)
+            {
+                return AppResult<FileDto>.NotFound($"File '{request.FileId}' was not found.");
+            }
+
+            MimeType? mime = request.Mime is null ? null : MimeType.From(request.Mime);
+            file.UpdateMetadata(mime, request.Author);
+            await PersistAsync(file, cancellationToken);
+            return AppResult<FileDto>.Success(DomainToDto.ToFileDto(file));
+        }
+        catch (Exception ex) when (ex is ArgumentException or ArgumentOutOfRangeException)
+        {
+            return AppResult<FileDto>.FromException(ex);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return AppResult<FileDto>.FromException(ex);
+        }
+        catch (Exception ex)
+        {
+            return AppResult<FileDto>.FromException(ex, "Failed to update file metadata.");
+        }
+    }
+
+    private async Task PersistAsync(FileEntity file, CancellationToken cancellationToken)
+    {
+        await PublishDomainEventsAsync(file, cancellationToken);
+        await IndexAndUpdateAsync(file, cancellationToken);
+    }
+
+    private async Task IndexAndUpdateAsync(FileEntity file, CancellationToken cancellationToken)
+    {
+        var document = file.ToSearchDocument();
+        await _searchIndexer.IndexAsync(document, cancellationToken);
+        file.ConfirmIndexed(file.SearchIndex.SchemaVersion, _clock.UtcNow);
+        await _repository.UpdateAsync(file, cancellationToken);
+    }
+
+    private async Task PublishDomainEventsAsync(FileEntity file, CancellationToken cancellationToken)
+    {
+        if (file.DomainEvents.Count == 0)
+        {
+            return;
+        }
+
+        await _eventPublisher.PublishAsync(file.DomainEvents, cancellationToken);
+        file.ClearDomainEvents();
+    }
+}

--- a/Veriado.Application/UseCases/Maintenance/BulkReindexCommand.cs
+++ b/Veriado.Application/UseCases/Maintenance/BulkReindexCommand.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Collections.Generic;
+using MediatR;
+using Veriado.Application.Common;
+
+namespace Veriado.Application.UseCases.Maintenance;
+
+/// <summary>
+/// Command to reindex multiple files in bulk.
+/// </summary>
+/// <param name="FileIds">The collection of file identifiers.</param>
+/// <param name="ExtractContent">Indicates whether binary content should be reprocessed.</param>
+public sealed record BulkReindexCommand(IReadOnlyCollection<Guid> FileIds, bool ExtractContent = false) : IRequest<AppResult<int>>;

--- a/Veriado.Application/UseCases/Maintenance/BulkReindexHandler.cs
+++ b/Veriado.Application/UseCases/Maintenance/BulkReindexHandler.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using Veriado.Application.Abstractions;
+using Veriado.Application.Common;
+
+namespace Veriado.Application.UseCases.Maintenance;
+
+/// <summary>
+/// Handles bulk reindex operations over multiple files.
+/// </summary>
+public sealed class BulkReindexHandler : IRequestHandler<BulkReindexCommand, AppResult<int>>
+{
+    private readonly IFileRepository _repository;
+    private readonly IEventPublisher _eventPublisher;
+    private readonly ISearchIndexer _searchIndexer;
+    private readonly ITextExtractor _textExtractor;
+    private readonly IClock _clock;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BulkReindexHandler"/> class.
+    /// </summary>
+    public BulkReindexHandler(
+        IFileRepository repository,
+        IEventPublisher eventPublisher,
+        ISearchIndexer searchIndexer,
+        ITextExtractor textExtractor,
+        IClock clock)
+    {
+        _repository = repository;
+        _eventPublisher = eventPublisher;
+        _searchIndexer = searchIndexer;
+        _textExtractor = textExtractor;
+        _clock = clock;
+    }
+
+    /// <inheritdoc />
+    public async Task<AppResult<int>> Handle(BulkReindexCommand request, CancellationToken cancellationToken)
+    {
+        if (request.FileIds is null || request.FileIds.Count == 0)
+        {
+            return AppResult<int>.Validation(new[] { "At least one file identifier must be provided." });
+        }
+
+        var distinctIds = request.FileIds.Distinct().ToArray();
+        var files = await _repository.GetManyAsync(distinctIds, cancellationToken);
+        if (files.Count != distinctIds.Length)
+        {
+            var foundIds = files.Select(f => f.Id).ToHashSet();
+            var missing = distinctIds.Where(id => !foundIds.Contains(id)).Select(id => id.ToString());
+            return AppResult<int>.NotFound($"Files not found: {string.Join(", ", missing)}");
+        }
+
+        foreach (var file in files)
+        {
+            await PublishDomainEventsAsync(file, cancellationToken);
+            var text = request.ExtractContent ? await _textExtractor.ExtractTextAsync(file, cancellationToken) : null;
+            var document = file.ToSearchDocument(text);
+            await _searchIndexer.IndexAsync(document, cancellationToken);
+            file.ConfirmIndexed(file.SearchIndex.SchemaVersion, _clock.UtcNow);
+            await _repository.UpdateAsync(file, cancellationToken);
+        }
+
+        return AppResult<int>.Success(files.Count);
+    }
+
+    private async Task PublishDomainEventsAsync(FileEntity file, CancellationToken cancellationToken)
+    {
+        if (file.DomainEvents.Count == 0)
+        {
+            return;
+        }
+
+        await _eventPublisher.PublishAsync(file.DomainEvents, cancellationToken);
+        file.ClearDomainEvents();
+    }
+}

--- a/Veriado.Application/UseCases/Maintenance/ReindexFileCommand.cs
+++ b/Veriado.Application/UseCases/Maintenance/ReindexFileCommand.cs
@@ -1,0 +1,13 @@
+using System;
+using MediatR;
+using Veriado.Application.Common;
+using Veriado.Application.DTO;
+
+namespace Veriado.Application.UseCases.Maintenance;
+
+/// <summary>
+/// Command that forces reindexing of a single file.
+/// </summary>
+/// <param name="FileId">The file identifier.</param>
+/// <param name="ExtractContent">Indicates whether the text extractor should be invoked.</param>
+public sealed record ReindexFileCommand(Guid FileId, bool ExtractContent = false) : IRequest<AppResult<FileDto>>;

--- a/Veriado.Application/UseCases/Maintenance/ReindexFileHandler.cs
+++ b/Veriado.Application/UseCases/Maintenance/ReindexFileHandler.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using Veriado.Application.Abstractions;
+using Veriado.Application.Common;
+using Veriado.Application.DTO;
+using Veriado.Application.Mapping;
+using Veriado.Domain.Files;
+
+namespace Veriado.Application.UseCases.Maintenance;
+
+/// <summary>
+/// Handles explicit reindexing requests for a file.
+/// </summary>
+public sealed class ReindexFileHandler : IRequestHandler<ReindexFileCommand, AppResult<FileDto>>
+{
+    private readonly IFileRepository _repository;
+    private readonly IEventPublisher _eventPublisher;
+    private readonly ISearchIndexer _searchIndexer;
+    private readonly ITextExtractor _textExtractor;
+    private readonly IClock _clock;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ReindexFileHandler"/> class.
+    /// </summary>
+    public ReindexFileHandler(
+        IFileRepository repository,
+        IEventPublisher eventPublisher,
+        ISearchIndexer searchIndexer,
+        ITextExtractor textExtractor,
+        IClock clock)
+    {
+        _repository = repository;
+        _eventPublisher = eventPublisher;
+        _searchIndexer = searchIndexer;
+        _textExtractor = textExtractor;
+        _clock = clock;
+    }
+
+    /// <inheritdoc />
+    public async Task<AppResult<FileDto>> Handle(ReindexFileCommand request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var file = await _repository.GetAsync(request.FileId, cancellationToken);
+            if (file is null)
+            {
+                return AppResult<FileDto>.NotFound($"File '{request.FileId}' was not found.");
+            }
+
+            await PublishDomainEventsAsync(file, cancellationToken);
+            await IndexAsync(file, request.ExtractContent, cancellationToken);
+            return AppResult<FileDto>.Success(DomainToDto.ToFileDto(file));
+        }
+        catch (Exception ex)
+        {
+            return AppResult<FileDto>.FromException(ex, "Failed to reindex the file.");
+        }
+    }
+
+    private async Task IndexAsync(FileEntity file, bool extractContent, CancellationToken cancellationToken)
+    {
+        var text = extractContent ? await _textExtractor.ExtractTextAsync(file, cancellationToken) : null;
+        var document = file.ToSearchDocument(text);
+        await _searchIndexer.IndexAsync(document, cancellationToken);
+        file.ConfirmIndexed(file.SearchIndex.SchemaVersion, _clock.UtcNow);
+        await _repository.UpdateAsync(file, cancellationToken);
+    }
+
+    private async Task PublishDomainEventsAsync(FileEntity file, CancellationToken cancellationToken)
+    {
+        if (file.DomainEvents.Count == 0)
+        {
+            return;
+        }
+
+        await _eventPublisher.PublishAsync(file.DomainEvents, cancellationToken);
+        file.ClearDomainEvents();
+    }
+}

--- a/Veriado.Application/UseCases/Maintenance/VerifyAndRepairFulltextCommand.cs
+++ b/Veriado.Application/UseCases/Maintenance/VerifyAndRepairFulltextCommand.cs
@@ -1,0 +1,11 @@
+using MediatR;
+using Veriado.Application.Common;
+
+namespace Veriado.Application.UseCases.Maintenance;
+
+/// <summary>
+/// Command that verifies the search index and repairs entries when necessary.
+/// </summary>
+/// <param name="ExtractContent">Indicates whether to re-extract text during repair.</param>
+/// <param name="Force">When set, reindexes all files regardless of state.</param>
+public sealed record VerifyAndRepairFulltextCommand(bool ExtractContent = false, bool Force = false) : IRequest<AppResult<int>>;

--- a/Veriado.Application/UseCases/Maintenance/VerifyAndRepairFulltextHandler.cs
+++ b/Veriado.Application/UseCases/Maintenance/VerifyAndRepairFulltextHandler.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using Veriado.Application.Abstractions;
+using Veriado.Application.Common;
+using Veriado.Domain.Files;
+
+namespace Veriado.Application.UseCases.Maintenance;
+
+/// <summary>
+/// Ensures that the search index accurately reflects the file corpus.
+/// </summary>
+public sealed class VerifyAndRepairFulltextHandler : IRequestHandler<VerifyAndRepairFulltextCommand, AppResult<int>>
+{
+    private readonly IFileRepository _repository;
+    private readonly ISearchIndexer _searchIndexer;
+    private readonly ITextExtractor _textExtractor;
+    private readonly IClock _clock;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="VerifyAndRepairFulltextHandler"/> class.
+    /// </summary>
+    public VerifyAndRepairFulltextHandler(
+        IFileRepository repository,
+        ISearchIndexer searchIndexer,
+        ITextExtractor textExtractor,
+        IClock clock)
+    {
+        _repository = repository;
+        _searchIndexer = searchIndexer;
+        _textExtractor = textExtractor;
+        _clock = clock;
+    }
+
+    /// <inheritdoc />
+    public async Task<AppResult<int>> Handle(VerifyAndRepairFulltextCommand request, CancellationToken cancellationToken)
+    {
+        var repaired = 0;
+
+        await foreach (var file in _repository.StreamAllAsync(cancellationToken))
+        {
+            if (!request.Force && !NeedsRepair(file))
+            {
+                continue;
+            }
+
+            var text = request.ExtractContent ? await _textExtractor.ExtractTextAsync(file, cancellationToken) : null;
+            var document = file.ToSearchDocument(text);
+            await _searchIndexer.IndexAsync(document, cancellationToken);
+            file.ConfirmIndexed(file.SearchIndex.SchemaVersion, _clock.UtcNow);
+            await _repository.UpdateAsync(file, cancellationToken);
+            repaired++;
+        }
+
+        return AppResult<int>.Success(repaired);
+    }
+
+    private static bool NeedsRepair(FileEntity file)
+    {
+        if (file.SearchIndex.IsStale)
+        {
+            return true;
+        }
+
+        var expectedHash = file.Content.Hash.Value;
+        if (!string.Equals(file.SearchIndex.IndexedContentHash, expectedHash, StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        var expectedTitle = file.GetTitle() ?? file.Name.Value;
+        if (!string.Equals(file.SearchIndex.IndexedTitle, expectedTitle, StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/Veriado.Application/UseCases/Queries/GetExpiringFilesHandler.cs
+++ b/Veriado.Application/UseCases/Queries/GetExpiringFilesHandler.cs
@@ -1,0 +1,40 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using Veriado.Application.Abstractions;
+using Veriado.Application.Common.Policies;
+using Veriado.Application.DTO;
+using Veriado.Application.Mapping;
+
+namespace Veriado.Application.UseCases.Queries;
+
+/// <summary>
+/// Handles retrieval of expiring files according to the reminder policy.
+/// </summary>
+public sealed class GetExpiringFilesHandler : IRequestHandler<GetExpiringFilesQuery, IReadOnlyList<FileListItemDto>>
+{
+    private readonly IFileReadRepository _readRepository;
+    private readonly ValidityReminderPolicy _policy;
+    private readonly IClock _clock;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GetExpiringFilesHandler"/> class.
+    /// </summary>
+    public GetExpiringFilesHandler(IFileReadRepository readRepository, ValidityReminderPolicy policy, IClock clock)
+    {
+        _readRepository = readRepository;
+        _policy = policy;
+        _clock = clock;
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<FileListItemDto>> Handle(GetExpiringFilesQuery request, CancellationToken cancellationToken)
+    {
+        var leadTime = request.LeadTime ?? _policy.ReminderLeadTime;
+        var threshold = _clock.UtcNow + leadTime;
+        var items = await _readRepository.ListExpiringAsync(threshold, cancellationToken);
+        return items.Select(DomainToDto.ToListItemDto).ToArray();
+    }
+}

--- a/Veriado.Application/UseCases/Queries/GetExpiringFilesQuery.cs
+++ b/Veriado.Application/UseCases/Queries/GetExpiringFilesQuery.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Collections.Generic;
+using MediatR;
+using Veriado.Application.DTO;
+
+namespace Veriado.Application.UseCases.Queries;
+
+/// <summary>
+/// Query to retrieve files that are expiring within a configured lead time.
+/// </summary>
+/// <param name="LeadTime">Optional lead time override before expiration.</param>
+public sealed record GetExpiringFilesQuery(TimeSpan? LeadTime) : IRequest<IReadOnlyList<FileListItemDto>>;

--- a/Veriado.Application/UseCases/Queries/GetFileDetailHandler.cs
+++ b/Veriado.Application/UseCases/Queries/GetFileDetailHandler.cs
@@ -1,0 +1,31 @@
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using Veriado.Application.Abstractions;
+using Veriado.Application.DTO;
+using Veriado.Application.Mapping;
+
+namespace Veriado.Application.UseCases.Queries;
+
+/// <summary>
+/// Handles retrieval of detailed file projections.
+/// </summary>
+public sealed class GetFileDetailHandler : IRequestHandler<GetFileDetailQuery, FileDetailDto?>
+{
+    private readonly IFileReadRepository _readRepository;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GetFileDetailHandler"/> class.
+    /// </summary>
+    public GetFileDetailHandler(IFileReadRepository readRepository)
+    {
+        _readRepository = readRepository;
+    }
+
+    /// <inheritdoc />
+    public async Task<FileDetailDto?> Handle(GetFileDetailQuery request, CancellationToken cancellationToken)
+    {
+        var detail = await _readRepository.GetDetailAsync(request.FileId, cancellationToken);
+        return detail is null ? null : DomainToDto.ToDetailDto(detail);
+    }
+}

--- a/Veriado.Application/UseCases/Queries/GetFileDetailQuery.cs
+++ b/Veriado.Application/UseCases/Queries/GetFileDetailQuery.cs
@@ -1,0 +1,11 @@
+using System;
+using MediatR;
+using Veriado.Application.DTO;
+
+namespace Veriado.Application.UseCases.Queries;
+
+/// <summary>
+/// Query to retrieve a detailed representation of a file.
+/// </summary>
+/// <param name="FileId">The file identifier.</param>
+public sealed record GetFileDetailQuery(Guid FileId) : IRequest<FileDetailDto?>;

--- a/Veriado.Application/UseCases/Queries/ListFilesHandler.cs
+++ b/Veriado.Application/UseCases/Queries/ListFilesHandler.cs
@@ -1,0 +1,35 @@
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using Veriado.Application.Abstractions;
+using Veriado.Application.Common;
+using Veriado.Application.DTO;
+using Veriado.Application.Mapping;
+
+namespace Veriado.Application.UseCases.Queries;
+
+/// <summary>
+/// Handles listing files with paging support.
+/// </summary>
+public sealed class ListFilesHandler : IRequestHandler<ListFilesQuery, Page<FileListItemDto>>
+{
+    private readonly IFileReadRepository _readRepository;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ListFilesHandler"/> class.
+    /// </summary>
+    public ListFilesHandler(IFileReadRepository readRepository)
+    {
+        _readRepository = readRepository;
+    }
+
+    /// <inheritdoc />
+    public async Task<Page<FileListItemDto>> Handle(ListFilesQuery request, CancellationToken cancellationToken)
+    {
+        var pageRequest = new PageRequest(request.PageNumber, request.PageSize);
+        var result = await _readRepository.ListAsync(pageRequest, cancellationToken);
+        var items = result.Items.Select(DomainToDto.ToListItemDto).ToList();
+        return new Page<FileListItemDto>(items, result.PageNumber, result.PageSize, result.TotalCount);
+    }
+}

--- a/Veriado.Application/UseCases/Queries/ListFilesQuery.cs
+++ b/Veriado.Application/UseCases/Queries/ListFilesQuery.cs
@@ -1,0 +1,12 @@
+using MediatR;
+using Veriado.Application.Common;
+using Veriado.Application.DTO;
+
+namespace Veriado.Application.UseCases.Queries;
+
+/// <summary>
+/// Query to obtain a paginated list of files.
+/// </summary>
+/// <param name="PageNumber">The 1-based page number.</param>
+/// <param name="PageSize">The size of the page.</param>
+public sealed record ListFilesQuery(int PageNumber, int PageSize) : IRequest<Page<FileListItemDto>>;

--- a/Veriado.Application/UseCases/Search/SearchFilesHandler.cs
+++ b/Veriado.Application/UseCases/Search/SearchFilesHandler.cs
@@ -1,0 +1,35 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using Veriado.Application.Abstractions;
+using Veriado.Application.Common;
+using Veriado.Application.DTO;
+using Veriado.Application.Mapping;
+
+namespace Veriado.Application.UseCases.Search;
+
+/// <summary>
+/// Handles full-text search queries for files.
+/// </summary>
+public sealed class SearchFilesHandler : IRequestHandler<SearchFilesQuery, IReadOnlyList<SearchHitDto>>
+{
+    private readonly ISearchQueryService _searchQueryService;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SearchFilesHandler"/> class.
+    /// </summary>
+    public SearchFilesHandler(ISearchQueryService searchQueryService)
+    {
+        _searchQueryService = searchQueryService;
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<SearchHitDto>> Handle(SearchFilesQuery request, CancellationToken cancellationToken)
+    {
+        Guard.AgainstNullOrWhiteSpace(request.Text, nameof(request.Text));
+        var hits = await _searchQueryService.SearchAsync(request.Text, request.Limit, cancellationToken);
+        return hits.Select(DomainToDto.ToSearchHitDto).ToArray();
+    }
+}

--- a/Veriado.Application/UseCases/Search/SearchFilesQuery.cs
+++ b/Veriado.Application/UseCases/Search/SearchFilesQuery.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using MediatR;
+using Veriado.Application.DTO;
+
+namespace Veriado.Application.UseCases.Search;
+
+/// <summary>
+/// Query to search for files in the indexed corpus.
+/// </summary>
+/// <param name="Text">The search text.</param>
+/// <param name="Limit">Optional limit of hits.</param>
+public sealed record SearchFilesQuery(string Text, int? Limit) : IRequest<IReadOnlyList<SearchHitDto>>;

--- a/Veriado.Application/Veriado.Application.csproj
+++ b/Veriado.Application/Veriado.Application.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <LangVersion>12.0</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="MediatR" Version="12.*" />
+    <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="11.*" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Veriado.Domain\Veriado.Domain.csproj" />
+  </ItemGroup>
+</Project>

--- a/Veriado.sln
+++ b/Veriado.sln
@@ -9,6 +9,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Veriado.Domain", "Veriado.D
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Veriado.Infrastructure", "Veriado.Infrastructure\Veriado.Infrastructure.csproj", "{6FA76EE3-8C55-4176-AF31-CA4AD7DA6777}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Veriado.Application", "Veriado.Application\Veriado.Application.csproj", "{A238B7DB-438E-4502-A0E1-068306307A3A}"
+EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Source", "Source", "{02EA681E-C7D8-13C7-8484-4AC65E1B71E8}"
 EndProject
 Global
@@ -63,14 +65,27 @@ Global
                 {6FA76EE3-8C55-4176-AF31-CA4AD7DA6777}.Release|x64.Build.0 = Release|Any CPU
                 {6FA76EE3-8C55-4176-AF31-CA4AD7DA6777}.Release|x86.ActiveCfg = Release|Any CPU
                 {6FA76EE3-8C55-4176-AF31-CA4AD7DA6777}.Release|x86.Build.0 = Release|Any CPU
+                {A238B7DB-438E-4502-A0E1-068306307A3A}.Debug|ARM64.ActiveCfg = Debug|Any CPU
+                {A238B7DB-438E-4502-A0E1-068306307A3A}.Debug|ARM64.Build.0 = Debug|Any CPU
+                {A238B7DB-438E-4502-A0E1-068306307A3A}.Debug|x64.ActiveCfg = Debug|Any CPU
+                {A238B7DB-438E-4502-A0E1-068306307A3A}.Debug|x64.Build.0 = Debug|Any CPU
+                {A238B7DB-438E-4502-A0E1-068306307A3A}.Debug|x86.ActiveCfg = Debug|Any CPU
+                {A238B7DB-438E-4502-A0E1-068306307A3A}.Debug|x86.Build.0 = Debug|Any CPU
+                {A238B7DB-438E-4502-A0E1-068306307A3A}.Release|ARM64.ActiveCfg = Release|Any CPU
+                {A238B7DB-438E-4502-A0E1-068306307A3A}.Release|ARM64.Build.0 = Release|Any CPU
+                {A238B7DB-438E-4502-A0E1-068306307A3A}.Release|x64.ActiveCfg = Release|Any CPU
+                {A238B7DB-438E-4502-A0E1-068306307A3A}.Release|x64.Build.0 = Release|Any CPU
+                {A238B7DB-438E-4502-A0E1-068306307A3A}.Release|x86.ActiveCfg = Release|Any CPU
+                {A238B7DB-438E-4502-A0E1-068306307A3A}.Release|x86.Build.0 = Release|Any CPU
         EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
-	EndGlobalSection
-	GlobalSection(NestedProjects) = preSolution
+        GlobalSection(SolutionProperties) = preSolution
+                HideSolutionNode = FALSE
+        EndGlobalSection
+        GlobalSection(NestedProjects) = preSolution
                 {DD7E39A9-548E-4BF2-918B-FFB26FF05BA0} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
                 {86B8F682-4E4A-4E11-804A-3513C85B8ADB} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
                 {6FA76EE3-8C55-4176-AF31-CA4AD7DA6777} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+                {A238B7DB-438E-4502-A0E1-068306307A3A} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
         EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {015A55A8-BE3A-4015-BDD2-CBAE0F721F7E}


### PR DESCRIPTION
## Summary
- add the Veriado.Application project with abstractions, DTOs, mapping, and MediatR use cases over the domain
- register application services and pipeline behaviors for logging, idempotency, and validation
- include third-party notices and Apache 2.0 license text for the MediatR dependency

## Testing
- `dotnet build` *(fails: command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce78ca19648326992c071425a08ef4