### PR TITLE
Fix FileQueryService contract mapping and adjust import parameters

### DIFF
--- a/Veriado.Services/Files/FileQueryService.cs
+++ b/Veriado.Services/Files/FileQueryService.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Threading;
 using System.Threading.Tasks;
 using MediatR;
@@ -9,6 +10,10 @@ using Veriado.Application.UseCases.Queries.FileGrid;
 using Veriado.Contracts.Common;
 using Veriado.Contracts.Files;
 using Veriado.Services.Files.Models;
+
+using AppFileDetailDto = Veriado.Application.DTO.FileDetailDto;
+using AppFileSystemMetadataDto = Veriado.Application.DTO.FileSystemMetadataDto;
+using AppFileValidityDto = Veriado.Application.DTO.FileValidityDto;
 
 namespace Veriado.Services.Files;
 
@@ -37,9 +42,10 @@ public sealed class FileQueryService : IFileQueryService
         return _mediator.Send(query, cancellationToken);
     }
 
-    public Task<FileDetailDto?> GetDetailAsync(Guid fileId, CancellationToken cancellationToken)
+    public async Task<FileDetailDto?> GetDetailAsync(Guid fileId, CancellationToken cancellationToken)
     {
-        return _mediator.Send(new GetFileDetailQuery(fileId), cancellationToken);
+        var detail = await _mediator.Send(new GetFileDetailQuery(fileId), cancellationToken).ConfigureAwait(false);
+        return detail is null ? null : MapToContract(detail);
     }
 
     public Task<IReadOnlyList<SearchHistoryEntry>> GetSearchHistoryAsync(int take, CancellationToken cancellationToken)
@@ -61,5 +67,124 @@ public sealed class FileQueryService : IFileQueryService
     public Task RemoveFavoriteAsync(Guid favoriteId, CancellationToken cancellationToken)
     {
         return _favoritesService.RemoveAsync(favoriteId, cancellationToken);
+    }
+
+    private static FileDetailDto MapToContract(AppFileDetailDto detail)
+    {
+        var file = detail.File;
+
+        return new FileDetailDto
+        {
+            Id = file.Id,
+            Name = file.Name,
+            Extension = file.Extension,
+            Mime = file.Mime,
+            Author = file.Author,
+            Size = file.SizeBytes,
+            CreatedUtc = file.CreatedUtc,
+            LastModifiedUtc = file.LastModifiedUtc,
+            IsReadOnly = file.IsReadOnly,
+            Version = file.Version,
+            Content = new FileContentDto(string.Empty, file.SizeBytes),
+            SystemMetadata = MapSystemMetadata(detail.SystemMetadata),
+            ExtendedMetadata = MapExtendedMetadata(detail.ExtendedMetadata),
+            Validity = MapValidity(file.Validity),
+        };
+    }
+
+    private static FileSystemMetadataDto MapSystemMetadata(AppFileSystemMetadataDto metadata)
+    {
+        return new FileSystemMetadataDto(
+            (int)metadata.Attributes,
+            metadata.CreatedUtc,
+            metadata.LastWriteUtc,
+            metadata.LastAccessUtc,
+            metadata.OwnerSid,
+            metadata.HardLinkCount,
+            metadata.AlternateDataStreamCount);
+    }
+
+    private static FileValidityDto? MapValidity(AppFileValidityDto? validity)
+    {
+        if (validity is null)
+        {
+            return null;
+        }
+
+        return new FileValidityDto(
+            validity.IssuedAtUtc,
+            validity.ValidUntilUtc,
+            validity.HasPhysicalCopy,
+            validity.HasElectronicCopy);
+    }
+
+    private static IReadOnlyList<ExtendedMetadataItemDto> MapExtendedMetadata(IReadOnlyDictionary<string, string?> metadata)
+    {
+        if (metadata is null || metadata.Count == 0)
+        {
+            return Array.Empty<ExtendedMetadataItemDto>();
+        }
+
+        var items = new List<ExtendedMetadataItemDto>(metadata.Count);
+        foreach (var pair in metadata)
+        {
+            if (!TryParsePropertyKey(pair.Key, out var formatId, out var propertyId))
+            {
+                continue;
+            }
+
+            var valueDto = pair.Value is null
+                ? new MetadataValueDto { Kind = MetadataValueDtoKind.Null }
+                : new MetadataValueDto
+                {
+                    Kind = MetadataValueDtoKind.String,
+                    StringValue = pair.Value,
+                };
+
+            items.Add(new ExtendedMetadataItemDto
+            {
+                FormatId = formatId,
+                PropertyId = propertyId,
+                Value = valueDto,
+                Remove = false,
+            });
+        }
+
+        if (items.Count == 0)
+        {
+            return Array.Empty<ExtendedMetadataItemDto>();
+        }
+
+        return items;
+    }
+
+    private static bool TryParsePropertyKey(string key, out Guid formatId, out int propertyId)
+    {
+        formatId = Guid.Empty;
+        propertyId = 0;
+
+        if (string.IsNullOrWhiteSpace(key))
+        {
+            return false;
+        }
+
+        var parts = key.Split('/', 2);
+        if (parts.Length != 2)
+        {
+            return false;
+        }
+
+        if (!Guid.TryParse(parts[0], out formatId))
+        {
+            return false;
+        }
+
+        if (!int.TryParse(parts[1], NumberStyles.Integer, CultureInfo.InvariantCulture, out propertyId))
+        {
+            formatId = Guid.Empty;
+            return false;
+        }
+
+        return true;
     }
 }

--- a/Veriado.Services/Import/ImportService.cs
+++ b/Veriado.Services/Import/ImportService.cs
@@ -171,7 +171,7 @@ public sealed class ImportService : IImportService
         if (!extractContent)
         {
             var reindexResult = await _mediator
-                .Send(new ReindexFileCommand(fileId, extractContent: false), cancellationToken)
+                .Send(new ReindexFileCommand(fileId, ExtractContent: false), cancellationToken)
                 .ConfigureAwait(false);
             if (reindexResult.IsFailure)
             {
@@ -211,7 +211,7 @@ public sealed class ImportService : IImportService
                 CoerceToUtc(info.CreationTimeUtc),
                 CoerceToUtc(info.LastWriteTimeUtc),
                 CoerceToUtc(info.LastAccessTimeUtc),
-                ownerSid: null,
+                OwnerSid: null,
                 HardLinkCount: null,
                 AlternateDataStreamCount: null);
             isReadOnly = info.IsReadOnly;


### PR DESCRIPTION
## Summary
- map the application detail DTO returned by GetFileDetailQuery to the contracts model and expand metadata conversion helpers
- fix ImportService named arguments to match FileSystemMetadataDto and ReindexFileCommand signatures

## Testing
- dotnet build *(fails: dotnet command is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d02f0a31f88326aa71d7e9701e4a5a