### PR TITLE
Fix search overlay converters and item click command parameter

### DIFF
--- a/Veriado.WinUI/App.xaml
+++ b/Veriado.WinUI/App.xaml
@@ -3,8 +3,7 @@
     x:Class="Veriado.App"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:converters="using:Veriado.WinUI.Converters"
-    xmlns:conv="using:CommunityToolkit.WinUI.Converters">
+    xmlns:converters="using:Veriado.WinUI.Converters">
   <Application.Resources>
     <ResourceDictionary>
       <ResourceDictionary.MergedDictionaries>
@@ -12,7 +11,8 @@
         <ResourceDictionary Source="Resources/Styles.xaml" />
       </ResourceDictionary.MergedDictionaries>
       <converters:BoolToSeverityConverter x:Key="BoolToSeverityConverter" />
-      <conv:BooleanToVisibilityConverter x:Key="BoolToVisibility" />
+      <converters:BoolToVisibilityConverter x:Key="BoolToVisibility" />
+      <converters:ItemClickEventArgsToItemConverter x:Key="ItemClickEventArgsToItemConverter" />
     </ResourceDictionary>
   </Application.Resources>
 </Application>

--- a/Veriado.WinUI/Converters/BoolToVisibilityConverter.cs
+++ b/Veriado.WinUI/Converters/BoolToVisibilityConverter.cs
@@ -1,0 +1,39 @@
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Data;
+
+namespace Veriado.WinUI.Converters;
+
+public sealed class BoolToVisibilityConverter : IValueConverter
+{
+    public Visibility TrueValue { get; set; } = Visibility.Visible;
+
+    public Visibility FalseValue { get; set; } = Visibility.Collapsed;
+
+    public object Convert(object value, Type targetType, object parameter, string language)
+    {
+        if (value is bool boolValue)
+        {
+            return boolValue ? TrueValue : FalseValue;
+        }
+
+        return FalseValue;
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, string language)
+    {
+        if (value is Visibility visibility)
+        {
+            if (visibility == TrueValue)
+            {
+                return true;
+            }
+
+            if (visibility == FalseValue)
+            {
+                return false;
+            }
+        }
+
+        return false;
+    }
+}

--- a/Veriado.WinUI/Converters/ItemClickEventArgsToItemConverter.cs
+++ b/Veriado.WinUI/Converters/ItemClickEventArgsToItemConverter.cs
@@ -1,0 +1,18 @@
+using System;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Data;
+
+namespace Veriado.WinUI.Converters;
+
+public sealed class ItemClickEventArgsToItemConverter : IValueConverter
+{
+    public object? Convert(object value, Type targetType, object parameter, string language)
+    {
+        return value is ItemClickEventArgs args ? args.ClickedItem : null;
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, string language)
+    {
+        throw new NotSupportedException();
+    }
+}

--- a/Veriado.WinUI/Veriado.WinUI.csproj
+++ b/Veriado.WinUI/Veriado.WinUI.csproj
@@ -40,7 +40,6 @@
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.8.250916003" />
     <PackageReference Include="Microsoft.Xaml.Behaviors.WinUI.Managed" Version="3.0.0" />
     <PackageReference Include="CommunityToolkit.WinUI.Behaviors" Version="8.2.250402" />
-    <PackageReference Include="CommunityToolkit.WinUI.Converters" Version="8.2.250402" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Veriado.WinUI/Views/MainWindow.xaml
+++ b/Veriado.WinUI/Views/MainWindow.xaml
@@ -5,15 +5,10 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:contracts="using:Veriado.Contracts.Search"
     xmlns:i="using:Microsoft.Xaml.Interactivity"
-    xmlns:ctb="using:CommunityToolkit.WinUI.Behaviors"
-    xmlns:conv="using:CommunityToolkit.WinUI.Converters"
     xmlns:winui="using:Microsoft.UI.Xaml.Controls"
     Title="Veriado">
 
     <Grid x:Name="LayoutRoot">
-        <Grid.Resources>
-            <conv:BooleanToVisibilityConverter x:Key="BoolToVisibility" />
-        </Grid.Resources>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
@@ -162,7 +157,7 @@
                                         <i:EventTriggerBehavior EventName="ItemClick">
                                             <i:InvokeCommandAction
                                                 Command="{x:Bind ViewModel.Search.UseFavoriteCommand, Mode=OneWay}"
-                                                CommandParameter="{Binding ClickedItem, RelativeSource={RelativeSource Mode=Self}}" />
+                                                InputConverter="{StaticResource ItemClickEventArgsToItemConverter}" />
                                         </i:EventTriggerBehavior>
                                     </i:Interaction.Behaviors>
                                     <winui:ListView.ItemTemplate>
@@ -185,7 +180,7 @@
                                         <i:EventTriggerBehavior EventName="ItemClick">
                                             <i:InvokeCommandAction
                                                 Command="{x:Bind ViewModel.Search.UseHistoryCommand, Mode=OneWay}"
-                                                CommandParameter="{Binding ClickedItem, RelativeSource={RelativeSource Mode=Self}}" />
+                                                InputConverter="{StaticResource ItemClickEventArgsToItemConverter}" />
                                         </i:EventTriggerBehavior>
                                     </i:Interaction.Behaviors>
                                     <winui:ListView.ItemTemplate>


### PR DESCRIPTION
## Summary
- add custom converters for boolean visibility and for extracting ListView items from ItemClick events
- update app resources to expose the new converters and consume them in the search overlay
- remove the unused CommunityToolkit WinUI converter package reference

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d2ff7435fc8326aa4bd8c1dbbf3f61