### PR TITLE
Fix MainWindow view model initialization

### DIFF
--- a/Veriado.WinUI/Views/MainWindow.xaml.cs
+++ b/Veriado.WinUI/Views/MainWindow.xaml.cs
@@ -8,10 +8,12 @@ namespace Veriado.Views
     {
         public MainWindow(ShellViewModel viewModel)
         {
-            this.InitializeComponent(); // (this. je volitelné)
-            DataContext = viewModel ?? throw new ArgumentNullException(nameof(viewModel));
+            InitializeComponent();
+
+            ViewModel = viewModel ?? throw new ArgumentNullException(nameof(viewModel));
+            LayoutRoot.DataContext = ViewModel;
         }
 
-        public ShellViewModel ViewModel => (ShellViewModel)DataContext!;
+        public ShellViewModel ViewModel { get; }
     }
 }


### PR DESCRIPTION
## Summary
- expose a ViewModel property on MainWindow and assign the layout grid's DataContext so bindings continue to work

## Testing
- dotnet build Veriado.sln *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68d305643ee483269ba59ded87c71828