### PR TITLE
Add application services and shared state infrastructure

### DIFF
--- a/Veriado.WinUI/App.xaml.cs
+++ b/Veriado.WinUI/App.xaml.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.UI.Xaml;
 using Veriado.WinUI.Services.Abstractions;
 using Veriado.WinUI.Views;
+using Veriado.WinUI.ViewModels.Settings;
 
 namespace Veriado;
 
@@ -33,6 +34,12 @@ public partial class App : Application
         MainWindow = Services.GetRequiredService<MainWindow>();
         var windowProvider = Services.GetRequiredService<IWindowProvider>();
         windowProvider.SetWindow(MainWindow);
+        var keyboardShortcuts = Services.GetRequiredService<IKeyboardShortcutsService>();
+        keyboardShortcuts.RegisterDefaultShortcuts();
+        var themeService = Services.GetRequiredService<IThemeService>();
+        themeService.InitializeAsync().GetAwaiter().GetResult();
+        var settingsViewModel = Services.GetRequiredService<SettingsViewModel>();
+        settingsViewModel.SelectedTheme = themeService.CurrentTheme;
         MainWindow.Closed += OnWindowClosed;
         MainWindow.Activate();
     }

--- a/Veriado.WinUI/AppHost.cs
+++ b/Veriado.WinUI/AppHost.cs
@@ -13,6 +13,7 @@ using Veriado.WinUI.ViewModels;
 using Veriado.WinUI.ViewModels.Files;
 using Veriado.WinUI.ViewModels.Import;
 using Veriado.WinUI.ViewModels.Search;
+using Veriado.WinUI.ViewModels.Settings;
 
 namespace Veriado;
 
@@ -38,6 +39,16 @@ internal sealed class AppHost : IAsyncDisposable
                 services.AddSingleton<IMessenger>(messenger);
 
                 services.AddSingleton<IWindowProvider, WindowProvider>();
+                services.AddSingleton<ISettingsService, JsonSettingsService>();
+                services.AddSingleton<IThemeService, ThemeService>();
+                services.AddSingleton<IDispatcherService, DispatcherService>();
+                services.AddSingleton<IExceptionHandler, ExceptionHandler>();
+                services.AddSingleton<IKeyboardShortcutsService, KeyboardShortcutsService>();
+                services.AddSingleton<IClipboardService, ClipboardService>();
+                services.AddSingleton<IShareService, ShareService>();
+                services.AddSingleton<IPreviewService, PreviewService>();
+                services.AddSingleton<ICacheService, MemoryCacheService>();
+                services.AddSingleton<IHotStateService, HotStateService>();
                 services.AddSingleton<INavigationService, NavigationService>();
                 services.AddSingleton<IDialogService, DialogService>();
                 services.AddSingleton<IPickerService, PickerService>();
@@ -50,6 +61,7 @@ internal sealed class AppHost : IAsyncDisposable
                 services.AddSingleton<ImportViewModel>();
                 services.AddSingleton<FavoritesViewModel>();
                 services.AddSingleton<HistoryViewModel>();
+                services.AddSingleton<SettingsViewModel>();
 
                 services.AddWinUiShell();
 
@@ -63,6 +75,7 @@ internal sealed class AppHost : IAsyncDisposable
 
         await host.StartAsync().ConfigureAwait(false);
         await host.Services.InitializeInfrastructureAsync().ConfigureAwait(false);
+        await host.Services.GetRequiredService<IHotStateService>().InitializeAsync().ConfigureAwait(false);
         return new AppHost(host);
     }
 

--- a/Veriado.WinUI/Services/Abstractions/ICacheService.cs
+++ b/Veriado.WinUI/Services/Abstractions/ICacheService.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace Veriado.WinUI.Services.Abstractions;
+
+public interface ICacheService
+{
+    bool TryGetValue<T>(string key, out T? value);
+
+    void Set<T>(string key, T value, TimeSpan timeToLive);
+
+    void Remove(string key);
+
+    void Clear();
+}

--- a/Veriado.WinUI/Services/Abstractions/IClipboardService.cs
+++ b/Veriado.WinUI/Services/Abstractions/IClipboardService.cs
@@ -1,0 +1,8 @@
+using System.Threading.Tasks;
+
+namespace Veriado.WinUI.Services.Abstractions;
+
+public interface IClipboardService
+{
+    Task CopyTextAsync(string text);
+}

--- a/Veriado.WinUI/Services/Abstractions/IDispatcherService.cs
+++ b/Veriado.WinUI/Services/Abstractions/IDispatcherService.cs
@@ -1,0 +1,11 @@
+using System;
+using System.Threading.Tasks;
+
+namespace Veriado.WinUI.Services.Abstractions;
+
+public interface IDispatcherService
+{
+    bool HasThreadAccess { get; }
+
+    Task RunAsync(Action action);
+}

--- a/Veriado.WinUI/Services/Abstractions/IExceptionHandler.cs
+++ b/Veriado.WinUI/Services/Abstractions/IExceptionHandler.cs
@@ -1,0 +1,8 @@
+using System;
+
+namespace Veriado.WinUI.Services.Abstractions;
+
+public interface IExceptionHandler
+{
+    string Handle(Exception exception);
+}

--- a/Veriado.WinUI/Services/Abstractions/IHotStateService.cs
+++ b/Veriado.WinUI/Services/Abstractions/IHotStateService.cs
@@ -1,0 +1,15 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Veriado.WinUI.Services.Abstractions;
+
+public interface IHotStateService
+{
+    string? LastQuery { get; set; }
+    
+    string? LastFolder { get; set; }
+
+    int PageSize { get; set; }
+
+    Task InitializeAsync(CancellationToken cancellationToken = default);
+}

--- a/Veriado.WinUI/Services/Abstractions/IKeyboardShortcutsService.cs
+++ b/Veriado.WinUI/Services/Abstractions/IKeyboardShortcutsService.cs
@@ -1,0 +1,6 @@
+namespace Veriado.WinUI.Services.Abstractions;
+
+public interface IKeyboardShortcutsService
+{
+    void RegisterDefaultShortcuts();
+}

--- a/Veriado.WinUI/Services/Abstractions/INavigationService.cs
+++ b/Veriado.WinUI/Services/Abstractions/INavigationService.cs
@@ -2,10 +2,16 @@ namespace Veriado.WinUI.Services.Abstractions;
 
 public interface INavigationService
 {
-    object? CurrentContent { get; }
-    object? CurrentDetail { get; }
+    void AttachHost(INavigationHost host);
 
-    void NavigateToContent(object view);
-    void NavigateToDetail(object? view);
-    void ClearDetail();
+    void NavigateTo(object view, object? viewModel = null);
+
+    void NavigateDetail(object view, object? viewModel = null);
+}
+
+public interface INavigationHost
+{
+    object? CurrentContent { get; set; }
+
+    object? CurrentDetail { get; set; }
 }

--- a/Veriado.WinUI/Services/Abstractions/IPickerService.cs
+++ b/Veriado.WinUI/Services/Abstractions/IPickerService.cs
@@ -1,10 +1,8 @@
-using System.Threading;
-using System.Threading.Tasks;
-
 namespace Veriado.WinUI.Services.Abstractions;
 
 public interface IPickerService
 {
-    Task<string?> PickFolderAsync(CancellationToken ct);
-    Task<string[]?> PickFilesAsync(string[]? extensions, CancellationToken ct);
+    System.Threading.Tasks.Task<string?> PickFolderAsync();
+
+    System.Threading.Tasks.Task<string[]?> PickFilesAsync(string[]? extensions = null, bool multiple = true);
 }

--- a/Veriado.WinUI/Services/Abstractions/IPreviewService.cs
+++ b/Veriado.WinUI/Services/Abstractions/IPreviewService.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Veriado.WinUI.Services.Abstractions;
+
+public sealed record PreviewResult(string? TextSnippet, byte[]? ThumbnailBytes);
+
+public interface IPreviewService
+{
+    Task<PreviewResult?> GetPreviewAsync(Guid fileId, CancellationToken cancellationToken = default);
+}

--- a/Veriado.WinUI/Services/Abstractions/ISettingsService.cs
+++ b/Veriado.WinUI/Services/Abstractions/ISettingsService.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Veriado.WinUI.Services.Abstractions;
+
+public interface ISettingsService
+{
+    Task<AppSettings> GetAsync(CancellationToken cancellationToken = default);
+
+    Task SaveAsync(AppSettings settings, CancellationToken cancellationToken = default);
+
+    Task UpdateAsync(Action<AppSettings> updateAction, CancellationToken cancellationToken = default);
+}
+
+public sealed class AppSettings
+{
+    public const int DefaultPageSize = 50;
+
+    public AppTheme Theme { get; set; } = AppTheme.Default;
+
+    public int PageSize { get; set; } = DefaultPageSize;
+
+    public string? LastFolder { get; set; }
+        = null;
+
+    public string? LastQuery { get; set; }
+        = null;
+}

--- a/Veriado.WinUI/Services/Abstractions/IShareService.cs
+++ b/Veriado.WinUI/Services/Abstractions/IShareService.cs
@@ -1,0 +1,11 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Veriado.WinUI.Services.Abstractions;
+
+public interface IShareService
+{
+    Task ShareTextAsync(string title, string text, CancellationToken cancellationToken = default);
+
+    Task ShareFileAsync(string title, string filePath, CancellationToken cancellationToken = default);
+}

--- a/Veriado.WinUI/Services/Abstractions/IStatusService.cs
+++ b/Veriado.WinUI/Services/Abstractions/IStatusService.cs
@@ -2,7 +2,9 @@ namespace Veriado.WinUI.Services.Abstractions;
 
 public interface IStatusService
 {
-    void ShowInfo(string message);
-    void ShowError(string message);
+    void Info(string? message);
+
+    void Error(string? message);
+
     void Clear();
 }

--- a/Veriado.WinUI/Services/Abstractions/IThemeService.cs
+++ b/Veriado.WinUI/Services/Abstractions/IThemeService.cs
@@ -1,0 +1,20 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Veriado.WinUI.Services.Abstractions;
+
+public enum AppTheme
+{
+    Default,
+    Light,
+    Dark,
+}
+
+public interface IThemeService
+{
+    AppTheme CurrentTheme { get; }
+
+    Task InitializeAsync(CancellationToken cancellationToken = default);
+
+    Task SetThemeAsync(AppTheme theme, CancellationToken cancellationToken = default);
+}

--- a/Veriado.WinUI/Services/Abstractions/IWindowProvider.cs
+++ b/Veriado.WinUI/Services/Abstractions/IWindowProvider.cs
@@ -2,6 +2,9 @@ namespace Veriado.WinUI.Services.Abstractions;
 
 public interface IWindowProvider
 {
-    nint GetWindowHandle();
     void SetWindow(Microsoft.UI.Xaml.Window window);
+
+    Microsoft.UI.Xaml.Window? TryGetWindow();
+
+    nint GetHwnd();
 }

--- a/Veriado.WinUI/Services/ClipboardService.cs
+++ b/Veriado.WinUI/Services/ClipboardService.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Threading.Tasks;
+using Veriado.WinUI.Services.Abstractions;
+using Windows.ApplicationModel.DataTransfer;
+
+namespace Veriado.WinUI.Services;
+
+public sealed class ClipboardService : IClipboardService
+{
+    private readonly IDispatcherService _dispatcher;
+
+    public ClipboardService(IDispatcherService dispatcher)
+    {
+        _dispatcher = dispatcher ?? throw new ArgumentNullException(nameof(dispatcher));
+    }
+
+    public async Task CopyTextAsync(string text)
+    {
+        await _dispatcher.RunAsync(() =>
+        {
+            if (string.IsNullOrEmpty(text))
+            {
+                Clipboard.Clear();
+                return;
+            }
+
+            var dataPackage = new DataPackage();
+            dataPackage.SetText(text);
+            Clipboard.SetContent(dataPackage);
+        }).ConfigureAwait(false);
+    }
+}

--- a/Veriado.WinUI/Services/DialogService.cs
+++ b/Veriado.WinUI/Services/DialogService.cs
@@ -16,7 +16,7 @@ public sealed class DialogService : IDialogService
 
     public async Task<bool> ConfirmAsync(string title, string message, string confirmText = "OK", string cancelText = "Cancel")
     {
-        var hwnd = _window.GetWindowHandle();
+        var hwnd = _window.GetHwnd();
         var dialog = new ContentDialog
         {
             Title = title,

--- a/Veriado.WinUI/Services/DispatcherService.cs
+++ b/Veriado.WinUI/Services/DispatcherService.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.UI.Dispatching;
+using Veriado.WinUI.Services.Abstractions;
+
+namespace Veriado.WinUI.Services;
+
+public sealed class DispatcherService : IDispatcherService
+{
+    private readonly IWindowProvider _windowProvider;
+    private DispatcherQueue? _dispatcher;
+
+    public DispatcherService(IWindowProvider windowProvider)
+    {
+        _windowProvider = windowProvider ?? throw new ArgumentNullException(nameof(windowProvider));
+    }
+
+    public bool HasThreadAccess => GetDispatcher().HasThreadAccess;
+
+    public Task RunAsync(Action action)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+
+        var dispatcher = GetDispatcher();
+        if (dispatcher.HasThreadAccess)
+        {
+            action();
+            return Task.CompletedTask;
+        }
+
+        var completion = new TaskCompletionSource<object?>();
+        if (!dispatcher.TryEnqueue(() =>
+            {
+                try
+                {
+                    action();
+                    completion.SetResult(null);
+                }
+                catch (Exception ex)
+                {
+                    completion.SetException(ex);
+                }
+            }))
+        {
+            completion.SetException(new InvalidOperationException("Unable to enqueue action on the UI dispatcher."));
+        }
+
+        return completion.Task;
+    }
+
+    private DispatcherQueue GetDispatcher()
+    {
+        if (_dispatcher is not null)
+        {
+            return _dispatcher;
+        }
+
+        if (_windowProvider.TryGetWindow() is { } window)
+        {
+            _dispatcher = window.DispatcherQueue;
+        }
+        else
+        {
+            _dispatcher = DispatcherQueue.GetForCurrentThread()
+                ?? throw new InvalidOperationException("UI dispatcher is not available.");
+        }
+
+        return _dispatcher;
+    }
+}

--- a/Veriado.WinUI/Services/ExceptionHandler.cs
+++ b/Veriado.WinUI/Services/ExceptionHandler.cs
@@ -1,0 +1,28 @@
+using System;
+using Microsoft.Extensions.Logging;
+using Veriado.WinUI.Services.Abstractions;
+
+namespace Veriado.WinUI.Services;
+
+public sealed class ExceptionHandler : IExceptionHandler
+{
+    private readonly ILogger<ExceptionHandler> _logger;
+
+    public ExceptionHandler(ILogger<ExceptionHandler> logger)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public string Handle(Exception exception)
+    {
+        ArgumentNullException.ThrowIfNull(exception);
+
+        if (exception is OperationCanceledException)
+        {
+            return "Operace byla zrušena.";
+        }
+
+        _logger.LogError(exception, "Unhandled exception in view model execution.");
+        return "Došlo k neočekávané chybě.";
+    }
+}

--- a/Veriado.WinUI/Services/HotStateService.cs
+++ b/Veriado.WinUI/Services/HotStateService.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel;
+using Veriado.WinUI.Services.Abstractions;
+
+namespace Veriado.WinUI.Services;
+
+public sealed partial class HotStateService : ObservableObject, IHotStateService
+{
+    private readonly ISettingsService _settingsService;
+    private readonly SemaphoreSlim _gate = new(1, 1);
+    private bool _initialized;
+
+    [ObservableProperty]
+    private string? lastQuery;
+
+    [ObservableProperty]
+    private string? lastFolder;
+
+    [ObservableProperty]
+    private int pageSize = AppSettings.DefaultPageSize;
+
+    public HotStateService(ISettingsService settingsService)
+    {
+        _settingsService = settingsService ?? throw new ArgumentNullException(nameof(settingsService));
+    }
+
+    public async Task InitializeAsync(CancellationToken cancellationToken = default)
+    {
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            var settings = await _settingsService.GetAsync(cancellationToken).ConfigureAwait(false);
+            lastQuery = settings.LastQuery;
+            lastFolder = settings.LastFolder;
+            pageSize = settings.PageSize > 0 ? settings.PageSize : AppSettings.DefaultPageSize;
+            _initialized = true;
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    partial void OnLastQueryChanged(string? value) => PersistAsync();
+
+    partial void OnLastFolderChanged(string? value) => PersistAsync();
+
+    partial void OnPageSizeChanged(int value)
+    {
+        if (value <= 0)
+        {
+            pageSize = AppSettings.DefaultPageSize;
+            OnPropertyChanged(nameof(PageSize));
+        }
+
+        PersistAsync();
+    }
+
+    private void PersistAsync()
+    {
+        if (!_initialized)
+        {
+            return;
+        }
+
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                await _gate.WaitAsync().ConfigureAwait(false);
+                try
+                {
+                    await _settingsService.UpdateAsync(settings =>
+                    {
+                        settings.LastQuery = LastQuery;
+                        settings.LastFolder = LastFolder;
+                        settings.PageSize = PageSize > 0 ? PageSize : AppSettings.DefaultPageSize;
+                    }).ConfigureAwait(false);
+                }
+                finally
+                {
+                    _gate.Release();
+                }
+            }
+            catch
+            {
+                // Persistence of hot state should not crash the UI layer.
+            }
+        });
+    }
+}

--- a/Veriado.WinUI/Services/JsonSettingsService.cs
+++ b/Veriado.WinUI/Services/JsonSettingsService.cs
@@ -1,0 +1,94 @@
+using System;
+using System.IO;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+using Veriado.WinUI.Services.Abstractions;
+
+namespace Veriado.WinUI.Services;
+
+public sealed class JsonSettingsService : ISettingsService
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        Converters = { new JsonStringEnumConverter() },
+    };
+
+    private readonly string _settingsPath;
+    private readonly SemaphoreSlim _gate = new(1, 1);
+
+    public JsonSettingsService()
+    {
+        var folder = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Veriado");
+        Directory.CreateDirectory(folder);
+        _settingsPath = Path.Combine(folder, "settings.json");
+    }
+
+    public async Task<AppSettings> GetAsync(CancellationToken cancellationToken = default)
+    {
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            if (!File.Exists(_settingsPath))
+            {
+                return new AppSettings();
+            }
+
+            await using var stream = File.OpenRead(_settingsPath);
+            var settings = await JsonSerializer.DeserializeAsync<AppSettings>(stream, SerializerOptions, cancellationToken).ConfigureAwait(false);
+            return settings ?? new AppSettings();
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    public async Task SaveAsync(AppSettings settings, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(settings);
+
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            await using var stream = File.Create(_settingsPath);
+            await JsonSerializer.SerializeAsync(stream, settings, SerializerOptions, cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    public async Task UpdateAsync(Action<AppSettings> updateAction, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(updateAction);
+
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            AppSettings settings;
+            if (File.Exists(_settingsPath))
+            {
+                await using var readStream = File.OpenRead(_settingsPath);
+                settings = await JsonSerializer.DeserializeAsync<AppSettings>(readStream, SerializerOptions, cancellationToken).ConfigureAwait(false) ?? new AppSettings();
+            }
+            else
+            {
+                settings = new AppSettings();
+            }
+
+            updateAction(settings);
+
+            await using var writeStream = File.Create(_settingsPath);
+            await JsonSerializer.SerializeAsync(writeStream, settings, SerializerOptions, cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+}

--- a/Veriado.WinUI/Services/KeyboardShortcutsService.cs
+++ b/Veriado.WinUI/Services/KeyboardShortcutsService.cs
@@ -1,0 +1,59 @@
+using System;
+using CommunityToolkit.Mvvm.Messaging;
+using Microsoft.UI.Xaml.Input;
+using Veriado.WinUI.Services.Abstractions;
+using Veriado.WinUI.Services.Messages;
+
+namespace Veriado.WinUI.Services;
+
+public sealed class KeyboardShortcutsService : IKeyboardShortcutsService
+{
+    private readonly IWindowProvider _windowProvider;
+    private readonly IMessenger _messenger;
+    private bool _registered;
+
+    public KeyboardShortcutsService(IWindowProvider windowProvider, IMessenger messenger)
+    {
+        _windowProvider = windowProvider ?? throw new ArgumentNullException(nameof(windowProvider));
+        _messenger = messenger ?? throw new ArgumentNullException(nameof(messenger));
+    }
+
+    public void RegisterDefaultShortcuts()
+    {
+        if (_registered)
+        {
+            return;
+        }
+
+        var window = _windowProvider.TryGetWindow();
+        if (window is null)
+        {
+            return;
+        }
+
+        var openSearch = new KeyboardAccelerator
+        {
+            Key = Windows.System.VirtualKey.Space,
+            Modifiers = Windows.System.VirtualKeyModifiers.Control,
+        };
+        openSearch.Invoked += (_, args) =>
+        {
+            _messenger.Send(new OpenSearchOverlayMessage());
+            args.Handled = true;
+        };
+
+        var closeSearch = new KeyboardAccelerator
+        {
+            Key = Windows.System.VirtualKey.Escape,
+        };
+        closeSearch.Invoked += (_, args) =>
+        {
+            _messenger.Send(new CloseSearchOverlayMessage());
+            args.Handled = true;
+        };
+
+        window.KeyboardAccelerators.Add(openSearch);
+        window.KeyboardAccelerators.Add(closeSearch);
+        _registered = true;
+    }
+}

--- a/Veriado.WinUI/Services/MemoryCacheService.cs
+++ b/Veriado.WinUI/Services/MemoryCacheService.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Collections.Concurrent;
+using Veriado.WinUI.Services.Abstractions;
+
+namespace Veriado.WinUI.Services;
+
+public sealed class MemoryCacheService : ICacheService
+{
+    private readonly ConcurrentDictionary<string, CacheEntry> _entries = new();
+
+    public bool TryGetValue<T>(string key, out T? value)
+    {
+        value = default;
+        if (string.IsNullOrWhiteSpace(key))
+        {
+            return false;
+        }
+
+        if (_entries.TryGetValue(key, out var entry) && !entry.IsExpired)
+        {
+            if (entry.Value is T typed)
+            {
+                value = typed;
+                return true;
+            }
+        }
+        else if (entry is not null && entry.IsExpired)
+        {
+            _entries.TryRemove(key, out _);
+        }
+
+        return false;
+    }
+
+    public void Set<T>(string key, T value, TimeSpan timeToLive)
+    {
+        if (string.IsNullOrWhiteSpace(key))
+        {
+            throw new ArgumentNullException(nameof(key));
+        }
+
+        var entry = new CacheEntry(value, DateTimeOffset.UtcNow.Add(timeToLive));
+        _entries.AddOrUpdate(key, entry, (_, _) => entry);
+    }
+
+    public void Remove(string key)
+    {
+        if (string.IsNullOrWhiteSpace(key))
+        {
+            return;
+        }
+
+        _entries.TryRemove(key, out _);
+    }
+
+    public void Clear()
+    {
+        _entries.Clear();
+    }
+
+    private sealed record CacheEntry(object? Value, DateTimeOffset ExpiresAt)
+    {
+        public bool IsExpired => DateTimeOffset.UtcNow >= ExpiresAt;
+    }
+}

--- a/Veriado.WinUI/Services/Messages/CloseSearchOverlayMessage.cs
+++ b/Veriado.WinUI/Services/Messages/CloseSearchOverlayMessage.cs
@@ -1,0 +1,3 @@
+namespace Veriado.WinUI.Services.Messages;
+
+public sealed record CloseSearchOverlayMessage;

--- a/Veriado.WinUI/Services/Messages/OpenSearchOverlayMessage.cs
+++ b/Veriado.WinUI/Services/Messages/OpenSearchOverlayMessage.cs
@@ -1,0 +1,3 @@
+namespace Veriado.WinUI.Services.Messages;
+
+public sealed record OpenSearchOverlayMessage;

--- a/Veriado.WinUI/Services/Messages/StatusChangedMessage.cs
+++ b/Veriado.WinUI/Services/Messages/StatusChangedMessage.cs
@@ -1,3 +1,3 @@
 namespace Veriado.WinUI.Services.Messages;
 
-public sealed record StatusChangedMessage(bool HasError, string Message);
+public sealed record StatusChangedMessage(bool HasError, string? Message);

--- a/Veriado.WinUI/Services/NavigationService.cs
+++ b/Veriado.WinUI/Services/NavigationService.cs
@@ -1,40 +1,47 @@
 using System;
-using CommunityToolkit.Mvvm.ComponentModel;
 using Veriado.WinUI.Services.Abstractions;
 
 namespace Veriado.WinUI.Services;
 
-public sealed class NavigationService : ObservableObject, INavigationService
+public sealed class NavigationService : INavigationService
 {
-    private object? _currentContent;
-    private object? _currentDetail;
+    private INavigationHost? _host;
 
-    public object? CurrentContent
+    public void AttachHost(INavigationHost host)
     {
-        get => _currentContent;
-        private set => SetProperty(ref _currentContent, value);
+        _host = host ?? throw new ArgumentNullException(nameof(host));
     }
 
-    public object? CurrentDetail
-    {
-        get => _currentDetail;
-        private set => SetProperty(ref _currentDetail, value);
-    }
-
-    public void NavigateToContent(object view)
+    public void NavigateTo(object view, object? viewModel = null)
     {
         ArgumentNullException.ThrowIfNull(view);
-        CurrentContent = view;
-        ClearDetail();
+        if (_host is null)
+        {
+            throw new InvalidOperationException("Navigation host has not been attached.");
+        }
+
+        if (view is Microsoft.UI.Xaml.FrameworkElement frameworkElement && viewModel is not null)
+        {
+            frameworkElement.DataContext = viewModel;
+        }
+
+        _host.CurrentDetail = null;
+        _host.CurrentContent = view;
     }
 
-    public void NavigateToDetail(object? view)
+    public void NavigateDetail(object view, object? viewModel = null)
     {
-        CurrentDetail = view;
-    }
+        ArgumentNullException.ThrowIfNull(view);
+        if (_host is null)
+        {
+            throw new InvalidOperationException("Navigation host has not been attached.");
+        }
 
-    public void ClearDetail()
-    {
-        CurrentDetail = null;
+        if (view is Microsoft.UI.Xaml.FrameworkElement frameworkElement && viewModel is not null)
+        {
+            frameworkElement.DataContext = viewModel;
+        }
+
+        _host.CurrentDetail = view;
     }
 }

--- a/Veriado.WinUI/Services/PickerService.cs
+++ b/Veriado.WinUI/Services/PickerService.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using Windows.Storage.Pickers;
 using Veriado.WinUI.Services.Abstractions;
@@ -16,19 +14,19 @@ public sealed class PickerService : IPickerService
         _window = window ?? throw new ArgumentNullException(nameof(window));
     }
 
-    public async Task<string?> PickFolderAsync(CancellationToken ct)
+    public async Task<string?> PickFolderAsync()
     {
         var picker = new FolderPicker();
-        WinRT.Interop.InitializeWithWindow.Initialize(picker, _window.GetWindowHandle());
+        WinRT.Interop.InitializeWithWindow.Initialize(picker, _window.GetHwnd());
         picker.FileTypeFilter.Add("*");
-        var folder = await picker.PickSingleFolderAsync().AsTask(ct);
+        var folder = await picker.PickSingleFolderAsync();
         return folder?.Path;
     }
 
-    public async Task<string[]?> PickFilesAsync(string[]? extensions, CancellationToken ct)
+    public async Task<string[]?> PickFilesAsync(string[]? extensions = null, bool multiple = true)
     {
         var picker = new FileOpenPicker();
-        WinRT.Interop.InitializeWithWindow.Initialize(picker, _window.GetWindowHandle());
+        WinRT.Interop.InitializeWithWindow.Initialize(picker, _window.GetHwnd());
         picker.FileTypeFilter.Clear();
 
         if (extensions is { Length: > 0 })
@@ -49,7 +47,24 @@ public sealed class PickerService : IPickerService
             picker.FileTypeFilter.Add("*");
         }
 
-        var files = await picker.PickMultipleFilesAsync().AsTask(ct);
-        return files?.Select(f => f.Path).ToArray();
+        if (multiple)
+        {
+            var files = await picker.PickMultipleFilesAsync();
+            if (files is null)
+            {
+                return null;
+            }
+
+            var paths = new string[files.Count];
+            for (var i = 0; i < files.Count; i++)
+            {
+                paths[i] = files[i].Path;
+            }
+
+            return paths;
+        }
+
+        var file = await picker.PickSingleFileAsync();
+        return file is null ? null : new[] { file.Path };
     }
 }

--- a/Veriado.WinUI/Services/PreviewService.cs
+++ b/Veriado.WinUI/Services/PreviewService.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Veriado.Services.Files;
+using Veriado.WinUI.Services.Abstractions;
+
+namespace Veriado.WinUI.Services;
+
+public sealed class PreviewService : IPreviewService
+{
+    private const int SnippetLength = 512;
+    private readonly IFileContentService _contentService;
+    private readonly ICacheService _cache;
+
+    public PreviewService(IFileContentService contentService, ICacheService cache)
+    {
+        _contentService = contentService ?? throw new ArgumentNullException(nameof(contentService));
+        _cache = cache ?? throw new ArgumentNullException(nameof(cache));
+    }
+
+    public async Task<PreviewResult?> GetPreviewAsync(Guid fileId, CancellationToken cancellationToken = default)
+    {
+        var cacheKey = $"preview::{fileId}";
+        if (_cache.TryGetValue(cacheKey, out PreviewResult? cached) && cached is not null)
+        {
+            return cached;
+        }
+
+        var content = await _contentService.GetContentAsync(fileId, cancellationToken).ConfigureAwait(false);
+        if (content is null || content.Content is null || content.Content.Length == 0)
+        {
+            return null;
+        }
+
+        var snippet = Encoding.UTF8.GetString(content.Content, 0, Math.Min(content.Content.Length, SnippetLength));
+        var result = new PreviewResult(snippet, null);
+        _cache.Set(cacheKey, result, TimeSpan.FromMinutes(5));
+        return result;
+    }
+}

--- a/Veriado.WinUI/Services/ShareService.cs
+++ b/Veriado.WinUI/Services/ShareService.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Veriado.WinUI.Services.Abstractions;
+using Windows.ApplicationModel.DataTransfer;
+using Windows.Storage;
+using WinRT.Interop;
+
+namespace Veriado.WinUI.Services;
+
+public sealed class ShareService : IShareService
+{
+    private readonly IWindowProvider _windowProvider;
+    private readonly SemaphoreSlim _gate = new(1, 1);
+
+    public ShareService(IWindowProvider windowProvider)
+    {
+        _windowProvider = windowProvider ?? throw new ArgumentNullException(nameof(windowProvider));
+    }
+
+    public async Task ShareTextAsync(string title, string text, CancellationToken cancellationToken = default)
+    {
+        await ShareAsync(title, async request =>
+        {
+            request.Data.SetText(text ?? string.Empty);
+            await Task.CompletedTask.ConfigureAwait(false);
+        }, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task ShareFileAsync(string title, string filePath, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(filePath))
+        {
+            throw new ArgumentNullException(nameof(filePath));
+        }
+
+        var storageFile = await StorageFile.GetFileFromPathAsync(filePath).AsTask(cancellationToken).ConfigureAwait(false);
+
+        await ShareAsync(title, async request =>
+        {
+            request.Data.SetStorageItems(new[] { storageFile });
+            await Task.CompletedTask.ConfigureAwait(false);
+        }, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task ShareAsync(string title, Func<DataRequest, Task> populateRequest, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(populateRequest);
+
+        if (_windowProvider.TryGetWindow() is null)
+        {
+            throw new InvalidOperationException("Window has not been initialized.");
+        }
+
+        var hwnd = _windowProvider.GetHwnd();
+
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            var manager = DataTransferManagerInterop.GetForWindow(hwnd, typeof(DataTransferManager).GUID);
+            TaskCompletionSource<object?>? completion = new();
+
+            void Handler(DataTransferManager sender, DataRequestedEventArgs args)
+            {
+                sender.DataRequested -= Handler;
+                var request = args.Request;
+                request.Data.Properties.Title = string.IsNullOrWhiteSpace(title) ? "Sdílet" : title;
+                populateRequest(request).ContinueWith(t =>
+                {
+                    if (t.IsFaulted && t.Exception is not null)
+                    {
+                        completion.TrySetException(t.Exception);
+                    }
+                    else if (t.IsCanceled)
+                    {
+                        completion.TrySetCanceled();
+                    }
+                    else
+                    {
+                        completion.TrySetResult(null);
+                    }
+                }, TaskScheduler.Default);
+            }
+
+            manager.DataRequested += Handler;
+
+            DataTransferManagerInterop.ShowShareUIForWindow(hwnd);
+            await completion.Task.ConfigureAwait(false);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+}

--- a/Veriado.WinUI/Services/StatusService.cs
+++ b/Veriado.WinUI/Services/StatusService.cs
@@ -14,7 +14,7 @@ public sealed class StatusService : IStatusService
         _messenger = messenger ?? throw new ArgumentNullException(nameof(messenger));
     }
 
-    public void ShowInfo(string message)
+    public void Info(string? message)
     {
         if (string.IsNullOrWhiteSpace(message))
         {
@@ -25,7 +25,7 @@ public sealed class StatusService : IStatusService
         _messenger.Send(new StatusChangedMessage(false, message));
     }
 
-    public void ShowError(string message)
+    public void Error(string? message)
     {
         if (string.IsNullOrWhiteSpace(message))
         {
@@ -38,6 +38,6 @@ public sealed class StatusService : IStatusService
 
     public void Clear()
     {
-        _messenger.Send(new StatusChangedMessage(false, string.Empty));
+        _messenger.Send(new StatusChangedMessage(false, null));
     }
 }

--- a/Veriado.WinUI/Services/ThemeService.cs
+++ b/Veriado.WinUI/Services/ThemeService.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.UI.Xaml;
+using Veriado.WinUI.Services.Abstractions;
+
+namespace Veriado.WinUI.Services;
+
+public sealed class ThemeService : IThemeService
+{
+    private readonly ISettingsService _settingsService;
+    private readonly IWindowProvider _windowProvider;
+    private AppTheme _currentTheme = AppTheme.Default;
+
+    public ThemeService(ISettingsService settingsService, IWindowProvider windowProvider)
+    {
+        _settingsService = settingsService ?? throw new ArgumentNullException(nameof(settingsService));
+        _windowProvider = windowProvider ?? throw new ArgumentNullException(nameof(windowProvider));
+    }
+
+    public AppTheme CurrentTheme => _currentTheme;
+
+    public async Task InitializeAsync(CancellationToken cancellationToken = default)
+    {
+        var settings = await _settingsService.GetAsync(cancellationToken).ConfigureAwait(false);
+        _currentTheme = settings.Theme;
+        ApplyTheme(_currentTheme);
+    }
+
+    public async Task SetThemeAsync(AppTheme theme, CancellationToken cancellationToken = default)
+    {
+        _currentTheme = theme;
+        ApplyTheme(theme);
+        await _settingsService.UpdateAsync(settings => settings.Theme = theme, cancellationToken).ConfigureAwait(false);
+    }
+
+    private void ApplyTheme(AppTheme theme)
+    {
+        var window = _windowProvider.TryGetWindow();
+        if (window?.Content is not FrameworkElement root)
+        {
+            return;
+        }
+
+        root.RequestedTheme = theme switch
+        {
+            AppTheme.Light => ElementTheme.Light,
+            AppTheme.Dark => ElementTheme.Dark,
+            _ => ElementTheme.Default,
+        };
+    }
+}

--- a/Veriado.WinUI/Services/WindowProvider.cs
+++ b/Veriado.WinUI/Services/WindowProvider.cs
@@ -13,7 +13,12 @@ public sealed class WindowProvider : IWindowProvider
         _window = window ?? throw new ArgumentNullException(nameof(window));
     }
 
-    public nint GetWindowHandle()
+    public Window? TryGetWindow()
+    {
+        return _window;
+    }
+
+    public nint GetHwnd()
     {
         if (_window is null)
         {

--- a/Veriado.WinUI/ViewModels/Search/HistoryViewModel.cs
+++ b/Veriado.WinUI/ViewModels/Search/HistoryViewModel.cs
@@ -15,8 +15,13 @@ public sealed partial class HistoryViewModel : ViewModelBase
 {
     private readonly IFileQueryService _fileQueryService;
 
-    public HistoryViewModel(IMessenger messenger, IStatusService statusService, IFileQueryService fileQueryService)
-        : base(messenger, statusService)
+    public HistoryViewModel(
+        IMessenger messenger,
+        IStatusService statusService,
+        IDispatcherService dispatcher,
+        IExceptionHandler exceptionHandler,
+        IFileQueryService fileQueryService)
+        : base(messenger, statusService, dispatcher, exceptionHandler)
     {
         _fileQueryService = fileQueryService ?? throw new ArgumentNullException(nameof(fileQueryService));
     }
@@ -39,9 +44,14 @@ public sealed partial class HistoryViewModel : ViewModelBase
                 Items.Add(entry);
             }
 
-            StatusMessage = Items.Count == 0
-                ? "Historie je prázdná."
-                : $"Načteno {Items.Count} položek historie.";
+            if (Items.Count == 0)
+            {
+                StatusService.Info("Historie je prázdná.");
+            }
+            else
+            {
+                StatusService.Info($"Načteno {Items.Count} položek historie.");
+            }
         }, "Načítám historii hledání…");
     }
 }

--- a/Veriado.WinUI/ViewModels/Settings/SettingsViewModel.cs
+++ b/Veriado.WinUI/ViewModels/Settings/SettingsViewModel.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Collections.ObjectModel;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using CommunityToolkit.Mvvm.Messaging;
+using Veriado.WinUI.Services.Abstractions;
+using Veriado.WinUI.ViewModels.Base;
+
+namespace Veriado.WinUI.ViewModels.Settings;
+
+public sealed partial class SettingsViewModel : ViewModelBase
+{
+    private readonly IThemeService _themeService;
+    private readonly IHotStateService _hotState;
+
+    public ObservableCollection<AppTheme> Themes { get; } = new(Enum.GetValues<AppTheme>());
+
+    [ObservableProperty]
+    private AppTheme selectedTheme;
+
+    [ObservableProperty]
+    private int pageSize;
+
+    [ObservableProperty]
+    private string? lastFolder;
+
+    public SettingsViewModel(
+        IMessenger messenger,
+        IStatusService statusService,
+        IDispatcherService dispatcher,
+        IExceptionHandler exceptionHandler,
+        IThemeService themeService,
+        IHotStateService hotState)
+        : base(messenger, statusService, dispatcher, exceptionHandler)
+    {
+        _themeService = themeService ?? throw new ArgumentNullException(nameof(themeService));
+        _hotState = hotState ?? throw new ArgumentNullException(nameof(hotState));
+
+        SelectedTheme = _themeService.CurrentTheme;
+        PageSize = _hotState.PageSize;
+        LastFolder = _hotState.LastFolder;
+    }
+
+    partial void OnPageSizeChanged(int value)
+    {
+        var normalized = value <= 0 ? AppSettings.DefaultPageSize : value;
+        if (normalized != value)
+        {
+            PageSize = normalized;
+            return;
+        }
+
+        _hotState.PageSize = normalized;
+        StatusService.Info($"Výchozí velikost stránky nastavena na {normalized}.");
+    }
+
+    partial void OnLastFolderChanged(string? value)
+    {
+        _hotState.LastFolder = string.IsNullOrWhiteSpace(value) ? null : value;
+    }
+
+    partial void OnSelectedThemeChanged(AppTheme value)
+    {
+        if (_themeService.CurrentTheme == value)
+        {
+            return;
+        }
+
+        _ = ApplyThemeAsync(value);
+    }
+
+    private async Task ApplyThemeAsync(AppTheme theme)
+    {
+        await SafeExecuteAsync(async _ =>
+        {
+            await _themeService.SetThemeAsync(theme).ConfigureAwait(false);
+            StatusService.Info("Téma aplikace bylo aktualizováno.");
+        });
+    }
+}

--- a/Veriado.WinUI/Views/FileDetailView.xaml
+++ b/Veriado.WinUI/Views/FileDetailView.xaml
@@ -55,7 +55,12 @@
                          Text="{Binding EditableMime, Mode=TwoWay}" />
                 <Button Content="Uložit metadata" Command="{Binding UpdateMetadataCommand}" />
             </StackPanel>
-            <TextBlock Text="{Binding StatusMessage}" />
+            <StackPanel Orientation="Horizontal" Spacing="8">
+                <Button Content="Kopírovat ID" Command="{Binding CopyIdCommand}" />
+                <Button Content="Kopírovat ukázku" Command="{Binding CopySnippetCommand}" />
+                <Button Content="Sdílet ukázku" Command="{Binding ShareSnippetCommand}" />
+            </StackPanel>
+            <TextBlock Text="{Binding ContentPreview}" TextWrapping="Wrap" />
         </StackPanel>
     </Grid>
 </UserControl>

--- a/Veriado.WinUI/Views/FilesView.xaml
+++ b/Veriado.WinUI/Views/FilesView.xaml
@@ -23,6 +23,11 @@
                      Text="{Binding SearchText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
             <Button Content="Hledat"
                     Command="{Binding RefreshCommand}" />
+            <winui:NumberBox Width="140"
+                             Header="Položek na stránku"
+                             Value="{Binding PageSize, Mode=TwoWay}"
+                             Minimum="1"
+                             Maximum="500" />
         </StackPanel>
 
         <winui:ItemsRepeater Grid.Row="1" ItemsSource="{Binding Items}">

--- a/Veriado.WinUI/Views/ImportView.xaml
+++ b/Veriado.WinUI/Views/ImportView.xaml
@@ -24,10 +24,9 @@
             <Button Content="Zrušit" Command="{Binding CancelImportCommand}" />
         </StackPanel>
 
-        <winui:InfoBar IsOpen="{x:Bind ViewModel.IsInfoBarOpen, Mode=OneWay}"
-                       Visibility="{x:Bind !string.IsNullOrEmpty(ViewModel.StatusMessage), Mode=OneWay, Converter={StaticResource BoolToVisibility}}"
-                       Severity="{x:Bind ViewModel.HasError, Mode=OneWay, Converter={StaticResource BoolToSeverityConverter}}"
-                       Message="{x:Bind ViewModel.StatusMessage, Mode=OneWay}" />
+        <TextBlock Text="{Binding LastError}"
+                   TextWrapping="Wrap"
+                   Foreground="{ThemeResource SystemFillColorCriticalBrush}" />
         <ProgressBar IsIndeterminate="{Binding IsBusy}"
                      Visibility="{Binding IsBusy, Converter={StaticResource BoolToVisibility}}" />
     </StackPanel>

--- a/Veriado.WinUI/Views/SettingsView.xaml
+++ b/Veriado.WinUI/Views/SettingsView.xaml
@@ -1,9 +1,19 @@
 <UserControl
     x:Class="Veriado.WinUI.Views.SettingsView"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:winui="using:Microsoft.UI.Xaml.Controls">
 
-    <Grid>
-        <TextBlock Text="Nastavení" FontSize="24" HorizontalAlignment="Center" VerticalAlignment="Center" />
-    </Grid>
+    <StackPanel Spacing="16">
+        <TextBlock Text="Nastavení" FontSize="24" />
+        <ComboBox Header="Téma aplikace"
+                  ItemsSource="{Binding Themes}"
+                  SelectedItem="{Binding SelectedTheme, Mode=TwoWay}" />
+        <winui:NumberBox Header="Výchozí velikost stránky"
+                         Value="{Binding PageSize, Mode=TwoWay}"
+                         Minimum="1"
+                         Maximum="500" />
+        <TextBox Header="Poslední složka"
+                 Text="{Binding LastFolder, Mode=TwoWay}" />
+    </StackPanel>
 </UserControl>

--- a/Veriado.WinUI/Views/SettingsView.xaml.cs
+++ b/Veriado.WinUI/Views/SettingsView.xaml.cs
@@ -1,0 +1,16 @@
+using System;
+using Microsoft.UI.Xaml.Controls;
+using Veriado.WinUI.ViewModels.Settings;
+
+namespace Veriado.WinUI.Views;
+
+public sealed partial class SettingsView : UserControl
+{
+    public SettingsView(SettingsViewModel viewModel)
+    {
+        InitializeComponent();
+        DataContext = viewModel ?? throw new ArgumentNullException(nameof(viewModel));
+    }
+
+    public SettingsViewModel ViewModel => (SettingsViewModel)DataContext!;
+}


### PR DESCRIPTION
## Summary
- add WinUI application services for themes, settings persistence, dispatcher execution, exception handling, keyboard shortcuts, clipboard/share, preview caching and hot state sharing
- wire the new services into the app host, window bootstrap and navigation while expanding view models to use the shared state and messenger-driven status updates
- update files, import, search and settings experiences with persisted preferences, preview actions and a dedicated settings view model/UI

## Testing
- dotnet build *(fails: dotnet command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d2a69a3b64832687bf4388e45f0220