### PR TITLE
Make file write handler base class public

### DIFF
--- a/Veriado.Application/UseCases/Files/Common/FileWriteHandlerBase.cs
+++ b/Veriado.Application/UseCases/Files/Common/FileWriteHandlerBase.cs
@@ -8,7 +8,7 @@ namespace Veriado.Application.UseCases.Files.Common;
 /// <summary>
 /// Provides reusable persistence helpers for file write handlers.
 /// </summary>
-internal abstract class FileWriteHandlerBase
+public abstract class FileWriteHandlerBase
 {
     private readonly IFileRepository _repository;
     private readonly IEventPublisher _eventPublisher;


### PR DESCRIPTION
## Summary
- change `FileWriteHandlerBase` to be public so that public handlers can access it

## Testing
- `dotnet build Veriado.sln` *(fails: `dotnet` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cfc56fbaf48326b33048cdb3b5ea71