### PR TITLE
Fix build errors for search entities and event publisher

### DIFF
--- a/Veriado.Application/Veriado.Application.csproj
+++ b/Veriado.Application/Veriado.Application.csproj
@@ -13,5 +13,6 @@
   <ItemGroup>
     <ProjectReference Include="..\Veriado.Contracts\Veriado.Contracts.csproj" />
     <ProjectReference Include="..\Veriado.Domain\Veriado.Domain.csproj" />
+    <ProjectReference Include="..\Veriado.Mapping\Veriado.Mapping.csproj" />
   </ItemGroup>
 </Project>

--- a/Veriado.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/Veriado.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -97,5 +98,5 @@ public static class ServiceCollectionExtensions
 
 internal sealed class NullEventPublisher : IEventPublisher
 {
-    public Task PublishAsync(IDomainEvent domainEvent, CancellationToken cancellationToken = default) => Task.CompletedTask;
+    public Task PublishAsync(IReadOnlyCollection<IDomainEvent> events, CancellationToken cancellationToken) => Task.CompletedTask;
 }

--- a/Veriado.Infrastructure/Search/Entities/SearchFavoriteEntity.cs
+++ b/Veriado.Infrastructure/Search/Entities/SearchFavoriteEntity.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace Veriado.Infrastructure.Search.Entities;
 
-internal sealed class SearchFavoriteEntity
+public sealed class SearchFavoriteEntity
 {
     public Guid Id { get; set; }
 

--- a/Veriado.Infrastructure/Search/Entities/SearchHistoryEntryEntity.cs
+++ b/Veriado.Infrastructure/Search/Entities/SearchHistoryEntryEntity.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace Veriado.Infrastructure.Search.Entities;
 
-internal sealed class SearchHistoryEntryEntity
+public sealed class SearchHistoryEntryEntity
 {
     public Guid Id { get; set; }
 


### PR DESCRIPTION
## Summary
- reference the mapping project from the application layer so EF projections compile
- align the null event publisher with the current IEventPublisher signature
- expose search history and favorite entities so the DbContext DbSets are accessible

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cea67954f4832682c193e3107502ff