### PR TITLE
Handle nullable system metadata when queuing commands

### DIFF
--- a/Veriado.Mapping/AC/WriteMappingPipeline.cs
+++ b/Veriado.Mapping/AC/WriteMappingPipeline.cs
@@ -154,9 +154,9 @@ public sealed class WriteMappingPipeline
             }
         }
 
-        ApplySystemMetadataCommand? systemCommand = systemMetadata is null
-            ? null
-            : CreateSystemMetadataCommand(request.FileId, systemMetadata);
+        ApplySystemMetadataCommand? systemCommand = systemMetadata is { } metadata
+            ? CreateSystemMetadataCommand(request.FileId, metadata)
+            : null;
 
         SetExtendedMetadataCommand? metadataSetCommand = metadataEntries.Count == 0
             ? null
@@ -309,17 +309,17 @@ public sealed record CreateFileMappedRequest(
             yield return new SetExtendedMetadataCommand(fileId, ExtendedMetadata);
         }
 
-        if (SystemMetadata is not null)
+        if (SystemMetadata is { } metadata)
         {
             yield return new ApplySystemMetadataCommand(
                 fileId,
-                SystemMetadata.Attributes,
-                SystemMetadata.CreatedUtc.Value,
-                SystemMetadata.LastWriteUtc.Value,
-                SystemMetadata.LastAccessUtc.Value,
-                SystemMetadata.OwnerSid,
-                SystemMetadata.HardLinkCount,
-                SystemMetadata.AlternateDataStreamCount);
+                metadata.Attributes,
+                metadata.CreatedUtc.Value,
+                metadata.LastWriteUtc.Value,
+                metadata.LastAccessUtc.Value,
+                metadata.OwnerSid,
+                metadata.HardLinkCount,
+                metadata.AlternateDataStreamCount);
         }
 
         if (SetReadOnly)


### PR DESCRIPTION
## Summary
- guard optional system metadata with pattern matching before creating apply commands
- use the extracted metadata instance when scheduling follow-up ApplySystemMetadataCommand requests

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cfc66663b883269fe53a0ed65d3b84