### PR TITLE
Refine shell navigation and spotlight interactions

### DIFF
--- a/Veriado.WinUI/Converters/KeyRoutedEventArgsConverter.cs
+++ b/Veriado.WinUI/Converters/KeyRoutedEventArgsConverter.cs
@@ -1,0 +1,22 @@
+using CommunityToolkit.WinUI.UI;
+using Microsoft.UI.Xaml.Input;
+using Windows.System;
+
+namespace Veriado.WinUI.Converters;
+
+/// <summary>
+/// Converts <see cref="KeyRoutedEventArgs"/> instances to <see cref="VirtualKey"/> values.
+/// </summary>
+public sealed class KeyRoutedEventArgsConverter : IEventArgsConverter
+{
+    /// <inheritdoc />
+    public object? Convert(object value, object parameter)
+    {
+        if (value is KeyRoutedEventArgs args)
+        {
+            return args.Key;
+        }
+
+        return VirtualKey.None;
+    }
+}

--- a/Veriado.WinUI/ViewModels/Search/SearchOverlayViewModel.cs
+++ b/Veriado.WinUI/ViewModels/Search/SearchOverlayViewModel.cs
@@ -7,11 +7,11 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.Mvvm.Messaging;
 using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml.Input;
 using Veriado.Application.Search.Abstractions;
 using Veriado.Contracts.Search;
 using Veriado.WinUI.ViewModels.Base;
 using Veriado.WinUI.Models.Search;
+using Windows.System;
 
 namespace Veriado.WinUI.ViewModels.Search;
 
@@ -61,12 +61,11 @@ public sealed partial class SearchOverlayViewModel : ViewModelBase
     private void Close() => IsOpen = false;
 
     [RelayCommand]
-    private void CloseOnEsc(KeyRoutedEventArgs args)
+    private void CloseOnEsc(VirtualKey key)
     {
-        if (args is not null && args.Key == Windows.System.VirtualKey.Escape)
+        if (key == VirtualKey.Escape && string.IsNullOrWhiteSpace(QueryText))
         {
             IsOpen = false;
-            args.Handled = true;
         }
     }
 

--- a/Veriado.WinUI/ViewModels/Shell/ShellViewModel.cs
+++ b/Veriado.WinUI/ViewModels/Shell/ShellViewModel.cs
@@ -1,6 +1,5 @@
 using System;
 using CommunityToolkit.Mvvm.ComponentModel;
-using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.Mvvm.Messaging;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.UI.Xaml.Controls;
@@ -75,12 +74,11 @@ public sealed partial class ShellViewModel : ViewModelBase
     {
         if (value is NavigationViewItem item)
         {
-            Navigate(item.Tag ?? item.Content);
+            NavigateTo(item.Tag ?? item.Content);
         }
     }
 
-    [RelayCommand]
-    private void Navigate(object? tag)
+    private void NavigateTo(object? tag)
     {
         switch (tag?.ToString())
         {

--- a/Veriado.WinUI/Views/FilesView.xaml
+++ b/Veriado.WinUI/Views/FilesView.xaml
@@ -33,7 +33,7 @@
                             <TextBlock Text="{x:Bind Name}" FontWeight="SemiBold" />
                             <TextBlock Text="{x:Bind Mime}" />
                             <Button Content="Otevřít detail"
-                                    Command="{x:Bind ElementName=Root, Path=DataContext.OpenDetailCommand, Mode=OneWay}"
+                                    Command="{x:Bind ViewModel.OpenDetailCommand, Mode=OneWay}"
                                     CommandParameter="{x:Bind Id, Mode=OneWay}" />
                         </StackPanel>
                     </Border>

--- a/Veriado.WinUI/Views/MainWindow.xaml
+++ b/Veriado.WinUI/Views/MainWindow.xaml
@@ -7,6 +7,7 @@
     xmlns:i="using:Microsoft.Xaml.Interactivity"
     xmlns:ctb="using:CommunityToolkit.WinUI.Behaviors"
     xmlns:conv="using:CommunityToolkit.WinUI.Converters"
+    xmlns:converters="using:Veriado.WinUI.Converters"
     xmlns:models="using:Veriado.WinUI.Models.Search"
     xmlns:winui="using:Microsoft.UI.Xaml.Controls"
     Title="Veriado"
@@ -15,6 +16,7 @@
 
     <Window.Resources>
         <conv:BooleanToVisibilityConverter x:Key="BoolToVisibility" />
+        <converters:KeyRoutedEventArgsConverter x:Key="KeyEventConverter" />
     </Window.Resources>
 
     <Grid x:Name="LayoutRoot">
@@ -44,11 +46,6 @@
                               Grid.Column="0"
                               IsSettingsVisible="True"
                               SelectedItem="{x:Bind ViewModel.SelectedNavItem, Mode=TwoWay}">
-            <i:Interaction.Behaviors>
-                <ctb:EventToCommandBehavior EventName="SelectionChanged"
-                                            Command="{x:Bind ViewModel.NavigateCommand, Mode=OneWay}"
-                                            CommandParameter="{x:Bind ShellNavigationView.SelectedItem?.Tag, Mode=OneWay}" />
-            </i:Interaction.Behaviors>
             <winui:NavigationView.MenuItems>
                 <winui:NavigationViewItem Content="Soubory" Icon="Folder" Tag="Files" IsSelected="True" />
                 <winui:NavigationViewItem Content="Import" Icon="Upload" Tag="Import" />
@@ -206,7 +203,8 @@
 
             <i:Interaction.Behaviors>
                 <ctb:EventToCommandBehavior EventName="KeyDown"
-                                            Command="{x:Bind ViewModel.Search.CloseOnEscCommand, Mode=OneWay}" />
+                                            Command="{x:Bind ViewModel.Search.CloseOnEscCommand, Mode=OneWay}"
+                                            EventArgsConverter="{StaticResource KeyEventConverter}" />
             </i:Interaction.Behaviors>
         </Grid>
     </Grid>


### PR DESCRIPTION
## Summary
- let `ShellViewModel` drive page selection and drop the redundant selection behavior from the navigation view
- pass the pressed key into the spotlight close command so Escape only closes the overlay when the query is empty
- bind the files repeater item command straight to the view model without relying on `ElementName`

## Testing
- dotnet build *(fails: `dotnet` is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d25bad26ec8326a3f72dd634e12e4f