### PR TITLE
Break application-mapping project cycle

### DIFF
--- a/Veriado.Application/Files/Queries/FileGridQueryHandler.cs
+++ b/Veriado.Application/Files/Queries/FileGridQueryHandler.cs
@@ -12,7 +12,6 @@ using Veriado.Application.Search.Abstractions;
 using Veriado.Contracts.Common;
 using Veriado.Contracts.Files;
 using Veriado.Domain.Files;
-using Veriado.Mapping.EF;
 
 namespace Veriado.Application.Files.Queries;
 

--- a/Veriado.Application/Files/Queries/QueryableMappingHelpers.cs
+++ b/Veriado.Application/Files/Queries/QueryableMappingHelpers.cs
@@ -4,7 +4,7 @@ using System.Linq.Expressions;
 using Veriado.Contracts.Files;
 using Veriado.Domain.Files;
 
-namespace Veriado.Mapping.EF;
+namespace Veriado.Application.Files.Queries;
 
 /// <summary>
 /// Provides reusable Entity Framework friendly projections for file aggregates.
@@ -74,7 +74,7 @@ public static class QueryableMappingHelpers
             file.SystemMetadata.OwnerSid,
             file.SystemMetadata.HardLinkCount,
             file.SystemMetadata.AlternateDataStreamCount),
-        ExtendedMetadata = new ExtendedMetadataItemDto[0],
+        ExtendedMetadata = Array.Empty<ExtendedMetadataItemDto>(),
         Validity = file.Validity == null
             ? null
             : new FileValidityDto(

--- a/Veriado.Application/Veriado.Application.csproj
+++ b/Veriado.Application/Veriado.Application.csproj
@@ -13,6 +13,5 @@
   <ItemGroup>
     <ProjectReference Include="..\Veriado.Contracts\Veriado.Contracts.csproj" />
     <ProjectReference Include="..\Veriado.Domain\Veriado.Domain.csproj" />
-    <ProjectReference Include="..\Veriado.Mapping\Veriado.Mapping.csproj" />
   </ItemGroup>
 </Project>

--- a/Veriado.Mapping/README.md
+++ b/Veriado.Mapping/README.md
@@ -6,7 +6,6 @@ The mapping project encapsulates all AutoMapper profiles and anti-corruption com
 
 - `Profiles/` defines read projections (`FileReadProfiles`), write conversions (`FileWriteProfiles`) and metadata conversions (`MetadataProfiles`) shared across the solution.
 - `AC/` contains anti-corruption helpers such as the `Parsers`, DTO guards and the `WriteMappingPipeline` orchestrating request-to-command mapping with validation.
-- `EF/QueryableMappingHelpers` provides LINQ expressions that can be safely translated by EF Core without materializing large binary payloads.
 - `DependencyInjection/MappingServiceCollectionExtensions` registers all mapping services, validators and the pipeline with `AssertConfigurationIsValid()` executed in DEBUG builds.
 
 The project targets .NET 8, uses AutoMapper for transformations and FluentValidation for command validation.


### PR DESCRIPTION
## Summary
- move the EF-friendly projection helpers into the application query layer so the application no longer references the mapping project
- update project references and documentation to reflect the new layout

## Testing
- dotnet build Veriado.sln *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cef409bce483269c33339007525d2c