### PR TITLE
Fix WriteWorker event publishing signature mismatch

### DIFF
--- a/Veriado.Infrastructure/Concurrency/WriteWorker.cs
+++ b/Veriado.Infrastructure/Concurrency/WriteWorker.cs
@@ -214,15 +214,16 @@ internal sealed class WriteWorker : BackgroundService
             batch[index].TrySetResult(results[index]);
         }
 
-        foreach (var domainEvent in domainEvents)
+        if (domainEvents.Count > 0)
         {
             try
             {
-                await _eventPublisher.PublishAsync(domainEvent, cancellationToken).ConfigureAwait(false);
+                await _eventPublisher.PublishAsync(domainEvents, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Domain event publication failed for {EventType}", domainEvent.GetType().Name);
+                var eventTypes = string.Join(", ", domainEvents.Select(domainEvent => domainEvent.GetType().Name));
+                _logger.LogError(ex, "Domain event publication failed for {EventTypes}", eventTypes);
             }
         }
     }


### PR DESCRIPTION
## Summary
- call the event publisher with the full domain event collection
- update logging to reflect the combined event types when publication fails

## Testing
- dotnet build Veriado.sln *(fails: dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cef56692b48326b54b28ac42ff90b7