### PR TITLE
Fix FileContentDto mapping construction

### DIFF
--- a/Veriado.Mapping/Profiles/FileReadProfiles.cs
+++ b/Veriado.Mapping/Profiles/FileReadProfiles.cs
@@ -95,7 +95,7 @@ public sealed class FileReadProfiles : Profile
             .ForMember(dest => dest.LastModifiedUtc, opt => opt.MapFrom(src => src.LastModifiedUtc))
             .ForMember(dest => dest.IsReadOnly, opt => opt.MapFrom(src => src.IsReadOnly))
             .ForMember(dest => dest.Version, opt => opt.MapFrom(src => src.Version))
-            .ForMember(dest => dest.Content, opt => opt.MapFrom(src => new FileContentDto(string.Empty, src.SizeBytes)))
+            .ForMember(dest => dest.Content, opt => opt.MapFrom(src => new FileContentDto(string.Empty, src.SizeBytes, null)))
             .ForMember(dest => dest.SystemMetadata, opt => opt.MapFrom(src => src.SystemMetadata))
             .ForMember(dest => dest.ExtendedMetadata, opt =>
             {


### PR DESCRIPTION
## Summary
- ensure AutoMapper's FileDetailReadModel to FileDetailDto mapping supplies the explicit bytes argument when constructing FileContentDto to avoid optional parameters in expression trees

## Testing
- ⚠️ `dotnet build` *(dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d17d7735848326919d49276f4fdd23