### PR TITLE
Add bulk repository operations and align search abstractions

### DIFF
--- a/Veriado.Application/Abstractions/IFileRepository.cs
+++ b/Veriado.Application/Abstractions/IFileRepository.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Veriado.Domain.Files;
@@ -17,6 +18,21 @@ public interface IFileRepository
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The loaded aggregate or <see langword="null"/> when it does not exist.</returns>
     Task<FileEntity?> GetAsync(Guid id, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Loads multiple file aggregates by their identifiers in a single call.
+    /// </summary>
+    /// <param name="ids">The identifiers of the files to retrieve.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The loaded aggregates. Missing identifiers are omitted from the result.</returns>
+    Task<IReadOnlyList<FileEntity>> GetManyAsync(IEnumerable<Guid> ids, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Streams all file aggregates from the persistence store.
+    /// </summary>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>An asynchronous sequence of file aggregates.</returns>
+    IAsyncEnumerable<FileEntity> StreamAllAsync(CancellationToken cancellationToken);
 
     /// <summary>
     /// Adds a newly created file aggregate to the persistence store.

--- a/Veriado.Application/Abstractions/ISearchIndexer.cs
+++ b/Veriado.Application/Abstractions/ISearchIndexer.cs
@@ -15,12 +15,12 @@ public interface ISearchIndexer
     /// </summary>
     /// <param name="document">The search document projection.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
-    Task UpsertAsync(SearchDocument document, CancellationToken cancellationToken);
+    Task IndexAsync(SearchDocument document, CancellationToken cancellationToken);
 
     /// <summary>
     /// Removes the search index entry associated with the supplied file identifier.
     /// </summary>
     /// <param name="fileId">The identifier of the file.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
-    Task RemoveAsync(Guid fileId, CancellationToken cancellationToken);
+    Task DeleteAsync(Guid fileId, CancellationToken cancellationToken);
 }

--- a/Veriado.Application/Abstractions/ITextExtractor.cs
+++ b/Veriado.Application/Abstractions/ITextExtractor.cs
@@ -15,5 +15,5 @@ public interface ITextExtractor
     /// <param name="file">The file aggregate whose content should be analyzed.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The extracted text or <see langword="null"/> when no text could be extracted.</returns>
-    Task<string?> ExtractAsync(FileEntity file, CancellationToken cancellationToken);
+    Task<string?> ExtractTextAsync(FileEntity file, CancellationToken cancellationToken);
 }

--- a/Veriado.Application/Files/Handlers/FileIndexingHelper.cs
+++ b/Veriado.Application/Files/Handlers/FileIndexingHelper.cs
@@ -14,9 +14,9 @@ internal static class FileIndexingHelper
         ISearchIndexer searchIndexer,
         CancellationToken cancellationToken)
     {
-        var text = await textExtractor.ExtractAsync(file, cancellationToken).ConfigureAwait(false);
+        var text = await textExtractor.ExtractTextAsync(file, cancellationToken).ConfigureAwait(false);
         var document = file.ToSearchDocument(text);
-        await searchIndexer.UpsertAsync(document, cancellationToken).ConfigureAwait(false);
+        await searchIndexer.IndexAsync(document, cancellationToken).ConfigureAwait(false);
         file.SearchIndex.ApplyIndexed(
             file.SearchIndex.SchemaVersion,
             DateTimeOffset.UtcNow,

--- a/Veriado.Infrastructure/Abstractions/ApplicationPorts.cs
+++ b/Veriado.Infrastructure/Abstractions/ApplicationPorts.cs
@@ -16,6 +16,10 @@ public interface IFileRepository
 {
     Task<FileEntity?> GetAsync(Guid id, CancellationToken cancellationToken = default);
 
+    Task<IReadOnlyList<FileEntity>> GetManyAsync(IEnumerable<Guid> ids, CancellationToken cancellationToken = default);
+
+    IAsyncEnumerable<FileEntity> StreamAllAsync(CancellationToken cancellationToken = default);
+
     Task<bool> ExistsByHashAsync(FileHash hash, CancellationToken cancellationToken = default);
 
     Task AddAsync(FileEntity entity, CancellationToken cancellationToken = default);
@@ -48,7 +52,7 @@ public interface ISearchQueryService
 /// </summary>
 public interface ITextExtractor
 {
-    Task<string?> ExtractAsync(FileEntity file, CancellationToken cancellationToken = default);
+    Task<string?> ExtractTextAsync(FileEntity file, CancellationToken cancellationToken = default);
 }
 
 /// <summary>

--- a/Veriado.Infrastructure/Concurrency/WriteWorker.cs
+++ b/Veriado.Infrastructure/Concurrency/WriteWorker.cs
@@ -250,7 +250,7 @@ internal sealed class WriteWorker : BackgroundService
         var now = DateTimeOffset.UtcNow;
         foreach (var file in filesToIndex)
         {
-            var text = await _textExtractor.ExtractAsync(file, cancellationToken).ConfigureAwait(false);
+            var text = await _textExtractor.ExtractTextAsync(file, cancellationToken).ConfigureAwait(false);
             var document = file.ToSearchDocument(text);
             await helper.IndexAsync(document, sqliteConnection, sqliteTransaction, cancellationToken).ConfigureAwait(false);
             file.ConfirmIndexed(file.SearchIndex.SchemaVersion, now);

--- a/Veriado.Infrastructure/Integrity/FulltextIntegrityService.cs
+++ b/Veriado.Infrastructure/Integrity/FulltextIntegrityService.cs
@@ -115,7 +115,7 @@ internal sealed class FulltextIntegrityService : IFulltextIntegrityService
             return;
         }
 
-        var text = await _textExtractor.ExtractAsync(file, cancellationToken).ConfigureAwait(false);
+        var text = await _textExtractor.ExtractTextAsync(file, cancellationToken).ConfigureAwait(false);
         var document = file.ToSearchDocument(text);
         await _searchIndexer.IndexAsync(document, cancellationToken).ConfigureAwait(false);
 

--- a/Veriado.Infrastructure/Search/Outbox/OutboxWorker.cs
+++ b/Veriado.Infrastructure/Search/Outbox/OutboxWorker.cs
@@ -122,7 +122,7 @@ internal sealed class OutboxWorker : BackgroundService
             return;
         }
 
-        var text = await _textExtractor.ExtractAsync(file, cancellationToken).ConfigureAwait(false);
+        var text = await _textExtractor.ExtractTextAsync(file, cancellationToken).ConfigureAwait(false);
         var document = file.ToSearchDocument(text);
         await _searchIndexer.IndexAsync(document, cancellationToken).ConfigureAwait(false);
 

--- a/Veriado.Infrastructure/Search/TextExtractor.cs
+++ b/Veriado.Infrastructure/Search/TextExtractor.cs
@@ -20,7 +20,7 @@ internal sealed class TextExtractor : ITextExtractor
         "application/json",
     };
 
-    public Task<string?> ExtractAsync(FileEntity file, CancellationToken cancellationToken = default)
+    public Task<string?> ExtractTextAsync(FileEntity file, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(file);
         cancellationToken.ThrowIfCancellationRequested();


### PR DESCRIPTION
## Summary
- add multi-fetch and streaming operations to the file repository contract
- rename search indexing and text extraction abstractions to match the command handlers
- update infrastructure implementations and helpers to use the revised APIs

## Testing
- `dotnet build Veriado.Application/Veriado.Application.csproj` *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ce8d63e2b48326a4c380ef19aa7170