### PR TITLE
Implement MVVM shell for WinUI host

### DIFF
--- a/Veriado.WinUI/App.xaml.cs
+++ b/Veriado.WinUI/App.xaml.cs
@@ -1,23 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Runtime.InteropServices.WindowsRuntime;
+// BEGIN CHANGE Veriado.WinUI/App.xaml.cs
+using System;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.UI.Xaml;
-using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml.Controls.Primitives;
-using Microsoft.UI.Xaml.Data;
-using Microsoft.UI.Xaml.Input;
-using Microsoft.UI.Xaml.Media;
-using Microsoft.UI.Xaml.Navigation;
-using Microsoft.UI.Xaml.Shapes;
-using Windows.ApplicationModel;
-using Windows.ApplicationModel.Activation;
-using Windows.Foundation;
-using Windows.Foundation.Collections;
-
-// To learn more about WinUI, the WinUI project structure,
-// and more about our project templates, see: http://aka.ms/winui-project-info.
 
 namespace Veriado
 {
@@ -38,13 +22,28 @@ namespace Veriado
         }
 
         /// <summary>
-        /// Invoked when the application is launched.
+        /// Gets the active WinUI window.
         /// </summary>
-        /// <param name="args">Details about the launch request and process.</param>
-        protected override void OnLaunched(Microsoft.UI.Xaml.LaunchActivatedEventArgs args)
+        public static Window? MainWindowInstance { get; private set; }
+
+        /// <inheritdoc />
+        protected override void OnLaunched(LaunchActivatedEventArgs args)
         {
-            _window = new MainWindow();
+            base.OnLaunched(args);
+
+            AppHost.StartAsync().GetAwaiter().GetResult();
+
+            _window = AppHost.Services.GetRequiredService<MainWindow>();
+            MainWindowInstance = _window;
+            _window.Closed += OnWindowClosed;
             _window.Activate();
+        }
+
+        private async void OnWindowClosed(object sender, WindowEventArgs e)
+        {
+            MainWindowInstance = null;
+            await AppHost.StopAsync().ConfigureAwait(false);
         }
     }
 }
+// END CHANGE Veriado.WinUI/App.xaml.cs

--- a/Veriado.WinUI/AppHost.cs
+++ b/Veriado.WinUI/AppHost.cs
@@ -1,0 +1,89 @@
+// BEGIN CHANGE Veriado.WinUI/AppHost.cs
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Veriado.Application.DependencyInjection;
+using Veriado.Infrastructure.DependencyInjection;
+using Veriado.Mapping.DependencyInjection;
+using Veriado.Services.DependencyInjection;
+using Veriado.WinUI.Services;
+using Veriado.WinUI.ViewModels;
+
+namespace Veriado;
+
+/// <summary>
+/// Configures and manages the WinUI host environment.
+/// </summary>
+internal static class AppHost
+{
+    private static readonly SemaphoreSlim StartLock = new(1, 1);
+    private static IHost? _host;
+
+    public static IServiceProvider Services => _host?.Services
+        ?? throw new InvalidOperationException("Host is not initialized.");
+
+    public static async Task StartAsync(CancellationToken cancellationToken = default)
+    {
+        if (_host is not null)
+        {
+            return;
+        }
+
+        await StartLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            if (_host is null)
+            {
+                _host = BuildHost();
+                await _host.Services.InitializeInfrastructureAsync(cancellationToken).ConfigureAwait(false);
+                await _host.StartAsync(cancellationToken).ConfigureAwait(false);
+            }
+        }
+        finally
+        {
+            StartLock.Release();
+        }
+    }
+
+    public static async Task StopAsync(CancellationToken cancellationToken = default)
+    {
+        if (_host is null)
+        {
+            return;
+        }
+
+        await _host.StopAsync(cancellationToken).ConfigureAwait(false);
+        _host.Dispose();
+        _host = null;
+    }
+
+    private static IHost BuildHost()
+    {
+        return Host
+            .CreateDefaultBuilder()
+            .UseContentRoot(AppContext.BaseDirectory)
+            .ConfigureServices((_, services) =>
+            {
+                services.AddSingleton<IMessenger>(WeakReferenceMessenger.Default);
+
+                services.AddApplication();
+                services.AddVeriadoMapping();
+                services.AddInfrastructure();
+                services.AddVeriadoServices();
+
+                services.AddSingleton<IPickerService, WinUIFolderPickerService>();
+
+                services.AddSingleton<ImportViewModel>();
+                services.AddSingleton<GridViewModel>();
+                services.AddSingleton<DetailViewModel>();
+                services.AddSingleton<MainViewModel>();
+
+                services.AddSingleton<MainWindow>();
+            })
+            .Build();
+    }
+}
+// END CHANGE Veriado.WinUI/AppHost.cs

--- a/Veriado.WinUI/MainWindow.xaml
+++ b/Veriado.WinUI/MainWindow.xaml
@@ -1,19 +1,146 @@
+// BEGIN CHANGE Veriado.WinUI/MainWindow.xaml
 <?xml version="1.0" encoding="utf-8"?>
 <Window
     x:Class="Veriado.MainWindow"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:Veriado"
+    xmlns:contracts="using:Veriado.Contracts.Files"
+    xmlns:controls="using:Microsoft.UI.Xaml.Controls"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d"
     Title="Veriado">
 
-    <Window.SystemBackdrop>
-        <MicaBackdrop />
-    </Window.SystemBackdrop>
+    <Window.Resources>
+        <BooleanToVisibilityConverter x:Key="BoolToVisibility" />
+    </Window.Resources>
 
-    <Grid>
+    <Grid RowDefinitions="Auto,* ,Auto" Padding="16" RowSpacing="12">
+        <StackPanel Grid.Row="0" Orientation="Horizontal" Spacing="8" DataContext="{Binding Import}">
+            <TextBox
+                Width="260"
+                Text="{Binding SelectedFolderPath, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                PlaceholderText="Vyberte složku" />
+            <Button Content="Procházet" Command="{Binding BrowseCommand}" />
+            <TextBox
+                Width="160"
+                Text="{Binding DefaultAuthor, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                PlaceholderText="Výchozí autor" />
+            <CheckBox Content="Extrahovat obsah" IsChecked="{Binding ExtractContent, Mode=TwoWay}" />
+            <CheckBox Content="Rekurzivně" IsChecked="{Binding Recursive, Mode=TwoWay}" />
+            <Button Content="Importovat" Command="{Binding ImportCommand}" />
+            <Button Content="Zrušit" Command="{Binding ImportCommandCancelCommand}" />
+            <TextBlock VerticalAlignment="Center" Text="{Binding LastResultSummary}" />
+            <TextBlock VerticalAlignment="Center" Text="{Binding StatusMessage}" Margin="12,0,0,0" />
+        </StackPanel>
 
+        <Grid Grid.Row="1" ColumnDefinitions="2*,3*" ColumnSpacing="16">
+            <Grid DataContext="{Binding Grid}" RowDefinitions="Auto,*,Auto" RowSpacing="8">
+                <StackPanel Orientation="Horizontal" Spacing="8">
+                    <TextBox
+                        Width="220"
+                        Text="{Binding SearchText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                        PlaceholderText="Hledat" />
+                    <controls:NumberBox
+                        Width="100"
+                        Minimum="10"
+                        Maximum="500"
+                        SmallChange="10"
+                        Value="{Binding PageSize, Mode=TwoWay}" />
+                    <Button Content="Obnovit" Command="{Binding RefreshCommand}" />
+                    <TextBlock VerticalAlignment="Center" Text="{Binding StatusMessage}" Margin="12,0,0,0" />
+                </StackPanel>
+
+                <ListView
+                    Grid.Row="1"
+                    ItemsSource="{Binding Items}"
+                    SelectedItem="{Binding SelectedItem, Mode=TwoWay}">
+                    <ListView.ItemTemplate>
+                        <DataTemplate x:DataType="contracts:FileSummaryDto">
+                            <Grid ColumnDefinitions="*,Auto" RowDefinitions="Auto,Auto" Padding="8">
+                                <TextBlock Grid.ColumnSpan="2" Text="{x:Bind Name}" FontWeight="SemiBold" />
+                                <TextBlock Grid.Row="1" Text="{x:Bind Author}" />
+                                <StackPanel Grid.Column="1" Grid.RowSpan="2" HorizontalAlignment="Right" Spacing="4">
+                                    <TextBlock Text="{x:Bind Extension}" />
+                                    <TextBlock Text="{x:Bind Mime}" />
+                                </StackPanel>
+                            </Grid>
+                        </DataTemplate>
+                    </ListView.ItemTemplate>
+                </ListView>
+
+                <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Left" Spacing="8">
+                    <Button Content="Předchozí" Command="{Binding PreviousPageCommand}" />
+                    <Button Content="Další" Command="{Binding NextPageCommand}" />
+                    <TextBlock VerticalAlignment="Center" Text="{Binding PageNumber}" />
+                    <TextBlock VerticalAlignment="Center" Text="/" />
+                    <TextBlock VerticalAlignment="Center" Text="{Binding TotalPages}" />
+                    <TextBlock VerticalAlignment="Center" Text="{Binding TotalCount, StringFormat='Počet: {0}'}" Margin="8,0,0,0" />
+                </StackPanel>
+            </Grid>
+
+            <ScrollViewer Grid.Column="1" DataContext="{Binding Detail}" VerticalScrollBarVisibility="Auto">
+                <StackPanel Spacing="12">
+                    <TextBlock Text="Detail dokumentu" FontSize="20" FontWeight="SemiBold" />
+
+                    <StackPanel Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
+                        <TextBlock Width="120" Text="Název" />
+                        <TextBox Width="220" Text="{Binding Name, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                        <Button Content="Přejmenovat" Command="{Binding RenameCommand}" />
+                    </StackPanel>
+
+                    <StackPanel Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
+                        <TextBlock Width="120" Text="Autor" />
+                        <TextBox Width="220" Text="{Binding Author, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                    </StackPanel>
+
+                    <StackPanel Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
+                        <TextBlock Width="120" Text="MIME" />
+                        <TextBox Width="220" Text="{Binding Mime, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                    </StackPanel>
+
+                    <StackPanel Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
+                        <TextBlock Width="120" Text="Jen pro čtení" />
+                        <CheckBox IsChecked="{Binding IsReadOnly, Mode=TwoWay}" />
+                        <Button Content="Uložit metadata" Command="{Binding SaveMetadataCommand}" />
+                    </StackPanel>
+
+                    <StackPanel Spacing="4">
+                        <TextBlock Text="Platnost dokumentu" FontWeight="SemiBold" />
+                        <StackPanel Orientation="Horizontal" Spacing="8">
+                            <TextBlock Width="120" Text="Platí od" />
+                            <CalendarDatePicker Width="220" Date="{Binding ValidityIssuedAt, Mode=TwoWay}" />
+                        </StackPanel>
+                        <StackPanel Orientation="Horizontal" Spacing="8">
+                            <TextBlock Width="120" Text="Platí do" />
+                            <CalendarDatePicker Width="220" Date="{Binding ValidityValidUntil, Mode=TwoWay}" />
+                        </StackPanel>
+                        <StackPanel Orientation="Horizontal" Spacing="8">
+                            <CheckBox Content="Fyzická kopie" IsChecked="{Binding HasPhysicalCopy, Mode=TwoWay}" />
+                            <CheckBox Content="Elektronická kopie" IsChecked="{Binding HasElectronicCopy, Mode=TwoWay}" />
+                        </StackPanel>
+                        <StackPanel Orientation="Horizontal" Spacing="8">
+                            <Button Content="Uložit platnost" Command="{Binding ApplyValidityCommand}" />
+                            <Button Content="Zrušit platnost" Command="{Binding ClearValidityCommand}" />
+                        </StackPanel>
+                    </StackPanel>
+
+                    <TextBlock Text="{Binding StatusMessage}" />
+                </StackPanel>
+            </ScrollViewer>
+        </Grid>
+
+        <Grid Grid.Row="2" ColumnDefinitions="Auto,*" ColumnSpacing="12">
+            <ProgressBar
+                Width="200"
+                IsIndeterminate="{Binding IsProgressIndeterminate}"
+                Visibility="{Binding IsProgressVisible, Converter={StaticResource BoolToVisibility}}"
+                Value="{Binding ProgressValue}" />
+            <StackPanel Grid.Column="1">
+                <TextBlock Text="{Binding ProgressMessage}" />
+                <TextBlock Text="{Binding StatusMessage}" />
+            </StackPanel>
+        </Grid>
     </Grid>
 </Window>
+// END CHANGE Veriado.WinUI/MainWindow.xaml

--- a/Veriado.WinUI/MainWindow.xaml.cs
+++ b/Veriado.WinUI/MainWindow.xaml.cs
@@ -1,31 +1,31 @@
+// BEGIN CHANGE Veriado.WinUI/MainWindow.xaml.cs
 using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Runtime.InteropServices.WindowsRuntime;
 using Microsoft.UI.Xaml;
-using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml.Controls.Primitives;
-using Microsoft.UI.Xaml.Data;
-using Microsoft.UI.Xaml.Input;
-using Microsoft.UI.Xaml.Media;
-using Microsoft.UI.Xaml.Navigation;
-using Windows.Foundation;
-using Windows.Foundation.Collections;
-
-// To learn more about WinUI, the WinUI project structure,
-// and more about our project templates, see: http://aka.ms/winui-project-info.
+using Veriado.WinUI.ViewModels;
 
 namespace Veriado
 {
     /// <summary>
-    /// An empty window that can be used on its own or navigated to within a Frame.
+    /// Main application window providing the composite shell.
     /// </summary>
     public sealed partial class MainWindow : Window
     {
-        public MainWindow()
+        public MainWindow(MainViewModel viewModel)
         {
+            ViewModel = viewModel ?? throw new ArgumentNullException(nameof(viewModel));
             InitializeComponent();
+            DataContext = ViewModel;
+            Title = "Veriado";
+            Loaded += OnLoaded;
+        }
+
+        public MainViewModel ViewModel { get; }
+
+        private async void OnLoaded(object sender, RoutedEventArgs e)
+        {
+            Loaded -= OnLoaded;
+            await ViewModel.InitializeAsync().ConfigureAwait(false);
         }
     }
 }
+// END CHANGE Veriado.WinUI/MainWindow.xaml.cs

--- a/Veriado.WinUI/Messages/GridRefreshMessage.cs
+++ b/Veriado.WinUI/Messages/GridRefreshMessage.cs
@@ -1,0 +1,22 @@
+// BEGIN CHANGE Veriado.WinUI/Messages/GridRefreshMessage.cs
+using CommunityToolkit.Mvvm.Messaging.Messages;
+
+namespace Veriado.WinUI.Messages;
+
+/// <summary>
+/// Describes a request to refresh the file grid.
+/// </summary>
+/// <param name="ForceReload">Indicates whether the refresh should be forced immediately.</param>
+public sealed record GridRefreshRequest(bool ForceReload);
+
+/// <summary>
+/// Messenger payload requesting a grid refresh.
+/// </summary>
+public sealed class GridRefreshMessage : ValueChangedMessage<GridRefreshRequest>
+{
+    public GridRefreshMessage(GridRefreshRequest value)
+        : base(value)
+    {
+    }
+}
+// END CHANGE Veriado.WinUI/Messages/GridRefreshMessage.cs

--- a/Veriado.WinUI/Messages/ImportProgressMessage.cs
+++ b/Veriado.WinUI/Messages/ImportProgressMessage.cs
@@ -1,0 +1,35 @@
+// BEGIN CHANGE Veriado.WinUI/Messages/ImportProgressMessage.cs
+using CommunityToolkit.Mvvm.Messaging.Messages;
+
+namespace Veriado.WinUI.Messages;
+
+/// <summary>
+/// Represents progress notifications emitted by the import workflow.
+/// </summary>
+/// <param name="ProgressValue">The optional progress value between 0 and 100.</param>
+/// <param name="Message">The human readable status message.</param>
+/// <param name="IsIndeterminate">Indicates whether the operation progress is indeterminate.</param>
+/// <param name="IsCompleted">Indicates whether the operation has finished (successfully or otherwise).</param>
+public sealed record ImportProgress(double? ProgressValue, string? Message, bool IsIndeterminate, bool IsCompleted)
+{
+    public static ImportProgress Started(string? message = null)
+        => new(null, message, true, false);
+
+    public static ImportProgress Completed(string? message = null)
+        => new(100d, message, false, true);
+
+    public static ImportProgress Failed(string? message = null)
+        => new(null, message, false, true);
+}
+
+/// <summary>
+/// Messenger payload carrying <see cref="ImportProgress"/> updates.
+/// </summary>
+public sealed class ImportProgressMessage : ValueChangedMessage<ImportProgress>
+{
+    public ImportProgressMessage(ImportProgress value)
+        : base(value)
+    {
+    }
+}
+// END CHANGE Veriado.WinUI/Messages/ImportProgressMessage.cs

--- a/Veriado.WinUI/Messages/SelectedFileChangedMessage.cs
+++ b/Veriado.WinUI/Messages/SelectedFileChangedMessage.cs
@@ -1,0 +1,17 @@
+// BEGIN CHANGE Veriado.WinUI/Messages/SelectedFileChangedMessage.cs
+using System;
+using CommunityToolkit.Mvvm.Messaging.Messages;
+
+namespace Veriado.WinUI.Messages;
+
+/// <summary>
+/// Messenger payload indicating that the selected file changed in the grid.
+/// </summary>
+public sealed class SelectedFileChangedMessage : ValueChangedMessage<Guid?>
+{
+    public SelectedFileChangedMessage(Guid? value)
+        : base(value)
+    {
+    }
+}
+// END CHANGE Veriado.WinUI/Messages/SelectedFileChangedMessage.cs

--- a/Veriado.WinUI/Services/IPickerService.cs
+++ b/Veriado.WinUI/Services/IPickerService.cs
@@ -1,0 +1,19 @@
+// BEGIN CHANGE Veriado.WinUI/Services/IPickerService.cs
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Veriado.WinUI.Services;
+
+/// <summary>
+/// Abstraction over platform pickers used to select folders or files.
+/// </summary>
+public interface IPickerService
+{
+    /// <summary>
+    /// Prompts the user to select a folder.
+    /// </summary>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The absolute folder path when selection succeeds; otherwise <see langword="null"/>.</returns>
+    Task<string?> PickFolderAsync(CancellationToken cancellationToken);
+}
+// END CHANGE Veriado.WinUI/Services/IPickerService.cs

--- a/Veriado.WinUI/Services/WinUIFolderPickerService.cs
+++ b/Veriado.WinUI/Services/WinUIFolderPickerService.cs
@@ -1,0 +1,29 @@
+// BEGIN CHANGE Veriado.WinUI/Services/WinUIFolderPickerService.cs
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.UI.Xaml;
+using Windows.Storage.Pickers;
+using WinRT.Interop;
+
+namespace Veriado.WinUI.Services;
+
+/// <summary>
+/// WinUI implementation of <see cref="IPickerService"/> using the platform folder picker.
+/// </summary>
+public sealed class WinUIFolderPickerService : IPickerService
+{
+    public async Task<string?> PickFolderAsync(CancellationToken cancellationToken)
+    {
+        var window = App.MainWindowInstance ?? throw new InvalidOperationException("Main window is not available.");
+        var hwnd = WindowNative.GetWindowHandle(window);
+
+        var picker = new FolderPicker();
+        picker.FileTypeFilter.Add("*");
+        InitializeWithWindow.Initialize(picker, hwnd);
+
+        var folder = await picker.PickSingleFolderAsync().AsTask(cancellationToken).ConfigureAwait(false);
+        return folder?.Path;
+    }
+}
+// END CHANGE Veriado.WinUI/Services/WinUIFolderPickerService.cs

--- a/Veriado.WinUI/Veriado.WinUI.csproj
+++ b/Veriado.WinUI/Veriado.WinUI.csproj
@@ -37,9 +37,17 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.4948" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.8.250907003" />
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
+    <PackageReference Include="CommunityToolkit.WinUI" Version="8.0.240109" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.9" />
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Veriado.Contracts\Veriado.Contracts.csproj" />
+    <ProjectReference Include="..\Veriado.Application\Veriado.Application.csproj" />
+    <ProjectReference Include="..\Veriado.Mapping\Veriado.Mapping.csproj" />
+    <ProjectReference Include="..\Veriado.Infrastructure\Veriado.Infrastructure.csproj" />
+    <ProjectReference Include="..\Veriado.Services\Veriado.Services.csproj" />
     <ProjectReference Include="..\Veriado.Domain\Veriado.Domain.csproj" />
   </ItemGroup>
 

--- a/Veriado.WinUI/ViewModels/BaseViewModel.cs
+++ b/Veriado.WinUI/ViewModels/BaseViewModel.cs
@@ -1,0 +1,94 @@
+// BEGIN CHANGE Veriado.WinUI/ViewModels/BaseViewModel.cs
+using System;
+using System.Collections;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Messaging;
+
+namespace Veriado.WinUI.ViewModels;
+
+/// <summary>
+/// Provides a common observable base type for view models with messaging and validation support.
+/// </summary>
+public abstract class BaseViewModel : ObservableRecipient, INotifyDataErrorInfo
+{
+    private readonly ObservableValidatorProxy _validator = new();
+    private bool _isBusy;
+    private string? _statusMessage;
+
+    protected BaseViewModel(IMessenger messenger)
+        : base(messenger)
+    {
+        _validator.ErrorsChanged += (sender, args) => ErrorsChanged?.Invoke(this, args);
+        IsActive = true;
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether the view model is performing a long-running operation.
+    /// </summary>
+    public bool IsBusy
+    {
+        get => _isBusy;
+        protected set
+        {
+            if (SetProperty(ref _isBusy, value))
+            {
+                OnIsBusyChanged(value);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets the current status message presented to the shell.
+    /// </summary>
+    public string? StatusMessage
+    {
+        get => _statusMessage;
+        protected set => SetProperty(ref _statusMessage, value);
+    }
+
+    /// <inheritdoc />
+    public bool HasErrors => _validator.HasErrors;
+
+    /// <inheritdoc />
+    public event EventHandler<DataErrorsChangedEventArgs>? ErrorsChanged;
+
+    /// <inheritdoc />
+    public IEnumerable GetErrors(string? propertyName) => _validator.GetErrors(propertyName);
+
+    /// <summary>
+    /// Clears all validation errors maintained by the view model.
+    /// </summary>
+    protected void ClearErrors() => _validator.ClearErrors();
+
+    /// <summary>
+    /// Validates all observable properties decorated with validation attributes.
+    /// </summary>
+    protected void ValidateAllProperties() => _validator.ValidateAllProperties();
+
+    /// <summary>
+    /// Validates the specified property value using data annotations.
+    /// </summary>
+    protected void ValidateProperty<T>(T value, [CallerMemberName] string? propertyName = null)
+        => _validator.ValidateProperty(value, propertyName);
+
+    /// <summary>
+    /// Allows derived classes to react to busy state transitions.
+    /// </summary>
+    /// <param name="value">The new busy state.</param>
+    protected virtual void OnIsBusyChanged(bool value)
+    {
+    }
+
+    private sealed class ObservableValidatorProxy : ObservableValidator
+    {
+        public new void ValidateProperty<T>(T value, [CallerMemberName] string? propertyName = null)
+            => base.ValidateProperty(value, propertyName);
+
+        public new void ValidateAllProperties() => base.ValidateAllProperties();
+
+        public new void ClearErrors() => base.ClearErrors();
+    }
+}
+// END CHANGE Veriado.WinUI/ViewModels/BaseViewModel.cs

--- a/Veriado.WinUI/ViewModels/DetailViewModel.cs
+++ b/Veriado.WinUI/ViewModels/DetailViewModel.cs
@@ -1,0 +1,303 @@
+// BEGIN CHANGE Veriado.WinUI/ViewModels/DetailViewModel.cs
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using CommunityToolkit.Mvvm.Messaging;
+using Veriado.Application.Common;
+using Veriado.Contracts.Files;
+using Veriado.Services.Files;
+using Veriado.WinUI.Messages;
+
+namespace Veriado.WinUI.ViewModels;
+
+/// <summary>
+/// Provides state and commands for the file detail view.
+/// </summary>
+public sealed partial class DetailViewModel : BaseViewModel, IRecipient<SelectedFileChangedMessage>
+{
+    private readonly IFileQueryService _fileQueryService;
+    private readonly IFileOperationsService _fileOperationsService;
+
+    [ObservableProperty]
+    private Guid? fileId;
+
+    [ObservableProperty]
+    private FileDetailDto? detail;
+
+    [ObservableProperty]
+    private string name = string.Empty;
+
+    [ObservableProperty]
+    private string extension = string.Empty;
+
+    [ObservableProperty]
+    private string mime = string.Empty;
+
+    [ObservableProperty]
+    private string author = string.Empty;
+
+    [ObservableProperty]
+    private bool isReadOnly;
+
+    [ObservableProperty]
+    private DateTimeOffset? validityIssuedAt;
+
+    [ObservableProperty]
+    private DateTimeOffset? validityValidUntil;
+
+    [ObservableProperty]
+    private bool hasPhysicalCopy;
+
+    [ObservableProperty]
+    private bool hasElectronicCopy;
+
+    public DetailViewModel(
+        IFileQueryService fileQueryService,
+        IFileOperationsService fileOperationsService,
+        IMessenger messenger)
+        : base(messenger)
+    {
+        _fileQueryService = fileQueryService ?? throw new ArgumentNullException(nameof(fileQueryService));
+        _fileOperationsService = fileOperationsService ?? throw new ArgumentNullException(nameof(fileOperationsService));
+    }
+
+    public bool HasDetail => Detail is not null;
+
+    [RelayCommand(IncludeCancelCommand = true, AllowConcurrentExecutions = false)]
+    private async Task LoadAsync(CancellationToken cancellationToken)
+    {
+        if (IsBusy)
+        {
+            return;
+        }
+
+        if (FileId is null)
+        {
+            Detail = null;
+            StatusMessage = "Nebyl vybrán žádný soubor.";
+            return;
+        }
+
+        IsBusy = true;
+        StatusMessage = "Načítám detail souboru...";
+
+        try
+        {
+            var detail = await _fileQueryService.GetDetailAsync(FileId.Value, cancellationToken).ConfigureAwait(false);
+            if (detail is null)
+            {
+                StatusMessage = "Soubor nebyl nalezen.";
+                Detail = null;
+                return;
+            }
+
+            Detail = detail;
+            Name = detail.Name;
+            Extension = detail.Extension;
+            Mime = detail.Mime;
+            Author = detail.Author;
+            IsReadOnly = detail.IsReadOnly;
+            ValidityIssuedAt = detail.Validity?.IssuedAt;
+            ValidityValidUntil = detail.Validity?.ValidUntil;
+            HasPhysicalCopy = detail.Validity?.HasPhysicalCopy ?? false;
+            HasElectronicCopy = detail.Validity?.HasElectronicCopy ?? false;
+            StatusMessage = "Detail načten.";
+        }
+        catch (OperationCanceledException)
+        {
+            StatusMessage = "Načítání detailu zrušeno.";
+        }
+        catch (Exception ex)
+        {
+            StatusMessage = $"Načítání detailu selhalo: {ex.Message}";
+        }
+        finally
+        {
+            IsBusy = false;
+            OnPropertyChanged(nameof(HasDetail));
+        }
+    }
+
+    [RelayCommand(IncludeCancelCommand = true, AllowConcurrentExecutions = false)]
+    private async Task SaveMetadataAsync(CancellationToken cancellationToken)
+    {
+        if (FileId is null)
+        {
+            StatusMessage = "Vyberte soubor.";
+            return;
+        }
+
+        if (IsBusy)
+        {
+            return;
+        }
+
+        IsBusy = true;
+        StatusMessage = "Ukládám metadata...";
+
+        try
+        {
+            var request = new UpdateMetadataRequest
+            {
+                FileId = FileId.Value,
+                Author = Author,
+                Mime = string.IsNullOrWhiteSpace(Mime) ? null : Mime,
+                IsReadOnly = IsReadOnly,
+            };
+
+            var result = await _fileOperationsService.UpdateMetadataAsync(request, cancellationToken).ConfigureAwait(false);
+            HandleResult(result, "Metadata byla uložena.");
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+
+        await LoadAsync(cancellationToken).ConfigureAwait(false);
+        Messenger.Send(new GridRefreshMessage(new GridRefreshRequest(false)));
+    }
+
+    [RelayCommand(IncludeCancelCommand = true, AllowConcurrentExecutions = false)]
+    private async Task RenameAsync(CancellationToken cancellationToken)
+    {
+        if (FileId is null || string.IsNullOrWhiteSpace(Name))
+        {
+            StatusMessage = "Zadejte nový název.";
+            return;
+        }
+
+        if (IsBusy)
+        {
+            return;
+        }
+
+        IsBusy = true;
+        StatusMessage = "Přejmenovávám soubor...";
+
+        try
+        {
+            var result = await _fileOperationsService
+                .RenameAsync(FileId.Value, Name.Trim(), cancellationToken)
+                .ConfigureAwait(false);
+            HandleResult(result, "Soubor byl přejmenován.");
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+
+        await LoadAsync(cancellationToken).ConfigureAwait(false);
+        Messenger.Send(new GridRefreshMessage(new GridRefreshRequest(true)));
+    }
+
+    [RelayCommand(IncludeCancelCommand = true, AllowConcurrentExecutions = false)]
+    private async Task ApplyValidityAsync(CancellationToken cancellationToken)
+    {
+        if (FileId is null)
+        {
+            StatusMessage = "Vyberte soubor.";
+            return;
+        }
+
+        if (ValidityIssuedAt is null || ValidityValidUntil is null)
+        {
+            StatusMessage = "Zadejte platné datumy platnosti.";
+            return;
+        }
+
+        if (IsBusy)
+        {
+            return;
+        }
+
+        IsBusy = true;
+        StatusMessage = "Aktualizuji platnost dokumentu...";
+
+        try
+        {
+            var dto = new FileValidityDto(
+                ValidityIssuedAt.Value,
+                ValidityValidUntil.Value,
+                HasPhysicalCopy,
+                HasElectronicCopy);
+
+            var result = await _fileOperationsService
+                .SetValidityAsync(FileId.Value, dto, cancellationToken)
+                .ConfigureAwait(false);
+            HandleResult(result, "Platnost dokumentu byla aktualizována.");
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+
+        await LoadAsync(cancellationToken).ConfigureAwait(false);
+        Messenger.Send(new GridRefreshMessage(new GridRefreshRequest(false)));
+    }
+
+    [RelayCommand(IncludeCancelCommand = true, AllowConcurrentExecutions = false)]
+    private async Task ClearValidityAsync(CancellationToken cancellationToken)
+    {
+        if (FileId is null)
+        {
+            return;
+        }
+
+        if (IsBusy)
+        {
+            return;
+        }
+
+        IsBusy = true;
+        StatusMessage = "Odstraňuji platnost dokumentu...";
+
+        try
+        {
+            var result = await _fileOperationsService
+                .ClearValidityAsync(FileId.Value, cancellationToken)
+                .ConfigureAwait(false);
+            HandleResult(result, "Platnost dokumentu byla odstraněna.");
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+
+        await LoadAsync(cancellationToken).ConfigureAwait(false);
+        Messenger.Send(new GridRefreshMessage(new GridRefreshRequest(false)));
+    }
+
+    public void Receive(SelectedFileChangedMessage message)
+    {
+        if (FileId == message.Value)
+        {
+            return;
+        }
+
+        FileId = message.Value;
+        _ = LoadCommand.ExecuteAsync(null);
+    }
+
+    partial void OnDetailChanged(FileDetailDto? value)
+    {
+        OnPropertyChanged(nameof(HasDetail));
+    }
+
+    private void HandleResult(AppResult<Guid> result, string successMessage)
+    {
+        if (result.IsSuccess)
+        {
+            StatusMessage = successMessage;
+            return;
+        }
+
+        var error = result.Error;
+        var message = string.IsNullOrWhiteSpace(error.Message)
+            ? error.Code.ToString()
+            : error.Message;
+        StatusMessage = $"Operace selhala: {message}";
+    }
+}
+// END CHANGE Veriado.WinUI/ViewModels/DetailViewModel.cs

--- a/Veriado.WinUI/ViewModels/GridViewModel.cs
+++ b/Veriado.WinUI/ViewModels/GridViewModel.cs
@@ -1,0 +1,238 @@
+// BEGIN CHANGE Veriado.WinUI/ViewModels/GridViewModel.cs
+using System;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using CommunityToolkit.Mvvm.Messaging;
+using Veriado.Application.Search.Abstractions;
+using Veriado.Application.UseCases.Queries.FileGrid;
+using Veriado.Contracts.Common;
+using Veriado.Contracts.Files;
+using Veriado.Services.Files;
+using Veriado.WinUI.Messages;
+
+namespace Veriado.WinUI.ViewModels;
+
+/// <summary>
+/// Provides the presentation logic for the file grid including search and paging.
+/// </summary>
+public sealed partial class GridViewModel : BaseViewModel, IRecipient<GridRefreshMessage>
+{
+    private readonly IFileQueryService _fileQueryService;
+    private readonly TimeSpan _searchDebounce = TimeSpan.FromMilliseconds(350);
+    private CancellationTokenSource? _searchCts;
+
+    public GridViewModel(IFileQueryService fileQueryService, IMessenger messenger)
+        : base(messenger)
+    {
+        _fileQueryService = fileQueryService ?? throw new ArgumentNullException(nameof(fileQueryService));
+        Items = new ObservableCollection<FileSummaryDto>();
+    }
+
+    public ObservableCollection<FileSummaryDto> Items { get; }
+
+    [ObservableProperty]
+    private FileSummaryDto? selectedItem;
+
+    [ObservableProperty]
+    private string? searchText;
+
+    [ObservableProperty]
+    private int pageNumber = 1;
+
+    [ObservableProperty]
+    private int pageSize = 50;
+
+    [ObservableProperty]
+    private int totalCount;
+
+    public int TotalPages => PageSize <= 0 ? 0 : (int)Math.Ceiling(TotalCount / (double)PageSize);
+
+    [ObservableProperty]
+    private bool showOnlyFavorites;
+
+    [ObservableProperty]
+    private bool showSearchHistory;
+
+    public ObservableCollection<SearchFavoriteItem> Favorites { get; } = new();
+
+    public ObservableCollection<SearchHistoryEntry> History { get; } = new();
+
+    [RelayCommand(IncludeCancelCommand = true, AllowConcurrentExecutions = false)]
+    private async Task RefreshAsync(CancellationToken cancellationToken)
+    {
+        if (IsBusy)
+        {
+            return;
+        }
+
+        IsBusy = true;
+        StatusMessage = "Načítám data...";
+
+        try
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var dto = new FileGridQueryDto
+            {
+                Text = string.IsNullOrWhiteSpace(SearchText) ? null : SearchText,
+                Page = new PageRequest
+                {
+                    Page = PageNumber,
+                    PageSize = PageSize,
+                },
+            };
+
+            var result = await _fileQueryService.GetGridAsync(new FileGridQuery(dto), cancellationToken).ConfigureAwait(false);
+            Items.Clear();
+            foreach (var item in result.Items)
+            {
+                Items.Add(item);
+            }
+
+            TotalCount = result.TotalCount;
+            StatusMessage = $"Načteno {Items.Count} z {result.TotalCount} položek.";
+        }
+        catch (OperationCanceledException)
+        {
+            StatusMessage = "Načítání zrušeno.";
+        }
+        catch (Exception ex)
+        {
+            StatusMessage = $"Načítání selhalo: {ex.Message}";
+        }
+        finally
+        {
+            IsBusy = false;
+            OnPropertyChanged(nameof(TotalPages));
+            PreviousPageCommand.NotifyCanExecuteChanged();
+            NextPageCommand.NotifyCanExecuteChanged();
+        }
+    }
+
+    [RelayCommand(CanExecute = nameof(CanGoToPreviousPage))]
+    private void PreviousPage()
+    {
+        if (PageNumber <= 1)
+        {
+            return;
+        }
+
+        PageNumber--;
+        _ = RefreshCommand.ExecuteAsync(null);
+    }
+
+    [RelayCommand(CanExecute = nameof(CanGoToNextPage))]
+    private void NextPage()
+    {
+        if (PageNumber >= TotalPages)
+        {
+            return;
+        }
+
+        PageNumber++;
+        _ = RefreshCommand.ExecuteAsync(null);
+    }
+
+    private bool CanGoToPreviousPage() => PageNumber > 1 && !IsBusy;
+
+    private bool CanGoToNextPage() => PageNumber < TotalPages && !IsBusy;
+
+    public async Task EnsureDataAsync(CancellationToken cancellationToken = default)
+    {
+        if (Items.Count == 0)
+        {
+            await RefreshAsync(cancellationToken).ConfigureAwait(false);
+            await LoadAncillaryDataAsync(cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private async Task LoadAncillaryDataAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            var favorites = await _fileQueryService.GetFavoritesAsync(cancellationToken).ConfigureAwait(false);
+            Favorites.Clear();
+            foreach (var favorite in favorites)
+            {
+                Favorites.Add(favorite);
+            }
+
+            var history = await _fileQueryService.GetSearchHistoryAsync(10, cancellationToken).ConfigureAwait(false);
+            History.Clear();
+            foreach (var entry in history.OrderByDescending(h => h.LastQueriedUtc))
+            {
+                History.Add(entry);
+            }
+        }
+        catch
+        {
+            // ancillary data is best-effort
+        }
+    }
+
+    public void Receive(GridRefreshMessage message)
+    {
+        if (message.Value.ForceReload)
+        {
+            _ = RefreshCommand.ExecuteAsync(null);
+        }
+        else
+        {
+            ScheduleRefresh();
+        }
+    }
+
+    partial void OnSearchTextChanged(string? value)
+    {
+        PageNumber = 1;
+        ScheduleRefresh();
+    }
+
+    partial void OnSelectedItemChanged(FileSummaryDto? value)
+    {
+        Messenger.Send(new SelectedFileChangedMessage(value?.Id));
+    }
+
+    partial void OnPageSizeChanged(int value)
+    {
+        if (value <= 0)
+        {
+            PageSize = 25;
+            return;
+        }
+
+        PageNumber = 1;
+        ScheduleRefresh();
+        OnPropertyChanged(nameof(TotalPages));
+    }
+
+    partial void OnPageNumberChanged(int value)
+    {
+        PreviousPageCommand.NotifyCanExecuteChanged();
+        NextPageCommand.NotifyCanExecuteChanged();
+    }
+
+    private void ScheduleRefresh()
+    {
+        _searchCts?.Cancel();
+        _searchCts = new CancellationTokenSource();
+        var token = _searchCts.Token;
+
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                await Task.Delay(_searchDebounce, token).ConfigureAwait(false);
+                await RefreshCommand.ExecuteAsync(null).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+            }
+        }, token);
+    }
+}
+// END CHANGE Veriado.WinUI/ViewModels/GridViewModel.cs

--- a/Veriado.WinUI/ViewModels/ImportViewModel.cs
+++ b/Veriado.WinUI/ViewModels/ImportViewModel.cs
@@ -1,0 +1,151 @@
+// BEGIN CHANGE Veriado.WinUI/ViewModels/ImportViewModel.cs
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using CommunityToolkit.Mvvm.Messaging;
+using Veriado.Services.Import;
+using Veriado.Services.Import.Models;
+using Veriado.WinUI.Messages;
+using Veriado.WinUI.Services;
+
+namespace Veriado.WinUI.ViewModels;
+
+/// <summary>
+/// Coordinates folder and single file imports.
+/// </summary>
+public sealed partial class ImportViewModel : BaseViewModel
+{
+    private readonly IImportService _importService;
+    private readonly IPickerService _pickerService;
+
+    [ObservableProperty]
+    private string? selectedFolderPath;
+
+    [ObservableProperty]
+    private string defaultAuthor = string.Empty;
+
+    [ObservableProperty]
+    private bool extractContent = true;
+
+    [ObservableProperty]
+    private bool recursive = true;
+
+    [ObservableProperty]
+    private int maxDegreeOfParallelism = Environment.ProcessorCount;
+
+    [ObservableProperty]
+    private string? searchPattern = "*";
+
+    [ObservableProperty]
+    private ImportBatchResult? lastResult;
+
+    public ImportViewModel(IImportService importService, IPickerService pickerService, IMessenger messenger)
+        : base(messenger)
+    {
+        _importService = importService ?? throw new ArgumentNullException(nameof(importService));
+        _pickerService = pickerService ?? throw new ArgumentNullException(nameof(pickerService));
+    }
+
+    public string? LastResultSummary => LastResult is { } result
+        ? $"Imported {result.Succeeded}/{result.Total} (failed: {result.Failed})"
+        : null;
+
+    [RelayCommand(IncludeCancelCommand = true, AllowConcurrentExecutions = false)]
+    private async Task BrowseAsync(CancellationToken cancellationToken)
+    {
+        var folder = await _pickerService.PickFolderAsync(cancellationToken).ConfigureAwait(false);
+        if (!string.IsNullOrWhiteSpace(folder))
+        {
+            SelectedFolderPath = folder;
+        }
+    }
+
+    [RelayCommand(IncludeCancelCommand = true, AllowConcurrentExecutions = false)]
+    private async Task ImportAsync(CancellationToken cancellationToken)
+    {
+        if (IsBusy)
+        {
+            return;
+        }
+
+        var folder = SelectedFolderPath;
+        if (string.IsNullOrWhiteSpace(folder))
+        {
+            StatusMessage = "Nejprve vyberte složku k importu.";
+            return;
+        }
+
+        if (!Directory.Exists(folder))
+        {
+            StatusMessage = $"Složka '{folder}' neexistuje.";
+            return;
+        }
+
+        IsBusy = true;
+        StatusMessage = "Import souborů byl spuštěn.";
+        Messenger.Send(new ImportProgressMessage(ImportProgress.Started(StatusMessage)));
+
+        try
+        {
+            var request = new ImportFolderRequest
+            {
+                FolderPath = folder,
+                DefaultAuthor = DefaultAuthor,
+                ExtractContent = ExtractContent,
+                Recursive = Recursive,
+                SearchPattern = string.IsNullOrWhiteSpace(SearchPattern) ? "*" : SearchPattern,
+                MaxDegreeOfParallelism = Math.Max(1, MaxDegreeOfParallelism),
+            };
+
+            var response = await _importService.ImportFolderAsync(request, cancellationToken).ConfigureAwait(false);
+            if (!response.IsSuccess)
+            {
+                StatusMessage = response.Errors.Count > 0
+                    ? response.Errors[0].Message
+                    : "Import selhal.";
+                Messenger.Send(new ImportProgressMessage(ImportProgress.Failed(StatusMessage)));
+                return;
+            }
+
+            LastResult = response.Data;
+            StatusMessage = LastResult is { } result
+                ? $"Import dokončen ({result.Succeeded}/{result.Total})"
+                : "Import dokončen.";
+
+            Messenger.Send(new ImportProgressMessage(ImportProgress.Completed(StatusMessage)));
+            Messenger.Send(new GridRefreshMessage(new GridRefreshRequest(true)));
+        }
+        catch (OperationCanceledException)
+        {
+            StatusMessage = "Import byl zrušen.";
+            Messenger.Send(new ImportProgressMessage(ImportProgress.Failed(StatusMessage)));
+        }
+        catch (Exception ex)
+        {
+            StatusMessage = $"Import selhal: {ex.Message}";
+            Messenger.Send(new ImportProgressMessage(ImportProgress.Failed(StatusMessage)));
+        }
+        finally
+        {
+            IsBusy = false;
+            OnPropertyChanged(nameof(LastResultSummary));
+        }
+    }
+
+    partial void OnLastResultChanged(ImportBatchResult? value)
+    {
+        OnPropertyChanged(nameof(LastResultSummary));
+    }
+
+    partial void OnMaxDegreeOfParallelismChanged(int value)
+    {
+        if (value <= 0)
+        {
+            MaxDegreeOfParallelism = 1;
+        }
+    }
+}
+// END CHANGE Veriado.WinUI/ViewModels/ImportViewModel.cs

--- a/Veriado.WinUI/ViewModels/MainViewModel.cs
+++ b/Veriado.WinUI/ViewModels/MainViewModel.cs
@@ -1,0 +1,70 @@
+// BEGIN CHANGE Veriado.WinUI/ViewModels/MainViewModel.cs
+using System.Threading;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Messaging;
+using Veriado.WinUI.Messages;
+
+namespace Veriado.WinUI.ViewModels;
+
+/// <summary>
+/// Root view model orchestrating shell state and coordinating child view models.
+/// </summary>
+public sealed partial class MainViewModel : BaseViewModel, IRecipient<ImportProgressMessage>
+{
+    public MainViewModel(ImportViewModel import, GridViewModel grid, DetailViewModel detail, IMessenger messenger)
+        : base(messenger)
+    {
+        Import = import;
+        Grid = grid;
+        Detail = detail;
+    }
+
+    public ImportViewModel Import { get; }
+
+    public GridViewModel Grid { get; }
+
+    public DetailViewModel Detail { get; }
+
+    [ObservableProperty]
+    private bool isProgressVisible;
+
+    [ObservableProperty]
+    private bool isProgressIndeterminate;
+
+    [ObservableProperty]
+    private double progressValue;
+
+    [ObservableProperty]
+    private string? progressMessage;
+
+    public async Task InitializeAsync(CancellationToken cancellationToken = default)
+    {
+        await Grid.EnsureDataAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    public void Receive(ImportProgressMessage message)
+    {
+        var progress = message.Value;
+        ProgressMessage = progress.Message;
+        IsProgressVisible = !progress.IsCompleted;
+        IsProgressIndeterminate = progress.IsIndeterminate;
+
+        if (progress.ProgressValue.HasValue)
+        {
+            ProgressValue = progress.ProgressValue.Value;
+        }
+
+        if (progress.IsCompleted)
+        {
+            IsBusy = false;
+        }
+        else
+        {
+            IsBusy = true;
+        }
+
+        StatusMessage = progress.Message;
+    }
+}
+// END CHANGE Veriado.WinUI/ViewModels/MainViewModel.cs


### PR DESCRIPTION
## Summary
- reference the application, infrastructure and service layers from the WinUI project and add CommunityToolkit dependencies
- introduce an AppHost with dependency injection setup, picker service, and CommunityToolkit-based view models coordinating messaging
- modernize the WinUI shell XAML to bind to the new view models for import, grid, and detail interactions

## Testing
- `dotnet build Veriado.WinUI/Veriado.WinUI.csproj` *(fails: `dotnet` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d04ce3d2648326bf3a229c8f59e6bf