### PR TITLE
Add missing contract DTOs for import and search

### DIFF
--- a/Veriado.Contracts/Files/FileContentResponseDto.cs
+++ b/Veriado.Contracts/Files/FileContentResponseDto.cs
@@ -1,0 +1,32 @@
+using System;
+
+namespace Veriado.Contracts.Files;
+
+/// <summary>
+/// Represents the hydrated binary payload of a file together with its core metadata.
+/// </summary>
+/// <param name="Id">The identifier of the file.</param>
+/// <param name="Name">The file name without extension.</param>
+/// <param name="Extension">The file extension without the leading dot.</param>
+/// <param name="Mime">The MIME type of the file.</param>
+/// <param name="Author">The author recorded for the file.</param>
+/// <param name="SizeBytes">The size of the binary content in bytes.</param>
+/// <param name="Version">The current version of the file content.</param>
+/// <param name="IsReadOnly">Indicates whether the file is marked read-only.</param>
+/// <param name="CreatedUtc">The creation timestamp in UTC.</param>
+/// <param name="LastModifiedUtc">The last modification timestamp in UTC.</param>
+/// <param name="Validity">Optional document validity information.</param>
+/// <param name="Content">The materialized binary payload.</param>
+public sealed record FileContentResponseDto(
+    Guid Id,
+    string Name,
+    string Extension,
+    string Mime,
+    string Author,
+    long SizeBytes,
+    int Version,
+    bool IsReadOnly,
+    DateTimeOffset CreatedUtc,
+    DateTimeOffset LastModifiedUtc,
+    FileValidityDto? Validity,
+    byte[] Content);

--- a/Veriado.Contracts/Import/ImportBatchResult.cs
+++ b/Veriado.Contracts/Import/ImportBatchResult.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+
+namespace Veriado.Contracts.Import;
+
+/// <summary>
+/// Represents the aggregated outcome of a folder import operation.
+/// </summary>
+/// <param name="Total">The total number of processed files.</param>
+/// <param name="Succeeded">The number of files imported successfully.</param>
+/// <param name="Failed">The number of files that failed to import.</param>
+/// <param name="Errors">The collection of import errors captured during processing.</param>
+public sealed record ImportBatchResult(
+    int Total,
+    int Succeeded,
+    int Failed,
+    IReadOnlyList<ImportError> Errors);

--- a/Veriado.Contracts/Import/ImportError.cs
+++ b/Veriado.Contracts/Import/ImportError.cs
@@ -1,0 +1,12 @@
+namespace Veriado.Contracts.Import;
+
+/// <summary>
+/// Represents a failure encountered while importing a file.
+/// </summary>
+/// <param name="FilePath">The path of the file that failed to import.</param>
+/// <param name="Code">The machine readable error code.</param>
+/// <param name="Message">The human readable error description.</param>
+public sealed record ImportError(
+    string FilePath,
+    string Code,
+    string Message);

--- a/Veriado.Contracts/Import/ImportFolderRequest.cs
+++ b/Veriado.Contracts/Import/ImportFolderRequest.cs
@@ -1,0 +1,42 @@
+namespace Veriado.Contracts.Import;
+
+/// <summary>
+/// Describes the options applied when importing all files from a folder.
+/// </summary>
+public sealed record class ImportFolderRequest
+{
+    /// <summary>
+    /// Gets or sets the absolute folder path that should be scanned for files.
+    /// </summary>
+    public string FolderPath { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the default author applied when file metadata does not specify one.
+    /// </summary>
+    public string? DefaultAuthor { get; init; }
+        = null;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether binary content extraction should be performed.
+    /// </summary>
+    public bool ExtractContent { get; init; }
+        = true;
+
+    /// <summary>
+    /// Gets or sets the maximum number of concurrent file imports.
+    /// </summary>
+    public int MaxDegreeOfParallelism { get; init; }
+        = 4;
+
+    /// <summary>
+    /// Gets or sets the search pattern applied when enumerating files.
+    /// </summary>
+    public string? SearchPattern { get; init; }
+        = "*";
+
+    /// <summary>
+    /// Gets or sets a value indicating whether sub-folders should be traversed.
+    /// </summary>
+    public bool Recursive { get; init; }
+        = true;
+}

--- a/Veriado.Contracts/Search/SearchFavoriteDefinition.cs
+++ b/Veriado.Contracts/Search/SearchFavoriteDefinition.cs
@@ -1,0 +1,14 @@
+namespace Veriado.Contracts.Search;
+
+/// <summary>
+/// Represents the information required to create a saved search favourite.
+/// </summary>
+/// <param name="Name">The unique display name assigned to the favourite.</param>
+/// <param name="MatchQuery">The generated FTS5 match query expression.</param>
+/// <param name="QueryText">The original user supplied query text.</param>
+/// <param name="IsFuzzy">Indicates whether the favourite uses trigram fuzzy matching.</param>
+public sealed record SearchFavoriteDefinition(
+    string Name,
+    string MatchQuery,
+    string? QueryText,
+    bool IsFuzzy);


### PR DESCRIPTION
## Summary
- add a contract record for search favorite definitions used by the UI orchestration layer
- introduce import contracts covering folder requests, batch results and captured errors
- add a file content response DTO that bundles metadata with the binary payload

## Testing
- dotnet build Veriado.sln *(fails: `dotnet` command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d13dca93388326bdea3f17b92d4078