### PR TITLE
Replace CommunityToolkit converters with local implementations

### DIFF
--- a/Veriado.WinUI/App.xaml
+++ b/Veriado.WinUI/App.xaml
@@ -3,15 +3,14 @@
     x:Class="Veriado.App"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:conv="using:CommunityToolkit.WinUI.Converters"
-    xmlns:converters="using:Veriado.Converters">
+    xmlns:conv="using:Veriado.WinUI.Converters">
   <Application.Resources>
     <ResourceDictionary>
       <ResourceDictionary.MergedDictionaries>
         <XamlControlsResources xmlns="using:Microsoft.UI.Xaml.Controls" />
         <ResourceDictionary Source="Resources/Styles.xaml" />
       </ResourceDictionary.MergedDictionaries>
-      <converters:BoolToSeverityConverter x:Key="BoolToSeverityConverter" />
+      <conv:BoolToSeverityConverter x:Key="BoolToSeverityConverter" />
       <conv:BooleanToVisibilityConverter x:Key="BoolToVisibility" />
     </ResourceDictionary>
   </Application.Resources>

--- a/Veriado.WinUI/Converters/BooleanToVisibilityConverter.cs
+++ b/Veriado.WinUI/Converters/BooleanToVisibilityConverter.cs
@@ -3,30 +3,29 @@
 using System;
 using System.Globalization;
 using Microsoft.UI.Xaml;
-using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Data;
 
 namespace Veriado.WinUI.Converters;
 
 /// <summary>
-/// Converts boolean-like values to <see cref="InfoBarSeverity"/> instances.
+/// Converts boolean-like values to <see cref="Visibility"/> values and back.
 /// </summary>
-public sealed class BoolToSeverityConverter : IValueConverter
+public sealed class BooleanToVisibilityConverter : IValueConverter
 {
     /// <summary>
-    /// Gets or sets the severity that is returned when the input resolves to <c>true</c>.
+    /// Gets or sets the <see cref="Visibility"/> that is returned when the input resolves to <c>true</c>.
     /// </summary>
-    public InfoBarSeverity TrueValue { get; set; } = InfoBarSeverity.Error;
+    public Visibility TrueValue { get; set; } = Visibility.Visible;
 
     /// <summary>
-    /// Gets or sets the severity that is returned when the input resolves to <c>false</c>.
+    /// Gets or sets the <see cref="Visibility"/> that is returned when the input resolves to <c>false</c>.
     /// </summary>
-    public InfoBarSeverity FalseValue { get; set; } = InfoBarSeverity.Informational;
+    public Visibility FalseValue { get; set; } = Visibility.Collapsed;
 
     /// <summary>
-    /// Gets or sets the severity that is returned when the input cannot be evaluated.
+    /// Gets or sets the <see cref="Visibility"/> that is returned when the input cannot be evaluated.
     /// </summary>
-    public InfoBarSeverity NullValue { get; set; } = InfoBarSeverity.Informational;
+    public Visibility NullValue { get; set; } = Visibility.Collapsed;
 
     /// <inheritdoc />
     public object Convert(object value, Type targetType, object parameter, string language)
@@ -44,25 +43,18 @@ public sealed class BoolToSeverityConverter : IValueConverter
     /// <inheritdoc />
     public object ConvertBack(object value, Type targetType, object parameter, string language)
     {
-        if (value is InfoBarSeverity severity)
+        if (value == DependencyProperty.UnsetValue)
         {
-            if (severity == TrueValue)
-            {
-                return true;
-            }
-
-            if (severity == FalseValue)
-            {
-                return false;
-            }
-
-            if (severity == NullValue && targetType == typeof(bool?))
-            {
-                return (bool?)null;
-            }
+            return DependencyProperty.UnsetValue;
         }
 
-        var boolean = TryConvertToBoolean(value);
+        bool? boolean = value switch
+        {
+            Visibility visibility when visibility == TrueValue => true,
+            Visibility visibility when visibility == FalseValue => false,
+            Visibility visibility when visibility == NullValue => (bool?)null,
+            _ => TryConvertToBoolean(value)
+        };
 
         if (targetType == typeof(bool))
         {
@@ -79,6 +71,11 @@ public sealed class BoolToSeverityConverter : IValueConverter
             return boolean.HasValue ? (object)boolean.Value : DependencyProperty.UnsetValue;
         }
 
+        if (targetType == typeof(Visibility))
+        {
+            return value is Visibility visibility ? visibility : DependencyProperty.UnsetValue;
+        }
+
         return DependencyProperty.UnsetValue;
     }
 
@@ -90,6 +87,8 @@ public sealed class BoolToSeverityConverter : IValueConverter
                 return null;
             case bool boolValue:
                 return boolValue;
+            case bool? nullableBool:
+                return nullableBool;
             case string text:
                 if (bool.TryParse(text, out var parsed))
                 {

--- a/Veriado.WinUI/Veriado.WinUI.csproj
+++ b/Veriado.WinUI/Veriado.WinUI.csproj
@@ -36,7 +36,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
-    <PackageReference Include="CommunityToolkit.WinUI.Converters" Version="8.2.250402" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.9" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.8.250907003" />
   </ItemGroup>

--- a/Veriado.WinUI/Views/MainWindow.xaml
+++ b/Veriado.WinUI/Views/MainWindow.xaml
@@ -4,7 +4,7 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:contracts="using:Veriado.Contracts.Search"
-    xmlns:conv="using:CommunityToolkit.WinUI.Converters"
+    xmlns:conv="using:Veriado.WinUI.Converters"
     xmlns:winui="using:Microsoft.UI.Xaml.Controls"
     Title="Veriado">
 


### PR DESCRIPTION
## Summary
- replace the CommunityToolkit BooleanToVisibility converter with a custom implementation
- move BoolToSeverityConverter into the Veriado.WinUI.Converters namespace and expand type handling
- remove the CommunityToolkit.WinUI.Converters package and update XAML resources to use the new converters

## Testing
- ⚠️ `dotnet build Veriado.sln` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68d39a55c0108326b55b73ecbaae5d3c