### PR TITLE
Add drag and drop folder support for import

### DIFF
--- a/Veriado.WinUI/ViewModels/Import/ImportViewModel.cs
+++ b/Veriado.WinUI/ViewModels/Import/ImportViewModel.cs
@@ -47,6 +47,20 @@ public sealed partial class ImportViewModel : ViewModelBase
     [ObservableProperty]
     private int total;
 
+    [RelayCommand]
+    private void UseFolderPath(string? folderPath)
+    {
+        if (IsBusy || IsImporting || string.IsNullOrWhiteSpace(folderPath))
+        {
+            return;
+        }
+
+        SelectedFolderPath = folderPath;
+        LastError = null;
+        HasError = false;
+        StatusService.Clear();
+    }
+
     public ImportViewModel(
         IMessenger messenger,
         IStatusService statusService,
@@ -73,7 +87,6 @@ public sealed partial class ImportViewModel : ViewModelBase
             if (!string.IsNullOrWhiteSpace(folder))
             {
                 SelectedFolderPath = folder;
-                _hotState.LastFolder = folder;
                 LastError = null;
                 StatusService.Clear();
             }
@@ -152,5 +165,10 @@ public sealed partial class ImportViewModel : ViewModelBase
         StatusService.Info("Import byl zrušen.");
         LastError = null;
         IsImporting = false;
+    }
+
+    partial void OnSelectedFolderPathChanged(string? value)
+    {
+        _hotState.LastFolder = string.IsNullOrWhiteSpace(value) ? null : value;
     }
 }

--- a/Veriado.WinUI/Views/ImportView.xaml
+++ b/Veriado.WinUI/Views/ImportView.xaml
@@ -4,7 +4,11 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:winui="using:Microsoft.UI.Xaml.Controls">
 
-    <StackPanel Spacing="8">
+    <StackPanel x:Name="RootPanel"
+                Spacing="8"
+                AllowDrop="True"
+                DragOver="RootPanel_DragOver"
+                Drop="RootPanel_Drop">
         <TextBox Header="Autor"
                  Text="{Binding DefaultAuthor, Mode=TwoWay}"
                  Width="300" />
@@ -29,5 +33,7 @@
                    Foreground="{ThemeResource SystemFillColorCriticalBrush}" />
         <ProgressBar IsIndeterminate="{Binding IsBusy}"
                      Visibility="{Binding IsBusy, Converter={StaticResource BoolToVisibility}}" />
+        <TextBlock Text="Tip: Složku můžete také přetáhnout do tohoto panelu."
+                   Style="{ThemeResource CaptionTextBlockStyle}" />
     </StackPanel>
 </UserControl>

--- a/Veriado.WinUI/Views/ImportView.xaml.cs
+++ b/Veriado.WinUI/Views/ImportView.xaml.cs
@@ -1,10 +1,14 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Veriado.WinUI.Infrastructure;
 using Veriado.WinUI.ViewModels.Import;
+using Windows.ApplicationModel.DataTransfer;
+using Windows.Storage;
 
 namespace Veriado.WinUI.Views;
 
@@ -37,5 +41,83 @@ public sealed partial class ImportView : UserControl
     private void CancelButton_Click(object sender, RoutedEventArgs e)
     {
         CommandForwarder.TryExecute(ViewModel.CancelImportCommand, null, _logger);
+    }
+
+    private void RootPanel_DragOver(object sender, DragEventArgs e)
+    {
+        if (e?.DataView?.Contains(StandardDataFormats.StorageItems) == true)
+        {
+            e.AcceptedOperation = DataPackageOperation.Link;
+            e.DragUIOverride.IsCaptionVisible = true;
+            e.DragUIOverride.IsGlyphVisible = true;
+            e.DragUIOverride.Caption = "Pustit pro výběr složky";
+        }
+        else
+        {
+            e.AcceptedOperation = DataPackageOperation.None;
+            e.DragUIOverride.IsGlyphVisible = false;
+        }
+    }
+
+    private async void RootPanel_Drop(object sender, DragEventArgs e)
+    {
+        if (e?.DataView?.Contains(StandardDataFormats.StorageItems) != true)
+        {
+            return;
+        }
+
+        var deferral = e.GetDeferral();
+        try
+        {
+            var items = await e.DataView.GetStorageItemsAsync();
+            if (items.Count == 0)
+            {
+                return;
+            }
+
+            var folder = await ResolveFolderAsync(items);
+            if (folder is null)
+            {
+                _logger.LogWarning("No folder could be resolved from the dropped items.");
+                return;
+            }
+
+            e.AcceptedOperation = DataPackageOperation.Link;
+            CommandForwarder.TryExecute(ViewModel.UseFolderPathCommand, folder.Path, _logger);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to process dropped folder.");
+        }
+        finally
+        {
+            deferral.Complete();
+        }
+    }
+
+    private static async Task<StorageFolder?> ResolveFolderAsync(IReadOnlyList<IStorageItem> items)
+    {
+        var folder = items.OfType<StorageFolder>().FirstOrDefault();
+        if (folder is not null)
+        {
+            return folder;
+        }
+
+        foreach (var item in items)
+        {
+            if (item is StorageFile file)
+            {
+                try
+                {
+                    return await file.GetParentAsync();
+                }
+                catch
+                {
+                    // Ignored – we'll try the remaining items.
+                }
+            }
+        }
+
+        return null;
     }
 }


### PR DESCRIPTION
## Summary
- add a command to ImportViewModel for applying a folder path from drag & drop and persist it in hot state
- enable drag & drop on ImportView with new code-behind to resolve dropped folders and forward them to the view model
- inform users about the new interaction with a caption in the import view

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d3963831b48326a7e7a47dc8668b0f