### PR TITLE
Ensure async host startup and dispatcher initialization

### DIFF
--- a/Veriado.WinUI/App.xaml.cs
+++ b/Veriado.WinUI/App.xaml.cs
@@ -71,7 +71,7 @@ public partial class App : Application
 
         try
         {
-            host = await Task.Run(AppHost.StartAsync).ConfigureAwait(true);
+            host = await AppHost.StartAsync().ConfigureAwait(true);
 
             var services = host.Services;
 

--- a/Veriado.WinUI/Services/DispatcherService.cs
+++ b/Veriado.WinUI/Services/DispatcherService.cs
@@ -8,14 +8,12 @@ namespace Veriado.Services;
 
 public sealed class DispatcherService : IDispatcherService
 {
-    private readonly IWindowProvider _windowProvider;
     private readonly TaskCompletionSource<DispatcherQueue> _dispatcherReady = new(TaskCreationOptions.RunContinuationsAsynchronously);
     private readonly object _dispatcherLock = new();
     private DispatcherQueue? _dispatcher;
 
-    public DispatcherService(IWindowProvider windowProvider)
+    public DispatcherService()
     {
-        _windowProvider = windowProvider ?? throw new ArgumentNullException(nameof(windowProvider));
     }
 
     public bool HasThreadAccess
@@ -145,20 +143,6 @@ public sealed class DispatcherService : IDispatcherService
         if (dispatcher is not null)
         {
             return dispatcher;
-        }
-
-        if (_windowProvider.TryGetWindow(out var window) && window is not null)
-        {
-            dispatcher = window.DispatcherQueue;
-            lock (_dispatcherLock)
-            {
-                if (_dispatcher is null)
-                {
-                    SetDispatcherUnsafe(dispatcher);
-                }
-
-                return _dispatcher!;
-            }
         }
 
         return await _dispatcherReady.Task.ConfigureAwait(false);


### PR DESCRIPTION
## Summary
- await the WinUI host startup directly during initialization to keep the splash window responsive
- rely on dispatcher reset from the main window instead of late binding through the window provider

## Testing
- `dotnet build Veriado.sln` *(fails: `dotnet` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d391fe83088326a5a4b5f3a9a961d3