### PR TITLE
Fix metadata DTO mapping and address analyzer warnings

### DIFF
--- a/Veriado.Domain/Files/FileEntity.cs
+++ b/Veriado.Domain/Files/FileEntity.cs
@@ -572,7 +572,7 @@ public sealed class FileEntity : AggregateRoot
         MarkSearchDirty(ReindexReason.SchemaUpgrade);
     }
 
-    private static string NormalizeAuthor(string value)
+    private static string NormalizeAuthor(string? value)
     {
         if (string.IsNullOrWhiteSpace(value))
         {

--- a/Veriado.Infrastructure/Repositories/FileRepository.cs
+++ b/Veriado.Infrastructure/Repositories/FileRepository.cs
@@ -80,20 +80,20 @@ internal sealed class FileRepository : IFileRepository
     public async Task AddAsync(FileEntity entity, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(entity);
-        await _writeQueue.EnqueueAsync(async (AppDbContext db, CancellationToken ct) =>
+        await _writeQueue.EnqueueAsync((AppDbContext db, CancellationToken ct) =>
         {
             db.Files.Add(entity);
-            return true;
+            return Task.FromResult(true);
         }, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task UpdateAsync(FileEntity entity, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(entity);
-        await _writeQueue.EnqueueAsync(async (AppDbContext db, CancellationToken ct) =>
+        await _writeQueue.EnqueueAsync((AppDbContext db, CancellationToken ct) =>
         {
             db.Files.Update(entity);
-            return true;
+            return Task.FromResult(true);
         }, cancellationToken).ConfigureAwait(false);
     }
 

--- a/Veriado.Mapping/Profiles/MetadataProfiles.cs
+++ b/Veriado.Mapping/Profiles/MetadataProfiles.cs
@@ -32,48 +32,80 @@ public sealed class MetadataProfiles : Profile
 
     private static MetadataValueDto ConvertMetadataValueToDto(MetadataValue source, MetadataValueDto destination, ResolutionContext context)
     {
-        var dto = new MetadataValueDto
-        {
-            Kind = source.Kind,
-        };
-
+        var kind = ConvertKind(source.Kind);
         var raw = ValueField.GetValue(source);
-        switch (source.Kind)
-        {
-            case MetadataValueKind.Null:
-                break;
-            case MetadataValueKind.String:
-                dto.StringValue = raw as string;
-                break;
-            case MetadataValueKind.StringArray:
-                dto.StringArrayValue = raw is string[] array ? array.ToArray() : Array.Empty<string>();
-                break;
-            case MetadataValueKind.UInt32:
-                dto.UInt32Value = raw is uint u ? u : null;
-                break;
-            case MetadataValueKind.Int32:
-                dto.Int32Value = raw is int i ? i : null;
-                break;
-            case MetadataValueKind.Double:
-                dto.DoubleValue = raw is double d ? d : null;
-                break;
-            case MetadataValueKind.Boolean:
-                dto.BooleanValue = raw is bool b ? b : null;
-                break;
-            case MetadataValueKind.Guid:
-                dto.GuidValue = raw is Guid g ? g : null;
-                break;
-            case MetadataValueKind.FileTime:
-                dto.FileTimeValue = raw is DateTimeOffset time ? time : null;
-                break;
-            case MetadataValueKind.Binary:
-                dto.BinaryValue = raw is byte[] bytes ? bytes.ToArray() : null;
-                break;
-            default:
-                throw new NotSupportedException($"Unsupported metadata value kind '{source.Kind}'.");
-        }
 
-        return dto;
+        return kind switch
+        {
+            MetadataValueDtoKind.Null => new MetadataValueDto
+            {
+                Kind = kind,
+            },
+            MetadataValueDtoKind.String => new MetadataValueDto
+            {
+                Kind = kind,
+                StringValue = raw as string,
+            },
+            MetadataValueDtoKind.StringArray => new MetadataValueDto
+            {
+                Kind = kind,
+                StringArrayValue = raw is string[] array ? array.ToArray() : Array.Empty<string>(),
+            },
+            MetadataValueDtoKind.UInt32 => new MetadataValueDto
+            {
+                Kind = kind,
+                UInt32Value = raw is uint u ? u : null,
+            },
+            MetadataValueDtoKind.Int32 => new MetadataValueDto
+            {
+                Kind = kind,
+                Int32Value = raw is int i ? i : null,
+            },
+            MetadataValueDtoKind.Double => new MetadataValueDto
+            {
+                Kind = kind,
+                DoubleValue = raw is double d ? d : null,
+            },
+            MetadataValueDtoKind.Boolean => new MetadataValueDto
+            {
+                Kind = kind,
+                BooleanValue = raw is bool b ? b : null,
+            },
+            MetadataValueDtoKind.Guid => new MetadataValueDto
+            {
+                Kind = kind,
+                GuidValue = raw is Guid g ? g : null,
+            },
+            MetadataValueDtoKind.FileTime => new MetadataValueDto
+            {
+                Kind = kind,
+                FileTimeValue = raw is DateTimeOffset time ? time : null,
+            },
+            MetadataValueDtoKind.Binary => new MetadataValueDto
+            {
+                Kind = kind,
+                BinaryValue = raw is byte[] bytes ? bytes.ToArray() : null,
+            },
+            _ => throw new NotSupportedException($"Unsupported metadata value kind '{source.Kind}'."),
+        };
+    }
+
+    private static MetadataValueDtoKind ConvertKind(MetadataValueKind kind)
+    {
+        return kind switch
+        {
+            MetadataValueKind.Null => MetadataValueDtoKind.Null,
+            MetadataValueKind.String => MetadataValueDtoKind.String,
+            MetadataValueKind.StringArray => MetadataValueDtoKind.StringArray,
+            MetadataValueKind.UInt32 => MetadataValueDtoKind.UInt32,
+            MetadataValueKind.Int32 => MetadataValueDtoKind.Int32,
+            MetadataValueKind.Double => MetadataValueDtoKind.Double,
+            MetadataValueKind.Boolean => MetadataValueDtoKind.Boolean,
+            MetadataValueKind.Guid => MetadataValueDtoKind.Guid,
+            MetadataValueKind.FileTime => MetadataValueDtoKind.FileTime,
+            MetadataValueKind.Binary => MetadataValueDtoKind.Binary,
+            _ => throw new NotSupportedException($"Unsupported metadata value kind '{kind}'."),
+        };
     }
 
     private static MetadataValue ConvertMetadataValueFromDto(MetadataValueDto source, MetadataValue destination, ResolutionContext context)


### PR DESCRIPTION
## Summary
- rework the metadata value conversion to emit new DTO instances per kind and add an explicit enum conversion helper
- adjust queued repository delegates to return completed tasks so async warnings disappear
- relax the author normalisation helper to accept nullable input for better nullability analysis

## Testing
- `dotnet build` *(fails: command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce9222f9b08326a7112c93a671f152