### PR TITLE
Add services orchestration layer

### DIFF
--- a/Veriado.Services/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/Veriado.Services/DependencyInjection/ServiceCollectionExtensions.cs
@@ -1,0 +1,36 @@
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Veriado.Services.Diagnostics;
+using Veriado.Services.Files;
+using Veriado.Services.Import;
+using Veriado.Services.Maintenance;
+
+namespace Veriado.Services.DependencyInjection;
+
+/// <summary>
+/// Provides dependency injection helpers for the services layer.
+/// </summary>
+public static class ServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers the orchestration services consumed by hosts such as WinUI or APIs.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <returns>The same service collection for chaining.</returns>
+    /// <remarks>
+    /// Hosts must invoke <c>InitializeInfrastructureAsync()</c> during startup to ensure the database is ready.
+    /// </remarks>
+    public static IServiceCollection AddVeriadoServices(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.AddScoped<IImportService, ImportService>();
+        services.AddScoped<IFileQueryService, FileQueryService>();
+        services.AddScoped<IFileOperationsService, FileOperationsService>();
+        services.AddScoped<IFileContentService, FileContentService>();
+        services.AddScoped<IMaintenanceService, MaintenanceService>();
+        services.AddScoped<IHealthService, HealthService>();
+
+        return services;
+    }
+}

--- a/Veriado.Services/Diagnostics/HealthService.cs
+++ b/Veriado.Services/Diagnostics/HealthService.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using Veriado.Application.Common;
+using Veriado.Application.UseCases.Diagnostics;
+using Veriado.Contracts.Diagnostics;
+
+namespace Veriado.Services.Diagnostics;
+
+/// <summary>
+/// Implements diagnostic queries over the infrastructure state.
+/// </summary>
+public sealed class HealthService : IHealthService
+{
+    private readonly IMediator _mediator;
+
+    public HealthService(IMediator mediator)
+    {
+        _mediator = mediator ?? throw new ArgumentNullException(nameof(mediator));
+    }
+
+    public Task<AppResult<HealthStatusDto>> GetAsync(CancellationToken cancellationToken)
+    {
+        return _mediator.Send(new GetHealthStatusQuery(), cancellationToken);
+    }
+
+    public Task<AppResult<IndexStatisticsDto>> GetIndexStatisticsAsync(CancellationToken cancellationToken)
+    {
+        return _mediator.Send(new GetIndexStatisticsQuery(), cancellationToken);
+    }
+}

--- a/Veriado.Services/Diagnostics/IHealthService.cs
+++ b/Veriado.Services/Diagnostics/IHealthService.cs
@@ -1,0 +1,16 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Veriado.Application.Common;
+using Veriado.Contracts.Diagnostics;
+
+namespace Veriado.Services.Diagnostics;
+
+/// <summary>
+/// Provides diagnostic information about infrastructure state and search index health.
+/// </summary>
+public interface IHealthService
+{
+    Task<AppResult<HealthStatusDto>> GetAsync(CancellationToken cancellationToken);
+
+    Task<AppResult<IndexStatisticsDto>> GetIndexStatisticsAsync(CancellationToken cancellationToken);
+}

--- a/Veriado.Services/Files/FileContentService.cs
+++ b/Veriado.Services/Files/FileContentService.cs
@@ -1,0 +1,71 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Veriado.Application.Abstractions;
+using Veriado.Application.Common;
+using Veriado.Application.DTO;
+using Veriado.Application.Mapping;
+
+namespace Veriado.Services.Files;
+
+/// <summary>
+/// Implements helpers for retrieving and persisting file binary content.
+/// </summary>
+public sealed class FileContentService : IFileContentService
+{
+    private readonly IFileRepository _repository;
+
+    public FileContentService(IFileRepository repository)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+    }
+
+    public async Task<(FileDto Meta, byte[] Content)?> GetContentAsync(Guid fileId, CancellationToken cancellationToken)
+    {
+        var file = await _repository.GetAsync(fileId, cancellationToken).ConfigureAwait(false);
+        if (file is null)
+        {
+            return null;
+        }
+
+        var dto = DomainToDto.ToFileDto(file);
+        var content = new byte[file.Content.Bytes.Length];
+        Array.Copy(file.Content.Bytes, content, file.Content.Bytes.Length);
+        return (dto, content);
+    }
+
+    public async Task<AppResult<Guid>> SaveContentToDiskAsync(Guid fileId, string targetPath, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(targetPath))
+        {
+            return AppResult<Guid>.Validation(new[] { "Target path is required." });
+        }
+
+        var file = await _repository.GetAsync(fileId, cancellationToken).ConfigureAwait(false);
+        if (file is null)
+        {
+            return AppResult<Guid>.NotFound($"File '{fileId}' was not found.");
+        }
+
+        try
+        {
+            var directory = Path.GetDirectoryName(targetPath);
+            if (!string.IsNullOrWhiteSpace(directory))
+            {
+                Directory.CreateDirectory(directory);
+            }
+
+            await File.WriteAllBytesAsync(targetPath, file.Content.Bytes, cancellationToken).ConfigureAwait(false);
+            return AppResult<Guid>.Success(file.Id);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            return AppResult<Guid>.FromException(ex, "Failed to save file content to disk.");
+        }
+    }
+}

--- a/Veriado.Services/Files/FileOperationsService.cs
+++ b/Veriado.Services/Files/FileOperationsService.cs
@@ -1,0 +1,206 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using Veriado.Application.Abstractions;
+using Veriado.Application.Common;
+using Veriado.Application.DTO;
+using Veriado.Application.UseCases.Files.ApplySystemMetadata;
+using Veriado.Application.UseCases.Files.ClearFileValidity;
+using Veriado.Application.UseCases.Files.ReplaceFileContent;
+using Veriado.Application.UseCases.Files.RenameFile;
+using Veriado.Application.UseCases.Files.SetFileReadOnly;
+using Veriado.Application.UseCases.Files.SetFileValidity;
+using Veriado.Application.UseCases.Maintenance;
+using Veriado.Contracts.Files;
+using Veriado.Mapping.AC;
+
+namespace Veriado.Services.Files;
+
+/// <summary>
+/// Implements orchestration helpers over file write operations.
+/// </summary>
+public sealed class FileOperationsService : IFileOperationsService
+{
+    private readonly IMediator _mediator;
+    private readonly WriteMappingPipeline _mappingPipeline;
+    private readonly IRequestContext _requestContext;
+
+    public FileOperationsService(IMediator mediator, WriteMappingPipeline mappingPipeline, IRequestContext requestContext)
+    {
+        _mediator = mediator ?? throw new ArgumentNullException(nameof(mediator));
+        _mappingPipeline = mappingPipeline ?? throw new ArgumentNullException(nameof(mappingPipeline));
+        _requestContext = requestContext ?? throw new ArgumentNullException(nameof(requestContext));
+    }
+
+    public async Task<AppResult<Guid>> RenameAsync(Guid fileId, string newName, CancellationToken cancellationToken)
+    {
+        var mapping = await _mappingPipeline.MapRenameAsync(fileId, newName, cancellationToken).ConfigureAwait(false);
+        if (!mapping.IsSuccess)
+        {
+            return ValidationFailure(mapping.Errors);
+        }
+
+        using var scope = BeginScope();
+        var result = await _mediator.Send(mapping.Data!, cancellationToken).ConfigureAwait(false);
+        return ToIdResult(result);
+    }
+
+    public async Task<AppResult<Guid>> UpdateMetadataAsync(UpdateMetadataRequest request, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        var mapping = await _mappingPipeline.MapUpdateMetadataAsync(request, cancellationToken).ConfigureAwait(false);
+        if (!mapping.IsSuccess)
+        {
+            return ValidationFailure(mapping.Errors);
+        }
+
+        using var scope = BeginScope();
+        AppResult<FileDto>? lastResult = null;
+        foreach (var command in mapping.Data!.Commands())
+        {
+            var commandResult = await _mediator.Send(command, cancellationToken).ConfigureAwait(false);
+            if (commandResult.IsFailure)
+            {
+                return ToIdResult(commandResult);
+            }
+
+            lastResult = commandResult;
+        }
+
+        if (lastResult is { } finalResult)
+        {
+            return ToIdResult(finalResult);
+        }
+
+        return AppResult<Guid>.Success(request.FileId);
+    }
+
+    public async Task<AppResult<Guid>> SetReadOnlyAsync(Guid fileId, bool isReadOnly, CancellationToken cancellationToken)
+    {
+        using var scope = BeginScope();
+        var result = await _mediator
+            .Send(new SetFileReadOnlyCommand(fileId, isReadOnly), cancellationToken)
+            .ConfigureAwait(false);
+        return ToIdResult(result);
+    }
+
+    public async Task<AppResult<Guid>> SetValidityAsync(Guid fileId, FileValidityDto validity, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(validity);
+        var request = new SetValidityRequest
+        {
+            FileId = fileId,
+            IssuedAt = validity.IssuedAtUtc,
+            ValidUntil = validity.ValidUntilUtc,
+            HasElectronicCopy = validity.HasElectronicCopy,
+            HasPhysicalCopy = validity.HasPhysicalCopy,
+        };
+
+        var mapping = await _mappingPipeline.MapSetValidityAsync(request, cancellationToken).ConfigureAwait(false);
+        if (!mapping.IsSuccess)
+        {
+            return ValidationFailure(mapping.Errors);
+        }
+
+        using var scope = BeginScope();
+        var result = await _mediator.Send(mapping.Data!, cancellationToken).ConfigureAwait(false);
+        return ToIdResult(result);
+    }
+
+    public async Task<AppResult<Guid>> ClearValidityAsync(Guid fileId, CancellationToken cancellationToken)
+    {
+        var mapping = await _mappingPipeline
+            .MapClearValidityAsync(new ClearValidityRequest { FileId = fileId }, cancellationToken)
+            .ConfigureAwait(false);
+        if (!mapping.IsSuccess)
+        {
+            return ValidationFailure(mapping.Errors);
+        }
+
+        using var scope = BeginScope();
+        var result = await _mediator.Send(mapping.Data!, cancellationToken).ConfigureAwait(false);
+        return ToIdResult(result);
+    }
+
+    public async Task<AppResult<Guid>> ReplaceContentAsync(Guid fileId, byte[] content, bool extractContent, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(content);
+        var request = new ReplaceContentRequest
+        {
+            FileId = fileId,
+            Content = content,
+        };
+
+        var mapping = await _mappingPipeline.MapReplaceContentAsync(request, cancellationToken).ConfigureAwait(false);
+        if (!mapping.IsSuccess)
+        {
+            return ValidationFailure(mapping.Errors);
+        }
+
+        using var scope = BeginScope();
+        var result = await _mediator.Send(mapping.Data!, cancellationToken).ConfigureAwait(false);
+        if (result.IsFailure)
+        {
+            return ToIdResult(result);
+        }
+
+        if (!extractContent)
+        {
+            var reindexResult = await _mediator
+                .Send(new ReindexFileCommand(fileId, extractContent: false), cancellationToken)
+                .ConfigureAwait(false);
+            if (reindexResult.IsFailure)
+            {
+                return ToIdResult(reindexResult);
+            }
+        }
+
+        return ToIdResult(result);
+    }
+
+    public async Task<AppResult<Guid>> ApplySystemMetadataAsync(Guid fileId, FileSystemMetadataDto metadata, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(metadata);
+        using var scope = BeginScope();
+        var command = new ApplySystemMetadataCommand(
+            fileId,
+            (Veriado.Domain.Metadata.FileAttributesFlags)metadata.Attributes,
+            metadata.CreatedUtc,
+            metadata.LastWriteUtc,
+            metadata.LastAccessUtc,
+            metadata.OwnerSid,
+            metadata.HardLinkCount,
+            metadata.AlternateDataStreamCount);
+
+        var result = await _mediator.Send(command, cancellationToken).ConfigureAwait(false);
+        return ToIdResult(result);
+    }
+    private AppResult<Guid> ValidationFailure(IReadOnlyList<ApiError> errors)
+    {
+        if (errors.Count == 0)
+        {
+            return AppResult<Guid>.Validation(Array.Empty<string>());
+        }
+
+        var messages = errors.Select(error =>
+            string.IsNullOrWhiteSpace(error.Target)
+                ? error.Message
+                : $"{error.Target}: {error.Message}").ToArray();
+        return AppResult<Guid>.Validation(messages);
+    }
+
+    private static AppResult<Guid> ToIdResult(AppResult<FileDto> result)
+    {
+        return result.IsSuccess
+            ? AppResult<Guid>.Success(result.Value.Id)
+            : AppResult<Guid>.Failure(result.Error);
+    }
+
+    private IDisposable BeginScope()
+    {
+        return AmbientRequestContext.Begin(Guid.NewGuid(), _requestContext.UserId, _requestContext.CorrelationId);
+    }
+}

--- a/Veriado.Services/Files/FileQueryService.cs
+++ b/Veriado.Services/Files/FileQueryService.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using Veriado.Application.Search.Abstractions;
+using Veriado.Application.UseCases.Queries;
+using Veriado.Application.UseCases.Queries.FileGrid;
+using Veriado.Contracts.Common;
+using Veriado.Contracts.Files;
+using Veriado.Services.Files.Models;
+
+namespace Veriado.Services.Files;
+
+/// <summary>
+/// Implements read-oriented orchestration over the file catalogue.
+/// </summary>
+public sealed class FileQueryService : IFileQueryService
+{
+    private readonly IMediator _mediator;
+    private readonly ISearchHistoryService _historyService;
+    private readonly ISearchFavoritesService _favoritesService;
+
+    public FileQueryService(
+        IMediator mediator,
+        ISearchHistoryService historyService,
+        ISearchFavoritesService favoritesService)
+    {
+        _mediator = mediator ?? throw new ArgumentNullException(nameof(mediator));
+        _historyService = historyService ?? throw new ArgumentNullException(nameof(historyService));
+        _favoritesService = favoritesService ?? throw new ArgumentNullException(nameof(favoritesService));
+    }
+
+    public Task<PageResult<FileSummaryDto>> GetGridAsync(FileGridQuery query, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        return _mediator.Send(query, cancellationToken);
+    }
+
+    public Task<FileDetailDto?> GetDetailAsync(Guid fileId, CancellationToken cancellationToken)
+    {
+        return _mediator.Send(new GetFileDetailQuery(fileId), cancellationToken);
+    }
+
+    public Task<IReadOnlyList<SearchHistoryEntry>> GetSearchHistoryAsync(int take, CancellationToken cancellationToken)
+    {
+        return _historyService.GetRecentAsync(take, cancellationToken);
+    }
+
+    public Task<IReadOnlyList<SearchFavoriteItem>> GetFavoritesAsync(CancellationToken cancellationToken)
+    {
+        return _favoritesService.GetAllAsync(cancellationToken);
+    }
+
+    public Task AddFavoriteAsync(SearchFavoriteDefinition favorite, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(favorite);
+        return _favoritesService.AddAsync(favorite.Name, favorite.MatchQuery, favorite.QueryText, favorite.IsFuzzy, cancellationToken);
+    }
+
+    public Task RemoveFavoriteAsync(Guid favoriteId, CancellationToken cancellationToken)
+    {
+        return _favoritesService.RemoveAsync(favoriteId, cancellationToken);
+    }
+}

--- a/Veriado.Services/Files/IFileContentService.cs
+++ b/Veriado.Services/Files/IFileContentService.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Veriado.Application.Common;
+using Veriado.Application.DTO;
+
+namespace Veriado.Services.Files;
+
+/// <summary>
+/// Provides helpers for accessing and persisting file binary content.
+/// </summary>
+public interface IFileContentService
+{
+    Task<(FileDto Meta, byte[] Content)?> GetContentAsync(Guid fileId, CancellationToken cancellationToken);
+
+    Task<AppResult<Guid>> SaveContentToDiskAsync(Guid fileId, string targetPath, CancellationToken cancellationToken);
+}

--- a/Veriado.Services/Files/IFileOperationsService.cs
+++ b/Veriado.Services/Files/IFileOperationsService.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Veriado.Application.Common;
+using Veriado.Contracts.Files;
+
+namespace Veriado.Services.Files;
+
+/// <summary>
+/// Provides orchestration helpers for file mutations.
+/// </summary>
+public interface IFileOperationsService
+{
+    Task<AppResult<Guid>> RenameAsync(Guid fileId, string newName, CancellationToken cancellationToken);
+
+    Task<AppResult<Guid>> UpdateMetadataAsync(UpdateMetadataRequest request, CancellationToken cancellationToken);
+
+    Task<AppResult<Guid>> SetReadOnlyAsync(Guid fileId, bool isReadOnly, CancellationToken cancellationToken);
+
+    Task<AppResult<Guid>> SetValidityAsync(Guid fileId, FileValidityDto validity, CancellationToken cancellationToken);
+
+    Task<AppResult<Guid>> ClearValidityAsync(Guid fileId, CancellationToken cancellationToken);
+
+    Task<AppResult<Guid>> ReplaceContentAsync(Guid fileId, byte[] content, bool extractContent, CancellationToken cancellationToken);
+
+    Task<AppResult<Guid>> ApplySystemMetadataAsync(Guid fileId, FileSystemMetadataDto metadata, CancellationToken cancellationToken);
+}

--- a/Veriado.Services/Files/IFileQueryService.cs
+++ b/Veriado.Services/Files/IFileQueryService.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Veriado.Application.Search.Abstractions;
+using Veriado.Application.UseCases.Queries.FileGrid;
+using Veriado.Contracts.Common;
+using Veriado.Contracts.Files;
+using Veriado.Services.Files.Models;
+
+namespace Veriado.Services.Files;
+
+/// <summary>
+/// Provides read-oriented orchestration services over the file catalogue.
+/// </summary>
+public interface IFileQueryService
+{
+    Task<PageResult<FileSummaryDto>> GetGridAsync(FileGridQuery query, CancellationToken cancellationToken);
+
+    Task<FileDetailDto?> GetDetailAsync(Guid fileId, CancellationToken cancellationToken);
+
+    Task<IReadOnlyList<SearchHistoryEntry>> GetSearchHistoryAsync(int take, CancellationToken cancellationToken);
+
+    Task<IReadOnlyList<SearchFavoriteItem>> GetFavoritesAsync(CancellationToken cancellationToken);
+
+    Task AddFavoriteAsync(SearchFavoriteDefinition favorite, CancellationToken cancellationToken);
+
+    Task RemoveFavoriteAsync(Guid favoriteId, CancellationToken cancellationToken);
+}

--- a/Veriado.Services/Files/Models/SearchFavoriteDefinition.cs
+++ b/Veriado.Services/Files/Models/SearchFavoriteDefinition.cs
@@ -1,0 +1,6 @@
+namespace Veriado.Services.Files.Models;
+
+/// <summary>
+/// Represents the information required to create a saved search favourite.
+/// </summary>
+public sealed record SearchFavoriteDefinition(string Name, string MatchQuery, string? QueryText, bool IsFuzzy);

--- a/Veriado.Services/Import/IImportService.cs
+++ b/Veriado.Services/Import/IImportService.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Veriado.Contracts.Common;
+using Veriado.Contracts.Files;
+using Veriado.Services.Import.Models;
+
+namespace Veriado.Services.Import;
+
+/// <summary>
+/// Provides high-level orchestration for importing files and folders through the application layer.
+/// </summary>
+public interface IImportService
+{
+    /// <summary>
+    /// Imports a single file described by the supplied request contract.
+    /// </summary>
+    /// <param name="request">The create-file request payload.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>An API response containing the created file identifier.</returns>
+    Task<ApiResponse<Guid>> ImportFileAsync(CreateFileRequest request, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Imports all files contained in the specified folder using the provided options.
+    /// </summary>
+    /// <param name="request">The folder import request.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>An API response containing the aggregated batch result.</returns>
+    Task<ApiResponse<ImportBatchResult>> ImportFolderAsync(ImportFolderRequest request, CancellationToken cancellationToken);
+}

--- a/Veriado.Services/Import/ImportService.cs
+++ b/Veriado.Services/Import/ImportService.cs
@@ -1,0 +1,333 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using Veriado.Application.Abstractions;
+using Veriado.Application.Common;
+using Veriado.Application.UseCases.Maintenance;
+using Veriado.Contracts.Common;
+using Veriado.Contracts.Files;
+using Veriado.Mapping.AC;
+using Veriado.Services.Import.Internal;
+using Veriado.Services.Import.Models;
+
+namespace Veriado.Services.Import;
+
+/// <summary>
+/// Coordinates high-level import workflows against the application layer.
+/// </summary>
+public sealed class ImportService : IImportService
+{
+    private readonly IMediator _mediator;
+    private readonly WriteMappingPipeline _mappingPipeline;
+    private readonly IClock _clock;
+    private readonly IRequestContext _requestContext;
+    private readonly ILogger<ImportService> _logger;
+
+    public ImportService(
+        IMediator mediator,
+        WriteMappingPipeline mappingPipeline,
+        IClock clock,
+        IRequestContext requestContext,
+        ILogger<ImportService> logger)
+    {
+        _mediator = mediator ?? throw new ArgumentNullException(nameof(mediator));
+        _mappingPipeline = mappingPipeline ?? throw new ArgumentNullException(nameof(mappingPipeline));
+        _clock = clock ?? throw new ArgumentNullException(nameof(clock));
+        _requestContext = requestContext ?? throw new ArgumentNullException(nameof(requestContext));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResponse<Guid>> ImportFileAsync(CreateFileRequest request, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var normalized = NormalizeRequest(request);
+        var descriptor = string.IsNullOrWhiteSpace(normalized.Name) ? normalized.Extension : normalized.Name;
+        return await ImportFileInternalAsync(normalized, extractContent: true, descriptor, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResponse<ImportBatchResult>> ImportFolderAsync(ImportFolderRequest request, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (string.IsNullOrWhiteSpace(request.FolderPath) || !Directory.Exists(request.FolderPath))
+        {
+            var error = new ApiError("folder_not_found", $"Folder '{request.FolderPath}' was not found.", nameof(request.FolderPath));
+            return ApiResponse<ImportBatchResult>.Failure(error);
+        }
+
+        var searchPattern = string.IsNullOrWhiteSpace(request.SearchPattern) ? "*" : request.SearchPattern!;
+        var searchOption = request.Recursive ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly;
+
+        var errors = new ConcurrentBag<ImportError>();
+        var total = 0;
+        var succeeded = 0;
+
+        try
+        {
+            var parallelOptions = new ParallelOptions
+            {
+                CancellationToken = cancellationToken,
+                MaxDegreeOfParallelism = request.MaxDegreeOfParallelism > 0
+                    ? request.MaxDegreeOfParallelism
+                    : 1,
+            };
+
+            await Parallel.ForEachAsync(
+                Directory.EnumerateFiles(request.FolderPath, searchPattern, searchOption),
+                parallelOptions,
+                async (filePath, token) =>
+                {
+                    Interlocked.Increment(ref total);
+
+                    try
+                    {
+                        var createRequest = await CreateRequestFromFileAsync(filePath, request, token).ConfigureAwait(false);
+                        var response = await ImportFileInternalAsync(createRequest, request.ExtractContent, filePath, token)
+                            .ConfigureAwait(false);
+
+                        if (response.IsSuccess)
+                        {
+                            Interlocked.Increment(ref succeeded);
+                            return;
+                        }
+
+                        RecordErrors(filePath, response.Errors, errors);
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        throw;
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogError(ex, "Failed to import file {FilePath}", filePath);
+                        errors.Add(new ImportError(filePath, "unexpected_error", ex.Message));
+                    }
+                }).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            errors.Add(new ImportError(request.FolderPath, "Canceled", "The import operation was canceled."));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Folder import failed for {FolderPath}", request.FolderPath);
+            errors.Add(new ImportError(request.FolderPath, "unexpected_error", ex.Message));
+        }
+
+        var processed = total;
+        var failed = Math.Max(0, processed - succeeded);
+        var batchResult = new ImportBatchResult(processed, succeeded, failed, errors.ToArray());
+        return ApiResponse<ImportBatchResult>.Success(batchResult);
+    }
+
+    private async Task<ApiResponse<Guid>> ImportFileInternalAsync(
+        CreateFileRequest request,
+        bool extractContent,
+        string? descriptor,
+        CancellationToken cancellationToken)
+    {
+        var mapping = await _mappingPipeline.MapCreateAsync(request, cancellationToken).ConfigureAwait(false);
+        if (!mapping.IsSuccess)
+        {
+            LogApiErrors(descriptor, mapping.Errors);
+            return ApiResponse<Guid>.Failure(mapping.Errors);
+        }
+
+        using var scope = BeginScope();
+
+        var mapped = mapping.Data!;
+        var createResult = await _mediator.Send(mapped.Command, cancellationToken).ConfigureAwait(false);
+        if (createResult.IsFailure)
+        {
+            var apiError = ConvertAppError(createResult.Error);
+            LogApiError(descriptor, apiError);
+            return ApiResponse<Guid>.Failure(apiError);
+        }
+
+        var fileId = createResult.Value;
+
+        foreach (var followUp in mapped.BuildFollowUpCommands(fileId))
+        {
+            var followUpResult = await _mediator.Send(followUp, cancellationToken).ConfigureAwait(false);
+            if (followUpResult.IsFailure)
+            {
+                var apiError = ConvertAppError(followUpResult.Error);
+                LogApiError(descriptor, apiError);
+                return ApiResponse<Guid>.Failure(apiError);
+            }
+        }
+
+        if (!extractContent)
+        {
+            var reindexResult = await _mediator
+                .Send(new ReindexFileCommand(fileId, extractContent: false), cancellationToken)
+                .ConfigureAwait(false);
+            if (reindexResult.IsFailure)
+            {
+                var apiError = ConvertAppError(reindexResult.Error);
+                LogApiError(descriptor, apiError);
+                return ApiResponse<Guid>.Failure(apiError);
+            }
+        }
+
+        return ApiResponse<Guid>.Success(fileId);
+    }
+
+    private async Task<CreateFileRequest> CreateRequestFromFileAsync(
+        string filePath,
+        ImportFolderRequest options,
+        CancellationToken cancellationToken)
+    {
+        var bytes = await File.ReadAllBytesAsync(filePath, cancellationToken).ConfigureAwait(false);
+        var extensionWithDot = Path.GetExtension(filePath);
+        var extension = string.IsNullOrWhiteSpace(extensionWithDot) ? string.Empty : extensionWithDot.TrimStart('.');
+        var name = Path.GetFileNameWithoutExtension(filePath);
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            name = Path.GetFileName(filePath);
+        }
+
+        var author = string.IsNullOrWhiteSpace(options.DefaultAuthor) ? string.Empty : options.DefaultAuthor;
+        FileSystemMetadataDto? systemMetadata = null;
+        var isReadOnly = false;
+
+        try
+        {
+            var info = new FileInfo(filePath);
+            info.Refresh();
+            systemMetadata = new FileSystemMetadataDto(
+                (int)info.Attributes,
+                CoerceToUtc(info.CreationTimeUtc),
+                CoerceToUtc(info.LastWriteTimeUtc),
+                CoerceToUtc(info.LastAccessTimeUtc),
+                ownerSid: null,
+                HardLinkCount: null,
+                AlternateDataStreamCount: null);
+            isReadOnly = info.IsReadOnly;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or NotSupportedException)
+        {
+            _logger.LogDebug(ex, "Failed to capture file metadata for {FilePath}", filePath);
+        }
+
+        return NormalizeRequest(new CreateFileRequest
+        {
+            Name = name,
+            Extension = extension,
+            Mime = MimeMap.GetMimeType(extension),
+            Author = author,
+            Content = bytes,
+            SystemMetadata = systemMetadata,
+            ExtendedMetadata = null,
+            IsReadOnly = isReadOnly,
+        });
+    }
+
+    private CreateFileRequest NormalizeRequest(CreateFileRequest request)
+    {
+        var normalizedExtension = (request.Extension ?? string.Empty).TrimStart('.');
+        var mime = string.IsNullOrWhiteSpace(request.Mime)
+            ? MimeMap.GetMimeType(normalizedExtension)
+            : request.Mime!;
+
+        return new CreateFileRequest
+        {
+            Name = request.Name ?? string.Empty,
+            Extension = normalizedExtension,
+            Mime = mime,
+            Author = request.Author ?? string.Empty,
+            Content = request.Content ?? Array.Empty<byte>(),
+            MaxContentLength = request.MaxContentLength,
+            SystemMetadata = request.SystemMetadata,
+            ExtendedMetadata = request.ExtendedMetadata,
+            IsReadOnly = request.IsReadOnly,
+        };
+    }
+
+    private void RecordErrors(string filePath, IReadOnlyList<ApiError> errors, ConcurrentBag<ImportError> sink)
+    {
+        foreach (var error in errors)
+        {
+            sink.Add(new ImportError(filePath, error.Code, error.Message));
+            _logger.LogError("Failed to import file {FilePath}: {ErrorCode} - {Message}", filePath, error.Code, error.Message);
+        }
+    }
+
+    private void LogApiErrors(string? descriptor, IReadOnlyList<ApiError> errors)
+    {
+        foreach (var error in errors)
+        {
+            LogApiError(descriptor, error);
+        }
+    }
+
+    private void LogApiError(string? descriptor, ApiError error)
+    {
+        if (!string.IsNullOrWhiteSpace(descriptor))
+        {
+            _logger.LogError("Import failed for {Descriptor}: {ErrorCode} - {Message}", descriptor, error.Code, error.Message);
+            return;
+        }
+
+        _logger.LogError("Import failed: {ErrorCode} - {Message}", error.Code, error.Message);
+    }
+
+    private static ApiError ConvertAppError(AppError error)
+    {
+        var code = error.Code switch
+        {
+            ErrorCode.NotFound => "not_found",
+            ErrorCode.Conflict => "conflict",
+            ErrorCode.Validation => "validation_error",
+            ErrorCode.Forbidden => "forbidden",
+            ErrorCode.TooLarge => "payload_too_large",
+            _ => "unexpected_error",
+        };
+
+        IReadOnlyDictionary<string, string[]>? details = null;
+        if (error.Details is { Count: > 0 })
+        {
+            details = new Dictionary<string, string[]>
+            {
+                ["messages"] = error.Details.ToArray(),
+            };
+        }
+
+        return new ApiError(code, error.Message, null, details);
+    }
+
+    private IDisposable BeginScope()
+    {
+        return AmbientRequestContext.Begin(Guid.NewGuid(), _requestContext.UserId, _requestContext.CorrelationId);
+    }
+
+    private DateTimeOffset CoerceToUtc(DateTime value)
+    {
+        if (value == DateTime.MinValue || value == DateTime.MaxValue)
+        {
+            return _clock.UtcNow;
+        }
+
+        if (value.Kind == DateTimeKind.Unspecified)
+        {
+            value = DateTime.SpecifyKind(value, DateTimeKind.Utc);
+        }
+        else if (value.Kind == DateTimeKind.Local)
+        {
+            value = value.ToUniversalTime();
+        }
+
+        return new DateTimeOffset(value, TimeSpan.Zero);
+    }
+}

--- a/Veriado.Services/Import/Internal/MimeMap.cs
+++ b/Veriado.Services/Import/Internal/MimeMap.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.Generic;
+
+namespace Veriado.Services.Import.Internal;
+
+/// <summary>
+/// Provides a simple file extension to MIME type mapping for folder imports.
+/// </summary>
+internal static class MimeMap
+{
+    private static readonly IReadOnlyDictionary<string, string> _map = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+    {
+        ["txt"] = "text/plain",
+        ["md"] = "text/markdown",
+        ["csv"] = "text/csv",
+        ["json"] = "application/json",
+        ["xml"] = "application/xml",
+        ["pdf"] = "application/pdf",
+        ["doc"] = "application/msword",
+        ["docx"] = "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        ["xls"] = "application/vnd.ms-excel",
+        ["xlsx"] = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        ["ppt"] = "application/vnd.ms-powerpoint",
+        ["pptx"] = "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+        ["png"] = "image/png",
+        ["jpg"] = "image/jpeg",
+        ["jpeg"] = "image/jpeg",
+        ["gif"] = "image/gif",
+        ["bmp"] = "image/bmp",
+        ["tif"] = "image/tiff",
+        ["tiff"] = "image/tiff",
+        ["rtf"] = "application/rtf",
+        ["zip"] = "application/zip",
+        ["7z"] = "application/x-7z-compressed",
+        ["rar"] = "application/vnd.rar",
+        ["eml"] = "message/rfc822",
+    };
+
+    /// <summary>
+    /// Gets the MIME type for the supplied extension, falling back to <c>application/octet-stream</c>.
+    /// </summary>
+    /// <param name="extension">The extension without a leading dot.</param>
+    /// <returns>The matching MIME type.</returns>
+    public static string GetMimeType(string? extension)
+    {
+        if (string.IsNullOrWhiteSpace(extension))
+        {
+            return "application/octet-stream";
+        }
+
+        var normalized = extension.TrimStart('.');
+        if (_map.TryGetValue(normalized, out var mime))
+        {
+            return mime;
+        }
+
+        return string.Concat("application/", normalized);
+    }
+}

--- a/Veriado.Services/Import/Models/ImportBatchResult.cs
+++ b/Veriado.Services/Import/Models/ImportBatchResult.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+
+namespace Veriado.Services.Import.Models;
+
+/// <summary>
+/// Represents the aggregated outcome of a folder import operation.
+/// </summary>
+public sealed class ImportBatchResult
+{
+    public ImportBatchResult(int total, int succeeded, int failed, IReadOnlyList<ImportError> errors)
+    {
+        Total = total;
+        Succeeded = succeeded;
+        Failed = failed;
+        Errors = errors;
+    }
+
+    /// <summary>
+    /// Gets the total number of files processed.
+    /// </summary>
+    public int Total { get; }
+
+    /// <summary>
+    /// Gets the number of files imported successfully.
+    /// </summary>
+    public int Succeeded { get; }
+
+    /// <summary>
+    /// Gets the number of files that failed to import.
+    /// </summary>
+    public int Failed { get; }
+
+    /// <summary>
+    /// Gets the collection of errors captured during the import.
+    /// </summary>
+    public IReadOnlyList<ImportError> Errors { get; }
+}

--- a/Veriado.Services/Import/Models/ImportError.cs
+++ b/Veriado.Services/Import/Models/ImportError.cs
@@ -1,0 +1,6 @@
+namespace Veriado.Services.Import.Models;
+
+/// <summary>
+/// Represents a failure encountered while importing a file.
+/// </summary>
+public sealed record ImportError(string FilePath, string Code, string Message);

--- a/Veriado.Services/Import/Models/ImportFolderRequest.cs
+++ b/Veriado.Services/Import/Models/ImportFolderRequest.cs
@@ -1,0 +1,39 @@
+using System;
+
+namespace Veriado.Services.Import.Models;
+
+/// <summary>
+/// Describes folder import settings including recursion and concurrency limits.
+/// </summary>
+public sealed class ImportFolderRequest
+{
+    /// <summary>
+    /// Gets or sets the absolute folder path that should be scanned for files.
+    /// </summary>
+    public string FolderPath { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the default author applied when file metadata does not specify one.
+    /// </summary>
+    public string DefaultAuthor { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether binary content extraction should be performed.
+    /// </summary>
+    public bool ExtractContent { get; init; } = true;
+
+    /// <summary>
+    /// Gets or sets the maximum number of concurrent file imports.
+    /// </summary>
+    public int MaxDegreeOfParallelism { get; init; } = 4;
+
+    /// <summary>
+    /// Gets or sets the search pattern applied when enumerating files.
+    /// </summary>
+    public string? SearchPattern { get; init; } = "*";
+
+    /// <summary>
+    /// Gets or sets a value indicating whether sub-folders should be traversed.
+    /// </summary>
+    public bool Recursive { get; init; } = true;
+}

--- a/Veriado.Services/Maintenance/IMaintenanceService.cs
+++ b/Veriado.Services/Maintenance/IMaintenanceService.cs
@@ -1,0 +1,19 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Veriado.Application.Common;
+
+namespace Veriado.Services.Maintenance;
+
+/// <summary>
+/// Provides orchestration helpers for infrastructure and index maintenance tasks.
+/// </summary>
+public interface IMaintenanceService
+{
+    Task InitializeAsync(CancellationToken cancellationToken);
+
+    Task<AppResult<int>> VerifyAndRepairAsync(bool forceRepair, bool extractContent, CancellationToken cancellationToken);
+
+    Task<AppResult<int>> RunVacuumAndOptimizeAsync(CancellationToken cancellationToken);
+
+    Task<AppResult<int>> ReindexAfterSchemaUpgradeAsync(int targetSchemaVersion, bool extractContent, bool allowDeferredIndexing, CancellationToken cancellationToken);
+}

--- a/Veriado.Services/Maintenance/MaintenanceService.cs
+++ b/Veriado.Services/Maintenance/MaintenanceService.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using Veriado.Application.Common;
+using Veriado.Application.UseCases.Maintenance;
+using Veriado.Infrastructure.DependencyInjection;
+
+namespace Veriado.Services.Maintenance;
+
+/// <summary>
+/// Implements orchestration over database and index maintenance workflows.
+/// </summary>
+public sealed class MaintenanceService : IMaintenanceService
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly IMediator _mediator;
+
+    public MaintenanceService(IServiceProvider serviceProvider, IMediator mediator)
+    {
+        _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
+        _mediator = mediator ?? throw new ArgumentNullException(nameof(mediator));
+    }
+
+    public async Task InitializeAsync(CancellationToken cancellationToken)
+    {
+        await _serviceProvider.InitializeInfrastructureAsync(cancellationToken).ConfigureAwait(false);
+        await RunVacuumAndOptimizeAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    public Task<AppResult<int>> VerifyAndRepairAsync(bool forceRepair, bool extractContent, CancellationToken cancellationToken)
+    {
+        var command = new VerifyAndRepairFulltextCommand(extractContent, forceRepair);
+        return _mediator.Send(command, cancellationToken);
+    }
+
+    public Task<AppResult<int>> RunVacuumAndOptimizeAsync(CancellationToken cancellationToken)
+    {
+        return _mediator.Send(new VacuumAndOptimizeDatabaseCommand(), cancellationToken);
+    }
+
+    public Task<AppResult<int>> ReindexAfterSchemaUpgradeAsync(int targetSchemaVersion, bool extractContent, bool allowDeferredIndexing, CancellationToken cancellationToken)
+    {
+        var command = new ReindexCorpusAfterSchemaUpgradeCommand(targetSchemaVersion, extractContent, allowDeferredIndexing);
+        return _mediator.Send(command, cancellationToken);
+    }
+}

--- a/Veriado.Services/Veriado.Services.csproj
+++ b/Veriado.Services/Veriado.Services.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>12.0</LangVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../Veriado.Application/Veriado.Application.csproj" />
+    <ProjectReference Include="../Veriado.Contracts/Veriado.Contracts.csproj" />
+    <ProjectReference Include="../Veriado.Mapping/Veriado.Mapping.csproj" />
+    <ProjectReference Include="../Veriado.Infrastructure/Veriado.Infrastructure.csproj" />
+  </ItemGroup>
+</Project>

--- a/Veriado.sln
+++ b/Veriado.sln
@@ -14,6 +14,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Veriado.Contracts", "Veriad
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Veriado.Mapping", "Veriado.Mapping\Veriado.Mapping.csproj", "{66A7082C-0D5F-4A1C-82B5-C0D878DDCAE2}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Veriado.Services", "Veriado.Services\Veriado.Services.csproj", "{62B8ABC0-5DB1-4F84-912F-6E9250AB8954}"
+EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Source", "Source", "{02EA681E-C7D8-13C7-8484-4AC65E1B71E8}"
 EndProject
 Global
@@ -100,10 +102,22 @@ Global
 		{66A7082C-0D5F-4A1C-82B5-C0D878DDCAE2}.Release|ARM64.ActiveCfg = Release|Any CPU
 		{66A7082C-0D5F-4A1C-82B5-C0D878DDCAE2}.Release|ARM64.Build.0 = Release|Any CPU
 		{66A7082C-0D5F-4A1C-82B5-C0D878DDCAE2}.Release|x64.ActiveCfg = Release|Any CPU
-		{66A7082C-0D5F-4A1C-82B5-C0D878DDCAE2}.Release|x64.Build.0 = Release|Any CPU
-		{66A7082C-0D5F-4A1C-82B5-C0D878DDCAE2}.Release|x86.ActiveCfg = Release|Any CPU
-		{66A7082C-0D5F-4A1C-82B5-C0D878DDCAE2}.Release|x86.Build.0 = Release|Any CPU
-	EndGlobalSection
+                {66A7082C-0D5F-4A1C-82B5-C0D878DDCAE2}.Release|x64.Build.0 = Release|Any CPU
+                {66A7082C-0D5F-4A1C-82B5-C0D878DDCAE2}.Release|x86.ActiveCfg = Release|Any CPU
+                {66A7082C-0D5F-4A1C-82B5-C0D878DDCAE2}.Release|x86.Build.0 = Release|Any CPU
+                {62B8ABC0-5DB1-4F84-912F-6E9250AB8954}.Debug|ARM64.ActiveCfg = Debug|Any CPU
+                {62B8ABC0-5DB1-4F84-912F-6E9250AB8954}.Debug|ARM64.Build.0 = Debug|Any CPU
+                {62B8ABC0-5DB1-4F84-912F-6E9250AB8954}.Debug|x64.ActiveCfg = Debug|Any CPU
+                {62B8ABC0-5DB1-4F84-912F-6E9250AB8954}.Debug|x64.Build.0 = Debug|Any CPU
+                {62B8ABC0-5DB1-4F84-912F-6E9250AB8954}.Debug|x86.ActiveCfg = Debug|Any CPU
+                {62B8ABC0-5DB1-4F84-912F-6E9250AB8954}.Debug|x86.Build.0 = Debug|Any CPU
+                {62B8ABC0-5DB1-4F84-912F-6E9250AB8954}.Release|ARM64.ActiveCfg = Release|Any CPU
+                {62B8ABC0-5DB1-4F84-912F-6E9250AB8954}.Release|ARM64.Build.0 = Release|Any CPU
+                {62B8ABC0-5DB1-4F84-912F-6E9250AB8954}.Release|x64.ActiveCfg = Release|Any CPU
+                {62B8ABC0-5DB1-4F84-912F-6E9250AB8954}.Release|x64.Build.0 = Release|Any CPU
+                {62B8ABC0-5DB1-4F84-912F-6E9250AB8954}.Release|x86.ActiveCfg = Release|Any CPU
+                {62B8ABC0-5DB1-4F84-912F-6E9250AB8954}.Release|x86.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
@@ -112,9 +126,10 @@ Global
 		{86B8F682-4E4A-4E11-804A-3513C85B8ADB} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 		{6FA76EE3-8C55-4176-AF31-CA4AD7DA6777} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 		{A238B7DB-438E-4502-A0E1-068306307A3A} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
-		{E3CF91DC-9121-404E-81CA-1BFED5C38420} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
-		{66A7082C-0D5F-4A1C-82B5-C0D878DDCAE2} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
-	EndGlobalSection
+                {E3CF91DC-9121-404E-81CA-1BFED5C38420} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+                {66A7082C-0D5F-4A1C-82B5-C0D878DDCAE2} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+                {62B8ABC0-5DB1-4F84-912F-6E9250AB8954} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+        EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {015A55A8-BE3A-4015-BDD2-CBAE0F721F7E}
 	EndGlobalSection


### PR DESCRIPTION
## Summary
- add scoped service registrations for orchestration helpers via `AddVeriadoServices`
- implement import orchestration with folder batching, ambient request scopes, and error aggregation
- add file query, operations, and content services that delegate to existing MediatR use cases
- expose maintenance and health services to invoke infrastructure initialization, verification, and diagnostics

## Testing
- `dotnet build` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68d021bd81248326a3a1558dba698b47