### PR TITLE
Switch services to contracts search DTOs

### DIFF
--- a/Veriado.Application/Search/Abstractions/SearchServices.cs
+++ b/Veriado.Application/Search/Abstractions/SearchServices.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Veriado.Contracts.Search;
 using Veriado.Domain.Search;
 
 namespace Veriado.Application.Search.Abstractions;
@@ -139,41 +140,3 @@ public interface ISearchFavoritesService
     /// <returns>The favourite when found, otherwise <see langword="null"/>.</returns>
     Task<SearchFavoriteItem?> TryGetByKeyAsync(string key, CancellationToken cancellationToken);
 }
-
-/// <summary>
-/// Represents a persisted search history entry.
-/// </summary>
-/// <param name="Id">The entry identifier.</param>
-/// <param name="QueryText">The user-supplied query text.</param>
-/// <param name="MatchQuery">The generated FTS match clause.</param>
-/// <param name="LastQueriedUtc">The timestamp of the most recent execution.</param>
-/// <param name="Executions">The number of times the query was executed.</param>
-/// <param name="LastTotalHits">The last recorded hit count.</param>
-/// <param name="IsFuzzy">Indicates whether the entry was produced by fuzzy search.</param>
-public sealed record SearchHistoryEntry(
-    Guid Id,
-    string? QueryText,
-    string MatchQuery,
-    DateTimeOffset LastQueriedUtc,
-    int Executions,
-    int? LastTotalHits,
-    bool IsFuzzy);
-
-/// <summary>
-/// Represents a saved search favourite definition.
-/// </summary>
-/// <param name="Id">The favourite identifier.</param>
-/// <param name="Name">The unique favourite name.</param>
-/// <param name="QueryText">The original query text.</param>
-/// <param name="MatchQuery">The FTS match query.</param>
-/// <param name="Position">The ordering position.</param>
-/// <param name="CreatedUtc">The creation timestamp.</param>
-/// <param name="IsFuzzy">Indicates whether the favourite uses trigram fuzzy search.</param>
-public sealed record SearchFavoriteItem(
-    Guid Id,
-    string Name,
-    string? QueryText,
-    string MatchQuery,
-    int Position,
-    DateTimeOffset CreatedUtc,
-    bool IsFuzzy);

--- a/Veriado.Application/UseCases/Queries/FileGrid/FileGridQueryHandler.cs
+++ b/Veriado.Application/UseCases/Queries/FileGrid/FileGridQueryHandler.cs
@@ -9,6 +9,7 @@ using Veriado.Application.Search;
 using Veriado.Application.Search.Abstractions;
 using Veriado.Contracts.Common;
 using Veriado.Contracts.Files;
+using Veriado.Contracts.Search;
 using Veriado.Domain.Files;
 
 namespace Veriado.Application.UseCases.Queries.FileGrid;

--- a/Veriado.Infrastructure/Search/SearchFavoritesService.cs
+++ b/Veriado.Infrastructure/Search/SearchFavoritesService.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Microsoft.Data.Sqlite;
 using Veriado.Application.Abstractions;
 using Veriado.Application.Search.Abstractions;
+using Veriado.Contracts.Search;
 using Veriado.Infrastructure.Persistence.Options;
 
 namespace Veriado.Infrastructure.Search;

--- a/Veriado.Infrastructure/Search/SearchHistoryService.cs
+++ b/Veriado.Infrastructure/Search/SearchHistoryService.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Microsoft.Data.Sqlite;
 using Veriado.Application.Abstractions;
 using Veriado.Application.Search.Abstractions;
+using Veriado.Contracts.Search;
 using Veriado.Infrastructure.Persistence.Options;
 
 namespace Veriado.Infrastructure.Search;

--- a/Veriado.Mapping/DependencyInjection/MappingServiceCollectionExtensions.cs
+++ b/Veriado.Mapping/DependencyInjection/MappingServiceCollectionExtensions.cs
@@ -38,6 +38,7 @@ public static class MappingServiceCollectionExtensions
                 cfg.AddProfile<FileReadProfiles>();
                 cfg.AddProfile<MetadataProfiles>();
                 cfg.AddProfile<FileWriteProfiles>();
+                cfg.AddProfile<SearchProfiles>();
             });
 #if DEBUG
             configuration.AssertConfigurationIsValid();

--- a/Veriado.Mapping/Profiles/SearchProfiles.cs
+++ b/Veriado.Mapping/Profiles/SearchProfiles.cs
@@ -1,0 +1,43 @@
+using AutoMapper;
+using Veriado.Contracts.Search;
+using Veriado.Domain.Search;
+
+namespace Veriado.Mapping.Profiles;
+
+/// <summary>
+/// Configures mappings between search domain models and contract DTOs.
+/// </summary>
+public sealed class SearchProfiles : Profile
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SearchProfiles"/> class.
+    /// </summary>
+    public SearchProfiles()
+    {
+        CreateMap<SearchHit, SearchHitDto>().ConstructUsing(src => new SearchHitDto(
+            src.FileId,
+            src.Title,
+            src.Mime,
+            src.Snippet,
+            src.Score,
+            src.LastModifiedUtc));
+
+        CreateMap<SearchHistoryEntryEntity, SearchHistoryEntry>().ConstructUsing(src => new SearchHistoryEntry(
+            src.Id,
+            src.QueryText,
+            src.Match,
+            src.CreatedUtc,
+            src.Executions,
+            src.LastTotalHits,
+            src.IsFuzzy));
+
+        CreateMap<SearchFavoriteEntity, SearchFavoriteItem>().ConstructUsing(src => new SearchFavoriteItem(
+            src.Id,
+            src.Name,
+            src.QueryText,
+            src.Match,
+            src.Position,
+            src.CreatedUtc,
+            src.IsFuzzy));
+    }
+}

--- a/Veriado.Services/Files/FileQueryService.cs
+++ b/Veriado.Services/Files/FileQueryService.cs
@@ -5,13 +5,10 @@ using System.Threading.Tasks;
 using MediatR;
 using Veriado.Application.UseCases.Queries;
 using Veriado.Application.UseCases.Queries.FileGrid;
+using Veriado.Application.Search.Abstractions;
 using Veriado.Contracts.Common;
 using Veriado.Contracts.Files;
 using Veriado.Contracts.Search;
-using Veriado.Application.Search.Abstractions;
-using Veriado.Services.Files.Models;
-using AppSearchHistoryEntry = Veriado.Application.Search.Abstractions.SearchHistoryEntry;
-using AppSearchFavoriteItem = Veriado.Application.Search.Abstractions.SearchFavoriteItem;
 
 namespace Veriado.Services.Files;
 
@@ -51,13 +48,7 @@ public sealed class FileQueryService : IFileQueryService
             return Array.Empty<SearchHistoryEntry>();
         }
 
-        var result = new List<SearchHistoryEntry>(entries.Count);
-        foreach (var entry in entries)
-        {
-            result.Add(MapHistory(entry));
-        }
-
-        return result;
+        return entries;
     }
 
     public async Task<IReadOnlyList<SearchFavoriteItem>> GetFavoritesAsync(CancellationToken cancellationToken)
@@ -68,13 +59,7 @@ public sealed class FileQueryService : IFileQueryService
             return Array.Empty<SearchFavoriteItem>();
         }
 
-        var result = new List<SearchFavoriteItem>(favorites.Count);
-        foreach (var favorite in favorites)
-        {
-            result.Add(MapFavorite(favorite));
-        }
-
-        return result;
+        return favorites;
     }
 
     public Task AddFavoriteAsync(SearchFavoriteDefinition favorite, CancellationToken cancellationToken)
@@ -88,9 +73,4 @@ public sealed class FileQueryService : IFileQueryService
         return _favoritesService.RemoveAsync(favoriteId, cancellationToken);
     }
 
-    private static SearchHistoryEntry MapHistory(AppSearchHistoryEntry entry)
-        => new(entry.Id, entry.QueryText, entry.MatchQuery, entry.LastQueriedUtc, entry.Executions, entry.LastTotalHits, entry.IsFuzzy);
-
-    private static SearchFavoriteItem MapFavorite(AppSearchFavoriteItem favorite)
-        => new(favorite.Id, favorite.Name, favorite.QueryText, favorite.MatchQuery, favorite.Position, favorite.CreatedUtc, favorite.IsFuzzy);
 }

--- a/Veriado.Services/Files/IFileQueryService.cs
+++ b/Veriado.Services/Files/IFileQueryService.cs
@@ -5,7 +5,6 @@ using System.Threading.Tasks;
 using Veriado.Contracts.Common;
 using Veriado.Contracts.Files;
 using Veriado.Contracts.Search;
-using Veriado.Services.Files.Models;
 
 namespace Veriado.Services.Files;
 

--- a/Veriado.Services/Files/Models/SearchFavoriteDefinition.cs
+++ b/Veriado.Services/Files/Models/SearchFavoriteDefinition.cs
@@ -1,6 +1,0 @@
-namespace Veriado.Services.Files.Models;
-
-/// <summary>
-/// Represents the information required to create a saved search favourite.
-/// </summary>
-public sealed record SearchFavoriteDefinition(string Name, string MatchQuery, string? QueryText, bool IsFuzzy);


### PR DESCRIPTION
## Summary
- reference search DTOs from `Veriado.Contracts` inside application abstractions and infrastructure services
- update service layer to consume and return contract DTOs and remove the duplicated services model
- add AutoMapper search profiles and register them so search entities map to the new contracts

## Testing
- `dotnet build` *(fails: dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d152927ae08326b8d5fd4d5eceee77