### PR TITLE
Refine indexing pipeline and add diagnostics maintenance

### DIFF
--- a/Veriado.Application/Abstractions/IDatabaseMaintenanceService.cs
+++ b/Veriado.Application/Abstractions/IDatabaseMaintenanceService.cs
@@ -1,0 +1,17 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Veriado.Application.Abstractions;
+
+/// <summary>
+/// Provides database maintenance operations such as vacuuming and optimisation.
+/// </summary>
+public interface IDatabaseMaintenanceService
+{
+    /// <summary>
+    /// Executes VACUUM and PRAGMA optimise commands.
+    /// </summary>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The number of maintenance statements executed.</returns>
+    Task<int> VacuumAndOptimizeAsync(CancellationToken cancellationToken);
+}

--- a/Veriado.Application/Abstractions/IDiagnosticsRepository.cs
+++ b/Veriado.Application/Abstractions/IDiagnosticsRepository.cs
@@ -1,0 +1,46 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Veriado.Application.Abstractions;
+
+/// <summary>
+/// Provides access to diagnostics and health information exposed by the infrastructure layer.
+/// </summary>
+public interface IDiagnosticsRepository
+{
+    /// <summary>
+    /// Retrieves general health information about the database.
+    /// </summary>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    Task<DatabaseHealthSnapshot> GetDatabaseHealthAsync(CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Retrieves statistics about the full-text search index.
+    /// </summary>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    Task<SearchIndexSnapshot> GetIndexStatisticsAsync(CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// Represents diagnostic information about the underlying SQLite database.
+/// </summary>
+/// <param name="DatabasePath">The absolute database file path.</param>
+/// <param name="JournalMode">The configured journal mode.</param>
+/// <param name="IsWalEnabled">Indicates whether WAL journaling is enabled.</param>
+/// <param name="PendingOutboxEvents">Number of pending outbox events awaiting processing.</param>
+public sealed record DatabaseHealthSnapshot(
+    string DatabasePath,
+    string JournalMode,
+    bool IsWalEnabled,
+    int PendingOutboxEvents);
+
+/// <summary>
+/// Represents aggregate statistics about the search index.
+/// </summary>
+/// <param name="TotalDocuments">Total number of indexed documents.</param>
+/// <param name="StaleDocuments">Number of documents marked as stale.</param>
+/// <param name="FtsVersion">The SQLite FTS5 version string.</param>
+public sealed record SearchIndexSnapshot(
+    int TotalDocuments,
+    int StaleDocuments,
+    string? FtsVersion);

--- a/Veriado.Application/Abstractions/ISearchIndexCoordinator.cs
+++ b/Veriado.Application/Abstractions/ISearchIndexCoordinator.cs
@@ -1,0 +1,21 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Veriado.Domain.Files;
+
+namespace Veriado.Application.Abstractions;
+
+/// <summary>
+/// Coordinates search indexing operations taking the configured infrastructure mode into account.
+/// </summary>
+public interface ISearchIndexCoordinator
+{
+    /// <summary>
+    /// Executes the indexing pipeline for the provided file aggregate.
+    /// </summary>
+    /// <param name="file">The file aggregate to index.</param>
+    /// <param name="extractContent">Indicates whether text extraction should be attempted.</param>
+    /// <param name="allowDeferred">When <see langword="true"/>, the coordinator may defer indexing to the outbox pipeline.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns><see langword="true"/> when the document was indexed immediately; otherwise <see langword="false"/>.</returns>
+    Task<bool> IndexAsync(FileEntity file, bool extractContent, bool allowDeferred, CancellationToken cancellationToken);
+}

--- a/Veriado.Application/UseCases/Diagnostics/GetHealthStatusHandler.cs
+++ b/Veriado.Application/UseCases/Diagnostics/GetHealthStatusHandler.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using Veriado.Application.Abstractions;
+using Veriado.Application.Common;
+using Veriado.Contracts.Diagnostics;
+
+namespace Veriado.Application.UseCases.Diagnostics;
+
+/// <summary>
+/// Handles retrieval of database health diagnostics.
+/// </summary>
+public sealed class GetHealthStatusHandler : IRequestHandler<GetHealthStatusQuery, AppResult<HealthStatusDto>>
+{
+    private readonly IDiagnosticsRepository _diagnosticsRepository;
+
+    public GetHealthStatusHandler(IDiagnosticsRepository diagnosticsRepository)
+    {
+        _diagnosticsRepository = diagnosticsRepository;
+    }
+
+    public async Task<AppResult<HealthStatusDto>> Handle(GetHealthStatusQuery request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var snapshot = await _diagnosticsRepository.GetDatabaseHealthAsync(cancellationToken).ConfigureAwait(false);
+            var dto = new HealthStatusDto(snapshot.DatabasePath, snapshot.JournalMode, snapshot.IsWalEnabled, snapshot.PendingOutboxEvents);
+            return AppResult<HealthStatusDto>.Success(dto);
+        }
+        catch (Exception ex)
+        {
+            return AppResult<HealthStatusDto>.FromException(ex, "Failed to retrieve database health information.");
+        }
+    }
+}

--- a/Veriado.Application/UseCases/Diagnostics/GetHealthStatusQuery.cs
+++ b/Veriado.Application/UseCases/Diagnostics/GetHealthStatusQuery.cs
@@ -1,0 +1,10 @@
+using MediatR;
+using Veriado.Application.Common;
+using Veriado.Contracts.Diagnostics;
+
+namespace Veriado.Application.UseCases.Diagnostics;
+
+/// <summary>
+/// Query to retrieve database health information.
+/// </summary>
+public sealed record GetHealthStatusQuery : IRequest<AppResult<HealthStatusDto>>;

--- a/Veriado.Application/UseCases/Diagnostics/GetIndexStatisticsHandler.cs
+++ b/Veriado.Application/UseCases/Diagnostics/GetIndexStatisticsHandler.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using Veriado.Application.Abstractions;
+using Veriado.Application.Common;
+using Veriado.Contracts.Diagnostics;
+
+namespace Veriado.Application.UseCases.Diagnostics;
+
+/// <summary>
+/// Handles retrieval of search index diagnostics.
+/// </summary>
+public sealed class GetIndexStatisticsHandler : IRequestHandler<GetIndexStatisticsQuery, AppResult<IndexStatisticsDto>>
+{
+    private readonly IDiagnosticsRepository _diagnosticsRepository;
+
+    public GetIndexStatisticsHandler(IDiagnosticsRepository diagnosticsRepository)
+    {
+        _diagnosticsRepository = diagnosticsRepository;
+    }
+
+    public async Task<AppResult<IndexStatisticsDto>> Handle(GetIndexStatisticsQuery request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var snapshot = await _diagnosticsRepository.GetIndexStatisticsAsync(cancellationToken).ConfigureAwait(false);
+            var dto = new IndexStatisticsDto(snapshot.TotalDocuments, snapshot.StaleDocuments, snapshot.FtsVersion);
+            return AppResult<IndexStatisticsDto>.Success(dto);
+        }
+        catch (Exception ex)
+        {
+            return AppResult<IndexStatisticsDto>.FromException(ex, "Failed to retrieve search index statistics.");
+        }
+    }
+}

--- a/Veriado.Application/UseCases/Diagnostics/GetIndexStatisticsQuery.cs
+++ b/Veriado.Application/UseCases/Diagnostics/GetIndexStatisticsQuery.cs
@@ -1,0 +1,10 @@
+using MediatR;
+using Veriado.Application.Common;
+using Veriado.Contracts.Diagnostics;
+
+namespace Veriado.Application.UseCases.Diagnostics;
+
+/// <summary>
+/// Query to retrieve high-level search index metrics.
+/// </summary>
+public sealed record GetIndexStatisticsQuery : IRequest<AppResult<IndexStatisticsDto>>;

--- a/Veriado.Application/UseCases/Files/ApplySystemMetadata/ApplySystemMetadataHandler.cs
+++ b/Veriado.Application/UseCases/Files/ApplySystemMetadata/ApplySystemMetadataHandler.cs
@@ -24,10 +24,9 @@ public sealed class ApplySystemMetadataHandler : FileWriteHandlerBase, IRequestH
     public ApplySystemMetadataHandler(
         IFileRepository repository,
         IEventPublisher eventPublisher,
-        ISearchIndexer searchIndexer,
-        ITextExtractor textExtractor,
+        ISearchIndexCoordinator indexCoordinator,
         IClock clock)
-        : base(repository, eventPublisher, searchIndexer, textExtractor, clock)
+        : base(repository, eventPublisher, indexCoordinator, clock)
     {
     }
 

--- a/Veriado.Application/UseCases/Files/ClearFileValidity/ClearFileValidityHandler.cs
+++ b/Veriado.Application/UseCases/Files/ClearFileValidity/ClearFileValidityHandler.cs
@@ -22,10 +22,9 @@ public sealed class ClearFileValidityHandler : FileWriteHandlerBase, IRequestHan
     public ClearFileValidityHandler(
         IFileRepository repository,
         IEventPublisher eventPublisher,
-        ISearchIndexer searchIndexer,
-        ITextExtractor textExtractor,
+        ISearchIndexCoordinator indexCoordinator,
         IClock clock)
-        : base(repository, eventPublisher, searchIndexer, textExtractor, clock)
+        : base(repository, eventPublisher, indexCoordinator, clock)
     {
     }
 

--- a/Veriado.Application/UseCases/Files/CreateFile/CreateFileHandler.cs
+++ b/Veriado.Application/UseCases/Files/CreateFile/CreateFileHandler.cs
@@ -24,11 +24,10 @@ public sealed class CreateFileHandler : FileWriteHandlerBase, IRequestHandler<Cr
     public CreateFileHandler(
         IFileRepository repository,
         IEventPublisher eventPublisher,
-        ISearchIndexer searchIndexer,
-        ITextExtractor textExtractor,
+        ISearchIndexCoordinator indexCoordinator,
         ImportPolicy importPolicy,
         IClock clock)
-        : base(repository, eventPublisher, searchIndexer, textExtractor, clock)
+        : base(repository, eventPublisher, indexCoordinator, clock)
     {
         _importPolicy = importPolicy;
     }

--- a/Veriado.Application/UseCases/Files/RenameFile/RenameFileHandler.cs
+++ b/Veriado.Application/UseCases/Files/RenameFile/RenameFileHandler.cs
@@ -23,10 +23,9 @@ public sealed class RenameFileHandler : FileWriteHandlerBase, IRequestHandler<Re
     public RenameFileHandler(
         IFileRepository repository,
         IEventPublisher eventPublisher,
-        ISearchIndexer searchIndexer,
-        ITextExtractor textExtractor,
+        ISearchIndexCoordinator indexCoordinator,
         IClock clock)
-        : base(repository, eventPublisher, searchIndexer, textExtractor, clock)
+        : base(repository, eventPublisher, indexCoordinator, clock)
     {
     }
 

--- a/Veriado.Application/UseCases/Files/ReplaceFileContent/ReplaceFileContentHandler.cs
+++ b/Veriado.Application/UseCases/Files/ReplaceFileContent/ReplaceFileContentHandler.cs
@@ -25,11 +25,10 @@ public sealed class ReplaceFileContentHandler : FileWriteHandlerBase, IRequestHa
     public ReplaceFileContentHandler(
         IFileRepository repository,
         IEventPublisher eventPublisher,
-        ISearchIndexer searchIndexer,
-        ITextExtractor textExtractor,
+        ISearchIndexCoordinator indexCoordinator,
         ImportPolicy importPolicy,
         IClock clock)
-        : base(repository, eventPublisher, searchIndexer, textExtractor, clock)
+        : base(repository, eventPublisher, indexCoordinator, clock)
     {
         _importPolicy = importPolicy;
     }

--- a/Veriado.Application/UseCases/Files/SetExtendedMetadata/SetExtendedMetadataHandler.cs
+++ b/Veriado.Application/UseCases/Files/SetExtendedMetadata/SetExtendedMetadataHandler.cs
@@ -23,10 +23,9 @@ public sealed class SetExtendedMetadataHandler : FileWriteHandlerBase, IRequestH
     public SetExtendedMetadataHandler(
         IFileRepository repository,
         IEventPublisher eventPublisher,
-        ISearchIndexer searchIndexer,
-        ITextExtractor textExtractor,
+        ISearchIndexCoordinator indexCoordinator,
         IClock clock)
-        : base(repository, eventPublisher, searchIndexer, textExtractor, clock)
+        : base(repository, eventPublisher, indexCoordinator, clock)
     {
     }
 

--- a/Veriado.Application/UseCases/Files/SetFileReadOnly/SetFileReadOnlyHandler.cs
+++ b/Veriado.Application/UseCases/Files/SetFileReadOnly/SetFileReadOnlyHandler.cs
@@ -22,10 +22,9 @@ public sealed class SetFileReadOnlyHandler : FileWriteHandlerBase, IRequestHandl
     public SetFileReadOnlyHandler(
         IFileRepository repository,
         IEventPublisher eventPublisher,
-        ISearchIndexer searchIndexer,
-        ITextExtractor textExtractor,
+        ISearchIndexCoordinator indexCoordinator,
         IClock clock)
-        : base(repository, eventPublisher, searchIndexer, textExtractor, clock)
+        : base(repository, eventPublisher, indexCoordinator, clock)
     {
     }
 

--- a/Veriado.Application/UseCases/Files/SetFileValidity/SetFileValidityHandler.cs
+++ b/Veriado.Application/UseCases/Files/SetFileValidity/SetFileValidityHandler.cs
@@ -23,10 +23,9 @@ public sealed class SetFileValidityHandler : FileWriteHandlerBase, IRequestHandl
     public SetFileValidityHandler(
         IFileRepository repository,
         IEventPublisher eventPublisher,
-        ISearchIndexer searchIndexer,
-        ITextExtractor textExtractor,
+        ISearchIndexCoordinator indexCoordinator,
         IClock clock)
-        : base(repository, eventPublisher, searchIndexer, textExtractor, clock)
+        : base(repository, eventPublisher, indexCoordinator, clock)
     {
     }
 

--- a/Veriado.Application/UseCases/Files/UpdateFileMetadata/UpdateFileMetadataHandler.cs
+++ b/Veriado.Application/UseCases/Files/UpdateFileMetadata/UpdateFileMetadataHandler.cs
@@ -23,10 +23,9 @@ public sealed class UpdateFileMetadataHandler : FileWriteHandlerBase, IRequestHa
     public UpdateFileMetadataHandler(
         IFileRepository repository,
         IEventPublisher eventPublisher,
-        ISearchIndexer searchIndexer,
-        ITextExtractor textExtractor,
+        ISearchIndexCoordinator indexCoordinator,
         IClock clock)
-        : base(repository, eventPublisher, searchIndexer, textExtractor, clock)
+        : base(repository, eventPublisher, indexCoordinator, clock)
     {
     }
 

--- a/Veriado.Application/UseCases/Maintenance/BulkReindexHandler.cs
+++ b/Veriado.Application/UseCases/Maintenance/BulkReindexHandler.cs
@@ -17,8 +17,7 @@ public sealed class BulkReindexHandler : IRequestHandler<BulkReindexCommand, App
 {
     private readonly IFileRepository _repository;
     private readonly IEventPublisher _eventPublisher;
-    private readonly ISearchIndexer _searchIndexer;
-    private readonly ITextExtractor _textExtractor;
+    private readonly ISearchIndexCoordinator _indexCoordinator;
     private readonly IClock _clock;
 
     /// <summary>
@@ -27,14 +26,12 @@ public sealed class BulkReindexHandler : IRequestHandler<BulkReindexCommand, App
     public BulkReindexHandler(
         IFileRepository repository,
         IEventPublisher eventPublisher,
-        ISearchIndexer searchIndexer,
-        ITextExtractor textExtractor,
+        ISearchIndexCoordinator indexCoordinator,
         IClock clock)
     {
         _repository = repository;
         _eventPublisher = eventPublisher;
-        _searchIndexer = searchIndexer;
-        _textExtractor = textExtractor;
+        _indexCoordinator = indexCoordinator;
         _clock = clock;
     }
 
@@ -58,10 +55,12 @@ public sealed class BulkReindexHandler : IRequestHandler<BulkReindexCommand, App
         foreach (var file in files)
         {
             await PublishDomainEventsAsync(file, cancellationToken);
-            var text = request.ExtractContent ? await _textExtractor.ExtractTextAsync(file, cancellationToken) : null;
-            var document = file.ToSearchDocument(text);
-            await _searchIndexer.IndexAsync(document, cancellationToken);
-            file.ConfirmIndexed(file.SearchIndex.SchemaVersion, _clock.UtcNow);
+            var indexed = await _indexCoordinator.IndexAsync(file, request.ExtractContent, allowDeferred: false, cancellationToken)
+                .ConfigureAwait(false);
+            if (indexed)
+            {
+                file.ConfirmIndexed(file.SearchIndex.SchemaVersion, _clock.UtcNow);
+            }
             await _repository.UpdateAsync(file, cancellationToken);
         }
 

--- a/Veriado.Application/UseCases/Maintenance/ReindexCorpusAfterSchemaUpgradeCommand.cs
+++ b/Veriado.Application/UseCases/Maintenance/ReindexCorpusAfterSchemaUpgradeCommand.cs
@@ -1,0 +1,12 @@
+using MediatR;
+using Veriado.Application.Common;
+
+namespace Veriado.Application.UseCases.Maintenance;
+
+/// <summary>
+/// Requests a complete reindex of the corpus after a search schema upgrade.
+/// </summary>
+public sealed record ReindexCorpusAfterSchemaUpgradeCommand(
+    int TargetSchemaVersion,
+    bool ExtractContent = true,
+    bool AllowDeferredIndexing = false) : IRequest<AppResult<int>>;

--- a/Veriado.Application/UseCases/Maintenance/ReindexCorpusAfterSchemaUpgradeHandler.cs
+++ b/Veriado.Application/UseCases/Maintenance/ReindexCorpusAfterSchemaUpgradeHandler.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using Veriado.Application.Abstractions;
+using Veriado.Application.Common;
+using Veriado.Domain.Files;
+
+namespace Veriado.Application.UseCases.Maintenance;
+
+/// <summary>
+/// Handles bulk reindex operations triggered by a schema upgrade.
+/// </summary>
+public sealed class ReindexCorpusAfterSchemaUpgradeHandler : IRequestHandler<ReindexCorpusAfterSchemaUpgradeCommand, AppResult<int>>
+{
+    private readonly IFileRepository _repository;
+    private readonly IEventPublisher _eventPublisher;
+    private readonly ISearchIndexCoordinator _indexCoordinator;
+    private readonly IClock _clock;
+
+    public ReindexCorpusAfterSchemaUpgradeHandler(
+        IFileRepository repository,
+        IEventPublisher eventPublisher,
+        ISearchIndexCoordinator indexCoordinator,
+        IClock clock)
+    {
+        _repository = repository;
+        _eventPublisher = eventPublisher;
+        _indexCoordinator = indexCoordinator;
+        _clock = clock;
+    }
+
+    public async Task<AppResult<int>> Handle(ReindexCorpusAfterSchemaUpgradeCommand request, CancellationToken cancellationToken)
+    {
+        if (request.TargetSchemaVersion <= 0)
+        {
+            return AppResult<int>.Validation(new[] { "Target schema version must be positive." });
+        }
+
+        var reindexed = 0;
+
+        try
+        {
+            await foreach (var file in _repository.StreamAllAsync(cancellationToken))
+            {
+                file.BumpSchemaVersion(request.TargetSchemaVersion);
+                await PublishDomainEventsAsync(file, cancellationToken).ConfigureAwait(false);
+
+                var indexed = await _indexCoordinator.IndexAsync(
+                    file,
+                    request.ExtractContent,
+                    request.AllowDeferredIndexing,
+                    cancellationToken).ConfigureAwait(false);
+
+                if (indexed)
+                {
+                    file.ConfirmIndexed(file.SearchIndex.SchemaVersion, _clock.UtcNow);
+                }
+
+                await _repository.UpdateAsync(file, cancellationToken).ConfigureAwait(false);
+                reindexed++;
+            }
+
+            return AppResult<int>.Success(reindexed);
+        }
+        catch (Exception ex)
+        {
+            return AppResult<int>.FromException(ex, "Failed to reindex the corpus after schema upgrade.");
+        }
+    }
+
+    private async Task PublishDomainEventsAsync(FileEntity file, CancellationToken cancellationToken)
+    {
+        if (file.DomainEvents.Count == 0)
+        {
+            return;
+        }
+
+        await _eventPublisher.PublishAsync(file.DomainEvents, cancellationToken).ConfigureAwait(false);
+        file.ClearDomainEvents();
+    }
+}

--- a/Veriado.Application/UseCases/Maintenance/VacuumAndOptimizeDatabaseCommand.cs
+++ b/Veriado.Application/UseCases/Maintenance/VacuumAndOptimizeDatabaseCommand.cs
@@ -1,0 +1,9 @@
+using MediatR;
+using Veriado.Application.Common;
+
+namespace Veriado.Application.UseCases.Maintenance;
+
+/// <summary>
+/// Triggers maintenance commands that reclaim unused space and optimise the SQLite database.
+/// </summary>
+public sealed record VacuumAndOptimizeDatabaseCommand : IRequest<AppResult<int>>;

--- a/Veriado.Application/UseCases/Maintenance/VacuumAndOptimizeDatabaseHandler.cs
+++ b/Veriado.Application/UseCases/Maintenance/VacuumAndOptimizeDatabaseHandler.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using Veriado.Application.Abstractions;
+using Veriado.Application.Common;
+
+namespace Veriado.Application.UseCases.Maintenance;
+
+/// <summary>
+/// Executes SQLite VACUUM and PRAGMA optimize commands to keep the database lean.
+/// </summary>
+public sealed class VacuumAndOptimizeDatabaseHandler : IRequestHandler<VacuumAndOptimizeDatabaseCommand, AppResult<int>>
+{
+    private readonly IDatabaseMaintenanceService _maintenanceService;
+    private readonly ILogger<VacuumAndOptimizeDatabaseHandler> _logger;
+
+    public VacuumAndOptimizeDatabaseHandler(
+        IDatabaseMaintenanceService maintenanceService,
+        ILogger<VacuumAndOptimizeDatabaseHandler> logger)
+    {
+        _maintenanceService = maintenanceService;
+        _logger = logger;
+    }
+
+    public async Task<AppResult<int>> Handle(VacuumAndOptimizeDatabaseCommand request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var executed = await _maintenanceService.VacuumAndOptimizeAsync(cancellationToken).ConfigureAwait(false);
+            _logger.LogInformation("SQLite vacuum and optimise completed");
+            return AppResult<int>.Success(executed);
+        }
+        catch (Exception ex)
+        {
+            return AppResult<int>.FromException(ex, "Failed to vacuum and optimise the database.");
+        }
+    }
+}

--- a/Veriado.Application/UseCases/Queries/FileGrid/QueryableMappingHelpers.cs
+++ b/Veriado.Application/UseCases/Queries/FileGrid/QueryableMappingHelpers.cs
@@ -65,7 +65,10 @@ public static class QueryableMappingHelpers
         LastModifiedUtc = file.LastModifiedUtc.Value,
         IsReadOnly = file.IsReadOnly,
         Version = file.Version,
-        Content = new FileContentDto(file.Content.Hash.Value, file.Content.Length.Value, null),
+        Content = new FileContentDto(
+            file.SearchIndex.IndexedContentHash ?? string.Empty,
+            file.Size.Value,
+            null),
         SystemMetadata = new FileSystemMetadataDto(
             (int)file.SystemMetadata.Attributes,
             file.SystemMetadata.CreatedUtc.Value,

--- a/Veriado.Contracts/Diagnostics/HealthStatusDto.cs
+++ b/Veriado.Contracts/Diagnostics/HealthStatusDto.cs
@@ -1,0 +1,14 @@
+namespace Veriado.Contracts.Diagnostics;
+
+/// <summary>
+/// Represents diagnostic information about the underlying SQLite database.
+/// </summary>
+/// <param name="DatabasePath">The absolute database path.</param>
+/// <param name="JournalMode">The current journal mode.</param>
+/// <param name="IsWalEnabled">Indicates whether WAL journaling is enabled.</param>
+/// <param name="PendingOutboxEvents">Number of pending outbox events.</param>
+public sealed record HealthStatusDto(
+    string DatabasePath,
+    string JournalMode,
+    bool IsWalEnabled,
+    int PendingOutboxEvents);

--- a/Veriado.Contracts/Diagnostics/IndexStatisticsDto.cs
+++ b/Veriado.Contracts/Diagnostics/IndexStatisticsDto.cs
@@ -1,0 +1,12 @@
+namespace Veriado.Contracts.Diagnostics;
+
+/// <summary>
+/// Represents aggregate metrics about the search index.
+/// </summary>
+/// <param name="TotalDocuments">Total number of indexed documents.</param>
+/// <param name="StaleDocuments">Documents pending reindexing.</param>
+/// <param name="FtsVersion">The SQLite FTS5 version string.</param>
+public sealed record IndexStatisticsDto(
+    int TotalDocuments,
+    int StaleDocuments,
+    string? FtsVersion);

--- a/Veriado.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/Veriado.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
@@ -15,6 +15,7 @@ using Veriado.Infrastructure.Concurrency;
 using Veriado.Infrastructure.Events;
 using Veriado.Infrastructure.Idempotency;
 using Veriado.Infrastructure.Integrity;
+using Veriado.Infrastructure.Maintenance;
 using Veriado.Infrastructure.Persistence;
 using Veriado.Infrastructure.Persistence.Interceptors;
 using Veriado.Infrastructure.Persistence.Options;
@@ -76,6 +77,8 @@ public static class ServiceCollectionExtensions
 
         services.AddSingleton<IWriteQueue, WriteQueue>();
         services.AddSingleton<ISearchIndexer, SqliteFts5Indexer>();
+        services.AddSingleton<ISearchIndexCoordinator, SqliteSearchIndexCoordinator>();
+        services.AddSingleton<IDatabaseMaintenanceService, SqliteDatabaseMaintenanceService>();
         services.AddSingleton<ISearchQueryService, SqliteFts5QueryService>();
         services.AddSingleton<ISearchHistoryService, SearchHistoryService>();
         services.AddSingleton<ISearchFavoritesService, SearchFavoritesService>();
@@ -95,8 +98,10 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IFileRepository, FileRepository>();
         services.AddScoped<IReadOnlyFileContextFactory, ReadOnlyFileContextFactory>();
         services.AddScoped<IFileReadRepository, FileReadRepository>();
+        services.AddSingleton<IDiagnosticsRepository, DiagnosticsRepository>();
 
         services.AddHostedService<WriteWorker>();
+        services.AddHostedService<IdempotencyCleanupWorker>();
         if (options.FtsIndexingMode == FtsIndexingMode.Outbox)
         {
             services.AddHostedService<OutboxWorker>();

--- a/Veriado.Infrastructure/Integrity/FulltextIntegrityService.cs
+++ b/Veriado.Infrastructure/Integrity/FulltextIntegrityService.cs
@@ -23,6 +23,7 @@ internal sealed class FulltextIntegrityService : IFulltextIntegrityService
     private readonly ITextExtractor _textExtractor;
     private readonly InfrastructureOptions _options;
     private readonly ILogger<FulltextIntegrityService> _logger;
+    private readonly IClock _clock;
 
     public FulltextIntegrityService(
         IDbContextFactory<ReadOnlyDbContext> readFactory,
@@ -30,7 +31,8 @@ internal sealed class FulltextIntegrityService : IFulltextIntegrityService
         ISearchIndexer searchIndexer,
         ITextExtractor textExtractor,
         InfrastructureOptions options,
-        ILogger<FulltextIntegrityService> logger)
+        ILogger<FulltextIntegrityService> logger,
+        IClock clock)
     {
         _readFactory = readFactory;
         _writeFactory = writeFactory;
@@ -38,6 +40,7 @@ internal sealed class FulltextIntegrityService : IFulltextIntegrityService
         _textExtractor = textExtractor;
         _options = options;
         _logger = logger;
+        _clock = clock;
     }
 
     public async Task<IntegrityReport> VerifyAsync(CancellationToken cancellationToken = default)
@@ -144,7 +147,7 @@ internal sealed class FulltextIntegrityService : IFulltextIntegrityService
         var tracked = await writeContext.Files.FirstOrDefaultAsync(f => f.Id == fileId, cancellationToken).ConfigureAwait(false);
         if (tracked is not null)
         {
-            tracked.ConfirmIndexed(tracked.SearchIndex.SchemaVersion, DateTimeOffset.UtcNow);
+            tracked.ConfirmIndexed(tracked.SearchIndex.SchemaVersion, _clock.UtcNow);
         }
     }
 

--- a/Veriado.Infrastructure/Maintenance/SqliteDatabaseMaintenanceService.cs
+++ b/Veriado.Infrastructure/Maintenance/SqliteDatabaseMaintenanceService.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Data.Sqlite;
+using Veriado.Application.Abstractions;
+using Veriado.Infrastructure.Persistence.Options;
+
+namespace Veriado.Infrastructure.Maintenance;
+
+/// <summary>
+/// Provides SQLite specific database maintenance operations.
+/// </summary>
+internal sealed class SqliteDatabaseMaintenanceService : IDatabaseMaintenanceService
+{
+    private readonly InfrastructureOptions _options;
+
+    public SqliteDatabaseMaintenanceService(InfrastructureOptions options)
+    {
+        _options = options;
+    }
+
+    public async Task<int> VacuumAndOptimizeAsync(CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(_options.ConnectionString))
+        {
+            throw new InvalidOperationException("Infrastructure has not been initialised with a connection string.");
+        }
+
+        await using var connection = new SqliteConnection(_options.ConnectionString);
+        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+        var statements = new[] { "VACUUM;", "PRAGMA optimize;" };
+        var executed = 0;
+
+        foreach (var sql in statements)
+        {
+            await using var command = connection.CreateCommand();
+            command.CommandText = sql;
+            await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            executed++;
+        }
+
+        return executed;
+    }
+}

--- a/Veriado.Infrastructure/Persistence/Options/InfrastructureOptions.cs
+++ b/Veriado.Infrastructure/Persistence/Options/InfrastructureOptions.cs
@@ -61,6 +61,16 @@ public sealed class InfrastructureOptions
     /// </summary>
     public bool RepairIntegrityAutomatically { get; set; } = false;
 
+    /// <summary>
+    /// Gets or sets the duration after which stored idempotency keys expire.
+    /// </summary>
+    public TimeSpan IdempotencyKeyTtl { get; set; } = TimeSpan.FromHours(12);
+
+    /// <summary>
+    /// Gets or sets the interval at which expired idempotency keys are purged.
+    /// </summary>
+    public TimeSpan IdempotencyCleanupInterval { get; set; } = TimeSpan.FromHours(1);
+
     private int _batchSize = DefaultBatchSize;
     private int _batchWindowMs = DefaultBatchWindowMs;
 

--- a/Veriado.Infrastructure/Repositories/DiagnosticsRepository.cs
+++ b/Veriado.Infrastructure/Repositories/DiagnosticsRepository.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Data.Sqlite;
+using Veriado.Application.Abstractions;
+using Veriado.Infrastructure.Persistence.Options;
+
+namespace Veriado.Infrastructure.Repositories;
+
+/// <summary>
+/// Provides diagnostics and statistical information about the SQLite database.
+/// </summary>
+internal sealed class DiagnosticsRepository : IDiagnosticsRepository
+{
+    private readonly InfrastructureOptions _options;
+
+    public DiagnosticsRepository(InfrastructureOptions options)
+    {
+        _options = options;
+    }
+
+    public async Task<DatabaseHealthSnapshot> GetDatabaseHealthAsync(CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(_options.ConnectionString))
+        {
+            throw new InvalidOperationException("Infrastructure has not been initialised with a connection string.");
+        }
+
+        await using var connection = new SqliteConnection(_options.ConnectionString);
+        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+        var journalMode = await GetScalarAsync(connection, "PRAGMA journal_mode;", cancellationToken).ConfigureAwait(false);
+        var isWal = string.Equals(journalMode, "wal", StringComparison.OrdinalIgnoreCase);
+
+        var pendingOutbox = 0;
+        if (_options.FtsIndexingMode == FtsIndexingMode.Outbox)
+        {
+            var pending = await GetScalarAsync(connection, "SELECT COUNT(*) FROM outbox_events WHERE processed_utc IS NULL;", cancellationToken)
+                .ConfigureAwait(false);
+            if (long.TryParse(pending, out var count))
+            {
+                pendingOutbox = (int)count;
+            }
+        }
+
+        return new DatabaseHealthSnapshot(_options.DbPath, journalMode, isWal, pendingOutbox);
+    }
+
+    public async Task<SearchIndexSnapshot> GetIndexStatisticsAsync(CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(_options.ConnectionString))
+        {
+            throw new InvalidOperationException("Infrastructure has not been initialised with a connection string.");
+        }
+
+        await using var connection = new SqliteConnection(_options.ConnectionString);
+        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+        var total = await GetScalarAsync(connection, "SELECT COUNT(*) FROM files;", cancellationToken).ConfigureAwait(false);
+        var stale = await GetScalarAsync(connection, "SELECT COUNT(*) FROM files WHERE fts_is_stale = 1;", cancellationToken).ConfigureAwait(false);
+        var version = await GetScalarAsync(connection, "SELECT fts5();", cancellationToken).ConfigureAwait(false);
+
+        var totalCount = int.TryParse(total, out var parsedTotal) ? parsedTotal : 0;
+        var staleCount = int.TryParse(stale, out var parsedStale) ? parsedStale : 0;
+
+        return new SearchIndexSnapshot(totalCount, staleCount, string.IsNullOrWhiteSpace(version) ? null : version);
+    }
+
+    private static async Task<string> GetScalarAsync(SqliteConnection connection, string sql, CancellationToken cancellationToken)
+    {
+        await using var command = connection.CreateCommand();
+        command.CommandText = sql;
+        var result = await command.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
+        return result?.ToString() ?? string.Empty;
+    }
+}

--- a/Veriado.Infrastructure/Search/Outbox/OutboxEvent.cs
+++ b/Veriado.Infrastructure/Search/Outbox/OutboxEvent.cs
@@ -18,7 +18,7 @@ public sealed class OutboxEvent
         = string.Empty;
 
     public DateTimeOffset CreatedUtc { get; set; }
-        = DateTimeOffset.UtcNow;
+        = default;
 
     public DateTimeOffset? ProcessedUtc { get; set; }
         = null;

--- a/Veriado.Infrastructure/Search/SearchFavoritesService.cs
+++ b/Veriado.Infrastructure/Search/SearchFavoritesService.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Data.Sqlite;
+using Veriado.Application.Abstractions;
 using Veriado.Application.Search.Abstractions;
 using Veriado.Infrastructure.Persistence.Options;
 
@@ -13,10 +14,12 @@ namespace Veriado.Infrastructure.Search;
 internal sealed class SearchFavoritesService : ISearchFavoritesService
 {
     private readonly InfrastructureOptions _options;
+    private readonly IClock _clock;
 
-    public SearchFavoritesService(InfrastructureOptions options)
+    public SearchFavoritesService(InfrastructureOptions options, IClock clock)
     {
         _options = options;
+        _clock = clock;
     }
 
     public async Task<IReadOnlyList<SearchFavoriteItem>> GetAllAsync(CancellationToken cancellationToken)
@@ -70,7 +73,7 @@ internal sealed class SearchFavoritesService : ISearchFavoritesService
         insert.Parameters.Add("$queryText", SqliteType.Text).Value = (object?)queryText ?? DBNull.Value;
         insert.Parameters.Add("$match", SqliteType.Text).Value = matchQuery;
         insert.Parameters.Add("$position", SqliteType.Integer).Value = maxPosition + 1;
-        insert.Parameters.Add("$createdUtc", SqliteType.Text).Value = DateTimeOffset.UtcNow.ToString("O");
+        insert.Parameters.Add("$createdUtc", SqliteType.Text).Value = _clock.UtcNow.ToString("O");
         insert.Parameters.Add("$isFuzzy", SqliteType.Integer).Value = isFuzzy ? 1 : 0;
         await insert.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
     }

--- a/Veriado.Infrastructure/Search/SearchHistoryService.cs
+++ b/Veriado.Infrastructure/Search/SearchHistoryService.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Data.Sqlite;
+using Veriado.Application.Abstractions;
 using Veriado.Application.Search.Abstractions;
 using Veriado.Infrastructure.Persistence.Options;
 
@@ -12,10 +13,12 @@ namespace Veriado.Infrastructure.Search;
 internal sealed class SearchHistoryService : ISearchHistoryService
 {
     private readonly InfrastructureOptions _options;
+    private readonly IClock _clock;
 
-    public SearchHistoryService(InfrastructureOptions options)
+    public SearchHistoryService(InfrastructureOptions options, IClock clock)
     {
         _options = options;
+        _clock = clock;
     }
 
     public async Task AddAsync(string? queryText, string matchQuery, int totalCount, bool isFuzzy, CancellationToken cancellationToken)
@@ -24,7 +27,7 @@ internal sealed class SearchHistoryService : ISearchHistoryService
         await using var connection = CreateConnection();
         await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
         await using var transaction = await connection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
-        var now = DateTimeOffset.UtcNow.ToString("O");
+        var now = _clock.UtcNow.ToString("O");
 
         await using (var update = connection.CreateCommand())
         {

--- a/Veriado.Infrastructure/Search/SqliteSearchIndexCoordinator.cs
+++ b/Veriado.Infrastructure/Search/SqliteSearchIndexCoordinator.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Veriado.Application.Abstractions;
+using Veriado.Domain.Files;
+using Veriado.Infrastructure.Persistence.Options;
+
+namespace Veriado.Infrastructure.Search;
+
+/// <summary>
+/// Coordinates immediate or deferred indexing operations based on infrastructure configuration.
+/// </summary>
+internal sealed class SqliteSearchIndexCoordinator : ISearchIndexCoordinator
+{
+    private readonly ITextExtractor _textExtractor;
+    private readonly ISearchIndexer _searchIndexer;
+    private readonly InfrastructureOptions _options;
+    private readonly ILogger<SqliteSearchIndexCoordinator> _logger;
+
+    public SqliteSearchIndexCoordinator(
+        ITextExtractor textExtractor,
+        ISearchIndexer searchIndexer,
+        InfrastructureOptions options,
+        ILogger<SqliteSearchIndexCoordinator> logger)
+    {
+        _textExtractor = textExtractor;
+        _searchIndexer = searchIndexer;
+        _options = options;
+        _logger = logger;
+    }
+
+    public async Task<bool> IndexAsync(FileEntity file, bool extractContent, bool allowDeferred, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(file);
+
+        if (_options.FtsIndexingMode == FtsIndexingMode.Outbox && allowDeferred)
+        {
+            _logger.LogDebug("Search indexing deferred to outbox for file {FileId}", file.Id);
+            return false;
+        }
+
+        var text = extractContent
+            ? await _textExtractor.ExtractTextAsync(file, cancellationToken).ConfigureAwait(false)
+            : null;
+
+        var document = file.ToSearchDocument(text);
+        await _searchIndexer.IndexAsync(document, cancellationToken).ConfigureAwait(false);
+        return true;
+    }
+}


### PR DESCRIPTION
## Summary
- introduce a search index coordinator and update file use cases and maintenance commands to use the unified pipeline
- add background maintenance services for idempotency cleanup, database vacuuming, and corpus reindexing with diagnostics access
- enhance the write worker, event publishing, and repositories with retry logic, telemetry, and clock abstraction

## Testing
- dotnet build *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cfc9e968dc83269452d7e35e7f8596