### PR TITLE
Fix search extractors for dependency changes

### DIFF
--- a/Veriado.Infrastructure/Search/PdfTextExtractor.cs
+++ b/Veriado.Infrastructure/Search/PdfTextExtractor.cs
@@ -36,7 +36,7 @@ internal sealed class PdfTextExtractor
 
         try
         {
-            using var document = PdfDocument.Open(content, ParsingOptions.LenientParsing);
+            using var document = PdfDocument.Open(content, new ParsingOptions { UseLenientParsing = true });
             var builder = new StringBuilder();
             var processedPages = 0;
 

--- a/Veriado.Infrastructure/Search/XlsxTextExtractor.cs
+++ b/Veriado.Infrastructure/Search/XlsxTextExtractor.cs
@@ -191,11 +191,11 @@ internal sealed class XlsxTextExtractor
 
         return cell.DataType.Value switch
         {
-            CellValues.SharedString => TryResolveSharedString(raw, sharedStrings),
-            CellValues.Boolean => raw == "1" ? "TRUE" : "FALSE",
-            CellValues.Date => raw,
-            CellValues.Number => raw,
-            CellValues.InlineString => cell.InnerText,
+            var dataType when dataType == CellValues.SharedString => TryResolveSharedString(raw, sharedStrings),
+            var dataType when dataType == CellValues.Boolean => raw == "1" ? "TRUE" : "FALSE",
+            var dataType when dataType == CellValues.Date => raw,
+            var dataType when dataType == CellValues.Number => raw,
+            var dataType when dataType == CellValues.InlineString => cell.InnerText,
             _ => raw,
         };
     }


### PR DESCRIPTION
## Summary
- adjust the XLSX text extractor to compare cell data types with guard patterns that work with DocumentFormat.OpenXml 3.3
- open PDF documents with an explicit ParsingOptions instance now that PdfPig no longer exposes LenientParsing

## Testing
- not run (dotnet CLI is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68cfc75e70f88326bc256ab56470d74c