### PR TITLE
Add MVVM scaffolding for WinUI presentation

### DIFF
--- a/Veriado.WinUI/AppHost.cs
+++ b/Veriado.WinUI/AppHost.cs
@@ -2,10 +2,16 @@ using System;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Veriado.Application.DependencyInjection;
 using Veriado.Converters;
+using Veriado.Infrastructure.DependencyInjection;
+using Veriado.Mapping.DependencyInjection;
+using Veriado.Presentation.Services;
 using Veriado.Services;
+using Veriado.Services.DependencyInjection;
 using Veriado.ViewModels.Files;
 using Veriado.ViewModels.Import;
+using Veriado.ViewModels.Search;
 using Veriado.ViewModels.Shell;
 
 namespace Veriado;
@@ -31,12 +37,20 @@ internal sealed class AppHost : IAsyncDisposable
                 services.AddTransient<FilesGridViewModel>();
                 services.AddTransient<FileDetailViewModel>();
                 services.AddTransient<ImportViewModel>();
+                services.AddTransient<HistoryViewModel>();
+                services.AddTransient<FavoritesViewModel>();
 
                 services.AddSingleton<BoolToSeverityConverter>();
 
                 services.AddSingleton<INavigationService, NavigationService>();
+                services.AddSingleton<IPickerService, PickerService>();
 
-                // TODO: Register application, infrastructure, mapping, and services layers when wiring the full stack.
+                services.AddApplication();
+                services.AddVeriadoMapping();
+                services.AddInfrastructure();
+                services.AddVeriadoServices();
+
+                // TODO: Configure infrastructure options (database path, etc.) when wiring the full stack.
             })
             .Build();
 

--- a/Veriado.WinUI/Mappers/UiMappers.cs
+++ b/Veriado.WinUI/Mappers/UiMappers.cs
@@ -1,0 +1,173 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using Veriado.Contracts.Files;
+using Veriado.Contracts.Search;
+using Veriado.Models.Files;
+using Veriado.Models.Search;
+
+namespace Veriado.Mappers;
+
+/// <summary>
+/// Provides helper extensions to convert contracts DTOs into UI-facing models.
+/// </summary>
+public static class UiMappers
+{
+    public static FileListItemModel ToFileListItemModel(this FileSummaryDto dto)
+    {
+        ArgumentNullException.ThrowIfNull(dto);
+
+        return new FileListItemModel
+        {
+            Id = dto.Id,
+            Name = dto.Name,
+            Extension = dto.Extension,
+            Mime = dto.Mime,
+            Author = dto.Author,
+            SizeBytes = dto.Size,
+            CreatedUtc = dto.CreatedUtc,
+            LastModifiedUtc = dto.LastModifiedUtc,
+            IsReadOnly = dto.IsReadOnly,
+            ValidUntilUtc = dto.Validity?.ValidUntil,
+            IsIndexStale = dto.IsIndexStale,
+            Score = dto.Score,
+        };
+    }
+
+    public static FileDetailModel ToFileDetailModel(this FileDetailDto dto)
+    {
+        ArgumentNullException.ThrowIfNull(dto);
+
+        return new FileDetailModel
+        {
+            Id = dto.Id,
+            Name = dto.Name,
+            Extension = dto.Extension,
+            Mime = dto.Mime,
+            Author = dto.Author,
+            SizeBytes = dto.Size,
+            CreatedUtc = dto.CreatedUtc,
+            LastModifiedUtc = dto.LastModifiedUtc,
+            IsReadOnly = dto.IsReadOnly,
+            Version = dto.Version,
+            Content = dto.Content,
+            SystemMetadata = dto.SystemMetadata,
+            ExtendedMetadata = MapExtendedMetadata(dto.ExtendedMetadata),
+            Validity = dto.Validity,
+            IsIndexStale = dto.IsIndexStale,
+            LastIndexedUtc = dto.LastIndexedUtc,
+            IndexedTitle = dto.IndexedTitle,
+            IndexSchemaVersion = dto.IndexSchemaVersion,
+            IndexedContentHash = dto.IndexedContentHash,
+        };
+    }
+
+    public static SearchHistoryItemModel ToSearchHistoryItemModel(this SearchHistoryEntry entry)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+
+        return new SearchHistoryItemModel
+        {
+            Id = entry.Id,
+            QueryText = entry.QueryText,
+            MatchQuery = entry.MatchQuery,
+            LastQueriedUtc = entry.LastQueriedUtc,
+            Executions = entry.Executions,
+            LastTotalHits = entry.LastTotalHits,
+            IsFuzzy = entry.IsFuzzy,
+        };
+    }
+
+    public static SearchFavoriteItemModel ToSearchFavoriteItemModel(this SearchFavoriteItem item)
+    {
+        ArgumentNullException.ThrowIfNull(item);
+
+        return new SearchFavoriteItemModel
+        {
+            Id = item.Id,
+            Name = item.Name,
+            QueryText = item.QueryText,
+            MatchQuery = item.MatchQuery,
+            Position = item.Position,
+            CreatedUtc = item.CreatedUtc,
+            IsFuzzy = item.IsFuzzy,
+        };
+    }
+
+    public static SearchFavoriteDefinitionModel ToSearchFavoriteDefinitionModel(this SearchFavoriteDefinition definition)
+    {
+        ArgumentNullException.ThrowIfNull(definition);
+
+        return new SearchFavoriteDefinitionModel
+        {
+            Name = definition.Name,
+            MatchQuery = definition.MatchQuery,
+            QueryText = definition.QueryText,
+            IsFuzzy = definition.IsFuzzy,
+        };
+    }
+
+    public static SearchHitModel ToSearchHitModel(this SearchHitDto dto)
+    {
+        ArgumentNullException.ThrowIfNull(dto);
+
+        return new SearchHitModel
+        {
+            FileId = dto.FileId,
+            Title = dto.Title,
+            Mime = dto.Mime,
+            Snippet = dto.Snippet,
+            Score = dto.Score,
+            LastModifiedUtc = dto.LastModifiedUtc,
+        };
+    }
+
+    private static IReadOnlyDictionary<string, string?> MapExtendedMetadata(IReadOnlyList<ExtendedMetadataItemDto> metadata)
+    {
+        if (metadata is null || metadata.Count == 0)
+        {
+            return new Dictionary<string, string?>(StringComparer.Ordinal);
+        }
+
+        var result = new Dictionary<string, string?>(metadata.Count, StringComparer.Ordinal);
+        foreach (var item in metadata)
+        {
+            if (item is null || item.Remove)
+            {
+                continue;
+            }
+
+            var key = $"{item.FormatId:D}:{item.PropertyId}";
+            result[key] = FormatMetadataValue(item.Value);
+        }
+
+        return result;
+    }
+
+    private static string? FormatMetadataValue(MetadataValueDto? value)
+    {
+        if (value is null)
+        {
+            return null;
+        }
+
+        return value.Kind switch
+        {
+            MetadataValueDtoKind.Null => null,
+            MetadataValueDtoKind.String => value.StringValue,
+            MetadataValueDtoKind.StringArray => value.StringArrayValue is null
+                ? null
+                : string.Join(", ", value.StringArrayValue),
+            MetadataValueDtoKind.UInt32 => value.UInt32Value?.ToString(CultureInfo.InvariantCulture),
+            MetadataValueDtoKind.Int32 => value.Int32Value?.ToString(CultureInfo.InvariantCulture),
+            MetadataValueDtoKind.Double => value.DoubleValue?.ToString(CultureInfo.InvariantCulture),
+            MetadataValueDtoKind.Boolean => value.BooleanValue?.ToString(CultureInfo.InvariantCulture),
+            MetadataValueDtoKind.Guid => value.GuidValue?.ToString(),
+            MetadataValueDtoKind.FileTime => value.FileTimeValue?.ToString("u", CultureInfo.InvariantCulture),
+            MetadataValueDtoKind.Binary => value.BinaryValue is null
+                ? null
+                : Convert.ToHexString(value.BinaryValue),
+            _ => value.ToString(),
+        };
+    }
+}

--- a/Veriado.WinUI/Models/Files/FileDetailModel.cs
+++ b/Veriado.WinUI/Models/Files/FileDetailModel.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Collections.Generic;
+using Veriado.Contracts.Files;
+
+namespace Veriado.Models.Files;
+
+/// <summary>
+/// Represents a presentation-friendly projection of <see cref="FileDetailDto"/>.
+/// </summary>
+public sealed class FileDetailModel
+{
+    /// <summary>
+    /// Gets or sets the file identifier.
+    /// </summary>
+    public Guid Id { get; init; }
+
+    /// <summary>
+    /// Gets or sets the file name without extension.
+    /// </summary>
+    public string Name { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the file extension without the leading dot.
+    /// </summary>
+    public string Extension { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the MIME type of the file.
+    /// </summary>
+    public string Mime { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the author assigned to the file.
+    /// </summary>
+    public string Author { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the file size in bytes.
+    /// </summary>
+    public long SizeBytes { get; init; }
+
+    /// <summary>
+    /// Gets or sets the creation timestamp in UTC.
+    /// </summary>
+    public DateTimeOffset CreatedUtc { get; init; }
+
+    /// <summary>
+    /// Gets or sets the last modification timestamp in UTC.
+    /// </summary>
+    public DateTimeOffset LastModifiedUtc { get; init; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the file is read-only.
+    /// </summary>
+    public bool IsReadOnly { get; init; }
+
+    /// <summary>
+    /// Gets or sets the aggregate content version.
+    /// </summary>
+    public int Version { get; init; }
+
+    /// <summary>
+    /// Gets or sets the binary content metadata.
+    /// </summary>
+    public FileContentDto Content { get; init; } = new(string.Empty, 0L);
+
+    /// <summary>
+    /// Gets or sets the captured file system metadata.
+    /// </summary>
+    public FileSystemMetadataDto SystemMetadata { get; init; }
+        = new(0, DateTimeOffset.MinValue, DateTimeOffset.MinValue, DateTimeOffset.MinValue, null, null, null);
+
+    /// <summary>
+    /// Gets or sets the structured extended metadata entries mapped to display-friendly values.
+    /// </summary>
+    public IReadOnlyDictionary<string, string?> ExtendedMetadata { get; init; }
+        = new Dictionary<string, string?>(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Gets or sets the optional validity information.
+    /// </summary>
+    public FileValidityDto? Validity { get; init; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the search index entry is stale.
+    /// </summary>
+    public bool IsIndexStale { get; init; }
+
+    /// <summary>
+    /// Gets or sets the timestamp of the last successful indexing operation.
+    /// </summary>
+    public DateTimeOffset? LastIndexedUtc { get; init; }
+
+    /// <summary>
+    /// Gets or sets the indexed title stored in the search index.
+    /// </summary>
+    public string? IndexedTitle { get; init; }
+
+    /// <summary>
+    /// Gets or sets the schema version of the search index entry.
+    /// </summary>
+    public int IndexSchemaVersion { get; init; }
+
+    /// <summary>
+    /// Gets or sets the indexed content hash when available.
+    /// </summary>
+    public string? IndexedContentHash { get; init; }
+
+    /// <summary>
+    /// Gets the optional validity expiration timestamp in UTC.
+    /// </summary>
+    public DateTimeOffset? ValidUntilUtc => Validity?.ValidUntil;
+}

--- a/Veriado.WinUI/Models/Files/FileListItemModel.cs
+++ b/Veriado.WinUI/Models/Files/FileListItemModel.cs
@@ -1,0 +1,69 @@
+using System;
+
+namespace Veriado.Models.Files;
+
+/// <summary>
+/// Represents a lightweight projection of <see cref="Contracts.Files.FileSummaryDto"/> tailored for list views.
+/// </summary>
+public sealed class FileListItemModel
+{
+    /// <summary>
+    /// Gets or sets the file identifier.
+    /// </summary>
+    public Guid Id { get; init; }
+
+    /// <summary>
+    /// Gets or sets the file name without extension.
+    /// </summary>
+    public string Name { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the file extension without the leading dot.
+    /// </summary>
+    public string Extension { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the MIME type of the file.
+    /// </summary>
+    public string Mime { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the author assigned to the file.
+    /// </summary>
+    public string Author { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the file size in bytes.
+    /// </summary>
+    public long SizeBytes { get; init; }
+
+    /// <summary>
+    /// Gets or sets the timestamp when the file was created.
+    /// </summary>
+    public DateTimeOffset CreatedUtc { get; init; }
+
+    /// <summary>
+    /// Gets or sets the timestamp when the file was last modified.
+    /// </summary>
+    public DateTimeOffset LastModifiedUtc { get; init; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the file is read-only.
+    /// </summary>
+    public bool IsReadOnly { get; init; }
+
+    /// <summary>
+    /// Gets or sets the optional validity expiration timestamp in UTC.
+    /// </summary>
+    public DateTimeOffset? ValidUntilUtc { get; init; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the search index entry is stale.
+    /// </summary>
+    public bool IsIndexStale { get; init; }
+
+    /// <summary>
+    /// Gets or sets the optional relevance score returned by full-text search.
+    /// </summary>
+    public double? Score { get; init; }
+}

--- a/Veriado.WinUI/Models/Import/ImportProgressModel.cs
+++ b/Veriado.WinUI/Models/Import/ImportProgressModel.cs
@@ -1,0 +1,38 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace Veriado.Models.Import;
+
+/// <summary>
+/// Represents the UI-facing progress of a long-running import operation.
+/// </summary>
+public sealed partial class ImportProgressModel : ObservableObject
+{
+    [ObservableProperty]
+    private int total;
+
+    [ObservableProperty]
+    private int processed;
+
+    [ObservableProperty]
+    private int errorsCount;
+
+    [ObservableProperty]
+    private string? currentPath;
+
+    [ObservableProperty]
+    private bool isRunning;
+
+    /// <summary>
+    /// Gets the completion percentage for the current batch.
+    /// </summary>
+    public double Percent => Total == 0 ? 0 : (double)Processed / Total * 100.0;
+
+    /// <summary>
+    /// Gets a value indicating whether any errors occurred.
+    /// </summary>
+    public bool HasErrors => ErrorsCount > 0;
+
+    partial void OnTotalChanged(int value) => OnPropertyChanged(nameof(Percent));
+
+    partial void OnProcessedChanged(int value) => OnPropertyChanged(nameof(Percent));
+}

--- a/Veriado.WinUI/Models/Search/SearchFavoriteDefinitionModel.cs
+++ b/Veriado.WinUI/Models/Search/SearchFavoriteDefinitionModel.cs
@@ -1,0 +1,15 @@
+namespace Veriado.Models.Search;
+
+/// <summary>
+/// Represents the data required to create a new search favourite from the UI.
+/// </summary>
+public sealed class SearchFavoriteDefinitionModel
+{
+    public string Name { get; init; } = string.Empty;
+
+    public string MatchQuery { get; init; } = string.Empty;
+
+    public string? QueryText { get; init; }
+
+    public bool IsFuzzy { get; init; }
+}

--- a/Veriado.WinUI/Models/Search/SearchFavoriteItemModel.cs
+++ b/Veriado.WinUI/Models/Search/SearchFavoriteItemModel.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace Veriado.Models.Search;
+
+/// <summary>
+/// Represents a saved favourite search entry exposed in the UI.
+/// </summary>
+public sealed class SearchFavoriteItemModel
+{
+    public Guid Id { get; init; }
+
+    public string Name { get; init; } = string.Empty;
+
+    public string? QueryText { get; init; }
+
+    public string MatchQuery { get; init; } = string.Empty;
+
+    public int Position { get; init; }
+
+    public DateTimeOffset CreatedUtc { get; init; }
+
+    public bool IsFuzzy { get; init; }
+}

--- a/Veriado.WinUI/Models/Search/SearchHistoryItemModel.cs
+++ b/Veriado.WinUI/Models/Search/SearchHistoryItemModel.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace Veriado.Models.Search;
+
+/// <summary>
+/// Represents a single entry in the user search history.
+/// </summary>
+public sealed class SearchHistoryItemModel
+{
+    public Guid Id { get; init; }
+
+    public string? QueryText { get; init; }
+
+    public string MatchQuery { get; init; } = string.Empty;
+
+    public DateTimeOffset LastQueriedUtc { get; init; }
+
+    public int Executions { get; init; }
+
+    public int? LastTotalHits { get; init; }
+
+    public bool IsFuzzy { get; init; }
+}

--- a/Veriado.WinUI/Models/Search/SearchHitModel.cs
+++ b/Veriado.WinUI/Models/Search/SearchHitModel.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace Veriado.Models.Search;
+
+/// <summary>
+/// Represents a single search result displayed in the UI.
+/// </summary>
+public sealed class SearchHitModel
+{
+    public Guid FileId { get; init; }
+
+    public string Title { get; init; } = string.Empty;
+
+    public string Mime { get; init; } = string.Empty;
+
+    public string? Snippet { get; init; }
+
+    public double Score { get; init; }
+
+    public DateTimeOffset LastModifiedUtc { get; init; }
+}

--- a/Veriado.WinUI/Services/PickerService.cs
+++ b/Veriado.WinUI/Services/PickerService.cs
@@ -1,0 +1,17 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Veriado.Presentation.Services;
+
+namespace Veriado.Services;
+
+/// <summary>
+/// Temporary picker service implementation that will be replaced with platform-specific pickers.
+/// </summary>
+internal sealed class PickerService : IPickerService
+{
+    public Task<string?> PickFolderAsync(CancellationToken cancellationToken)
+        => Task.FromResult<string?>(null);
+
+    public Task<PickedFile?> PickFileAsync(CancellationToken cancellationToken)
+        => Task.FromResult<PickedFile?>(null);
+}

--- a/Veriado.WinUI/ViewModels/Base/ViewModelBase.cs
+++ b/Veriado.WinUI/ViewModels/Base/ViewModelBase.cs
@@ -26,7 +26,10 @@ public abstract partial class ViewModelBase : ObservableObject
         }
 
         HasError = false;
-        StatusMessage = busyMessage;
+        if (!string.IsNullOrWhiteSpace(busyMessage))
+        {
+            StatusMessage = busyMessage;
+        }
 
         using var cts = new CancellationTokenSource();
         Cts = cts;
@@ -35,7 +38,10 @@ public abstract partial class ViewModelBase : ObservableObject
         try
         {
             await action(cts.Token).ConfigureAwait(false);
-            StatusMessage = null;
+            if (!string.IsNullOrWhiteSpace(busyMessage) && StatusMessage == busyMessage)
+            {
+                StatusMessage = null;
+            }
         }
         catch (OperationCanceledException)
         {

--- a/Veriado.WinUI/ViewModels/Files/FileDetailViewModel.cs
+++ b/Veriado.WinUI/ViewModels/Files/FileDetailViewModel.cs
@@ -2,42 +2,56 @@ using System;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Veriado.Mappers;
+using Veriado.Models.Files;
 using Veriado.Services;
+using Veriado.Services.Files;
 using Veriado.ViewModels.Base;
 
 namespace Veriado.ViewModels.Files;
 
 public sealed partial class FileDetailViewModel : ViewModelBase
 {
+    private readonly IFileQueryService _fileQueryService;
     private readonly INavigationService _navigationService;
 
-    public FileDetailViewModel(INavigationService navigationService)
+    public FileDetailViewModel(IFileQueryService fileQueryService, INavigationService navigationService)
     {
-        _navigationService = navigationService;
+        _fileQueryService = fileQueryService ?? throw new ArgumentNullException(nameof(fileQueryService));
+        _navigationService = navigationService ?? throw new ArgumentNullException(nameof(navigationService));
     }
 
     [ObservableProperty]
-    private Guid fileId;
+    private Guid? id;
 
     [ObservableProperty]
-    private string? fileName;
+    private FileDetailModel? detail;
 
     [RelayCommand]
-    private async Task LoadAsync(Guid id)
+    private async Task LoadAsync(Guid fileId)
     {
-        FileId = id;
+        Id = fileId;
+
         await SafeExecuteAsync(async ct =>
         {
-            await Task.Delay(120, ct).ConfigureAwait(false);
-            FileName = $"Detail dokumentu {id.ToString()[..8]}";
-        }, "Načítám detail…");
+            var dto = await _fileQueryService.GetDetailAsync(fileId, ct).ConfigureAwait(false);
+            if (dto is null)
+            {
+                Detail = null;
+                HasError = true;
+                StatusMessage = "Dokument nebyl nalezen.";
+                return;
+            }
 
-        StatusMessage = "Detail načten.";
+            Detail = dto.ToFileDetailModel();
+            StatusMessage = "Detail načten.";
+        }, "Načítám detail…");
     }
 
     [RelayCommand]
     private void Close()
     {
+        Cancel();
         _navigationService.GoBack();
     }
 }

--- a/Veriado.WinUI/ViewModels/Import/ImportViewModel.cs
+++ b/Veriado.WinUI/ViewModels/Import/ImportViewModel.cs
@@ -1,42 +1,134 @@
+using System;
+using System.Linq;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Veriado.Contracts.Import;
+using Veriado.Models.Import;
+using Veriado.Presentation.Services;
+using Veriado.Services.Import;
 using Veriado.ViewModels.Base;
 
 namespace Veriado.ViewModels.Import;
 
 public sealed partial class ImportViewModel : ViewModelBase
 {
-    [ObservableProperty]
-    private double progress;
+    private readonly IImportService _importService;
+    private readonly IPickerService _pickerService;
+
+    public ImportViewModel(IImportService importService, IPickerService pickerService)
+    {
+        _importService = importService ?? throw new ArgumentNullException(nameof(importService));
+        _pickerService = pickerService ?? throw new ArgumentNullException(nameof(pickerService));
+        progress = new ImportProgressModel();
+    }
 
     [ObservableProperty]
-    private bool isCompleted;
+    private string? selectedFolderPath;
+
+    [ObservableProperty]
+    private string? defaultAuthor;
+
+    [ObservableProperty]
+    private string searchPattern = "*.*";
+
+    [ObservableProperty]
+    private bool recursive = true;
+
+    [ObservableProperty]
+    private bool extractContent = true;
+
+    [ObservableProperty]
+    private int maxDegreeOfParallelism = 2;
+
+    [ObservableProperty]
+    private ImportProgressModel progress;
 
     [RelayCommand]
-    private async Task StartImportAsync()
+    private async Task BrowseFolderAsync()
     {
         await SafeExecuteAsync(async ct =>
         {
-            for (var i = 0; i <= 10; i++)
+            var folder = await _pickerService.PickFolderAsync(ct).ConfigureAwait(false);
+            if (!string.IsNullOrWhiteSpace(folder))
             {
-                ct.ThrowIfCancellationRequested();
-                await Task.Delay(120, ct).ConfigureAwait(false);
-                Progress = i * 10;
+                SelectedFolderPath = folder;
+                StatusMessage = $"Vybrána složka: {folder}.";
             }
+        }, "Otevírám výběr složky…");
+    }
 
-            IsCompleted = true;
-        }, "Import probíhá…");
+    [RelayCommand]
+    private async Task ImportAsync()
+    {
+        if (string.IsNullOrWhiteSpace(SelectedFolderPath))
+        {
+            HasError = true;
+            StatusMessage = "Vyberte prosím složku k importu.";
+            return;
+        }
 
-        StatusMessage = IsCompleted ? "Import dokončen." : StatusMessage;
+        await SafeExecuteAsync(async ct =>
+        {
+            ResetProgress();
+            Progress.IsRunning = true;
+            Progress.CurrentPath = SelectedFolderPath;
+
+            try
+            {
+                var request = new ImportFolderRequest
+                {
+                    FolderPath = SelectedFolderPath!,
+                    DefaultAuthor = string.IsNullOrWhiteSpace(DefaultAuthor) ? null : DefaultAuthor,
+                    ExtractContent = ExtractContent,
+                    MaxDegreeOfParallelism = MaxDegreeOfParallelism,
+                    SearchPattern = string.IsNullOrWhiteSpace(SearchPattern) ? "*.*" : SearchPattern,
+                    Recursive = Recursive,
+                };
+
+                var response = await _importService.ImportFolderAsync(request, ct).ConfigureAwait(false);
+                if (!response.IsSuccess || response.Data is null)
+                {
+                    HasError = true;
+                    StatusMessage = response.Errors.Count > 0
+                        ? string.Join(Environment.NewLine, response.Errors.Select(e => e.Message))
+                        : "Import selhal.";
+                    return;
+                }
+
+                var result = response.Data;
+                Progress.Total = result.Total;
+                Progress.Processed = result.Succeeded + result.Failed;
+                Progress.ErrorsCount = result.Failed;
+
+                HasError = result.Errors.Count > 0;
+                StatusMessage = HasError
+                    ? $"Import dokončen s {result.Errors.Count} chybami."
+                    : $"Import dokončen. Zpracováno {result.Succeeded} z {result.Total} souborů.";
+            }
+            finally
+            {
+                Progress.IsRunning = false;
+                Progress.CurrentPath = null;
+            }
+        }, "Importuji soubory…");
     }
 
     [RelayCommand]
     private void Reset()
     {
-        Progress = 0;
-        IsCompleted = false;
+        Cancel();
+        Progress = new ImportProgressModel();
         StatusMessage = null;
         HasError = false;
+    }
+
+    private void ResetProgress()
+    {
+        Progress.Total = 0;
+        Progress.Processed = 0;
+        Progress.ErrorsCount = 0;
+        Progress.CurrentPath = null;
+        Progress.IsRunning = false;
     }
 }

--- a/Veriado.WinUI/ViewModels/Search/FavoritesViewModel.cs
+++ b/Veriado.WinUI/ViewModels/Search/FavoritesViewModel.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Collections.ObjectModel;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Veriado.Contracts.Search;
+using Veriado.Mappers;
+using Veriado.Models.Search;
+using Veriado.Services.Files;
+using Veriado.ViewModels.Base;
+
+namespace Veriado.ViewModels.Search;
+
+public sealed partial class FavoritesViewModel : ViewModelBase
+{
+    private readonly IFileQueryService _fileQueryService;
+
+    public FavoritesViewModel(IFileQueryService fileQueryService)
+    {
+        _fileQueryService = fileQueryService ?? throw new ArgumentNullException(nameof(fileQueryService));
+    }
+
+    public ObservableCollection<SearchFavoriteItemModel> Items { get; } = new();
+
+    [RelayCommand]
+    private async Task LoadAsync()
+    {
+        await SafeExecuteAsync(async ct =>
+        {
+            var favorites = await _fileQueryService.GetFavoritesAsync(ct).ConfigureAwait(false);
+
+            Items.Clear();
+            foreach (var favorite in favorites)
+            {
+                Items.Add(favorite.ToSearchFavoriteItemModel());
+            }
+
+            StatusMessage = Items.Count == 0
+                ? "Žádné uložené oblíbené položky."
+                : $"Načteno {Items.Count} oblíbených vyhledávání.";
+        }, "Načítám oblíbená vyhledávání…");
+    }
+
+    [RelayCommand]
+    private async Task RemoveAsync(Guid id)
+    {
+        if (id == Guid.Empty)
+        {
+            return;
+        }
+
+        await SafeExecuteAsync(async ct =>
+        {
+            await _fileQueryService.RemoveFavoriteAsync(id, ct).ConfigureAwait(false);
+        }, "Odstraňuji oblíbené vyhledávání…");
+
+        await LoadAsync();
+    }
+
+    [RelayCommand]
+    private async Task AddAsync(SearchFavoriteDefinitionModel? favorite)
+    {
+        if (favorite is null || string.IsNullOrWhiteSpace(favorite.Name))
+        {
+            HasError = true;
+            StatusMessage = "Název oblíbeného vyhledávání je povinný.";
+            return;
+        }
+
+        await SafeExecuteAsync(async ct =>
+        {
+            var definition = new SearchFavoriteDefinition(
+                favorite.Name,
+                favorite.MatchQuery,
+                favorite.QueryText,
+                favorite.IsFuzzy);
+
+            await _fileQueryService.AddFavoriteAsync(definition, ct).ConfigureAwait(false);
+        }, "Ukládám oblíbené vyhledávání…");
+
+        await LoadAsync();
+    }
+}

--- a/Veriado.WinUI/ViewModels/Search/HistoryViewModel.cs
+++ b/Veriado.WinUI/ViewModels/Search/HistoryViewModel.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.ObjectModel;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Veriado.Mappers;
+using Veriado.Models.Search;
+using Veriado.Services.Files;
+using Veriado.ViewModels.Base;
+
+namespace Veriado.ViewModels.Search;
+
+public sealed partial class HistoryViewModel : ViewModelBase
+{
+    private readonly IFileQueryService _fileQueryService;
+
+    public HistoryViewModel(IFileQueryService fileQueryService)
+    {
+        _fileQueryService = fileQueryService ?? throw new ArgumentNullException(nameof(fileQueryService));
+    }
+
+    public ObservableCollection<SearchHistoryItemModel> Items { get; } = new();
+
+    [ObservableProperty]
+    private int take = 50;
+
+    [RelayCommand]
+    private async Task LoadAsync()
+    {
+        await SafeExecuteAsync(async ct =>
+        {
+            var entries = await _fileQueryService.GetSearchHistoryAsync(Take, ct).ConfigureAwait(false);
+
+            Items.Clear();
+            foreach (var entry in entries)
+            {
+                Items.Add(entry.ToSearchHistoryItemModel());
+            }
+
+            StatusMessage = Items.Count == 0
+                ? "Historie je prázdná."
+                : $"Načteno {Items.Count} položek historie.";
+        }, "Načítám historii hledání…");
+    }
+}

--- a/Veriado.WinUI/ViewModels/Shell/ShellViewModel.cs
+++ b/Veriado.WinUI/ViewModels/Shell/ShellViewModel.cs
@@ -1,10 +1,11 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Veriado.Services;
+using Veriado.ViewModels.Base;
 
 namespace Veriado.ViewModels.Shell;
 
-public sealed partial class ShellViewModel : ObservableObject
+public sealed partial class ShellViewModel : ViewModelBase
 {
     private readonly INavigationService _navigationService;
 

--- a/Veriado.WinUI/Views/FileDetailPage.xaml
+++ b/Veriado.WinUI/Views/FileDetailPage.xaml
@@ -16,23 +16,49 @@
 
     <StackPanel Orientation="Horizontal" Spacing="12">
       <Button Content="Zpět" Command="{Binding CloseCommand}" />
-      <TextBlock Text="{Binding FileName}" Style="{StaticResource SectionTitleTextBlockStyle}" />
+      <TextBlock Text="{Binding Detail.Name}" Style="{StaticResource SectionTitleTextBlockStyle}" />
+      <ProgressRing Width="24" Height="24" IsActive="{Binding IsBusy}" />
     </StackPanel>
 
-    <InfoBar
-        Grid.Row="1"
-        x:Name="DetailStatusInfoBar"
-        IsOpen="True"
-        Severity="{Binding HasError, Converter={StaticResource BoolToSeverityConverter}}"
-        Title="Stav detailu">
-      <i:Interaction.Behaviors>
-        <core:EventTriggerBehavior EventName="Loaded">
-          <core:CallMethodAction TargetObject="{Binding ElementName=DetailStatusInfoBar}" MethodName="BringIntoView" />
-        </core:EventTriggerBehavior>
-      </i:Interaction.Behaviors>
-      <StackPanel>
-        <TextBlock Text="{Binding StatusMessage}" />
+    <Grid Grid.Row="1" ColumnSpacing="24">
+      <Grid.ColumnDefinitions>
+        <ColumnDefinition Width="200" />
+        <ColumnDefinition Width="*" />
+      </Grid.ColumnDefinitions>
+      <StackPanel Grid.Column="0" Spacing="8">
+        <TextBlock Text="Autor" Style="{ThemeResource BodyStrongTextBlockStyle}" />
+        <TextBlock Text="{Binding Detail.Author}" />
+        <TextBlock Text="Typ" Style="{ThemeResource BodyStrongTextBlockStyle}" Margin="0,12,0,0" />
+        <TextBlock Text="{Binding Detail.Mime}" />
+        <TextBlock Text="Velikost" Style="{ThemeResource BodyStrongTextBlockStyle}" Margin="0,12,0,0" />
+        <TextBlock Text="{Binding Detail.SizeBytes}" />
+        <TextBlock Text="Platí do" Style="{ThemeResource BodyStrongTextBlockStyle}" Margin="0,12,0,0" />
+        <TextBlock Text="{Binding Detail.ValidUntilUtc, StringFormat='{}{0:G}'}" />
       </StackPanel>
-    </InfoBar>
+
+      <StackPanel Grid.Column="1" Spacing="12">
+        <InfoBar
+            x:Name="DetailStatusInfoBar"
+            IsOpen="True"
+            Severity="{Binding HasError, Converter={StaticResource BoolToSeverityConverter}}"
+            Title="Stav detailu">
+          <i:Interaction.Behaviors>
+            <core:EventTriggerBehavior EventName="Loaded">
+              <core:CallMethodAction TargetObject="{Binding ElementName=DetailStatusInfoBar}" MethodName="BringIntoView" />
+            </core:EventTriggerBehavior>
+          </i:Interaction.Behaviors>
+          <StackPanel>
+            <TextBlock Text="{Binding StatusMessage}" />
+          </StackPanel>
+        </InfoBar>
+
+        <StackPanel>
+          <TextBlock Text="Systémová metadata" Style="{ThemeResource BodyStrongTextBlockStyle}" />
+          <TextBlock Text="Vytvořeno: {Binding Detail.SystemMetadata.CreatedUtc, StringFormat='{}{0:G}'}" />
+          <TextBlock Text="Změněno: {Binding Detail.LastModifiedUtc, StringFormat='{}{0:G}'}" />
+          <TextBlock Text="Verze: {Binding Detail.Version}" />
+        </StackPanel>
+      </StackPanel>
+    </Grid>
   </Grid>
 </Page>

--- a/Veriado.WinUI/Views/FilesPage.xaml
+++ b/Veriado.WinUI/Views/FilesPage.xaml
@@ -10,6 +10,7 @@
     xmlns:trig="using:CommunityToolkit.WinUI.Triggers"
     xmlns:controls="using:CommunityToolkit.WinUI.Controls"
     xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+    xmlns:models="using:Veriado.Models.Files"
     xmlns:vm="using:Veriado.ViewModels.Files"
     NavigationCacheMode="Enabled"
     x:DataType="vm:FilesGridViewModel">
@@ -44,7 +45,7 @@
               MinRowSpacing="12" />
         </muxc:ItemsRepeater.Layout>
         <muxc:ItemsRepeater.ItemTemplate>
-          <DataTemplate x:DataType="vm:FileListItemModel">
+          <DataTemplate x:DataType="models:FileListItemModel">
             <Border
                 Padding="16"
                 Margin="8"
@@ -58,7 +59,8 @@
               </i:Interaction.Behaviors>
               <StackPanel Spacing="8">
                 <TextBlock Text="{Binding Name}" Style="{ThemeResource BodyStrongTextBlockStyle}" />
-                <TextBlock Text="{Binding Id}" Opacity="0.6" TextTrimming="CharacterEllipsis" />
+                <TextBlock Text="{Binding Author}" Opacity="0.8" />
+                <TextBlock Text="{Binding LastModifiedUtc, StringFormat='{}{0:G}'}" Opacity="0.6" />
               </StackPanel>
             </Border>
           </DataTemplate>

--- a/Veriado.WinUI/Views/ImportPage.xaml
+++ b/Veriado.WinUI/Views/ImportPage.xaml
@@ -17,19 +17,51 @@
   </i:Interaction.Behaviors>
 
   <Grid Padding="24" RowSpacing="16">
-    <StackPanel Spacing="12">
+    <StackPanel Spacing="16">
       <TextBlock Text="Import souborů" Style="{StaticResource SectionTitleTextBlockStyle}" />
-      <ProgressBar Value="{Binding Progress}" Maximum="100" />
-      <StackPanel Orientation="Horizontal" Spacing="12">
-        <Button x:Name="StartButton" Content="Spustit import" Command="{Binding StartImportCommand}" />
-        <Button Content="Reset" Command="{Binding ResetCommand}" />
+
+      <StackPanel Orientation="Horizontal" Spacing="12" VerticalAlignment="Center">
+        <TextBox Width="320" Text="{Binding SelectedFolderPath, Mode=TwoWay}" PlaceholderText="Vyberte složku" IsReadOnly="True" />
+        <Button Content="Vybrat složku" Command="{Binding BrowseFolderCommand}" />
       </StackPanel>
+
+      <Grid ColumnSpacing="12">
+        <Grid.ColumnDefinitions>
+          <ColumnDefinition Width="*" />
+          <ColumnDefinition Width="*" />
+        </Grid.ColumnDefinitions>
+        <StackPanel Grid.Column="0" Spacing="8">
+          <TextBlock Text="Výchozí autor" />
+          <TextBox Text="{Binding DefaultAuthor, Mode=TwoWay}" />
+          <TextBlock Text="Maska souborů" Margin="0,12,0,0" />
+          <TextBox Text="{Binding SearchPattern, Mode=TwoWay}" />
+        </StackPanel>
+        <StackPanel Grid.Column="1" Spacing="8">
+          <CheckBox Content="Včetně podadresářů" IsChecked="{Binding Recursive, Mode=TwoWay}" />
+          <CheckBox Content="Extrahovat obsah" IsChecked="{Binding ExtractContent, Mode=TwoWay}" />
+          <StackPanel Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
+            <TextBlock Text="Paralelní úlohy" VerticalAlignment="Center" />
+            <muxc:NumberBox Value="{Binding MaxDegreeOfParallelism, Mode=TwoWay}" Minimum="1" Maximum="8" Width="96" />
+          </StackPanel>
+        </StackPanel>
+      </Grid>
+
+      <ProgressBar Value="{Binding Progress.Percent}" Maximum="100" />
+      <TextBlock Text="{Binding Progress.Processed, StringFormat='Zpracováno: {0}'}" />
+
+      <StackPanel Orientation="Horizontal" Spacing="12">
+        <Button x:Name="StartButton" Content="Spustit import" Command="{Binding ImportCommand}" />
+        <Button Content="Reset" Command="{Binding ResetCommand}" />
+        <ProgressRing Width="24" Height="24" IsActive="{Binding Progress.IsRunning}" />
+      </StackPanel>
+
       <InfoBar
           IsOpen="True"
           Severity="{Binding HasError, Converter={StaticResource BoolToSeverityConverter}}"
           Title="Stav">
         <StackPanel>
           <TextBlock x:Name="StatusMessageText" Text="{Binding StatusMessage}" />
+          <TextBlock Text="{Binding Progress.ErrorsCount, StringFormat='Chyb: {0}'}" />
         </StackPanel>
       </InfoBar>
     </StackPanel>
@@ -38,7 +70,7 @@
       <VisualStateGroup>
         <VisualState x:Name="Completed">
           <VisualState.StateTriggers>
-            <trig:ComparisonStateTrigger Comparison="GreaterThanOrEqual" Value="100" Source="{Binding Progress}" />
+            <trig:ComparisonStateTrigger Comparison="GreaterThanOrEqual" Value="100" Source="{Binding Progress.Percent}" />
           </VisualState.StateTriggers>
           <VisualState.Setters>
             <Setter Target="StatusMessageText.Text" Value="Import dokončen." />


### PR DESCRIPTION
## Summary
- add WinUI-specific UI models and mapping helpers for files, search, and import projections
- implement CommunityToolkit-based view models with busy/error management and commands for shell, files, import, and search features
- wire the new view models and services into the WinUI host and refresh the XAML pages to consume the MVVM state

## Testing
- `dotnet build Veriado.sln` *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d22491b0648326bc62f5f0e7e51151