### PR TITLE
Ensure viewmodels update UI on dispatcher context

### DIFF
--- a/Veriado.WinUI/ViewModels/Base/ViewModelBase.cs
+++ b/Veriado.WinUI/ViewModels/Base/ViewModelBase.cs
@@ -77,7 +77,7 @@ public abstract partial class ViewModelBase : ObservableObject
         {
             HasError = false;
             IsBusy = true;
-        }).ConfigureAwait(false);
+        });
 
         if (!string.IsNullOrWhiteSpace(busyMessage))
         {
@@ -86,18 +86,18 @@ public abstract partial class ViewModelBase : ObservableObject
 
         try
         {
-            await action(cts.Token).ConfigureAwait(false);
-            await _dispatcher.Enqueue(() => HasError = false).ConfigureAwait(false);
+            await action(cts.Token);
+            await _dispatcher.Enqueue(() => HasError = false);
         }
         catch (OperationCanceledException)
         {
-            await _dispatcher.Enqueue(() => HasError = false).ConfigureAwait(false);
+            await _dispatcher.Enqueue(() => HasError = false);
             _statusService.Info("Operace byla zrušena.");
         }
         catch (Exception ex)
         {
             var message = _exceptionHandler.Handle(ex);
-            await _dispatcher.Enqueue(() => HasError = true).ConfigureAwait(false);
+            await _dispatcher.Enqueue(() => HasError = true);
             if (!string.IsNullOrWhiteSpace(message))
             {
                 _statusService.Error(message);
@@ -106,7 +106,7 @@ public abstract partial class ViewModelBase : ObservableObject
         finally
         {
             _cancellationSource = null;
-            await _dispatcher.Enqueue(() => IsBusy = false).ConfigureAwait(false);
+            await _dispatcher.Enqueue(() => IsBusy = false);
 
             if (!HasError && !string.IsNullOrWhiteSpace(busyMessage))
             {

--- a/Veriado.WinUI/ViewModels/Files/FileDetailViewModel.cs
+++ b/Veriado.WinUI/ViewModels/Files/FileDetailViewModel.cs
@@ -98,8 +98,7 @@ public sealed partial class FileDetailViewModel : ViewModelBase
         await SafeExecuteAsync(async ct =>
         {
             var response = await _operations
-                .RenameAsync(Detail.Id, EditableName.Trim(), ct)
-                .ConfigureAwait(false);
+                .RenameAsync(Detail.Id, EditableName.Trim(), ct);
 
             if (!response.IsSuccess)
             {
@@ -109,7 +108,7 @@ public sealed partial class FileDetailViewModel : ViewModelBase
             }
 
             var fileId = response.Data != Guid.Empty ? response.Data : Detail.Id;
-            await LoadCoreAsync(fileId, ct).ConfigureAwait(false);
+            await LoadCoreAsync(fileId, ct);
             StatusService.Info("Název byl aktualizován.");
         }, "Aktualizuji název souboru…");
     }
@@ -131,7 +130,7 @@ public sealed partial class FileDetailViewModel : ViewModelBase
                 Mime = string.IsNullOrWhiteSpace(EditableMime) ? null : EditableMime,
             };
 
-            var response = await _operations.UpdateMetadataAsync(request, ct).ConfigureAwait(false);
+            var response = await _operations.UpdateMetadataAsync(request, ct);
             if (!response.IsSuccess)
             {
                 HasError = true;
@@ -140,7 +139,7 @@ public sealed partial class FileDetailViewModel : ViewModelBase
             }
 
             var fileId = response.Data != Guid.Empty ? response.Data : Detail.Id;
-            await LoadCoreAsync(fileId, ct).ConfigureAwait(false);
+            await LoadCoreAsync(fileId, ct);
             StatusService.Info("Metadata byla aktualizována.");
         }, "Aktualizuji metadata…");
     }
@@ -156,8 +155,7 @@ public sealed partial class FileDetailViewModel : ViewModelBase
         await SafeExecuteAsync(async ct =>
         {
             var response = await _operations
-                .SetReadOnlyAsync(Detail.Id, isReadOnly, ct)
-                .ConfigureAwait(false);
+                .SetReadOnlyAsync(Detail.Id, isReadOnly, ct);
 
             if (!response.IsSuccess)
             {
@@ -167,7 +165,7 @@ public sealed partial class FileDetailViewModel : ViewModelBase
             }
 
             var fileId = response.Data != Guid.Empty ? response.Data : Detail.Id;
-            await LoadCoreAsync(fileId, ct).ConfigureAwait(false);
+            await LoadCoreAsync(fileId, ct);
             StatusService.Info(isReadOnly
                 ? "Soubor je nyní jen pro čtení."
                 : "Soubor lze znovu upravovat.");
@@ -189,8 +187,7 @@ public sealed partial class FileDetailViewModel : ViewModelBase
             var validity = new FileValidityDto(issuedAt, validUntil, ValidityHasPhysicalCopy, ValidityHasElectronicCopy);
 
             var response = await _operations
-                .SetValidityAsync(Detail.Id, validity, ct)
-                .ConfigureAwait(false);
+                .SetValidityAsync(Detail.Id, validity, ct);
 
             if (!response.IsSuccess)
             {
@@ -200,7 +197,7 @@ public sealed partial class FileDetailViewModel : ViewModelBase
             }
 
             var fileId = response.Data != Guid.Empty ? response.Data : Detail.Id;
-            await LoadCoreAsync(fileId, ct).ConfigureAwait(false);
+            await LoadCoreAsync(fileId, ct);
             StatusService.Info("Platnost byla aktualizována.");
         }, "Ukládám platnost dokumentu…");
     }
@@ -214,8 +211,7 @@ public sealed partial class FileDetailViewModel : ViewModelBase
         }
 
         var confirmed = await _dialogService
-            .ConfirmAsync("Odebrat platnost", "Opravdu chcete odstranit platnost dokumentu?", "Odebrat", "Zrušit")
-            .ConfigureAwait(false);
+            .ConfirmAsync("Odebrat platnost", "Opravdu chcete odstranit platnost dokumentu?", "Odebrat", "Zrušit");
 
         if (!confirmed)
         {
@@ -225,8 +221,7 @@ public sealed partial class FileDetailViewModel : ViewModelBase
         await SafeExecuteAsync(async ct =>
         {
             var response = await _operations
-                .ClearValidityAsync(Detail.Id, ct)
-                .ConfigureAwait(false);
+                .ClearValidityAsync(Detail.Id, ct);
 
             if (!response.IsSuccess)
             {
@@ -235,7 +230,7 @@ public sealed partial class FileDetailViewModel : ViewModelBase
                 return;
             }
 
-            await LoadCoreAsync(Detail.Id, ct).ConfigureAwait(false);
+            await LoadCoreAsync(Detail.Id, ct);
             StatusService.Info("Platnost byla odstraněna.");
         }, "Odebírám platnost dokumentu…");
     }
@@ -277,7 +272,7 @@ public sealed partial class FileDetailViewModel : ViewModelBase
 
     private async Task LoadCoreAsync(Guid id, CancellationToken cancellationToken)
     {
-        var detail = await _queryService.GetDetailAsync(id, cancellationToken).ConfigureAwait(false);
+        var detail = await _queryService.GetDetailAsync(id, cancellationToken);
         Detail = detail;
 
         if (detail is null)
@@ -309,7 +304,7 @@ public sealed partial class FileDetailViewModel : ViewModelBase
             ValidityHasElectronicCopy = false;
         }
 
-        var preview = await _previewService.GetPreviewAsync(detail.Id, cancellationToken).ConfigureAwait(false);
+        var preview = await _previewService.GetPreviewAsync(detail.Id, cancellationToken);
         ContentPreview = preview?.TextSnippet;
         HasError = false;
     }

--- a/Veriado.WinUI/ViewModels/Files/FilesGridViewModel.cs
+++ b/Veriado.WinUI/ViewModels/Files/FilesGridViewModel.cs
@@ -88,7 +88,7 @@ public sealed partial class FilesGridViewModel : ViewModelBase
                 },
             };
 
-            var page = await _queryService.GetGridAsync(request, ct).ConfigureAwait(false);
+            var page = await _queryService.GetGridAsync(request, ct);
 
             Items.Clear();
             foreach (var item in page.Items)

--- a/Veriado.WinUI/ViewModels/Import/ImportViewModel.cs
+++ b/Veriado.WinUI/ViewModels/Import/ImportViewModel.cs
@@ -69,7 +69,7 @@ public sealed partial class ImportViewModel : ViewModelBase
     {
         await SafeExecuteAsync(async _ =>
         {
-            var folder = await _picker.PickFolderAsync().ConfigureAwait(false);
+            var folder = await _picker.PickFolderAsync();
             if (!string.IsNullOrWhiteSpace(folder))
             {
                 SelectedFolderPath = folder;
@@ -111,7 +111,7 @@ public sealed partial class ImportViewModel : ViewModelBase
                     SearchPattern = string.IsNullOrWhiteSpace(SearchPattern) ? null : SearchPattern,
                 };
 
-                var response = await _import.ImportFolderAsync(request, ct).ConfigureAwait(false);
+                var response = await _import.ImportFolderAsync(request, ct);
                 if (!response.IsSuccess || response.Data is null)
                 {
                     HasError = true;

--- a/Veriado.WinUI/ViewModels/Search/FavoritesViewModel.cs
+++ b/Veriado.WinUI/ViewModels/Search/FavoritesViewModel.cs
@@ -33,7 +33,7 @@ public sealed partial class FavoritesViewModel : ViewModelBase
     {
         await SafeExecuteAsync(async ct =>
         {
-            var favorites = await _fileQueryService.GetFavoritesAsync(ct).ConfigureAwait(false);
+            var favorites = await _fileQueryService.GetFavoritesAsync(ct);
 
             Items.Clear();
             foreach (var favorite in favorites)
@@ -62,7 +62,7 @@ public sealed partial class FavoritesViewModel : ViewModelBase
 
         await SafeExecuteAsync(async ct =>
         {
-            await _fileQueryService.RemoveFavoriteAsync(id, ct).ConfigureAwait(false);
+            await _fileQueryService.RemoveFavoriteAsync(id, ct);
             StatusService.Info("Oblíbené vyhledávání bylo odstraněno.");
         }, "Odstraňuji oblíbené vyhledávání…");
 
@@ -87,7 +87,7 @@ public sealed partial class FavoritesViewModel : ViewModelBase
                 favorite.QueryText,
                 favorite.IsFuzzy);
 
-            await _fileQueryService.AddFavoriteAsync(definition, ct).ConfigureAwait(false);
+            await _fileQueryService.AddFavoriteAsync(definition, ct);
             StatusService.Info("Oblíbené vyhledávání bylo uloženo.");
         }, "Ukládám oblíbené vyhledávání…");
 

--- a/Veriado.WinUI/ViewModels/Search/HistoryViewModel.cs
+++ b/Veriado.WinUI/ViewModels/Search/HistoryViewModel.cs
@@ -36,7 +36,7 @@ public sealed partial class HistoryViewModel : ViewModelBase
     {
         await SafeExecuteAsync(async ct =>
         {
-            var entries = await _fileQueryService.GetSearchHistoryAsync(Take, ct).ConfigureAwait(false);
+            var entries = await _fileQueryService.GetSearchHistoryAsync(Take, ct);
 
             Items.Clear();
             foreach (var entry in entries)

--- a/Veriado.WinUI/ViewModels/Search/SearchOverlayViewModel.cs
+++ b/Veriado.WinUI/ViewModels/Search/SearchOverlayViewModel.cs
@@ -69,8 +69,8 @@ public sealed partial class SearchOverlayViewModel : ViewModelBase
         {
             await Task.WhenAll(
                 LoadFavoritesAsync(ct),
-                LoadHistoryAsync(ct)).ConfigureAwait(false);
-        }).ConfigureAwait(false);
+                LoadHistoryAsync(ct));
+        });
     }
 
     [RelayCommand]
@@ -107,9 +107,9 @@ public sealed partial class SearchOverlayViewModel : ViewModelBase
             query,
             afterSearch: async ct =>
             {
-                await _searchFacade.AddToHistoryAsync(query, ct).ConfigureAwait(false);
-                await LoadHistoryAsync(ct).ConfigureAwait(false);
-            }).ConfigureAwait(false);
+                await _searchFacade.AddToHistoryAsync(query, ct);
+                await LoadHistoryAsync(ct);
+            });
     }
 
     [RelayCommand]
@@ -179,7 +179,7 @@ public sealed partial class SearchOverlayViewModel : ViewModelBase
         await ExecuteSearchAsync(
             query,
             beforeSearch: ct => _searchFacade.UseFavoriteAsync(definition, ct),
-            afterSearch: LoadHistoryAsync).ConfigureAwait(false);
+            afterSearch: LoadHistoryAsync);
     }
 
     [RelayCommand]
@@ -198,7 +198,7 @@ public sealed partial class SearchOverlayViewModel : ViewModelBase
         }
 
         var query = QueryText!;
-        await ExecuteSearchAsync(query, afterSearch: LoadHistoryAsync).ConfigureAwait(false);
+        await ExecuteSearchAsync(query, afterSearch: LoadHistoryAsync);
     }
 
     private Task ExecuteSearchAsync(
@@ -210,27 +210,27 @@ public sealed partial class SearchOverlayViewModel : ViewModelBase
         {
             if (beforeSearch is not null)
             {
-                await beforeSearch(ct).ConfigureAwait(false);
+                await beforeSearch(ct);
             }
 
-            await SearchAsync(query, ct).ConfigureAwait(false);
+            await SearchAsync(query, ct);
 
             if (afterSearch is not null)
             {
-                await afterSearch(ct).ConfigureAwait(false);
+                await afterSearch(ct);
             }
         }, "Vyhledávám…");
     }
 
     private async Task LoadFavoritesAsync(CancellationToken ct)
     {
-        var favorites = await _searchFacade.GetFavoritesAsync(ct).ConfigureAwait(false);
+        var favorites = await _searchFacade.GetFavoritesAsync(ct);
         ReplaceItems(Favorites.Items, favorites);
     }
 
     private async Task LoadHistoryAsync(CancellationToken ct)
     {
-        var history = await _searchFacade.GetHistoryAsync(HistoryTake, ct).ConfigureAwait(false);
+        var history = await _searchFacade.GetHistoryAsync(HistoryTake, ct);
         ReplaceItems(History.Items, history);
     }
 
@@ -238,7 +238,7 @@ public sealed partial class SearchOverlayViewModel : ViewModelBase
     {
         Results.Clear();
 
-        var hits = await _searchFacade.SearchAsync(query, SearchResultLimit, ct).ConfigureAwait(false);
+        var hits = await _searchFacade.SearchAsync(query, SearchResultLimit, ct);
         if (hits.Count > 0)
         {
             foreach (var hit in hits)

--- a/Veriado.WinUI/ViewModels/Settings/SettingsViewModel.cs
+++ b/Veriado.WinUI/ViewModels/Settings/SettingsViewModel.cs
@@ -74,7 +74,7 @@ public sealed partial class SettingsViewModel : ViewModelBase
     {
         await SafeExecuteAsync(async _ =>
         {
-            await _themeService.SetThemeAsync(theme).ConfigureAwait(false);
+            await _themeService.SetThemeAsync(theme);
             StatusService.Info("Téma aplikace bylo aktualizováno.");
         });
     }


### PR DESCRIPTION
## Summary
- ensure SafeExecuteAsync keeps viewmodel busy/error updates on the UI dispatcher
- remove ConfigureAwait(false) from WinUI viewmodels so property and collection updates stay on the UI thread

## Testing
- dotnet test *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d3138f4414832690878c7d481d8d83