### PR TITLE
Add contracts, commands, and mapping pipeline

### DIFF
--- a/Veriado.Application/Abstractions/IEventPublisher.cs
+++ b/Veriado.Application/Abstractions/IEventPublisher.cs
@@ -6,21 +6,14 @@ using Veriado.Domain.Primitives;
 namespace Veriado.Application.Abstractions;
 
 /// <summary>
-/// Defines a publisher capable of dispatching domain events raised by aggregates.
+/// Provides an abstraction for publishing domain events raised by aggregates.
 /// </summary>
 public interface IEventPublisher
 {
     /// <summary>
-    /// Publishes a single domain event.
+    /// Publishes the supplied domain events to their respective handlers.
     /// </summary>
-    /// <param name="domainEvent">The domain event to publish.</param>
+    /// <param name="events">The events to publish.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
-    Task PublishAsync(IDomainEvent domainEvent, CancellationToken cancellationToken);
-
-    /// <summary>
-    /// Publishes a collection of domain events.
-    /// </summary>
-    /// <param name="domainEvents">The events to publish.</param>
-    /// <param name="cancellationToken">The cancellation token.</param>
-    Task PublishAsync(IEnumerable<IDomainEvent> domainEvents, CancellationToken cancellationToken);
+    Task PublishAsync(IReadOnlyCollection<IDomainEvent> events, CancellationToken cancellationToken);
 }

--- a/Veriado.Application/Abstractions/IFileRepository.cs
+++ b/Veriado.Application/Abstractions/IFileRepository.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Veriado.Domain.Files;
@@ -7,44 +6,29 @@ using Veriado.Domain.Files;
 namespace Veriado.Application.Abstractions;
 
 /// <summary>
-/// Defines write-oriented persistence operations for <see cref="FileEntity"/> aggregates.
+/// Provides access to persisted file aggregates.
 /// </summary>
 public interface IFileRepository
 {
     /// <summary>
-    /// Gets a file aggregate by its identifier.
+    /// Loads a file aggregate by its identifier.
     /// </summary>
-    /// <param name="id">The file identifier.</param>
+    /// <param name="id">The identifier of the file.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns>The aggregate or <see langword="null"/> if not found.</returns>
+    /// <returns>The loaded aggregate or <see langword="null"/> when it does not exist.</returns>
     Task<FileEntity?> GetAsync(Guid id, CancellationToken cancellationToken);
 
     /// <summary>
-    /// Gets a collection of file aggregates by their identifiers.
-    /// </summary>
-    /// <param name="ids">The file identifiers to retrieve.</param>
-    /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns>The collection of aggregates found for the provided identifiers.</returns>
-    Task<IReadOnlyList<FileEntity>> GetManyAsync(IReadOnlyCollection<Guid> ids, CancellationToken cancellationToken);
-
-    /// <summary>
-    /// Streams all file aggregates.
-    /// </summary>
-    /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns>An asynchronous sequence of files.</returns>
-    IAsyncEnumerable<FileEntity> StreamAllAsync(CancellationToken cancellationToken);
-
-    /// <summary>
-    /// Adds a new file aggregate to the store.
+    /// Adds a newly created file aggregate to the persistence store.
     /// </summary>
     /// <param name="file">The aggregate to add.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     Task AddAsync(FileEntity file, CancellationToken cancellationToken);
 
     /// <summary>
-    /// Persists changes to an existing aggregate.
+    /// Persists the provided file aggregate updates.
     /// </summary>
-    /// <param name="file">The aggregate to update.</param>
+    /// <param name="file">The aggregate to persist.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     Task UpdateAsync(FileEntity file, CancellationToken cancellationToken);
 }

--- a/Veriado.Application/Abstractions/ISearchIndexer.cs
+++ b/Veriado.Application/Abstractions/ISearchIndexer.cs
@@ -6,21 +6,21 @@ using Veriado.Domain.Search;
 namespace Veriado.Application.Abstractions;
 
 /// <summary>
-/// Provides operations for projecting file aggregates into the search index.
+/// Provides an abstraction for interacting with the full-text search indexing infrastructure.
 /// </summary>
 public interface ISearchIndexer
 {
     /// <summary>
-    /// Indexes or updates the provided search document.
+    /// Schedules or updates the search index entry for the supplied document.
     /// </summary>
-    /// <param name="document">The document to index.</param>
+    /// <param name="document">The search document projection.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
-    Task IndexAsync(SearchDocument document, CancellationToken cancellationToken);
+    Task UpsertAsync(SearchDocument document, CancellationToken cancellationToken);
 
     /// <summary>
-    /// Removes the search document associated with the file identifier.
+    /// Removes the search index entry associated with the supplied file identifier.
     /// </summary>
-    /// <param name="fileId">The identifier of the file to remove from the index.</param>
+    /// <param name="fileId">The identifier of the file.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     Task RemoveAsync(Guid fileId, CancellationToken cancellationToken);
 }

--- a/Veriado.Application/Abstractions/ISearchQueryService.cs
+++ b/Veriado.Application/Abstractions/ISearchQueryService.cs
@@ -1,38 +1,22 @@
-using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Veriado.Domain.Search;
 
 namespace Veriado.Application.Abstractions;
 
 /// <summary>
-/// Executes search queries against the indexed document corpus.
+/// Provides search capabilities over indexed file documents.
 /// </summary>
 public interface ISearchQueryService
 {
     /// <summary>
-    /// Executes a search query and returns ranked hits.
+    /// Executes a search query and returns the matching documents.
     /// </summary>
-    /// <param name="query">The textual query to execute.</param>
-    /// <param name="limit">Optional maximum number of hits to return.</param>
+    /// <param name="query">The search query text.</param>
+    /// <param name="skip">The number of results to skip.</param>
+    /// <param name="take">The maximum number of results to return.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns>The ranked collection of search hits.</returns>
-    Task<IReadOnlyList<SearchHit>> SearchAsync(string query, int? limit, CancellationToken cancellationToken);
+    /// <returns>The matched search documents.</returns>
+    Task<IReadOnlyList<SearchDocument>> QueryAsync(string query, int skip, int take, CancellationToken cancellationToken);
 }
-
-/// <summary>
-/// Represents a single search hit returned by the search infrastructure.
-/// </summary>
-/// <param name="FileId">The identifier of the matching file.</param>
-/// <param name="Title">The indexed title.</param>
-/// <param name="Mime">The MIME type of the file.</param>
-/// <param name="Snippet">An optional snippet highlighting the match.</param>
-/// <param name="Score">The relevance score.</param>
-/// <param name="LastModifiedUtc">The last modification timestamp in UTC.</param>
-public sealed record SearchHit(
-    Guid FileId,
-    string Title,
-    string Mime,
-    string? Snippet,
-    double Score,
-    DateTimeOffset LastModifiedUtc);

--- a/Veriado.Application/Abstractions/ITextExtractor.cs
+++ b/Veriado.Application/Abstractions/ITextExtractor.cs
@@ -5,15 +5,15 @@ using Veriado.Domain.Files;
 namespace Veriado.Application.Abstractions;
 
 /// <summary>
-/// Extracts textual content from file aggregates for indexing purposes.
+/// Provides facilities to extract searchable text from file content.
 /// </summary>
 public interface ITextExtractor
 {
     /// <summary>
-    /// Extracts text from the provided file aggregate.
+    /// Extracts plain text from the supplied file aggregate.
     /// </summary>
-    /// <param name="file">The file aggregate.</param>
+    /// <param name="file">The file aggregate whose content should be analyzed.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns>The extracted text or <see langword="null"/> when none could be produced.</returns>
-    Task<string?> ExtractTextAsync(FileEntity file, CancellationToken cancellationToken);
+    /// <returns>The extracted text or <see langword="null"/> when no text could be extracted.</returns>
+    Task<string?> ExtractAsync(FileEntity file, CancellationToken cancellationToken);
 }

--- a/Veriado.Application/Files/Commands/ClearValidityCommand.cs
+++ b/Veriado.Application/Files/Commands/ClearValidityCommand.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace Veriado.Application.Files.Commands;
+
+/// <summary>
+/// Represents a command describing the removal of validity information from a file.
+/// </summary>
+/// <param name="FileId">The identifier of the file to update.</param>
+public sealed record ClearValidityCommand(Guid FileId);

--- a/Veriado.Application/Files/Commands/CreateFileCommand.cs
+++ b/Veriado.Application/Files/Commands/CreateFileCommand.cs
@@ -1,0 +1,28 @@
+using System.Collections.Generic;
+using Veriado.Domain.Metadata;
+using Veriado.Domain.ValueObjects;
+
+namespace Veriado.Application.Files.Commands;
+
+/// <summary>
+/// Represents a command describing the creation of a new file aggregate.
+/// </summary>
+/// <param name="Name">The file name without extension.</param>
+/// <param name="Extension">The file extension.</param>
+/// <param name="Mime">The MIME type of the file.</param>
+/// <param name="Author">The author recorded for the file.</param>
+/// <param name="ContentBytes">The binary content to persist.</param>
+/// <param name="MaxContentLength">An optional maximum content length constraint.</param>
+/// <param name="ExtendedMetadata">Optional extended metadata patches to apply.</param>
+/// <param name="SystemMetadata">Optional system metadata snapshot.</param>
+/// <param name="IsReadOnly">Indicates whether the file should be marked read-only.</param>
+public sealed record CreateFileCommand(
+    FileName Name,
+    FileExtension Extension,
+    MimeType Mime,
+    string Author,
+    byte[] ContentBytes,
+    int? MaxContentLength,
+    IReadOnlyCollection<MetadataPatch> ExtendedMetadata,
+    FileSystemMetadata? SystemMetadata,
+    bool IsReadOnly);

--- a/Veriado.Application/Files/Commands/MetadataPatch.cs
+++ b/Veriado.Application/Files/Commands/MetadataPatch.cs
@@ -1,0 +1,16 @@
+using Veriado.Domain.Metadata;
+
+namespace Veriado.Application.Files.Commands;
+
+/// <summary>
+/// Represents a patch instruction for extended metadata.
+/// </summary>
+/// <param name="Key">The property key.</param>
+/// <param name="Value">The metadata value to assign, or <see langword="null"/> to remove the key.</param>
+public sealed record MetadataPatch(PropertyKey Key, MetadataValue? Value)
+{
+    /// <summary>
+    /// Gets a value indicating whether the patch removes the metadata entry.
+    /// </summary>
+    public bool IsRemoval => Value is null;
+}

--- a/Veriado.Application/Files/Commands/RenameFileCommand.cs
+++ b/Veriado.Application/Files/Commands/RenameFileCommand.cs
@@ -1,0 +1,11 @@
+using System;
+using Veriado.Domain.ValueObjects;
+
+namespace Veriado.Application.Files.Commands;
+
+/// <summary>
+/// Represents a command describing a request to rename a file.
+/// </summary>
+/// <param name="FileId">The identifier of the file to rename.</param>
+/// <param name="NewName">The new file name without extension.</param>
+public sealed record RenameFileCommand(Guid FileId, FileName NewName);

--- a/Veriado.Application/Files/Commands/ReplaceContentCommand.cs
+++ b/Veriado.Application/Files/Commands/ReplaceContentCommand.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace Veriado.Application.Files.Commands;
+
+/// <summary>
+/// Represents a command describing a request to replace the binary content of a file.
+/// </summary>
+/// <param name="FileId">The identifier of the file to update.</param>
+/// <param name="ContentBytes">The new binary content.</param>
+/// <param name="MaxContentLength">An optional maximum content length constraint.</param>
+public sealed record ReplaceContentCommand(Guid FileId, byte[] ContentBytes, int? MaxContentLength);

--- a/Veriado.Application/Files/Commands/SetValidityCommand.cs
+++ b/Veriado.Application/Files/Commands/SetValidityCommand.cs
@@ -1,0 +1,19 @@
+using System;
+using Veriado.Domain.ValueObjects;
+
+namespace Veriado.Application.Files.Commands;
+
+/// <summary>
+/// Represents a command describing the desired validity settings for a file.
+/// </summary>
+/// <param name="FileId">The identifier of the file to update.</param>
+/// <param name="IssuedAt">The timestamp when the document becomes valid.</param>
+/// <param name="ValidUntil">The timestamp when the document expires.</param>
+/// <param name="HasPhysicalCopy">Indicates whether a physical copy exists.</param>
+/// <param name="HasElectronicCopy">Indicates whether an electronic copy exists.</param>
+public sealed record SetValidityCommand(
+    Guid FileId,
+    UtcTimestamp IssuedAt,
+    UtcTimestamp ValidUntil,
+    bool HasPhysicalCopy,
+    bool HasElectronicCopy);

--- a/Veriado.Application/Files/Commands/UpdateMetadataCommand.cs
+++ b/Veriado.Application/Files/Commands/UpdateMetadataCommand.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Collections.Generic;
+using Veriado.Domain.Metadata;
+using Veriado.Domain.ValueObjects;
+
+namespace Veriado.Application.Files.Commands;
+
+/// <summary>
+/// Represents a command describing metadata updates for a file.
+/// </summary>
+/// <param name="FileId">The identifier of the file to update.</param>
+/// <param name="Mime">The optional new MIME type.</param>
+/// <param name="Author">The optional new author value.</param>
+/// <param name="IsReadOnly">An optional flag indicating whether the file should be read-only.</param>
+/// <param name="SystemMetadata">An optional system metadata snapshot.</param>
+/// <param name="ExtendedMetadata">Optional extended metadata patches.</param>
+public sealed record UpdateMetadataCommand(
+    Guid FileId,
+    MimeType? Mime,
+    string? Author,
+    bool? IsReadOnly,
+    FileSystemMetadata? SystemMetadata,
+    IReadOnlyCollection<MetadataPatch> ExtendedMetadata);

--- a/Veriado.Application/Files/Handlers/ClearValidityHandler.cs
+++ b/Veriado.Application/Files/Handlers/ClearValidityHandler.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Veriado.Application.Abstractions;
+using Veriado.Application.Files.Commands;
+using Veriado.Domain.Files;
+
+namespace Veriado.Application.Files.Handlers;
+
+/// <summary>
+/// Handles <see cref="ClearValidityCommand"/> operations.
+/// </summary>
+public sealed class ClearValidityHandler
+{
+    private readonly IFileRepository _repository;
+    private readonly IEventPublisher _eventPublisher;
+    private readonly ITextExtractor _textExtractor;
+    private readonly ISearchIndexer _searchIndexer;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ClearValidityHandler"/> class.
+    /// </summary>
+    public ClearValidityHandler(
+        IFileRepository repository,
+        IEventPublisher eventPublisher,
+        ITextExtractor textExtractor,
+        ISearchIndexer searchIndexer)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        _eventPublisher = eventPublisher ?? throw new ArgumentNullException(nameof(eventPublisher));
+        _textExtractor = textExtractor ?? throw new ArgumentNullException(nameof(textExtractor));
+        _searchIndexer = searchIndexer ?? throw new ArgumentNullException(nameof(searchIndexer));
+    }
+
+    /// <summary>
+    /// Executes the supplied command and persists the changes.
+    /// </summary>
+    /// <param name="command">The command describing the validity removal.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The updated aggregate.</returns>
+    public async Task<FileEntity> HandleAsync(ClearValidityCommand command, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        var file = await _repository.GetAsync(command.FileId, cancellationToken).ConfigureAwait(false);
+        if (file is null)
+        {
+            throw new InvalidOperationException($"File '{command.FileId}' was not found.");
+        }
+
+        file.ClearValidity();
+        if (file.DomainEvents.Count == 0)
+        {
+            return file;
+        }
+
+        await FileIndexingHelper.ReindexAsync(file, _textExtractor, _searchIndexer, cancellationToken).ConfigureAwait(false);
+        await _repository.UpdateAsync(file, cancellationToken).ConfigureAwait(false);
+        await FileCommandHandlerHelpers.PublishAndClearAsync(_eventPublisher, file, cancellationToken).ConfigureAwait(false);
+        return file;
+    }
+}

--- a/Veriado.Application/Files/Handlers/CreateFileHandler.cs
+++ b/Veriado.Application/Files/Handlers/CreateFileHandler.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Veriado.Application.Abstractions;
+using Veriado.Application.Files.Commands;
+using Veriado.Domain.Files;
+
+namespace Veriado.Application.Files.Handlers;
+
+/// <summary>
+/// Handles <see cref="CreateFileCommand"/> operations.
+/// </summary>
+public sealed class CreateFileHandler
+{
+    private readonly IFileRepository _repository;
+    private readonly IEventPublisher _eventPublisher;
+    private readonly ITextExtractor _textExtractor;
+    private readonly ISearchIndexer _searchIndexer;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CreateFileHandler"/> class.
+    /// </summary>
+    public CreateFileHandler(
+        IFileRepository repository,
+        IEventPublisher eventPublisher,
+        ITextExtractor textExtractor,
+        ISearchIndexer searchIndexer)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        _eventPublisher = eventPublisher ?? throw new ArgumentNullException(nameof(eventPublisher));
+        _textExtractor = textExtractor ?? throw new ArgumentNullException(nameof(textExtractor));
+        _searchIndexer = searchIndexer ?? throw new ArgumentNullException(nameof(searchIndexer));
+    }
+
+    /// <summary>
+    /// Executes the supplied command and persists the created aggregate.
+    /// </summary>
+    /// <param name="command">The command describing the new file.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The created aggregate.</returns>
+    public async Task<FileEntity> HandleAsync(CreateFileCommand command, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        var file = FileEntity.CreateNew(
+            command.Name,
+            command.Extension,
+            command.Mime,
+            command.Author,
+            command.ContentBytes,
+            command.MaxContentLength);
+
+        ApplyExtendedMetadata(file, command.ExtendedMetadata);
+
+        if (command.SystemMetadata.HasValue)
+        {
+            file.ApplySystemMetadata(command.SystemMetadata.Value);
+        }
+
+        if (command.IsReadOnly)
+        {
+            file.SetReadOnly(true);
+        }
+
+        await _repository.AddAsync(file, cancellationToken).ConfigureAwait(false);
+        await FileCommandHandlerHelpers.PublishAndClearAsync(_eventPublisher, file, cancellationToken).ConfigureAwait(false);
+
+        if (await FileIndexingHelper.ReindexAsync(file, _textExtractor, _searchIndexer, cancellationToken).ConfigureAwait(false))
+        {
+            await _repository.UpdateAsync(file, cancellationToken).ConfigureAwait(false);
+        }
+
+        return file;
+    }
+
+    private static void ApplyExtendedMetadata(FileEntity file, IReadOnlyCollection<MetadataPatch> patches)
+    {
+        if (patches.Count == 0)
+        {
+            return;
+        }
+
+        file.SetExtendedMetadata(builder =>
+        {
+            foreach (var patch in patches)
+            {
+                if (patch.IsRemoval)
+                {
+                    builder.Remove(patch.Key);
+                }
+                else
+                {
+                    builder.Set(patch.Key, patch.Value!.Value);
+                }
+            }
+        });
+    }
+}

--- a/Veriado.Application/Files/Handlers/FileCommandHandlerHelpers.cs
+++ b/Veriado.Application/Files/Handlers/FileCommandHandlerHelpers.cs
@@ -1,0 +1,21 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Veriado.Application.Abstractions;
+using Veriado.Domain.Files;
+
+namespace Veriado.Application.Files.Handlers;
+
+internal static class FileCommandHandlerHelpers
+{
+    public static async Task PublishAndClearAsync(IEventPublisher publisher, FileEntity file, CancellationToken cancellationToken)
+    {
+        var events = file.DomainEvents;
+        if (events.Count == 0)
+        {
+            return;
+        }
+
+        await publisher.PublishAsync(events, cancellationToken).ConfigureAwait(false);
+        file.ClearDomainEvents();
+    }
+}

--- a/Veriado.Application/Files/Handlers/FileIndexingHelper.cs
+++ b/Veriado.Application/Files/Handlers/FileIndexingHelper.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Veriado.Application.Abstractions;
+using Veriado.Domain.Files;
+
+namespace Veriado.Application.Files.Handlers;
+
+internal static class FileIndexingHelper
+{
+    public static async Task<bool> ReindexAsync(
+        FileEntity file,
+        ITextExtractor textExtractor,
+        ISearchIndexer searchIndexer,
+        CancellationToken cancellationToken)
+    {
+        var text = await textExtractor.ExtractAsync(file, cancellationToken).ConfigureAwait(false);
+        var document = file.ToSearchDocument(text);
+        await searchIndexer.UpsertAsync(document, cancellationToken).ConfigureAwait(false);
+        file.SearchIndex.ApplyIndexed(
+            file.SearchIndex.SchemaVersion,
+            DateTimeOffset.UtcNow,
+            file.Content.Hash.Value,
+            document.Title);
+        return true;
+    }
+}

--- a/Veriado.Application/Files/Handlers/RenameFileHandler.cs
+++ b/Veriado.Application/Files/Handlers/RenameFileHandler.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Veriado.Application.Abstractions;
+using Veriado.Application.Files.Commands;
+using Veriado.Domain.Files;
+
+namespace Veriado.Application.Files.Handlers;
+
+/// <summary>
+/// Handles <see cref="RenameFileCommand"/> operations.
+/// </summary>
+public sealed class RenameFileHandler
+{
+    private readonly IFileRepository _repository;
+    private readonly IEventPublisher _eventPublisher;
+    private readonly ITextExtractor _textExtractor;
+    private readonly ISearchIndexer _searchIndexer;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RenameFileHandler"/> class.
+    /// </summary>
+    public RenameFileHandler(
+        IFileRepository repository,
+        IEventPublisher eventPublisher,
+        ITextExtractor textExtractor,
+        ISearchIndexer searchIndexer)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        _eventPublisher = eventPublisher ?? throw new ArgumentNullException(nameof(eventPublisher));
+        _textExtractor = textExtractor ?? throw new ArgumentNullException(nameof(textExtractor));
+        _searchIndexer = searchIndexer ?? throw new ArgumentNullException(nameof(searchIndexer));
+    }
+
+    /// <summary>
+    /// Executes the supplied command and persists the changes.
+    /// </summary>
+    /// <param name="command">The command describing the rename.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The updated aggregate.</returns>
+    public async Task<FileEntity> HandleAsync(RenameFileCommand command, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        var file = await _repository.GetAsync(command.FileId, cancellationToken).ConfigureAwait(false);
+        if (file is null)
+        {
+            throw new InvalidOperationException($"File '{command.FileId}' was not found.");
+        }
+
+        file.Rename(command.NewName);
+        if (file.DomainEvents.Count == 0)
+        {
+            return file;
+        }
+
+        await FileIndexingHelper.ReindexAsync(file, _textExtractor, _searchIndexer, cancellationToken).ConfigureAwait(false);
+        await _repository.UpdateAsync(file, cancellationToken).ConfigureAwait(false);
+        await FileCommandHandlerHelpers.PublishAndClearAsync(_eventPublisher, file, cancellationToken).ConfigureAwait(false);
+        return file;
+    }
+}

--- a/Veriado.Application/Files/Handlers/ReplaceContentHandler.cs
+++ b/Veriado.Application/Files/Handlers/ReplaceContentHandler.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Veriado.Application.Abstractions;
+using Veriado.Application.Files.Commands;
+using Veriado.Domain.Files;
+
+namespace Veriado.Application.Files.Handlers;
+
+/// <summary>
+/// Handles <see cref="ReplaceContentCommand"/> operations.
+/// </summary>
+public sealed class ReplaceContentHandler
+{
+    private readonly IFileRepository _repository;
+    private readonly IEventPublisher _eventPublisher;
+    private readonly ITextExtractor _textExtractor;
+    private readonly ISearchIndexer _searchIndexer;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ReplaceContentHandler"/> class.
+    /// </summary>
+    public ReplaceContentHandler(
+        IFileRepository repository,
+        IEventPublisher eventPublisher,
+        ITextExtractor textExtractor,
+        ISearchIndexer searchIndexer)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        _eventPublisher = eventPublisher ?? throw new ArgumentNullException(nameof(eventPublisher));
+        _textExtractor = textExtractor ?? throw new ArgumentNullException(nameof(textExtractor));
+        _searchIndexer = searchIndexer ?? throw new ArgumentNullException(nameof(searchIndexer));
+    }
+
+    /// <summary>
+    /// Executes the supplied command and persists the changes.
+    /// </summary>
+    /// <param name="command">The command describing the content replacement.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The updated aggregate.</returns>
+    public async Task<FileEntity> HandleAsync(ReplaceContentCommand command, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        var file = await _repository.GetAsync(command.FileId, cancellationToken).ConfigureAwait(false);
+        if (file is null)
+        {
+            throw new InvalidOperationException($"File '{command.FileId}' was not found.");
+        }
+
+        file.ReplaceContent(command.ContentBytes, command.MaxContentLength);
+        if (file.DomainEvents.Count == 0)
+        {
+            return file;
+        }
+
+        await FileIndexingHelper.ReindexAsync(file, _textExtractor, _searchIndexer, cancellationToken).ConfigureAwait(false);
+        await _repository.UpdateAsync(file, cancellationToken).ConfigureAwait(false);
+        await FileCommandHandlerHelpers.PublishAndClearAsync(_eventPublisher, file, cancellationToken).ConfigureAwait(false);
+        return file;
+    }
+}

--- a/Veriado.Application/Files/Handlers/SetValidityHandler.cs
+++ b/Veriado.Application/Files/Handlers/SetValidityHandler.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Veriado.Application.Abstractions;
+using Veriado.Application.Files.Commands;
+using Veriado.Domain.Files;
+
+namespace Veriado.Application.Files.Handlers;
+
+/// <summary>
+/// Handles <see cref="SetValidityCommand"/> operations.
+/// </summary>
+public sealed class SetValidityHandler
+{
+    private readonly IFileRepository _repository;
+    private readonly IEventPublisher _eventPublisher;
+    private readonly ITextExtractor _textExtractor;
+    private readonly ISearchIndexer _searchIndexer;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SetValidityHandler"/> class.
+    /// </summary>
+    public SetValidityHandler(
+        IFileRepository repository,
+        IEventPublisher eventPublisher,
+        ITextExtractor textExtractor,
+        ISearchIndexer searchIndexer)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        _eventPublisher = eventPublisher ?? throw new ArgumentNullException(nameof(eventPublisher));
+        _textExtractor = textExtractor ?? throw new ArgumentNullException(nameof(textExtractor));
+        _searchIndexer = searchIndexer ?? throw new ArgumentNullException(nameof(searchIndexer));
+    }
+
+    /// <summary>
+    /// Executes the supplied command and persists the changes.
+    /// </summary>
+    /// <param name="command">The command describing the validity update.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The updated aggregate.</returns>
+    public async Task<FileEntity> HandleAsync(SetValidityCommand command, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        var file = await _repository.GetAsync(command.FileId, cancellationToken).ConfigureAwait(false);
+        if (file is null)
+        {
+            throw new InvalidOperationException($"File '{command.FileId}' was not found.");
+        }
+
+        file.SetValidity(command.IssuedAt, command.ValidUntil, command.HasPhysicalCopy, command.HasElectronicCopy);
+        if (file.DomainEvents.Count == 0)
+        {
+            return file;
+        }
+
+        await FileIndexingHelper.ReindexAsync(file, _textExtractor, _searchIndexer, cancellationToken).ConfigureAwait(false);
+        await _repository.UpdateAsync(file, cancellationToken).ConfigureAwait(false);
+        await FileCommandHandlerHelpers.PublishAndClearAsync(_eventPublisher, file, cancellationToken).ConfigureAwait(false);
+        return file;
+    }
+}

--- a/Veriado.Application/Files/Handlers/UpdateMetadataHandler.cs
+++ b/Veriado.Application/Files/Handlers/UpdateMetadataHandler.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Veriado.Application.Abstractions;
+using Veriado.Application.Files.Commands;
+using Veriado.Domain.Files;
+
+namespace Veriado.Application.Files.Handlers;
+
+/// <summary>
+/// Handles <see cref="UpdateMetadataCommand"/> operations.
+/// </summary>
+public sealed class UpdateMetadataHandler
+{
+    private readonly IFileRepository _repository;
+    private readonly IEventPublisher _eventPublisher;
+    private readonly ITextExtractor _textExtractor;
+    private readonly ISearchIndexer _searchIndexer;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="UpdateMetadataHandler"/> class.
+    /// </summary>
+    public UpdateMetadataHandler(
+        IFileRepository repository,
+        IEventPublisher eventPublisher,
+        ITextExtractor textExtractor,
+        ISearchIndexer searchIndexer)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        _eventPublisher = eventPublisher ?? throw new ArgumentNullException(nameof(eventPublisher));
+        _textExtractor = textExtractor ?? throw new ArgumentNullException(nameof(textExtractor));
+        _searchIndexer = searchIndexer ?? throw new ArgumentNullException(nameof(searchIndexer));
+    }
+
+    /// <summary>
+    /// Executes the supplied command and persists the changes.
+    /// </summary>
+    /// <param name="command">The command describing the metadata updates.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The updated aggregate.</returns>
+    public async Task<FileEntity> HandleAsync(UpdateMetadataCommand command, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        var file = await _repository.GetAsync(command.FileId, cancellationToken).ConfigureAwait(false);
+        if (file is null)
+        {
+            throw new InvalidOperationException($"File '{command.FileId}' was not found.");
+        }
+
+        if (command.Mime.HasValue || command.Author is not null)
+        {
+            file.UpdateMetadata(command.Mime, command.Author);
+        }
+
+        if (command.IsReadOnly.HasValue)
+        {
+            file.SetReadOnly(command.IsReadOnly.Value);
+        }
+
+        if (command.SystemMetadata.HasValue)
+        {
+            file.ApplySystemMetadata(command.SystemMetadata.Value);
+        }
+
+        ApplyExtendedMetadata(file, command.ExtendedMetadata);
+
+        if (file.DomainEvents.Count == 0)
+        {
+            return file;
+        }
+
+        await FileIndexingHelper.ReindexAsync(file, _textExtractor, _searchIndexer, cancellationToken).ConfigureAwait(false);
+        await _repository.UpdateAsync(file, cancellationToken).ConfigureAwait(false);
+        await FileCommandHandlerHelpers.PublishAndClearAsync(_eventPublisher, file, cancellationToken).ConfigureAwait(false);
+        return file;
+    }
+
+    private static void ApplyExtendedMetadata(FileEntity file, IReadOnlyCollection<MetadataPatch> patches)
+    {
+        if (patches.Count == 0)
+        {
+            return;
+        }
+
+        file.SetExtendedMetadata(builder =>
+        {
+            foreach (var patch in patches)
+            {
+                if (patch.IsRemoval)
+                {
+                    builder.Remove(patch.Key);
+                }
+                else
+                {
+                    builder.Set(patch.Key, patch.Value!.Value);
+                }
+            }
+        });
+    }
+}

--- a/Veriado.Application/Files/Validation/ClearValidityRequestValidator.cs
+++ b/Veriado.Application/Files/Validation/ClearValidityRequestValidator.cs
@@ -1,0 +1,19 @@
+using System;
+using FluentValidation;
+using Veriado.Application.Files.Commands;
+
+namespace Veriado.Application.Files.Validation;
+
+/// <summary>
+/// Validates <see cref="ClearValidityCommand"/> instances.
+/// </summary>
+public sealed class ClearValidityRequestValidator : AbstractValidator<ClearValidityCommand>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ClearValidityRequestValidator"/> class.
+    /// </summary>
+    public ClearValidityRequestValidator()
+    {
+        RuleFor(command => command.FileId).NotEmpty();
+    }
+}

--- a/Veriado.Application/Files/Validation/CreateFileRequestValidator.cs
+++ b/Veriado.Application/Files/Validation/CreateFileRequestValidator.cs
@@ -1,0 +1,31 @@
+using System;
+using FluentValidation;
+using Veriado.Application.Files.Commands;
+
+namespace Veriado.Application.Files.Validation;
+
+/// <summary>
+/// Validates <see cref="CreateFileCommand"/> instances.
+/// </summary>
+public sealed class CreateFileRequestValidator : AbstractValidator<CreateFileCommand>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CreateFileRequestValidator"/> class.
+    /// </summary>
+    public CreateFileRequestValidator()
+    {
+        RuleFor(command => command.Name).NotNull();
+        RuleFor(command => command.Extension).NotNull();
+        RuleFor(command => command.Mime).NotNull();
+        RuleFor(command => command.Author)
+            .NotEmpty()
+            .MaximumLength(256);
+        RuleFor(command => command.ContentBytes)
+            .NotNull()
+            .Must(bytes => bytes.Length > 0)
+            .WithMessage("Content must not be empty.");
+        RuleFor(command => command.MaxContentLength)
+            .GreaterThan(0)
+            .When(command => command.MaxContentLength.HasValue);
+    }
+}

--- a/Veriado.Application/Files/Validation/RenameFileRequestValidator.cs
+++ b/Veriado.Application/Files/Validation/RenameFileRequestValidator.cs
@@ -1,0 +1,20 @@
+using System;
+using FluentValidation;
+using Veriado.Application.Files.Commands;
+
+namespace Veriado.Application.Files.Validation;
+
+/// <summary>
+/// Validates <see cref="RenameFileCommand"/> instances.
+/// </summary>
+public sealed class RenameFileRequestValidator : AbstractValidator<RenameFileCommand>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RenameFileRequestValidator"/> class.
+    /// </summary>
+    public RenameFileRequestValidator()
+    {
+        RuleFor(command => command.FileId).NotEmpty();
+        RuleFor(command => command.NewName).NotNull();
+    }
+}

--- a/Veriado.Application/Files/Validation/ReplaceContentRequestValidator.cs
+++ b/Veriado.Application/Files/Validation/ReplaceContentRequestValidator.cs
@@ -1,0 +1,26 @@
+using System;
+using FluentValidation;
+using Veriado.Application.Files.Commands;
+
+namespace Veriado.Application.Files.Validation;
+
+/// <summary>
+/// Validates <see cref="ReplaceContentCommand"/> instances.
+/// </summary>
+public sealed class ReplaceContentRequestValidator : AbstractValidator<ReplaceContentCommand>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ReplaceContentRequestValidator"/> class.
+    /// </summary>
+    public ReplaceContentRequestValidator()
+    {
+        RuleFor(command => command.FileId).NotEmpty();
+        RuleFor(command => command.ContentBytes)
+            .NotNull()
+            .Must(bytes => bytes.Length > 0)
+            .WithMessage("Content must not be empty.");
+        RuleFor(command => command.MaxContentLength)
+            .GreaterThan(0)
+            .When(command => command.MaxContentLength.HasValue);
+    }
+}

--- a/Veriado.Application/Files/Validation/SetValidityRequestValidator.cs
+++ b/Veriado.Application/Files/Validation/SetValidityRequestValidator.cs
@@ -1,0 +1,22 @@
+using System;
+using FluentValidation;
+using Veriado.Application.Files.Commands;
+
+namespace Veriado.Application.Files.Validation;
+
+/// <summary>
+/// Validates <see cref="SetValidityCommand"/> instances.
+/// </summary>
+public sealed class SetValidityRequestValidator : AbstractValidator<SetValidityCommand>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SetValidityRequestValidator"/> class.
+    /// </summary>
+    public SetValidityRequestValidator()
+    {
+        RuleFor(command => command.FileId).NotEmpty();
+        RuleFor(command => command)
+            .Must(command => command.ValidUntil.Value >= command.IssuedAt.Value)
+            .WithMessage("Valid-until must be greater than or equal to issued-at.");
+    }
+}

--- a/Veriado.Application/Files/Validation/UpdateMetadataRequestValidator.cs
+++ b/Veriado.Application/Files/Validation/UpdateMetadataRequestValidator.cs
@@ -1,0 +1,50 @@
+using System;
+using FluentValidation;
+using Veriado.Application.Files.Commands;
+
+namespace Veriado.Application.Files.Validation;
+
+/// <summary>
+/// Validates <see cref="UpdateMetadataCommand"/> instances.
+/// </summary>
+public sealed class UpdateMetadataRequestValidator : AbstractValidator<UpdateMetadataCommand>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="UpdateMetadataRequestValidator"/> class.
+    /// </summary>
+    public UpdateMetadataRequestValidator()
+    {
+        RuleFor(command => command.FileId).NotEmpty();
+        RuleFor(command => command.Author)
+            .MaximumLength(256)
+            .When(command => command.Author is not null);
+        RuleFor(command => command)
+            .Must(HasAnyChange)
+            .WithMessage("At least one metadata change must be provided.");
+    }
+
+    private static bool HasAnyChange(UpdateMetadataCommand command)
+    {
+        if (command.Mime.HasValue)
+        {
+            return true;
+        }
+
+        if (!string.IsNullOrWhiteSpace(command.Author))
+        {
+            return true;
+        }
+
+        if (command.IsReadOnly.HasValue)
+        {
+            return true;
+        }
+
+        if (command.SystemMetadata.HasValue)
+        {
+            return true;
+        }
+
+        return command.ExtendedMetadata.Count > 0;
+    }
+}

--- a/Veriado.Contracts/Common/ApiResponse.cs
+++ b/Veriado.Contracts/Common/ApiResponse.cs
@@ -1,0 +1,193 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Veriado.Contracts.Common;
+
+/// <summary>
+/// Represents a standardized API response with optional data and error payloads.
+/// </summary>
+/// <typeparam name="T">The response data type.</typeparam>
+public sealed class ApiResponse<T>
+{
+    private ApiResponse(bool isSuccess, T? data, IReadOnlyList<ApiError> errors)
+    {
+        IsSuccess = isSuccess;
+        Data = data;
+        Errors = errors;
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether the response is successful.
+    /// </summary>
+    public bool IsSuccess { get; }
+
+    /// <summary>
+    /// Gets the response payload.
+    /// </summary>
+    public T? Data { get; }
+
+    /// <summary>
+    /// Gets the errors associated with the response.
+    /// </summary>
+    public IReadOnlyList<ApiError> Errors { get; }
+
+    /// <summary>
+    /// Creates a successful response.
+    /// </summary>
+    /// <param name="data">The response payload.</param>
+    /// <returns>The created response.</returns>
+    public static ApiResponse<T> Success(T data) => new(true, data, Array.Empty<ApiError>());
+
+    /// <summary>
+    /// Creates a failure response with the supplied errors.
+    /// </summary>
+    /// <param name="errors">The errors to attach to the response.</param>
+    /// <returns>The failure response.</returns>
+    public static ApiResponse<T> Failure(IEnumerable<ApiError> errors)
+    {
+        ArgumentNullException.ThrowIfNull(errors);
+        var materialized = errors.ToArray();
+        if (materialized.Length == 0)
+        {
+            throw new ArgumentException("Failure response must contain at least one error.", nameof(errors));
+        }
+
+        return new ApiResponse<T>(false, default, materialized);
+    }
+
+    /// <summary>
+    /// Creates a failure response from a single error.
+    /// </summary>
+    /// <param name="error">The error to attach.</param>
+    /// <returns>The failure response.</returns>
+    public static ApiResponse<T> Failure(ApiError error)
+    {
+        ArgumentNullException.ThrowIfNull(error);
+        return new ApiResponse<T>(false, default, new[] { error });
+    }
+}
+
+/// <summary>
+/// Represents a non-generic API response suitable for commands without return data.
+/// </summary>
+public sealed class ApiResponse
+{
+    private ApiResponse(bool isSuccess, IReadOnlyList<ApiError> errors)
+    {
+        IsSuccess = isSuccess;
+        Errors = errors;
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether the response is successful.
+    /// </summary>
+    public bool IsSuccess { get; }
+
+    /// <summary>
+    /// Gets the errors associated with the response.
+    /// </summary>
+    public IReadOnlyList<ApiError> Errors { get; }
+
+    /// <summary>
+    /// Creates a successful response without a payload.
+    /// </summary>
+    /// <returns>The created response.</returns>
+    public static ApiResponse Success() => new(true, Array.Empty<ApiError>());
+
+    /// <summary>
+    /// Creates a failure response with the provided errors.
+    /// </summary>
+    /// <param name="errors">The errors to attach.</param>
+    /// <returns>The created failure response.</returns>
+    public static ApiResponse Failure(IEnumerable<ApiError> errors)
+    {
+        ArgumentNullException.ThrowIfNull(errors);
+        var materialized = errors.ToArray();
+        if (materialized.Length == 0)
+        {
+            throw new ArgumentException("Failure response must contain at least one error.", nameof(errors));
+        }
+
+        return new ApiResponse(false, materialized);
+    }
+
+    /// <summary>
+    /// Creates a failure response with a single error.
+    /// </summary>
+    /// <param name="error">The error to attach.</param>
+    /// <returns>The created failure response.</returns>
+    public static ApiResponse Failure(ApiError error)
+    {
+        ArgumentNullException.ThrowIfNull(error);
+        return new ApiResponse(false, new[] { error });
+    }
+}
+
+/// <summary>
+/// Represents a structured API error entry.
+/// </summary>
+public sealed record ApiError
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ApiError"/> record.
+    /// </summary>
+    /// <param name="code">The machine-readable error code.</param>
+    /// <param name="message">The human-readable error message.</param>
+    /// <param name="target">An optional target identifying the failing input.</param>
+    /// <param name="details">Optional structured error details.</param>
+    public ApiError(string code, string message, string? target = null, IReadOnlyDictionary<string, string[]>? details = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(code);
+        ArgumentException.ThrowIfNullOrWhiteSpace(message);
+
+        Code = code;
+        Message = message;
+        Target = target;
+        Details = details ?? new Dictionary<string, string[]>();
+    }
+
+    /// <summary>
+    /// Gets the machine-readable error code.
+    /// </summary>
+    public string Code { get; }
+
+    /// <summary>
+    /// Gets the human-readable error message.
+    /// </summary>
+    public string Message { get; }
+
+    /// <summary>
+    /// Gets the optional target describing the invalid input member.
+    /// </summary>
+    public string? Target { get; }
+
+    /// <summary>
+    /// Gets the optional structured error details.
+    /// </summary>
+    public IReadOnlyDictionary<string, string[]> Details { get; }
+
+    /// <summary>
+    /// Creates an error describing an invalid value for the specified target.
+    /// </summary>
+    /// <param name="target">The property or parameter name.</param>
+    /// <param name="message">The associated message.</param>
+    /// <returns>The created error.</returns>
+    public static ApiError ForValue(string target, string message)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(target);
+        ArgumentException.ThrowIfNullOrWhiteSpace(message);
+        return new ApiError("invalid_value", message, target);
+    }
+
+    /// <summary>
+    /// Creates an error describing a missing required value.
+    /// </summary>
+    /// <param name="target">The missing value target.</param>
+    /// <returns>The created error.</returns>
+    public static ApiError MissingValue(string target)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(target);
+        return new ApiError("missing_value", $"The value for '{target}' is required.", target);
+    }
+}

--- a/Veriado.Contracts/Common/Paging.cs
+++ b/Veriado.Contracts/Common/Paging.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Collections.Generic;
+
+namespace Veriado.Contracts.Common;
+
+/// <summary>
+/// Represents a paging request describing the desired page number and page size.
+/// </summary>
+public sealed record PagingRequest
+{
+    /// <summary>
+    /// Gets the one-based page number.
+    /// </summary>
+    public int PageNumber { get; init; } = 1;
+
+    /// <summary>
+    /// Gets the page size.
+    /// </summary>
+    public int PageSize { get; init; } = 50;
+}
+
+/// <summary>
+/// Represents a paged result containing items and accompanying paging metadata.
+/// </summary>
+/// <typeparam name="T">The item type.</typeparam>
+public sealed record PagedResult<T>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PagedResult{T}"/> record.
+    /// </summary>
+    /// <param name="items">The page items.</param>
+    /// <param name="pageNumber">The current one-based page number.</param>
+    /// <param name="pageSize">The requested page size.</param>
+    /// <param name="totalCount">The total number of items across all pages.</param>
+    public PagedResult(IReadOnlyList<T> items, int pageNumber, int pageSize, int totalCount)
+    {
+        ArgumentNullException.ThrowIfNull(items);
+        if (pageNumber <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(pageNumber), pageNumber, "Page number must be positive.");
+        }
+
+        if (pageSize <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "Page size must be positive.");
+        }
+
+        if (totalCount < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(totalCount), totalCount, "Total count cannot be negative.");
+        }
+
+        Items = items;
+        PageNumber = pageNumber;
+        PageSize = pageSize;
+        TotalCount = totalCount;
+    }
+
+    /// <summary>
+    /// Gets the items in the current page.
+    /// </summary>
+    public IReadOnlyList<T> Items { get; }
+
+    /// <summary>
+    /// Gets the one-based page number.
+    /// </summary>
+    public int PageNumber { get; }
+
+    /// <summary>
+    /// Gets the page size.
+    /// </summary>
+    public int PageSize { get; }
+
+    /// <summary>
+    /// Gets the total number of items available.
+    /// </summary>
+    public int TotalCount { get; }
+
+    /// <summary>
+    /// Gets the total number of pages available.
+    /// </summary>
+    public int TotalPages => (int)Math.Ceiling(TotalCount / (double)PageSize);
+}

--- a/Veriado.Contracts/Files/ClearValidityRequest.cs
+++ b/Veriado.Contracts/Files/ClearValidityRequest.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace Veriado.Contracts.Files;
+
+/// <summary>
+/// Represents the payload required to clear the validity information of a file.
+/// </summary>
+public sealed class ClearValidityRequest
+{
+    /// <summary>
+    /// Gets or sets the identifier of the file to update.
+    /// </summary>
+    public Guid FileId { get; init; }
+}

--- a/Veriado.Contracts/Files/CreateFileRequest.cs
+++ b/Veriado.Contracts/Files/CreateFileRequest.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Collections.Generic;
+
+namespace Veriado.Contracts.Files;
+
+/// <summary>
+/// Represents the payload required to create a new file aggregate.
+/// </summary>
+public sealed class CreateFileRequest
+{
+    /// <summary>
+    /// Gets or sets the file name without extension.
+    /// </summary>
+    public string Name { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the file extension without the leading dot.
+    /// </summary>
+    public string Extension { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the MIME type of the file.
+    /// </summary>
+    public string Mime { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the author recorded for the file.
+    /// </summary>
+    public string Author { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the binary content of the file.
+    /// </summary>
+    public byte[] Content { get; init; } = Array.Empty<byte>();
+
+    /// <summary>
+    /// Gets or sets an optional maximum content length constraint.
+    /// </summary>
+    public int? MaxContentLength { get; init; }
+
+    /// <summary>
+    /// Gets or sets an optional initial file system metadata snapshot.
+    /// </summary>
+    public FileSystemMetadataDto? SystemMetadata { get; init; }
+
+    /// <summary>
+    /// Gets or sets optional extended metadata entries to apply after creation.
+    /// </summary>
+    public IReadOnlyList<ExtendedMetadataItemDto>? ExtendedMetadata { get; init; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the file should be marked read-only after creation.
+    /// </summary>
+    public bool IsReadOnly { get; init; }
+}

--- a/Veriado.Contracts/Files/ExtendedMetadataItemDto.cs
+++ b/Veriado.Contracts/Files/ExtendedMetadataItemDto.cs
@@ -1,0 +1,142 @@
+using System;
+using System.Collections.Generic;
+
+namespace Veriado.Contracts.Files;
+
+/// <summary>
+/// Represents a metadata key/value pair originating from an external consumer.
+/// </summary>
+public sealed class ExtendedMetadataItemDto
+{
+    /// <summary>
+    /// Gets or sets the property set format identifier.
+    /// </summary>
+    public Guid FormatId { get; init; }
+
+    /// <summary>
+    /// Gets or sets the property identifier within the property set.
+    /// </summary>
+    public int PropertyId { get; init; }
+
+    /// <summary>
+    /// Gets or sets the metadata value payload.
+    /// </summary>
+    public MetadataValueDto? Value { get; init; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the metadata value should be removed.
+    /// </summary>
+    public bool Remove { get; init; }
+}
+
+/// <summary>
+/// Represents a discriminated union describing a metadata value payload.
+/// </summary>
+public sealed class MetadataValueDto
+{
+    /// <summary>
+    /// Gets or sets the value kind represented by the DTO.
+    /// </summary>
+    public MetadataValueDtoKind Kind { get; init; }
+
+    /// <summary>
+    /// Gets or sets a string value when <see cref="Kind"/> equals <see cref="MetadataValueDtoKind.String"/>.
+    /// </summary>
+    public string? StringValue { get; init; }
+
+    /// <summary>
+    /// Gets or sets a string array when <see cref="Kind"/> equals <see cref="MetadataValueDtoKind.StringArray"/>.
+    /// </summary>
+    public IReadOnlyList<string>? StringArrayValue { get; init; }
+
+    /// <summary>
+    /// Gets or sets an unsigned 32-bit integer when the kind equals <see cref="MetadataValueDtoKind.UInt32"/>.
+    /// </summary>
+    public uint? UInt32Value { get; init; }
+
+    /// <summary>
+    /// Gets or sets a signed 32-bit integer when the kind equals <see cref="MetadataValueDtoKind.Int32"/>.
+    /// </summary>
+    public int? Int32Value { get; init; }
+
+    /// <summary>
+    /// Gets or sets a double precision floating point value when the kind equals <see cref="MetadataValueDtoKind.Double"/>.
+    /// </summary>
+    public double? DoubleValue { get; init; }
+
+    /// <summary>
+    /// Gets or sets a Boolean value when the kind equals <see cref="MetadataValueDtoKind.Boolean"/>.
+    /// </summary>
+    public bool? BooleanValue { get; init; }
+
+    /// <summary>
+    /// Gets or sets a GUID value when the kind equals <see cref="MetadataValueDtoKind.Guid"/>.
+    /// </summary>
+    public Guid? GuidValue { get; init; }
+
+    /// <summary>
+    /// Gets or sets a timestamp when the kind equals <see cref="MetadataValueDtoKind.FileTime"/>.
+    /// </summary>
+    public DateTimeOffset? FileTimeValue { get; init; }
+
+    /// <summary>
+    /// Gets or sets the binary payload when the kind equals <see cref="MetadataValueDtoKind.Binary"/>.
+    /// </summary>
+    public byte[]? BinaryValue { get; init; }
+}
+
+/// <summary>
+/// Enumerates the supported metadata value kinds for DTO exchanges.
+/// </summary>
+public enum MetadataValueDtoKind
+{
+    /// <summary>
+    /// Represents a null value.
+    /// </summary>
+    Null,
+
+    /// <summary>
+    /// Represents a string value.
+    /// </summary>
+    String,
+
+    /// <summary>
+    /// Represents an array of strings.
+    /// </summary>
+    StringArray,
+
+    /// <summary>
+    /// Represents an unsigned 32-bit integer value.
+    /// </summary>
+    UInt32,
+
+    /// <summary>
+    /// Represents a signed 32-bit integer value.
+    /// </summary>
+    Int32,
+
+    /// <summary>
+    /// Represents a double precision floating point value.
+    /// </summary>
+    Double,
+
+    /// <summary>
+    /// Represents a Boolean value.
+    /// </summary>
+    Boolean,
+
+    /// <summary>
+    /// Represents a GUID value.
+    /// </summary>
+    Guid,
+
+    /// <summary>
+    /// Represents a UTC timestamp stored as a file time.
+    /// </summary>
+    FileTime,
+
+    /// <summary>
+    /// Represents a binary payload.
+    /// </summary>
+    Binary,
+}

--- a/Veriado.Contracts/Files/FileContentDto.cs
+++ b/Veriado.Contracts/Files/FileContentDto.cs
@@ -1,0 +1,40 @@
+using System;
+
+namespace Veriado.Contracts.Files;
+
+/// <summary>
+/// Represents the binary content metadata of a file.
+/// </summary>
+/// <param name="Hash">The SHA-256 hash of the content in hexadecimal representation.</param>
+/// <param name="Length">The length of the content in bytes.</param>
+/// <param name="Bytes">The optional materialized content bytes.</param>
+public sealed record FileContentDto(string Hash, long Length, byte[]? Bytes = null)
+{
+    /// <summary>
+    /// Gets a value indicating whether the binary payload has been materialized.
+    /// </summary>
+    public bool HasBytes => Bytes is { Length: > 0 };
+
+    /// <summary>
+    /// Returns a copy of the DTO with content bytes cleared.
+    /// </summary>
+    /// <returns>The DTO without materialized bytes.</returns>
+    public FileContentDto WithoutBytes() => this with { Bytes = null };
+
+    /// <summary>
+    /// Returns a copy of the DTO with the provided binary payload.
+    /// </summary>
+    /// <param name="payload">The content bytes to attach.</param>
+    /// <returns>The DTO carrying the materialized bytes.</returns>
+    public FileContentDto WithBytes(byte[]? payload)
+    {
+        if (payload is null)
+        {
+            return this with { Bytes = null };
+        }
+
+        var clone = new byte[payload.Length];
+        Array.Copy(payload, clone, payload.Length);
+        return this with { Bytes = clone };
+    }
+}

--- a/Veriado.Contracts/Files/FileDetailDto.cs
+++ b/Veriado.Contracts/Files/FileDetailDto.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Collections.Generic;
+
+namespace Veriado.Contracts.Files;
+
+/// <summary>
+/// Represents a detailed view of a file aggregate suitable for edit screens.
+/// </summary>
+public sealed record FileDetailDto
+{
+    /// <summary>
+    /// Gets the unique identifier of the file.
+    /// </summary>
+    public Guid Id { get; init; }
+
+    /// <summary>
+    /// Gets the file name without extension.
+    /// </summary>
+    public string Name { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets the file extension without the leading dot.
+    /// </summary>
+    public string Extension { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets the MIME type of the file.
+    /// </summary>
+    public string Mime { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets the author of the file.
+    /// </summary>
+    public string Author { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets the file size in bytes.
+    /// </summary>
+    public long Size { get; init; }
+
+    /// <summary>
+    /// Gets the creation timestamp in UTC.
+    /// </summary>
+    public DateTimeOffset CreatedUtc { get; init; }
+
+    /// <summary>
+    /// Gets the last modification timestamp in UTC.
+    /// </summary>
+    public DateTimeOffset LastModifiedUtc { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether the file is read-only.
+    /// </summary>
+    public bool IsReadOnly { get; init; }
+
+    /// <summary>
+    /// Gets the current version of the file content.
+    /// </summary>
+    public int Version { get; init; }
+
+    /// <summary>
+    /// Gets the file content metadata.
+    /// </summary>
+    public FileContentDto Content { get; init; } = new(string.Empty, 0L);
+
+    /// <summary>
+    /// Gets the file system metadata snapshot.
+    /// </summary>
+    public FileSystemMetadataDto SystemMetadata { get; init; } =
+        new(0, DateTimeOffset.MinValue, DateTimeOffset.MinValue, DateTimeOffset.MinValue, null, null, null);
+
+    /// <summary>
+    /// Gets the extended metadata entries associated with the file.
+    /// </summary>
+    public IReadOnlyList<ExtendedMetadataItemDto> ExtendedMetadata { get; init; } = Array.Empty<ExtendedMetadataItemDto>();
+
+    /// <summary>
+    /// Gets the optional validity information for the document.
+    /// </summary>
+    public FileValidityDto? Validity { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether the search index entry is stale.
+    /// </summary>
+    public bool IsIndexStale { get; init; }
+
+    /// <summary>
+    /// Gets the timestamp of the last successful indexing operation, if any.
+    /// </summary>
+    public DateTimeOffset? LastIndexedUtc { get; init; }
+
+    /// <summary>
+    /// Gets the indexed title stored in the search index, if known.
+    /// </summary>
+    public string? IndexedTitle { get; init; }
+
+    /// <summary>
+    /// Gets the schema version of the search index entry.
+    /// </summary>
+    public int IndexSchemaVersion { get; init; }
+
+    /// <summary>
+    /// Gets the indexed content hash if known.
+    /// </summary>
+    public string? IndexedContentHash { get; init; }
+}

--- a/Veriado.Contracts/Files/FileSummaryDto.cs
+++ b/Veriado.Contracts/Files/FileSummaryDto.cs
@@ -1,0 +1,89 @@
+using System;
+
+namespace Veriado.Contracts.Files;
+
+/// <summary>
+/// Represents a lightweight view of a file suitable for list displays.
+/// </summary>
+public sealed record FileSummaryDto
+{
+    /// <summary>
+    /// Gets the unique identifier of the file.
+    /// </summary>
+    public Guid Id { get; init; }
+
+    /// <summary>
+    /// Gets the file name without extension.
+    /// </summary>
+    public string Name { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets the file extension without the leading dot.
+    /// </summary>
+    public string Extension { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets the MIME type of the file.
+    /// </summary>
+    public string Mime { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets the author of the file.
+    /// </summary>
+    public string Author { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets the file size in bytes.
+    /// </summary>
+    public long Size { get; init; }
+
+    /// <summary>
+    /// Gets the creation timestamp in UTC.
+    /// </summary>
+    public DateTimeOffset CreatedUtc { get; init; }
+
+    /// <summary>
+    /// Gets the last modification timestamp in UTC.
+    /// </summary>
+    public DateTimeOffset LastModifiedUtc { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether the file is read-only.
+    /// </summary>
+    public bool IsReadOnly { get; init; }
+
+    /// <summary>
+    /// Gets the current version of the file content.
+    /// </summary>
+    public int Version { get; init; }
+
+    /// <summary>
+    /// Gets the optional validity information for the document.
+    /// </summary>
+    public FileValidityDto? Validity { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether the search index entry is stale.
+    /// </summary>
+    public bool IsIndexStale { get; init; }
+
+    /// <summary>
+    /// Gets the timestamp of the last successful indexing operation, if any.
+    /// </summary>
+    public DateTimeOffset? LastIndexedUtc { get; init; }
+
+    /// <summary>
+    /// Gets the indexed title stored in the search index, if known.
+    /// </summary>
+    public string? IndexedTitle { get; init; }
+
+    /// <summary>
+    /// Gets the schema version of the search index entry.
+    /// </summary>
+    public int IndexSchemaVersion { get; init; }
+
+    /// <summary>
+    /// Gets the indexed content hash if known.
+    /// </summary>
+    public string? IndexedContentHash { get; init; }
+}

--- a/Veriado.Contracts/Files/FileSystemMetadataDto.cs
+++ b/Veriado.Contracts/Files/FileSystemMetadataDto.cs
@@ -1,0 +1,22 @@
+using System;
+
+namespace Veriado.Contracts.Files;
+
+/// <summary>
+/// Represents the file system metadata snapshot captured for a file entity.
+/// </summary>
+/// <param name="Attributes">The file attribute flags encoded as an integer.</param>
+/// <param name="CreatedUtc">The creation timestamp in UTC.</param>
+/// <param name="LastWriteUtc">The last write timestamp in UTC.</param>
+/// <param name="LastAccessUtc">The last access timestamp in UTC.</param>
+/// <param name="OwnerSid">The optional owner security identifier.</param>
+/// <param name="HardLinkCount">The optional number of hard links.</param>
+/// <param name="AlternateDataStreamCount">The optional number of alternate data streams.</param>
+public sealed record FileSystemMetadataDto(
+    int Attributes,
+    DateTimeOffset CreatedUtc,
+    DateTimeOffset LastWriteUtc,
+    DateTimeOffset LastAccessUtc,
+    string? OwnerSid,
+    uint? HardLinkCount,
+    uint? AlternateDataStreamCount);

--- a/Veriado.Contracts/Files/FileValidityDto.cs
+++ b/Veriado.Contracts/Files/FileValidityDto.cs
@@ -1,0 +1,22 @@
+using System;
+
+namespace Veriado.Contracts.Files;
+
+/// <summary>
+/// Represents the document validity window and related copy information.
+/// </summary>
+/// <param name="IssuedAt">The timestamp when the document became valid.</param>
+/// <param name="ValidUntil">The timestamp when the document expires.</param>
+/// <param name="HasPhysicalCopy">Indicates whether a physical copy exists.</param>
+/// <param name="HasElectronicCopy">Indicates whether a digital copy exists.</param>
+public sealed record FileValidityDto(
+    DateTimeOffset IssuedAt,
+    DateTimeOffset ValidUntil,
+    bool HasPhysicalCopy,
+    bool HasElectronicCopy)
+{
+    /// <summary>
+    /// Gets the total number of days in the validity range.
+    /// </summary>
+    public double DaysTotal => (ValidUntil - IssuedAt).TotalDays;
+}

--- a/Veriado.Contracts/Files/ReplaceContentRequest.cs
+++ b/Veriado.Contracts/Files/ReplaceContentRequest.cs
@@ -1,0 +1,24 @@
+using System;
+
+namespace Veriado.Contracts.Files;
+
+/// <summary>
+/// Represents the payload required to replace the binary content of an existing file.
+/// </summary>
+public sealed class ReplaceContentRequest
+{
+    /// <summary>
+    /// Gets or sets the identifier of the file to update.
+    /// </summary>
+    public Guid FileId { get; init; }
+
+    /// <summary>
+    /// Gets or sets the new binary content of the file.
+    /// </summary>
+    public byte[] Content { get; init; } = Array.Empty<byte>();
+
+    /// <summary>
+    /// Gets or sets an optional maximum content length constraint.
+    /// </summary>
+    public int? MaxContentLength { get; init; }
+}

--- a/Veriado.Contracts/Files/SetValidityRequest.cs
+++ b/Veriado.Contracts/Files/SetValidityRequest.cs
@@ -1,0 +1,34 @@
+using System;
+
+namespace Veriado.Contracts.Files;
+
+/// <summary>
+/// Represents the payload required to set or update document validity information.
+/// </summary>
+public sealed class SetValidityRequest
+{
+    /// <summary>
+    /// Gets or sets the identifier of the file to update.
+    /// </summary>
+    public Guid FileId { get; init; }
+
+    /// <summary>
+    /// Gets or sets the timestamp when the document became valid.
+    /// </summary>
+    public DateTimeOffset IssuedAt { get; init; }
+
+    /// <summary>
+    /// Gets or sets the timestamp when the document expires.
+    /// </summary>
+    public DateTimeOffset ValidUntil { get; init; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether a physical copy exists.
+    /// </summary>
+    public bool HasPhysicalCopy { get; init; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether an electronic copy exists.
+    /// </summary>
+    public bool HasElectronicCopy { get; init; }
+}

--- a/Veriado.Contracts/Files/UpdateMetadataRequest.cs
+++ b/Veriado.Contracts/Files/UpdateMetadataRequest.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+
+namespace Veriado.Contracts.Files;
+
+/// <summary>
+/// Represents the payload required to update metadata for an existing file.
+/// </summary>
+public sealed class UpdateMetadataRequest
+{
+    /// <summary>
+    /// Gets or sets the identifier of the file to update.
+    /// </summary>
+    public Guid FileId { get; init; }
+
+    /// <summary>
+    /// Gets or sets the optional new MIME type.
+    /// </summary>
+    public string? Mime { get; init; }
+
+    /// <summary>
+    /// Gets or sets the optional new author.
+    /// </summary>
+    public string? Author { get; init; }
+
+    /// <summary>
+    /// Gets or sets an optional flag indicating whether the file should be read-only.
+    /// </summary>
+    public bool? IsReadOnly { get; init; }
+
+    /// <summary>
+    /// Gets or sets an optional system metadata snapshot to apply.
+    /// </summary>
+    public FileSystemMetadataDto? SystemMetadata { get; init; }
+
+    /// <summary>
+    /// Gets or sets optional extended metadata patches to apply.
+    /// </summary>
+    public IReadOnlyList<ExtendedMetadataItemDto>? ExtendedMetadata { get; init; }
+}

--- a/Veriado.Contracts/Veriado.Contracts.csproj
+++ b/Veriado.Contracts/Veriado.Contracts.csproj
@@ -5,10 +5,4 @@
     <ImplicitUsings>disable</ImplicitUsings>
     <LangVersion>12.0</LangVersion>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="FluentValidation" Version="11.7.1" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\Veriado.Domain\Veriado.Domain.csproj" />
-  </ItemGroup>
 </Project>

--- a/Veriado.Mapping/AC/Guards.cs
+++ b/Veriado.Mapping/AC/Guards.cs
@@ -1,0 +1,39 @@
+using System;
+using Veriado.Contracts.Files;
+
+namespace Veriado.Mapping.AC;
+
+/// <summary>
+/// Provides guard utilities preventing unintended binary materialization.
+/// </summary>
+public static class Guards
+{
+    /// <summary>
+    /// Ensures that the supplied file detail DTO does not expose binary content bytes.
+    /// </summary>
+    /// <param name="detail">The detail DTO.</param>
+    /// <returns>The DTO with cleared binary payload.</returns>
+    public static FileDetailDto WithoutContentBytes(FileDetailDto detail)
+    {
+        ArgumentNullException.ThrowIfNull(detail);
+        return detail with { Content = detail.Content.WithoutBytes() };
+    }
+
+    /// <summary>
+    /// Optionally attaches binary content bytes to the detail DTO.
+    /// </summary>
+    /// <param name="detail">The detail DTO.</param>
+    /// <param name="bytes">The binary payload.</param>
+    /// <param name="includeContent">Indicates whether the payload should be attached.</param>
+    /// <returns>The resulting DTO.</returns>
+    public static FileDetailDto WithContentBytes(FileDetailDto detail, byte[]? bytes, bool includeContent)
+    {
+        ArgumentNullException.ThrowIfNull(detail);
+        if (!includeContent || bytes is null)
+        {
+            return detail with { Content = detail.Content.WithoutBytes() };
+        }
+
+        return detail with { Content = detail.Content.WithBytes(bytes) };
+    }
+}

--- a/Veriado.Mapping/AC/Parsers.cs
+++ b/Veriado.Mapping/AC/Parsers.cs
@@ -1,0 +1,225 @@
+using System;
+using System.Collections.Generic;
+using Veriado.Application.Files.Commands;
+using Veriado.Contracts.Common;
+using Veriado.Contracts.Files;
+using Veriado.Domain.Metadata;
+using Veriado.Domain.ValueObjects;
+
+namespace Veriado.Mapping.AC;
+
+/// <summary>
+/// Provides anti-corruption parsing helpers converting external DTOs into domain value objects.
+/// </summary>
+internal static class Parsers
+{
+    internal static ParserResult<FileName> ParseFileName(string? value, string target)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return ParserResult<FileName>.Failure(ApiError.MissingValue(target));
+        }
+
+        try
+        {
+            return ParserResult<FileName>.Success(FileName.From(value));
+        }
+        catch (Exception ex)
+        {
+            return ParserResult<FileName>.Failure(ApiError.ForValue(target, ex.Message));
+        }
+    }
+
+    internal static ParserResult<FileExtension> ParseFileExtension(string? value, string target)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return ParserResult<FileExtension>.Failure(ApiError.MissingValue(target));
+        }
+
+        try
+        {
+            return ParserResult<FileExtension>.Success(FileExtension.From(value));
+        }
+        catch (Exception ex)
+        {
+            return ParserResult<FileExtension>.Failure(ApiError.ForValue(target, ex.Message));
+        }
+    }
+
+    internal static ParserResult<MimeType> ParseMimeType(string? value, string target)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return ParserResult<MimeType>.Failure(ApiError.MissingValue(target));
+        }
+
+        try
+        {
+            return ParserResult<MimeType>.Success(MimeType.From(value));
+        }
+        catch (Exception ex)
+        {
+            return ParserResult<MimeType>.Failure(ApiError.ForValue(target, ex.Message));
+        }
+    }
+
+    internal static ParserResult<FileSystemMetadata> ParseFileSystemMetadata(FileSystemMetadataDto dto, string target)
+    {
+        try
+        {
+            var metadata = new FileSystemMetadata(
+                (FileAttributesFlags)dto.Attributes,
+                UtcTimestamp.From(dto.CreatedUtc),
+                UtcTimestamp.From(dto.LastWriteUtc),
+                UtcTimestamp.From(dto.LastAccessUtc),
+                dto.OwnerSid,
+                dto.HardLinkCount,
+                dto.AlternateDataStreamCount);
+            return ParserResult<FileSystemMetadata>.Success(metadata);
+        }
+        catch (Exception ex)
+        {
+            return ParserResult<FileSystemMetadata>.Failure(ApiError.ForValue(target, ex.Message));
+        }
+    }
+
+    internal static IReadOnlyCollection<MetadataPatch> ParseMetadataPatches(
+        IReadOnlyList<ExtendedMetadataItemDto>? items,
+        string target,
+        ICollection<ApiError> errors)
+    {
+        if (items is null || items.Count == 0)
+        {
+            return Array.Empty<MetadataPatch>();
+        }
+
+        var patches = new List<MetadataPatch>(items.Count);
+        for (var i = 0; i < items.Count; i++)
+        {
+            var result = ParseMetadataPatch(items[i], $"{target}[{i}]");
+            if (!result.IsSuccess)
+            {
+                errors.Add(result.Error!);
+                continue;
+            }
+
+            patches.Add(result.Value);
+        }
+
+        return patches;
+    }
+
+    internal static ParserResult<MetadataPatch> ParseMetadataPatch(ExtendedMetadataItemDto dto, string target)
+    {
+        if (dto is null)
+        {
+            return ParserResult<MetadataPatch>.Failure(ApiError.MissingValue(target));
+        }
+
+        if (dto.FormatId == Guid.Empty)
+        {
+            return ParserResult<MetadataPatch>.Failure(ApiError.ForValue($"{target}.FormatId", "Format identifier must be a non-empty GUID."));
+        }
+
+        var key = new PropertyKey(dto.FormatId, dto.PropertyId);
+        if (dto.Remove)
+        {
+            return ParserResult<MetadataPatch>.Success(new MetadataPatch(key, null));
+        }
+
+        if (dto.Value is null)
+        {
+            return ParserResult<MetadataPatch>.Failure(ApiError.MissingValue($"{target}.Value"));
+        }
+
+        var valueResult = ParseMetadataValue(dto.Value, $"{target}.Value");
+        if (!valueResult.IsSuccess)
+        {
+            return ParserResult<MetadataPatch>.Failure(valueResult.Error!);
+        }
+
+        return ParserResult<MetadataPatch>.Success(new MetadataPatch(key, valueResult.Value));
+    }
+
+    internal static ParserResult<MetadataValue> ParseMetadataValue(MetadataValueDto dto, string target)
+    {
+        try
+        {
+            return ParserResult<MetadataValue>.Success(dto.Kind switch
+            {
+                MetadataValueDtoKind.Null => MetadataValue.Null,
+                MetadataValueDtoKind.String => MetadataValue.FromString(dto.StringValue ?? throw new ArgumentException("String value is required.")),
+                MetadataValueDtoKind.StringArray => MetadataValue.FromStringArray(dto.StringArrayValue ?? Array.Empty<string>()),
+                MetadataValueDtoKind.UInt32 => MetadataValue.FromUInt(dto.UInt32Value ?? throw new ArgumentException("UInt32 value is required.")),
+                MetadataValueDtoKind.Int32 => MetadataValue.FromInt(dto.Int32Value ?? throw new ArgumentException("Int32 value is required.")),
+                MetadataValueDtoKind.Double => MetadataValue.FromReal(dto.DoubleValue ?? throw new ArgumentException("Double value is required.")),
+                MetadataValueDtoKind.Boolean => MetadataValue.FromBool(dto.BooleanValue ?? throw new ArgumentException("Boolean value is required.")),
+                MetadataValueDtoKind.Guid => MetadataValue.FromGuid(dto.GuidValue ?? throw new ArgumentException("Guid value is required.")),
+                MetadataValueDtoKind.FileTime => MetadataValue.FromFileTime(dto.FileTimeValue ?? throw new ArgumentException("Timestamp value is required.")),
+                MetadataValueDtoKind.Binary => MetadataValue.FromBinary(dto.BinaryValue ?? Array.Empty<byte>()),
+                _ => throw new NotSupportedException($"Unsupported metadata value kind '{dto.Kind}'."),
+            });
+        }
+        catch (Exception ex)
+        {
+            return ParserResult<MetadataValue>.Failure(ApiError.ForValue(target, ex.Message));
+        }
+    }
+
+    internal static FileSystemMetadata? ParseOptionalMetadata(
+        FileSystemMetadataDto? dto,
+        string target,
+        ICollection<ApiError> errors)
+    {
+        if (dto is null)
+        {
+            return null;
+        }
+
+        var result = ParseFileSystemMetadata(dto, target);
+        if (!result.IsSuccess)
+        {
+            errors.Add(result.Error!);
+            return null;
+        }
+
+        return result.Value;
+    }
+
+    internal static ParserResult<UtcTimestamp> ParseUtcTimestamp(DateTimeOffset value)
+    {
+        try
+        {
+            return ParserResult<UtcTimestamp>.Success(UtcTimestamp.From(value));
+        }
+        catch (Exception ex)
+        {
+            return ParserResult<UtcTimestamp>.Failure(ApiError.ForValue(nameof(value), ex.Message));
+        }
+    }
+}
+
+internal readonly struct ParserResult<T>
+{
+    private ParserResult(bool success, T value, ApiError? error)
+    {
+        IsSuccess = success;
+        Value = value;
+        Error = error;
+    }
+
+    public bool IsSuccess { get; }
+
+    public T Value { get; }
+
+    public ApiError? Error { get; }
+
+    public static ParserResult<T> Success(T value) => new(true, value, default);
+
+    public static ParserResult<T> Failure(ApiError error)
+    {
+        ArgumentNullException.ThrowIfNull(error);
+        return new ParserResult<T>(false, default!, error);
+    }
+}

--- a/Veriado.Mapping/AC/WriteMappingPipeline.cs
+++ b/Veriado.Mapping/AC/WriteMappingPipeline.cs
@@ -1,0 +1,253 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentValidation;
+using FluentValidation.Results;
+using Veriado.Application.Files.Commands;
+using Veriado.Contracts.Common;
+using Veriado.Contracts.Files;
+using Veriado.Domain.Metadata;
+using Veriado.Domain.ValueObjects;
+
+namespace Veriado.Mapping.AC;
+
+/// <summary>
+/// Coordinates DTO-to-command mapping, value object parsing and validation.
+/// </summary>
+public sealed class WriteMappingPipeline
+{
+    private readonly IValidator<CreateFileCommand> _createValidator;
+    private readonly IValidator<ReplaceContentCommand> _replaceValidator;
+    private readonly IValidator<UpdateMetadataCommand> _updateValidator;
+    private readonly IValidator<RenameFileCommand> _renameValidator;
+    private readonly IValidator<SetValidityCommand> _setValidityValidator;
+    private readonly IValidator<ClearValidityCommand> _clearValidityValidator;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="WriteMappingPipeline"/> class.
+    /// </summary>
+    public WriteMappingPipeline(
+        IValidator<CreateFileCommand> createValidator,
+        IValidator<ReplaceContentCommand> replaceValidator,
+        IValidator<UpdateMetadataCommand> updateValidator,
+        IValidator<RenameFileCommand> renameValidator,
+        IValidator<SetValidityCommand> setValidityValidator,
+        IValidator<ClearValidityCommand> clearValidityValidator)
+    {
+        _createValidator = createValidator ?? throw new ArgumentNullException(nameof(createValidator));
+        _replaceValidator = replaceValidator ?? throw new ArgumentNullException(nameof(replaceValidator));
+        _updateValidator = updateValidator ?? throw new ArgumentNullException(nameof(updateValidator));
+        _renameValidator = renameValidator ?? throw new ArgumentNullException(nameof(renameValidator));
+        _setValidityValidator = setValidityValidator ?? throw new ArgumentNullException(nameof(setValidityValidator));
+        _clearValidityValidator = clearValidityValidator ?? throw new ArgumentNullException(nameof(clearValidityValidator));
+    }
+
+    /// <summary>
+    /// Maps a create request to a validated command.
+    /// </summary>
+    public async Task<ApiResponse<CreateFileCommand>> MapCreateAsync(CreateFileRequest request, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        var errors = new List<ApiError>();
+
+        var nameResult = Parsers.ParseFileName(request.Name, nameof(request.Name));
+        var extensionResult = Parsers.ParseFileExtension(request.Extension, nameof(request.Extension));
+        var mimeResult = Parsers.ParseMimeType(request.Mime, nameof(request.Mime));
+        var metadataPatches = Parsers.ParseMetadataPatches(request.ExtendedMetadata, nameof(request.ExtendedMetadata), errors);
+        var systemMetadata = Parsers.ParseOptionalMetadata(request.SystemMetadata, nameof(request.SystemMetadata), errors);
+
+        CollectError(nameResult, errors);
+        CollectError(extensionResult, errors);
+        CollectError(mimeResult, errors);
+
+        if (errors.Count > 0)
+        {
+            return ApiResponse<CreateFileCommand>.Failure(errors);
+        }
+
+        var command = new CreateFileCommand(
+            nameResult.Value,
+            extensionResult.Value,
+            mimeResult.Value,
+            request.Author ?? string.Empty,
+            request.Content ?? Array.Empty<byte>(),
+            request.MaxContentLength,
+            metadataPatches,
+            systemMetadata,
+            request.IsReadOnly);
+
+        var validation = await _createValidator.ValidateAsync(command, cancellationToken).ConfigureAwait(false);
+        if (!validation.IsValid)
+        {
+            AddValidationErrors(errors, validation);
+            return ApiResponse<CreateFileCommand>.Failure(errors);
+        }
+
+        return ApiResponse<CreateFileCommand>.Success(command);
+    }
+
+    /// <summary>
+    /// Maps a replace content request to a validated command.
+    /// </summary>
+    public async Task<ApiResponse<ReplaceContentCommand>> MapReplaceContentAsync(ReplaceContentRequest request, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        var command = new ReplaceContentCommand(request.FileId, request.Content ?? Array.Empty<byte>(), request.MaxContentLength);
+        var validation = await _replaceValidator.ValidateAsync(command, cancellationToken).ConfigureAwait(false);
+        if (!validation.IsValid)
+        {
+            var errors = new List<ApiError>();
+            AddValidationErrors(errors, validation);
+            return ApiResponse<ReplaceContentCommand>.Failure(errors);
+        }
+
+        return ApiResponse<ReplaceContentCommand>.Success(command);
+    }
+
+    /// <summary>
+    /// Maps an update metadata request to a validated command.
+    /// </summary>
+    public async Task<ApiResponse<UpdateMetadataCommand>> MapUpdateMetadataAsync(UpdateMetadataRequest request, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        var errors = new List<ApiError>();
+
+        MimeType? mime = null;
+        if (!string.IsNullOrWhiteSpace(request.Mime))
+        {
+            var mimeResult = Parsers.ParseMimeType(request.Mime, nameof(request.Mime));
+            if (!mimeResult.IsSuccess)
+            {
+                errors.Add(mimeResult.Error!);
+            }
+            else
+            {
+                mime = mimeResult.Value;
+            }
+        }
+
+        var systemMetadata = Parsers.ParseOptionalMetadata(request.SystemMetadata, nameof(request.SystemMetadata), errors);
+        var metadataPatches = Parsers.ParseMetadataPatches(request.ExtendedMetadata, nameof(request.ExtendedMetadata), errors);
+
+        if (errors.Count > 0)
+        {
+            return ApiResponse<UpdateMetadataCommand>.Failure(errors);
+        }
+
+        var command = new UpdateMetadataCommand(
+            request.FileId,
+            mime,
+            request.Author,
+            request.IsReadOnly,
+            systemMetadata,
+            metadataPatches);
+
+        var validation = await _updateValidator.ValidateAsync(command, cancellationToken).ConfigureAwait(false);
+        if (!validation.IsValid)
+        {
+            AddValidationErrors(errors, validation);
+            return ApiResponse<UpdateMetadataCommand>.Failure(errors);
+        }
+
+        return ApiResponse<UpdateMetadataCommand>.Success(command);
+    }
+
+    /// <summary>
+    /// Maps a rename request to a validated command.
+    /// </summary>
+    public async Task<ApiResponse<RenameFileCommand>> MapRenameAsync(Guid fileId, string newName, CancellationToken cancellationToken)
+    {
+        var errors = new List<ApiError>();
+        if (fileId == Guid.Empty)
+        {
+            errors.Add(ApiError.ForValue(nameof(fileId), "File identifier must be a non-empty GUID."));
+        }
+
+        var nameResult = Parsers.ParseFileName(newName, nameof(newName));
+        CollectError(nameResult, errors);
+
+        if (errors.Count > 0)
+        {
+            return ApiResponse<RenameFileCommand>.Failure(errors);
+        }
+
+        var command = new RenameFileCommand(fileId, nameResult.Value);
+        var validation = await _renameValidator.ValidateAsync(command, cancellationToken).ConfigureAwait(false);
+        if (!validation.IsValid)
+        {
+            AddValidationErrors(errors, validation);
+            return ApiResponse<RenameFileCommand>.Failure(errors);
+        }
+
+        return ApiResponse<RenameFileCommand>.Success(command);
+    }
+
+    /// <summary>
+    /// Maps a set-validity request to a validated command.
+    /// </summary>
+    public async Task<ApiResponse<SetValidityCommand>> MapSetValidityAsync(SetValidityRequest request, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        var issuedResult = Parsers.ParseUtcTimestamp(request.IssuedAt);
+        var untilResult = Parsers.ParseUtcTimestamp(request.ValidUntil);
+        var errors = new List<ApiError>();
+        CollectError(issuedResult, errors);
+        CollectError(untilResult, errors);
+
+        if (errors.Count > 0)
+        {
+            return ApiResponse<SetValidityCommand>.Failure(errors);
+        }
+
+        var command = new SetValidityCommand(
+            request.FileId,
+            issuedResult.Value,
+            untilResult.Value,
+            request.HasPhysicalCopy,
+            request.HasElectronicCopy);
+
+        var validation = await _setValidityValidator.ValidateAsync(command, cancellationToken).ConfigureAwait(false);
+        if (!validation.IsValid)
+        {
+            AddValidationErrors(errors, validation);
+            return ApiResponse<SetValidityCommand>.Failure(errors);
+        }
+
+        return ApiResponse<SetValidityCommand>.Success(command);
+    }
+
+    /// <summary>
+    /// Maps a clear-validity request to a validated command.
+    /// </summary>
+    public async Task<ApiResponse<ClearValidityCommand>> MapClearValidityAsync(ClearValidityRequest request, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        var command = new ClearValidityCommand(request.FileId);
+        var validation = await _clearValidityValidator.ValidateAsync(command, cancellationToken).ConfigureAwait(false);
+        if (!validation.IsValid)
+        {
+            var errors = new List<ApiError>();
+            AddValidationErrors(errors, validation);
+            return ApiResponse<ClearValidityCommand>.Failure(errors);
+        }
+
+        return ApiResponse<ClearValidityCommand>.Success(command);
+    }
+
+    private static void CollectError<T>(ParserResult<T> result, ICollection<ApiError> errors)
+    {
+        if (!result.IsSuccess && result.Error is not null)
+        {
+            errors.Add(result.Error);
+        }
+    }
+
+    private static void AddValidationErrors(ICollection<ApiError> errors, ValidationResult validation)
+    {
+        foreach (var failure in validation.Errors)
+        {
+            errors.Add(ApiError.ForValue(failure.PropertyName, failure.ErrorMessage));
+        }
+    }
+}

--- a/Veriado.Mapping/DependencyInjection/MappingServiceCollectionExtensions.cs
+++ b/Veriado.Mapping/DependencyInjection/MappingServiceCollectionExtensions.cs
@@ -1,0 +1,57 @@
+using System;
+using AutoMapper;
+using FluentValidation;
+using Microsoft.Extensions.DependencyInjection;
+using Veriado.Application.Files.Commands;
+using Veriado.Application.Files.Validation;
+using Veriado.Mapping.AC;
+using Veriado.Mapping.Profiles;
+
+namespace Veriado.Mapping.DependencyInjection;
+
+/// <summary>
+/// Provides dependency injection helpers for mapping infrastructure.
+/// </summary>
+public static class MappingServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers mapping profiles, validators and the write mapping pipeline.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <returns>The same service collection for chaining.</returns>
+    public static IServiceCollection AddVeriadoMapping(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.AddSingleton(provider =>
+        {
+            var configuration = new MapperConfiguration(cfg =>
+            {
+                cfg.AddProfile<FileReadProfiles>();
+                cfg.AddProfile<MetadataProfiles>();
+                cfg.AddProfile<FileWriteProfiles>();
+            });
+#if DEBUG
+            configuration.AssertConfigurationIsValid();
+#endif
+            return configuration;
+        });
+
+        services.AddSingleton<IMapper>(provider =>
+        {
+            var configuration = provider.GetRequiredService<MapperConfiguration>();
+            return configuration.CreateMapper(provider.GetService);
+        });
+
+        services.AddTransient<IValidator<CreateFileCommand>, CreateFileRequestValidator>();
+        services.AddTransient<IValidator<ReplaceContentCommand>, ReplaceContentRequestValidator>();
+        services.AddTransient<IValidator<UpdateMetadataCommand>, UpdateMetadataRequestValidator>();
+        services.AddTransient<IValidator<RenameFileCommand>, RenameFileRequestValidator>();
+        services.AddTransient<IValidator<SetValidityCommand>, SetValidityRequestValidator>();
+        services.AddTransient<IValidator<ClearValidityCommand>, ClearValidityRequestValidator>();
+
+        services.AddTransient<WriteMappingPipeline>();
+
+        return services;
+    }
+}

--- a/Veriado.Mapping/EF/QueryableMappingHelpers.cs
+++ b/Veriado.Mapping/EF/QueryableMappingHelpers.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+using Veriado.Contracts.Files;
+using Veriado.Domain.Files;
+
+namespace Veriado.Mapping.EF;
+
+/// <summary>
+/// Provides reusable Entity Framework friendly projections for file aggregates.
+/// </summary>
+public static class QueryableMappingHelpers
+{
+    /// <summary>
+    /// Gets an expression projecting a <see cref="FileEntity"/> to a <see cref="FileSummaryDto"/>.
+    /// </summary>
+    public static Expression<Func<FileEntity, FileSummaryDto>> FileSummaryProjection() => file => new FileSummaryDto
+    {
+        Id = file.Id,
+        Name = file.Name.Value,
+        Extension = file.Extension.Value,
+        Mime = file.Mime.Value,
+        Author = file.Author,
+        Size = file.Size.Value,
+        CreatedUtc = file.CreatedUtc.Value,
+        LastModifiedUtc = file.LastModifiedUtc.Value,
+        IsReadOnly = file.IsReadOnly,
+        Version = file.Version,
+        Validity = file.Validity == null
+            ? null
+            : new FileValidityDto(
+                file.Validity.IssuedAt.Value,
+                file.Validity.ValidUntil.Value,
+                file.Validity.HasPhysicalCopy,
+                file.Validity.HasElectronicCopy),
+        IsIndexStale = file.SearchIndex.IsStale,
+        LastIndexedUtc = file.SearchIndex.LastIndexedUtc,
+        IndexedTitle = file.SearchIndex.IndexedTitle,
+        IndexSchemaVersion = file.SearchIndex.SchemaVersion,
+        IndexedContentHash = file.SearchIndex.IndexedContentHash,
+    };
+
+    /// <summary>
+    /// Projects an <see cref="IQueryable{T}"/> of <see cref="FileEntity"/> instances to <see cref="FileSummaryDto"/>s.
+    /// </summary>
+    public static IQueryable<FileSummaryDto> ProjectToFileSummary(this IQueryable<FileEntity> query)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        return query.Select(FileSummaryProjection());
+    }
+
+    /// <summary>
+    /// Gets an expression projecting a <see cref="FileEntity"/> to a lightweight <see cref="FileDetailDto"/> without materializing binary content.
+    /// </summary>
+    public static Expression<Func<FileEntity, FileDetailDto>> FileDetailProjection() => file => new FileDetailDto
+    {
+        Id = file.Id,
+        Name = file.Name.Value,
+        Extension = file.Extension.Value,
+        Mime = file.Mime.Value,
+        Author = file.Author,
+        Size = file.Size.Value,
+        CreatedUtc = file.CreatedUtc.Value,
+        LastModifiedUtc = file.LastModifiedUtc.Value,
+        IsReadOnly = file.IsReadOnly,
+        Version = file.Version,
+        Content = new FileContentDto(file.Content.Hash.Value, file.Content.Length.Value, null),
+        SystemMetadata = new FileSystemMetadataDto(
+            (int)file.SystemMetadata.Attributes,
+            file.SystemMetadata.CreatedUtc.Value,
+            file.SystemMetadata.LastWriteUtc.Value,
+            file.SystemMetadata.LastAccessUtc.Value,
+            file.SystemMetadata.OwnerSid,
+            file.SystemMetadata.HardLinkCount,
+            file.SystemMetadata.AlternateDataStreamCount),
+        ExtendedMetadata = new ExtendedMetadataItemDto[0],
+        Validity = file.Validity == null
+            ? null
+            : new FileValidityDto(
+                file.Validity.IssuedAt.Value,
+                file.Validity.ValidUntil.Value,
+                file.Validity.HasPhysicalCopy,
+                file.Validity.HasElectronicCopy),
+        IsIndexStale = file.SearchIndex.IsStale,
+        LastIndexedUtc = file.SearchIndex.LastIndexedUtc,
+        IndexedTitle = file.SearchIndex.IndexedTitle,
+        IndexSchemaVersion = file.SearchIndex.SchemaVersion,
+        IndexedContentHash = file.SearchIndex.IndexedContentHash,
+    };
+}

--- a/Veriado.Mapping/Profiles/CommonValueConverters.cs
+++ b/Veriado.Mapping/Profiles/CommonValueConverters.cs
@@ -1,0 +1,52 @@
+using System;
+using AutoMapper;
+using Veriado.Domain.Metadata;
+using Veriado.Domain.ValueObjects;
+
+namespace Veriado.Mapping.Profiles;
+
+/// <summary>
+/// Provides reusable AutoMapper value converters for domain primitives.
+/// </summary>
+public static class CommonValueConverters
+{
+    public sealed class FileNameToStringConverter : IValueConverter<FileName, string>
+    {
+        public string Convert(FileName sourceMember, ResolutionContext context) => sourceMember.Value;
+    }
+
+    public sealed class FileExtensionToStringConverter : IValueConverter<FileExtension, string>
+    {
+        public string Convert(FileExtension sourceMember, ResolutionContext context) => sourceMember.Value;
+    }
+
+    public sealed class MimeTypeToStringConverter : IValueConverter<MimeType, string>
+    {
+        public string Convert(MimeType sourceMember, ResolutionContext context) => sourceMember.Value;
+    }
+
+    public sealed class ByteSizeToLongConverter : IValueConverter<ByteSize, long>
+    {
+        public long Convert(ByteSize sourceMember, ResolutionContext context) => sourceMember.Value;
+    }
+
+    public sealed class UtcTimestampToDateTimeOffsetConverter : IValueConverter<UtcTimestamp, DateTimeOffset>
+    {
+        public DateTimeOffset Convert(UtcTimestamp sourceMember, ResolutionContext context) => sourceMember.Value;
+    }
+
+    public sealed class NullableUtcTimestampToNullableDateTimeOffsetConverter : IValueConverter<UtcTimestamp?, DateTimeOffset?>
+    {
+        public DateTimeOffset? Convert(UtcTimestamp? sourceMember, ResolutionContext context) => sourceMember?.Value;
+    }
+
+    public sealed class FileHashToStringConverter : IValueConverter<FileHash, string>
+    {
+        public string Convert(FileHash sourceMember, ResolutionContext context) => sourceMember.Value;
+    }
+
+    public sealed class FileAttributesToIntConverter : IValueConverter<FileAttributesFlags, int>
+    {
+        public int Convert(FileAttributesFlags sourceMember, ResolutionContext context) => (int)sourceMember;
+    }
+}

--- a/Veriado.Mapping/Profiles/FileReadProfiles.cs
+++ b/Veriado.Mapping/Profiles/FileReadProfiles.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Linq;
+using AutoMapper;
+using Veriado.Contracts.Files;
+using Veriado.Domain.Files;
+using Veriado.Domain.Metadata;
+
+namespace Veriado.Mapping.Profiles;
+
+/// <summary>
+/// Configures mappings used when projecting domain entities to read DTOs.
+/// </summary>
+public sealed class FileReadProfiles : Profile
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FileReadProfiles"/> class.
+    /// </summary>
+    public FileReadProfiles()
+    {
+        CreateMap<FileDocumentValidityEntity, FileValidityDto>().ConstructUsing(src => new FileValidityDto(
+            src.IssuedAt.Value,
+            src.ValidUntil.Value,
+            src.HasPhysicalCopy,
+            src.HasElectronicCopy));
+
+        CreateMap<FileSystemMetadata, FileSystemMetadataDto>().ConstructUsing(src => new FileSystemMetadataDto(
+            (int)src.Attributes,
+            src.CreatedUtc.Value,
+            src.LastWriteUtc.Value,
+            src.LastAccessUtc.Value,
+            src.OwnerSid,
+            src.HardLinkCount,
+            src.AlternateDataStreamCount));
+
+        CreateMap<FileContentEntity, FileContentDto>().ConstructUsing(src => new FileContentDto(
+            src.Hash.Value,
+            src.Length.Value,
+            null));
+
+        CreateMap<FileEntity, FileSummaryDto>()
+            .ForMember(dest => dest.Name, opt => opt.ConvertUsing(new CommonValueConverters.FileNameToStringConverter(), src => src.Name))
+            .ForMember(dest => dest.Extension, opt => opt.ConvertUsing(new CommonValueConverters.FileExtensionToStringConverter(), src => src.Extension))
+            .ForMember(dest => dest.Mime, opt => opt.ConvertUsing(new CommonValueConverters.MimeTypeToStringConverter(), src => src.Mime))
+            .ForMember(dest => dest.Size, opt => opt.ConvertUsing(new CommonValueConverters.ByteSizeToLongConverter(), src => src.Size))
+            .ForMember(dest => dest.CreatedUtc, opt => opt.ConvertUsing(new CommonValueConverters.UtcTimestampToDateTimeOffsetConverter(), src => src.CreatedUtc))
+            .ForMember(dest => dest.LastModifiedUtc, opt => opt.ConvertUsing(new CommonValueConverters.UtcTimestampToDateTimeOffsetConverter(), src => src.LastModifiedUtc))
+            .ForMember(dest => dest.Validity, opt => opt.MapFrom(src => src.Validity))
+            .ForMember(dest => dest.IsIndexStale, opt => opt.MapFrom(src => src.SearchIndex.IsStale))
+            .ForMember(dest => dest.LastIndexedUtc, opt => opt.MapFrom(src => src.SearchIndex.LastIndexedUtc))
+            .ForMember(dest => dest.IndexedTitle, opt => opt.MapFrom(src => src.SearchIndex.IndexedTitle))
+            .ForMember(dest => dest.IndexSchemaVersion, opt => opt.MapFrom(src => src.SearchIndex.SchemaVersion))
+            .ForMember(dest => dest.IndexedContentHash, opt => opt.MapFrom(src => src.SearchIndex.IndexedContentHash));
+
+        CreateMap<FileEntity, FileDetailDto>()
+            .IncludeBase<FileEntity, FileSummaryDto>()
+            .ForMember(dest => dest.Content, opt => opt.MapFrom(src => src.Content))
+            .ForMember(dest => dest.SystemMetadata, opt => opt.MapFrom(src => src.SystemMetadata))
+            .ForMember(dest => dest.ExtendedMetadata, opt =>
+            {
+                opt.MapFrom(src => src.ExtendedMetadata.AsEnumerable());
+                opt.NullSubstitute(Array.Empty<ExtendedMetadataItemDto>());
+            })
+            .ForMember(dest => dest.Validity, opt => opt.MapFrom(src => src.Validity));
+    }
+}

--- a/Veriado.Mapping/Profiles/FileWriteProfiles.cs
+++ b/Veriado.Mapping/Profiles/FileWriteProfiles.cs
@@ -1,0 +1,27 @@
+using AutoMapper;
+using Veriado.Contracts.Files;
+using Veriado.Domain.Metadata;
+using Veriado.Domain.ValueObjects;
+
+namespace Veriado.Mapping.Profiles;
+
+/// <summary>
+/// Configures mappings used when converting write DTOs to domain constructs.
+/// </summary>
+public sealed class FileWriteProfiles : Profile
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FileWriteProfiles"/> class.
+    /// </summary>
+    public FileWriteProfiles()
+    {
+        CreateMap<FileSystemMetadataDto, FileSystemMetadata>().ConvertUsing(dto => new FileSystemMetadata(
+            (FileAttributesFlags)dto.Attributes,
+            UtcTimestamp.From(dto.CreatedUtc),
+            UtcTimestamp.From(dto.LastWriteUtc),
+            UtcTimestamp.From(dto.LastAccessUtc),
+            dto.OwnerSid,
+            dto.HardLinkCount,
+            dto.AlternateDataStreamCount));
+    }
+}

--- a/Veriado.Mapping/Profiles/MetadataProfiles.cs
+++ b/Veriado.Mapping/Profiles/MetadataProfiles.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using AutoMapper;
+using Veriado.Contracts.Files;
+using Veriado.Domain.Metadata;
+
+namespace Veriado.Mapping.Profiles;
+
+/// <summary>
+/// Configures metadata conversions between domain types and DTOs.
+/// </summary>
+public sealed class MetadataProfiles : Profile
+{
+    private static readonly FieldInfo ValueField = typeof(MetadataValue).GetField("_value", BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MetadataProfiles"/> class.
+    /// </summary>
+    public MetadataProfiles()
+    {
+        CreateMap<MetadataValue, MetadataValueDto>().ConvertUsing(ConvertMetadataValueToDto);
+        CreateMap<MetadataValueDto, MetadataValue>().ConvertUsing(ConvertMetadataValueFromDto);
+
+        CreateMap<KeyValuePair<PropertyKey, MetadataValue>, ExtendedMetadataItemDto>()
+            .ForMember(dest => dest.FormatId, opt => opt.MapFrom(src => src.Key.FormatId))
+            .ForMember(dest => dest.PropertyId, opt => opt.MapFrom(src => src.Key.PropertyId))
+            .ForMember(dest => dest.Remove, opt => opt.MapFrom(_ => false))
+            .ForMember(dest => dest.Value, opt => opt.MapFrom(src => src.Value));
+    }
+
+    private static MetadataValueDto ConvertMetadataValueToDto(MetadataValue source, MetadataValueDto destination, ResolutionContext context)
+    {
+        var dto = new MetadataValueDto
+        {
+            Kind = source.Kind,
+        };
+
+        var raw = ValueField.GetValue(source);
+        switch (source.Kind)
+        {
+            case MetadataValueKind.Null:
+                break;
+            case MetadataValueKind.String:
+                dto.StringValue = raw as string;
+                break;
+            case MetadataValueKind.StringArray:
+                dto.StringArrayValue = raw is string[] array ? array.ToArray() : Array.Empty<string>();
+                break;
+            case MetadataValueKind.UInt32:
+                dto.UInt32Value = raw is uint u ? u : null;
+                break;
+            case MetadataValueKind.Int32:
+                dto.Int32Value = raw is int i ? i : null;
+                break;
+            case MetadataValueKind.Double:
+                dto.DoubleValue = raw is double d ? d : null;
+                break;
+            case MetadataValueKind.Boolean:
+                dto.BooleanValue = raw is bool b ? b : null;
+                break;
+            case MetadataValueKind.Guid:
+                dto.GuidValue = raw is Guid g ? g : null;
+                break;
+            case MetadataValueKind.FileTime:
+                dto.FileTimeValue = raw is DateTimeOffset time ? time : null;
+                break;
+            case MetadataValueKind.Binary:
+                dto.BinaryValue = raw is byte[] bytes ? bytes.ToArray() : null;
+                break;
+            default:
+                throw new NotSupportedException($"Unsupported metadata value kind '{source.Kind}'.");
+        }
+
+        return dto;
+    }
+
+    private static MetadataValue ConvertMetadataValueFromDto(MetadataValueDto source, MetadataValue destination, ResolutionContext context)
+    {
+        return source.Kind switch
+        {
+            MetadataValueDtoKind.Null => MetadataValue.Null,
+            MetadataValueDtoKind.String => MetadataValue.FromString(source.StringValue ?? throw new ArgumentException("String value is required.")),
+            MetadataValueDtoKind.StringArray => MetadataValue.FromStringArray(source.StringArrayValue ?? Array.Empty<string>()),
+            MetadataValueDtoKind.UInt32 => MetadataValue.FromUInt(source.UInt32Value ?? throw new ArgumentException("UInt32 value is required.")),
+            MetadataValueDtoKind.Int32 => MetadataValue.FromInt(source.Int32Value ?? throw new ArgumentException("Int32 value is required.")),
+            MetadataValueDtoKind.Double => MetadataValue.FromReal(source.DoubleValue ?? throw new ArgumentException("Double value is required.")),
+            MetadataValueDtoKind.Boolean => MetadataValue.FromBool(source.BooleanValue ?? throw new ArgumentException("Boolean value is required.")),
+            MetadataValueDtoKind.Guid => MetadataValue.FromGuid(source.GuidValue ?? throw new ArgumentException("Guid value is required.")),
+            MetadataValueDtoKind.FileTime => MetadataValue.FromFileTime(source.FileTimeValue ?? throw new ArgumentException("Timestamp value is required.")),
+            MetadataValueDtoKind.Binary => MetadataValue.FromBinary(source.BinaryValue ?? Array.Empty<byte>()),
+            _ => throw new NotSupportedException($"Unsupported metadata value kind '{source.Kind}'."),
+        };
+    }
+}

--- a/Veriado.Mapping/README.md
+++ b/Veriado.Mapping/README.md
@@ -1,0 +1,12 @@
+# Veriado.Mapping
+
+The mapping project encapsulates all AutoMapper profiles and anti-corruption components required to bridge the public DTO layer and the application/domain core.
+
+## Composition
+
+- `Profiles/` defines read projections (`FileReadProfiles`), write conversions (`FileWriteProfiles`) and metadata conversions (`MetadataProfiles`) shared across the solution.
+- `AC/` contains anti-corruption helpers such as the `Parsers`, DTO guards and the `WriteMappingPipeline` orchestrating request-to-command mapping with validation.
+- `EF/QueryableMappingHelpers` provides LINQ expressions that can be safely translated by EF Core without materializing large binary payloads.
+- `DependencyInjection/MappingServiceCollectionExtensions` registers all mapping services, validators and the pipeline with `AssertConfigurationIsValid()` executed in DEBUG builds.
+
+The project targets .NET 8, uses AutoMapper for transformations and FluentValidation for command validation.

--- a/Veriado.Mapping/Veriado.Mapping.csproj
+++ b/Veriado.Mapping/Veriado.Mapping.csproj
@@ -6,9 +6,13 @@
     <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="AutoMapper" Version="12.0.1" />
+    <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
     <PackageReference Include="FluentValidation" Version="11.7.1" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\Veriado.Contracts\Veriado.Contracts.csproj" />
+    <ProjectReference Include="..\Veriado.Application\Veriado.Application.csproj" />
     <ProjectReference Include="..\Veriado.Domain\Veriado.Domain.csproj" />
   </ItemGroup>
 </Project>

--- a/Veriado.sln
+++ b/Veriado.sln
@@ -11,6 +11,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Veriado.Infrastructure", "V
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Veriado.Application", "Veriado.Application\Veriado.Application.csproj", "{A238B7DB-438E-4502-A0E1-068306307A3A}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Veriado.Contracts", "Veriado.Contracts\Veriado.Contracts.csproj", "{E3CF91DC-9121-404E-81CA-1BFED5C38420}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Veriado.Mapping", "Veriado.Mapping\Veriado.Mapping.csproj", "{66A7082C-0D5F-4A1C-82B5-C0D878DDCAE2}"
+EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Source", "Source", "{02EA681E-C7D8-13C7-8484-4AC65E1B71E8}"
 EndProject
 Global
@@ -77,6 +81,30 @@ Global
                 {A238B7DB-438E-4502-A0E1-068306307A3A}.Release|x64.Build.0 = Release|Any CPU
                 {A238B7DB-438E-4502-A0E1-068306307A3A}.Release|x86.ActiveCfg = Release|Any CPU
                 {A238B7DB-438E-4502-A0E1-068306307A3A}.Release|x86.Build.0 = Release|Any CPU
+                {E3CF91DC-9121-404E-81CA-1BFED5C38420}.Debug|ARM64.ActiveCfg = Debug|Any CPU
+                {E3CF91DC-9121-404E-81CA-1BFED5C38420}.Debug|ARM64.Build.0 = Debug|Any CPU
+                {E3CF91DC-9121-404E-81CA-1BFED5C38420}.Debug|x64.ActiveCfg = Debug|Any CPU
+                {E3CF91DC-9121-404E-81CA-1BFED5C38420}.Debug|x64.Build.0 = Debug|Any CPU
+                {E3CF91DC-9121-404E-81CA-1BFED5C38420}.Debug|x86.ActiveCfg = Debug|Any CPU
+                {E3CF91DC-9121-404E-81CA-1BFED5C38420}.Debug|x86.Build.0 = Debug|Any CPU
+                {E3CF91DC-9121-404E-81CA-1BFED5C38420}.Release|ARM64.ActiveCfg = Release|Any CPU
+                {E3CF91DC-9121-404E-81CA-1BFED5C38420}.Release|ARM64.Build.0 = Release|Any CPU
+                {E3CF91DC-9121-404E-81CA-1BFED5C38420}.Release|x64.ActiveCfg = Release|Any CPU
+                {E3CF91DC-9121-404E-81CA-1BFED5C38420}.Release|x64.Build.0 = Release|Any CPU
+                {E3CF91DC-9121-404E-81CA-1BFED5C38420}.Release|x86.ActiveCfg = Release|Any CPU
+                {E3CF91DC-9121-404E-81CA-1BFED5C38420}.Release|x86.Build.0 = Release|Any CPU
+                {66A7082C-0D5F-4A1C-82B5-C0D878DDCAE2}.Debug|ARM64.ActiveCfg = Debug|Any CPU
+                {66A7082C-0D5F-4A1C-82B5-C0D878DDCAE2}.Debug|ARM64.Build.0 = Debug|Any CPU
+                {66A7082C-0D5F-4A1C-82B5-C0D878DDCAE2}.Debug|x64.ActiveCfg = Debug|Any CPU
+                {66A7082C-0D5F-4A1C-82B5-C0D878DDCAE2}.Debug|x64.Build.0 = Debug|Any CPU
+                {66A7082C-0D5F-4A1C-82B5-C0D878DDCAE2}.Debug|x86.ActiveCfg = Debug|Any CPU
+                {66A7082C-0D5F-4A1C-82B5-C0D878DDCAE2}.Debug|x86.Build.0 = Debug|Any CPU
+                {66A7082C-0D5F-4A1C-82B5-C0D878DDCAE2}.Release|ARM64.ActiveCfg = Release|Any CPU
+                {66A7082C-0D5F-4A1C-82B5-C0D878DDCAE2}.Release|ARM64.Build.0 = Release|Any CPU
+                {66A7082C-0D5F-4A1C-82B5-C0D878DDCAE2}.Release|x64.ActiveCfg = Release|Any CPU
+                {66A7082C-0D5F-4A1C-82B5-C0D878DDCAE2}.Release|x64.Build.0 = Release|Any CPU
+                {66A7082C-0D5F-4A1C-82B5-C0D878DDCAE2}.Release|x86.ActiveCfg = Release|Any CPU
+                {66A7082C-0D5F-4A1C-82B5-C0D878DDCAE2}.Release|x86.Build.0 = Release|Any CPU
         EndGlobalSection
         GlobalSection(SolutionProperties) = preSolution
                 HideSolutionNode = FALSE
@@ -86,6 +114,8 @@ Global
                 {86B8F682-4E4A-4E11-804A-3513C85B8ADB} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
                 {6FA76EE3-8C55-4176-AF31-CA4AD7DA6777} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
                 {A238B7DB-438E-4502-A0E1-068306307A3A} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+                {E3CF91DC-9121-404E-81CA-1BFED5C38420} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+                {66A7082C-0D5F-4A1C-82B5-C0D878DDCAE2} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
         EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {015A55A8-BE3A-4015-BDD2-CBAE0F721F7E}


### PR DESCRIPTION
## Summary
- introduce Veriado.Contracts project with DTOs for file operations and API responses
- add application-level commands, handlers, and validators for file workflows
- create mapping project with AutoMapper profiles, anti-corruption parsers, and DI registration

## Testing
- not run (dotnet CLI unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68ce8610500c8326a5f18f470755adb4