### PR TITLE
Fix WinUI bindings and clean dependencies

### DIFF
--- a/Veriado.WinUI/App.xaml
+++ b/Veriado.WinUI/App.xaml
@@ -4,10 +4,6 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:converters="using:Veriado.WinUI.Converters"
-    xmlns:i="using:Microsoft.Xaml.Interactivity"
-    xmlns:core="using:Microsoft.Xaml.Interactions.Core"
-    xmlns:ctb="using:CommunityToolkit.WinUI.Behaviors"
-    xmlns:trig="using:CommunityToolkit.WinUI.Triggers"
     xmlns:conv="using:CommunityToolkit.WinUI.Converters">
   <Application.Resources>
     <ResourceDictionary>

--- a/Veriado.WinUI/Veriado.WinUI.csproj
+++ b/Veriado.WinUI/Veriado.WinUI.csproj
@@ -35,30 +35,12 @@
     <ProjectCapability Include="Msix" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="CommunityToolkit.Common" Version="8.4.0" />
-    <PackageReference Include="CommunityToolkit.WinUI.Animations" Version="8.2.250402" />
-    <PackageReference Include="CommunityToolkit.WinUI.Behaviors" Version="8.2.250402" />
-    <PackageReference Include="CommunityToolkit.WinUI.Collections" Version="8.2.250402" />
-    <PackageReference Include="CommunityToolkit.WinUI.Controls.HeaderedControls" Version="8.2.250402" />
-    <PackageReference Include="CommunityToolkit.WinUI.Controls.LayoutTransformControl" Version="8.2.250402" />
-    <PackageReference Include="CommunityToolkit.WinUI.Controls.Primitives" Version="8.2.250402" />
-    <PackageReference Include="CommunityToolkit.WinUI.Controls.RangeSelector" Version="8.2.250402" />
-    <PackageReference Include="CommunityToolkit.WinUI.Controls.RichSuggestBox" Version="8.2.250402" />
-    <PackageReference Include="CommunityToolkit.WinUI.Controls.Segmented" Version="8.2.250402" />
-    <PackageReference Include="CommunityToolkit.WinUI.Controls.SettingsControls" Version="8.2.250402" />
-    <PackageReference Include="CommunityToolkit.WinUI.Controls.Sizers" Version="8.2.250402" />
-    <PackageReference Include="CommunityToolkit.WinUI.Controls.TokenizingTextBox" Version="8.2.250402" />
-    <PackageReference Include="CommunityToolkit.WinUI.Converters" Version="8.2.250402" />
-    <PackageReference Include="CommunityToolkit.WinUI.DeveloperTools" Version="8.2.250402" />
-    <PackageReference Include="CommunityToolkit.WinUI.Extensions" Version="8.2.250402" />
-    <PackageReference Include="CommunityToolkit.WinUI.Helpers" Version="8.2.250402" />
-    <PackageReference Include="CommunityToolkit.WinUI.Media" Version="8.2.250402" />
-    <PackageReference Include="CommunityToolkit.WinUI.Triggers" Version="8.2.250402" />
-    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.4948" />
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.8.250907003" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.9" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.8.250907003" />
     <PackageReference Include="Microsoft.Xaml.Behaviors.WinUI.Managed" Version="3.0.0" />
+    <PackageReference Include="CommunityToolkit.WinUI.Behaviors" Version="8.2.250402" />
+    <PackageReference Include="CommunityToolkit.WinUI.Converters" Version="8.2.250402" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Veriado.WinUI/Views/FileDetailView.xaml
+++ b/Veriado.WinUI/Views/FileDetailView.xaml
@@ -14,7 +14,7 @@
         </Grid.RowDefinitions>
 
         <StackPanel Spacing="8">
-            <TextBlock Text="{Binding Detail.Name}" FontSize="18" FontWeight="SemiBold" />
+            <TextBlock Text="{x:Bind ViewModel.Detail?.Name, Mode=OneWay}" FontSize="18" FontWeight="SemiBold" />
             <StackPanel Orientation="Horizontal" Spacing="8">
                 <TextBox Width="220"
                          PlaceholderText="Nový název"
@@ -25,8 +25,8 @@
                               IsEnabled="{Binding CanEdit}">
                     <i:Interaction.Behaviors>
                         <ctb:EventToCommandBehavior EventName="Toggled"
-                                                    Command="{x:Bind ViewModel.SetReadOnlyCommand}"
-                                                    CommandParameter="{x:Bind ViewModel.EditableIsReadOnly}" />
+                                                    Command="{x:Bind ViewModel.SetReadOnlyCommand, Mode=OneWay}"
+                                                    CommandParameter="{x:Bind ViewModel.EditableIsReadOnly, Mode=OneWay}" />
                     </i:Interaction.Behaviors>
                 </ToggleSwitch>
             </StackPanel>

--- a/Veriado.WinUI/Views/FilesView.xaml
+++ b/Veriado.WinUI/Views/FilesView.xaml
@@ -33,8 +33,8 @@
                             <TextBlock Text="{x:Bind Name}" FontWeight="SemiBold" />
                             <TextBlock Text="{x:Bind Mime}" />
                             <Button Content="Otevřít detail"
-                                    Command="{x:Bind ElementName=Root, Path=DataContext.OpenDetailCommand}"
-                                    CommandParameter="{x:Bind Id}" />
+                                    Command="{x:Bind ElementName=Root, Path=DataContext.OpenDetailCommand, Mode=OneWay}"
+                                    CommandParameter="{x:Bind Id, Mode=OneWay}" />
                         </StackPanel>
                     </Border>
                 </DataTemplate>

--- a/Veriado.WinUI/Views/ImportView.xaml
+++ b/Veriado.WinUI/Views/ImportView.xaml
@@ -25,7 +25,7 @@
         </StackPanel>
 
         <winui:InfoBar IsOpen="True"
-                       Visibility="{x:Bind !string.IsNullOrEmpty(ViewModel.StatusMessage), Converter={StaticResource BoolToVisibility}}"
+                       Visibility="{x:Bind !string.IsNullOrEmpty(ViewModel.StatusMessage), Mode=OneWay, Converter={StaticResource BoolToVisibility}}"
                        Severity="{Binding HasError, Converter={StaticResource BoolToSeverityConverter}}"
                        Message="{Binding StatusMessage}" />
         <ProgressBar IsIndeterminate="{Binding IsBusy}"

--- a/Veriado.WinUI/Views/MainWindow.xaml
+++ b/Veriado.WinUI/Views/MainWindow.xaml
@@ -32,11 +32,11 @@
         <winui:CommandBar Grid.Row="0" Grid.ColumnSpan="3">
             <winui:AppBarButton Icon="Refresh"
                                 Label="Obnovit"
-                                Command="{x:Bind ViewModel.Files.RefreshCommand}" />
+                                Command="{x:Bind ViewModel.Files.RefreshCommand, Mode=OneWay}" />
             <winui:AppBarSeparator />
             <winui:AppBarButton Icon="Find"
                                 Label="Spotlight"
-                                Command="{x:Bind ViewModel.Search.OpenCommand}" />
+                                Command="{x:Bind ViewModel.Search.OpenCommand, Mode=OneWay}" />
         </winui:CommandBar>
 
         <winui:NavigationView x:Name="ShellNavigationView"
@@ -46,8 +46,8 @@
                               SelectedItem="{x:Bind ViewModel.SelectedNavItem, Mode=TwoWay}">
             <i:Interaction.Behaviors>
                 <ctb:EventToCommandBehavior EventName="SelectionChanged"
-                                            Command="{x:Bind ViewModel.NavigateCommand}"
-                                            CommandParameter="{x:Bind ShellNavigationView.SelectedItem.Tag}" />
+                                            Command="{x:Bind ViewModel.NavigateCommand, Mode=OneWay}"
+                                            CommandParameter="{x:Bind ShellNavigationView.SelectedItem?.Tag, Mode=OneWay}" />
             </i:Interaction.Behaviors>
             <winui:NavigationView.MenuItems>
                 <winui:NavigationViewItem Content="Soubory" Icon="Folder" Tag="Files" IsSelected="True" />
@@ -58,7 +58,7 @@
 
         <ContentPresenter Grid.Row="1"
                           Grid.Column="1"
-                          Content="{x:Bind ViewModel.CurrentContent}" />
+                          Content="{x:Bind ViewModel.CurrentContent, Mode=OneWay}" />
 
         <Grid Grid.Row="1" Grid.Column="2" MinWidth="360">
             <VisualStateManager.VisualStateGroups>
@@ -83,22 +83,22 @@
             </VisualStateManager.VisualStateGroups>
 
             <Border x:Name="RightPane" Padding="12">
-                <ContentPresenter Content="{x:Bind ViewModel.CurrentDetail}" />
+                <ContentPresenter Content="{x:Bind ViewModel.CurrentDetail, Mode=OneWay}" />
             </Border>
         </Grid>
 
         <winui:InfoBar Grid.Row="2"
                        Grid.ColumnSpan="3"
-                       IsOpen="{x:Bind ViewModel.IsInfoBarOpen}"
-                       Severity="{x:Bind ViewModel.HasError, Converter={StaticResource BoolToSeverityConverter}}"
-                       Message="{x:Bind ViewModel.StatusMessage}" />
+                       IsOpen="{x:Bind ViewModel.IsInfoBarOpen, Mode=OneWay}"
+                       Severity="{x:Bind ViewModel.HasError, Mode=OneWay, Converter={StaticResource BoolToSeverityConverter}}"
+                       Message="{x:Bind ViewModel.StatusMessage, Mode=OneWay}" />
 
         <Grid x:Name="SearchOverlayRoot"
               Grid.RowSpan="3"
               Grid.ColumnSpan="3"
               Background="{ThemeResource LayerOnAcrylicFillColorDefaultBrush}"
-              Visibility="{x:Bind ViewModel.Search.IsOpen, Converter={StaticResource BoolToVisibility}}"
-              IsHitTestVisible="{x:Bind ViewModel.Search.IsOpen}">
+              Visibility="{x:Bind ViewModel.Search.IsOpen, Mode=OneWay, Converter={StaticResource BoolToVisibility}}"
+              IsHitTestVisible="{x:Bind ViewModel.Search.IsOpen, Mode=OneWay}">
             <Border MaxWidth="900"
                     Margin="100"
                     HorizontalAlignment="Center"
@@ -122,20 +122,20 @@
                                         PlaceholderText="Hledat..."
                                         QueryIcon="Find"
                                         Text="{x:Bind ViewModel.Search.QueryText, Mode=TwoWay}"
-                                        ItemsSource="{x:Bind ViewModel.Search.Suggestions}">
+                                        ItemsSource="{x:Bind ViewModel.Search.Suggestions, Mode=OneWay}">
                             <i:Interaction.Behaviors>
                                 <ctb:EventToCommandBehavior EventName="TextChanged"
-                                                            Command="{x:Bind ViewModel.Search.TextChangedCommand}" />
+                                                            Command="{x:Bind ViewModel.Search.TextChangedCommand, Mode=OneWay}" />
                                 <ctb:EventToCommandBehavior EventName="QuerySubmitted"
-                                                            Command="{x:Bind ViewModel.Search.QuerySubmittedCommand}" />
+                                                            Command="{x:Bind ViewModel.Search.QuerySubmittedCommand, Mode=OneWay}" />
                                 <ctb:EventToCommandBehavior EventName="SuggestionChosen"
-                                                            Command="{x:Bind ViewModel.Search.SuggestionChosenCommand}" />
+                                                            Command="{x:Bind ViewModel.Search.SuggestionChosenCommand, Mode=OneWay}" />
                             </i:Interaction.Behaviors>
                         </AutoSuggestBox>
 
                         <Button Grid.Column="1"
                                 Content="Zavřít"
-                                Command="{x:Bind ViewModel.Search.CloseCommand}" />
+                                Command="{x:Bind ViewModel.Search.CloseCommand, Mode=OneWay}" />
                     </Grid>
 
                     <Grid Grid.Row="1" ColumnSpacing="16">
@@ -144,7 +144,7 @@
                             <ColumnDefinition Width="*" />
                         </Grid.ColumnDefinitions>
 
-                        <winui:ListView ItemsSource="{x:Bind ViewModel.Search.Results}"
+                        <winui:ListView ItemsSource="{x:Bind ViewModel.Search.Results, Mode=OneWay}"
                                         SelectionMode="None">
                             <winui:ListView.ItemTemplate>
                                 <DataTemplate x:DataType="contracts:SearchHitDto">
@@ -159,12 +159,12 @@
                         <StackPanel Grid.Column="1" Spacing="16">
                             <StackPanel Spacing="8">
                                 <TextBlock Text="Oblíbené" Style="{ThemeResource SubtitleTextBlockStyle}" />
-                                <winui:ListView ItemsSource="{x:Bind ViewModel.Search.Favorites.Items}"
+                                <winui:ListView ItemsSource="{x:Bind ViewModel.Search.Favorites.Items, Mode=OneWay}"
                                                 SelectionMode="None"
                                                 IsItemClickEnabled="True">
                                     <i:Interaction.Behaviors>
                                         <ctb:EventToCommandBehavior EventName="ItemClick"
-                                                                    Command="{x:Bind ViewModel.Search.UseFavoriteCommand}"
+                                                                    Command="{x:Bind ViewModel.Search.UseFavoriteCommand, Mode=OneWay}"
                                                                     CommandParameterPath="ClickedItem" />
                                     </i:Interaction.Behaviors>
                                     <winui:ListView.ItemTemplate>
@@ -180,12 +180,12 @@
 
                             <StackPanel Spacing="8">
                                 <TextBlock Text="Historie" Style="{ThemeResource SubtitleTextBlockStyle}" />
-                                <winui:ListView ItemsSource="{x:Bind ViewModel.Search.History.Items}"
+                                <winui:ListView ItemsSource="{x:Bind ViewModel.Search.History.Items, Mode=OneWay}"
                                                 SelectionMode="None"
                                                 IsItemClickEnabled="True">
                                     <i:Interaction.Behaviors>
                                         <ctb:EventToCommandBehavior EventName="ItemClick"
-                                                                    Command="{x:Bind ViewModel.Search.UseHistoryCommand}"
+                                                                    Command="{x:Bind ViewModel.Search.UseHistoryCommand, Mode=OneWay}"
                                                                     CommandParameterPath="ClickedItem" />
                                     </i:Interaction.Behaviors>
                                     <winui:ListView.ItemTemplate>
@@ -206,7 +206,7 @@
 
             <i:Interaction.Behaviors>
                 <ctb:EventToCommandBehavior EventName="KeyDown"
-                                            Command="{x:Bind ViewModel.Search.CloseOnEscCommand}" />
+                                            Command="{x:Bind ViewModel.Search.CloseOnEscCommand, Mode=OneWay}" />
             </i:Interaction.Behaviors>
         </Grid>
     </Grid>


### PR DESCRIPTION
## Summary
- trim Veriado.WinUI package references to the minimal toolkit and hosting dependencies that are actually used
- remove unused XAML namespace aliases and convert MainWindow bindings to safe OneWay x:Bind expressions for navigation, overlays, and InfoBar
- update FileDetail, Files, and Import views to use null-safe x:Bind with correct modes for commands and visibility

## Testing
- dotnet build Veriado.sln *(fails: `dotnet` command is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d2516b4b708326964a9db99c352275