### PR TITLE
Implement async startup and reliability fixes

### DIFF
--- a/Veriado.WinUI/App.xaml.cs
+++ b/Veriado.WinUI/App.xaml.cs
@@ -1,14 +1,22 @@
 using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.UI.Xaml;
-using Veriado.WinUI.ViewModels.Settings;
 using Veriado.Services.Abstractions;
 using Veriado.Views;
+using Veriado.WinUI.ViewModels.Settings;
+using Veriado.WinUI.ViewModels.Startup;
 
 namespace Veriado;
 
 public partial class App : Application
 {
+    private static readonly ILogger<App> BootstrapLogger = LoggerFactory
+        .Create(builder => builder.AddProvider(new DebugLoggerProvider()))
+        .CreateLogger<App>();
+
     private AppHost? _appHost;
 
     public App()
@@ -24,27 +32,109 @@ public partial class App : Application
 
     public Window MainWindow { get; private set; } = default!;
 
-    protected override void OnLaunched(LaunchActivatedEventArgs args)
+    protected override async void OnLaunched(LaunchActivatedEventArgs args)
     {
         base.OnLaunched(args);
 
-        _appHost = AppHost.StartAsync().GetAwaiter().GetResult();
+        var startupViewModel = new StartupViewModel();
+        var startupWindow = new StartupWindow(startupViewModel);
+        startupWindow.Activate();
 
-        MainWindow = Services.GetRequiredService<MainWindow>();
-        var windowProvider = Services.GetRequiredService<IWindowProvider>();
-        windowProvider.SetWindow(MainWindow);
+        while (!await TryInitializeAsync(startupViewModel).ConfigureAwait(true))
+        {
+            await WaitForRetryAsync(startupViewModel).ConfigureAwait(true);
+        }
 
-        var keyboardShortcuts = Services.GetRequiredService<IKeyboardShortcutsService>();
-        keyboardShortcuts.RegisterDefaultShortcuts();
+        startupWindow.Close();
+    }
 
-        var themeService = Services.GetRequiredService<IThemeService>();
-        themeService.InitializeAsync().GetAwaiter().GetResult();
+    private static Task WaitForRetryAsync(StartupViewModel viewModel)
+    {
+        var completion = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        var settingsViewModel = Services.GetRequiredService<SettingsViewModel>();
-        settingsViewModel.SelectedTheme = themeService.CurrentTheme;
+        void Handler(object? sender, EventArgs e)
+        {
+            viewModel.RetryRequested -= Handler;
+            completion.TrySetResult(null);
+        }
 
-        MainWindow.Closed += OnWindowClosed;
-        MainWindow.Activate();
+        viewModel.RetryRequested += Handler;
+
+        return completion.Task;
+    }
+
+    private async Task<bool> TryInitializeAsync(StartupViewModel startupViewModel)
+    {
+        startupViewModel.ShowProgress("Spouštím služby aplikace...");
+
+        AppHost? host = null;
+
+        try
+        {
+            host = await Task.Run(AppHost.StartAsync).ConfigureAwait(true);
+
+            var services = host.Services;
+
+            var mainWindow = services.GetRequiredService<MainWindow>();
+            var windowProvider = services.GetRequiredService<IWindowProvider>();
+            windowProvider.SetWindow(mainWindow);
+
+            var dispatcherService = services.GetRequiredService<IDispatcherService>();
+            dispatcherService.ResetDispatcher(mainWindow.DispatcherQueue);
+
+            var keyboardShortcuts = services.GetRequiredService<IKeyboardShortcutsService>();
+            keyboardShortcuts.RegisterDefaultShortcuts();
+
+            var themeService = services.GetRequiredService<IThemeService>();
+            await themeService.InitializeAsync().ConfigureAwait(true);
+
+            var settingsViewModel = services.GetRequiredService<SettingsViewModel>();
+            settingsViewModel.SelectedTheme = themeService.CurrentTheme;
+
+            mainWindow.Activate();
+            mainWindow.Closed += OnWindowClosed;
+
+            _appHost = host;
+            MainWindow = mainWindow;
+
+            return true;
+        }
+        catch (Exception ex)
+        {
+            startupViewModel.ShowError(
+                "Nepodařilo se spustit aplikaci.",
+                ex.Message);
+
+            LogStartupFailure(host, ex);
+
+            if (host is not null)
+            {
+                await host.DisposeAsync().ConfigureAwait(false);
+            }
+
+            _appHost = null;
+            MainWindow = null!;
+            return false;
+        }
+    }
+
+    private void LogStartupFailure(AppHost? host, Exception exception)
+    {
+        ILogger<App>? logger = null;
+
+        if (host is not null)
+        {
+            try
+            {
+                logger = host.Services.GetService<ILogger<App>>();
+            }
+            catch
+            {
+                // Ignore errors retrieving the logger during startup failure handling.
+            }
+        }
+
+        (logger ?? BootstrapLogger).LogError(exception, "Application startup failed.");
     }
 
     private async void OnWindowClosed(object sender, WindowEventArgs e)
@@ -56,5 +146,48 @@ public partial class App : Application
         }
 
         MainWindow = null!;
+    }
+
+    private sealed class DebugLoggerProvider : ILoggerProvider
+    {
+        public ILogger CreateLogger(string categoryName) => new DebugLogger(categoryName);
+
+        public void Dispose()
+        {
+        }
+
+        private sealed class DebugLogger : ILogger
+        {
+            private readonly string _categoryName;
+
+            public DebugLogger(string categoryName)
+            {
+                _categoryName = categoryName;
+            }
+
+            public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+            public bool IsEnabled(LogLevel logLevel) => true;
+
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+            {
+                if (formatter is null)
+                {
+                    throw new ArgumentNullException(nameof(formatter));
+                }
+
+                var message = formatter(state, exception);
+                if (string.IsNullOrWhiteSpace(message) && exception is null)
+                {
+                    return;
+                }
+
+                Debug.WriteLine($"{DateTimeOffset.Now:u} [{logLevel}] {_categoryName}: {message}");
+                if (exception is not null)
+                {
+                    Debug.WriteLine(exception);
+                }
+            }
+        }
     }
 }

--- a/Veriado.WinUI/Services/Abstractions/IDispatcherService.cs
+++ b/Veriado.WinUI/Services/Abstractions/IDispatcherService.cs
@@ -1,11 +1,14 @@
 using System;
 using System.Threading.Tasks;
+using Microsoft.UI.Dispatching;
 
 namespace Veriado.Services.Abstractions;
 
 public interface IDispatcherService
 {
     bool HasThreadAccess { get; }
+
+    void ResetDispatcher(DispatcherQueue dispatcher);
 
     Task Enqueue(Action action);
 

--- a/Veriado.WinUI/ViewModels/Startup/StartupViewModel.cs
+++ b/Veriado.WinUI/ViewModels/Startup/StartupViewModel.cs
@@ -1,0 +1,51 @@
+using System;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+
+namespace Veriado.WinUI.ViewModels.Startup;
+
+public partial class StartupViewModel : ObservableObject
+{
+    [ObservableProperty]
+    private bool isLoading;
+
+    [ObservableProperty]
+    private bool hasError;
+
+    [ObservableProperty]
+    private string? statusMessage;
+
+    [ObservableProperty]
+    private string? detailsMessage;
+
+    public event EventHandler? RetryRequested;
+
+    public void ShowProgress(string message)
+    {
+        StatusMessage = message;
+        DetailsMessage = null;
+        HasError = false;
+        IsLoading = true;
+    }
+
+    public void ShowError(string message, string? details)
+    {
+        StatusMessage = message;
+        DetailsMessage = details;
+        IsLoading = false;
+        HasError = true;
+    }
+
+    [RelayCommand(CanExecute = nameof(CanRetry))]
+    private void Retry()
+    {
+        RetryRequested?.Invoke(this, EventArgs.Empty);
+    }
+
+    private bool CanRetry() => HasError;
+
+    partial void OnHasErrorChanged(bool value)
+    {
+        RetryCommand.NotifyCanExecuteChanged();
+    }
+}

--- a/Veriado.WinUI/Views/StartupWindow.xaml
+++ b/Veriado.WinUI/Views/StartupWindow.xaml
@@ -1,0 +1,35 @@
+<Window
+    x:Class="Veriado.Views.StartupWindow"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:winui="using:Microsoft.UI.Xaml.Controls"
+    Title="Veriado"
+    Width="420"
+    Height="260">
+    <Grid x:Name="ContentRoot">
+        <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="12" Width="320">
+            <winui:ProgressRing
+                Width="48"
+                Height="48"
+                IsActive="{x:Bind ViewModel.IsLoading, Mode=OneWay}"
+                Visibility="{x:Bind ViewModel.IsLoading, Mode=OneWay, Converter={StaticResource BoolToVisibility}}" />
+            <TextBlock
+                Text="{x:Bind ViewModel.StatusMessage, Mode=OneWay}"
+                TextAlignment="Center"
+                TextWrapping="Wrap"
+                Style="{ThemeResource BodyStrongTextBlockStyle}" />
+            <TextBlock
+                Margin="0,0,0,8"
+                Text="{x:Bind ViewModel.DetailsMessage, Mode=OneWay}"
+                TextAlignment="Center"
+                TextWrapping="Wrap"
+                Visibility="{x:Bind ViewModel.HasError, Mode=OneWay, Converter={StaticResource BoolToVisibility}}" />
+            <Button
+                Width="160"
+                HorizontalAlignment="Center"
+                Content="Zkusit znovu"
+                Command="{x:Bind ViewModel.RetryCommand, Mode=OneWay}"
+                Visibility="{x:Bind ViewModel.HasError, Mode=OneWay, Converter={StaticResource BoolToVisibility}}" />
+        </StackPanel>
+    </Grid>
+</Window>

--- a/Veriado.WinUI/Views/StartupWindow.xaml.cs
+++ b/Veriado.WinUI/Views/StartupWindow.xaml.cs
@@ -1,0 +1,18 @@
+using System;
+using Microsoft.UI.Xaml;
+using Veriado.WinUI.ViewModels.Startup;
+
+namespace Veriado.Views;
+
+public sealed partial class StartupWindow : Window
+{
+    public StartupWindow(StartupViewModel viewModel)
+    {
+        InitializeComponent();
+
+        ViewModel = viewModel ?? throw new ArgumentNullException(nameof(viewModel));
+        ContentRoot.DataContext = ViewModel;
+    }
+
+    public StartupViewModel ViewModel { get; }
+}


### PR DESCRIPTION
## Summary
- start the WinUI host asynchronously behind a lightweight startup window that reports failures and logs them
- ensure the dispatcher service waits for the real UI dispatcher and can be reset when the main window is assigned
- harden ancillary services by removing the share handler leak and logging hot state persistence errors

## Testing
- `dotnet build Veriado.sln` *(fails: dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d3771d8c6c8326a3d80ef01739066f