### PR TITLE
Fix enum conversion in BooleanToVisibilityConverter

### DIFF
--- a/Veriado.WinUI/Converters/BooleanToVisibilityConverter.cs
+++ b/Veriado.WinUI/Converters/BooleanToVisibilityConverter.cs
@@ -124,7 +124,7 @@ public sealed class BooleanToVisibilityConverter : IValueConverter
             case decimal dec:
                 return dec != 0m;
             case Enum enumValue:
-                return Convert.ToInt64(enumValue, CultureInfo.InvariantCulture) != 0;
+                return System.Convert.ToInt64(enumValue, CultureInfo.InvariantCulture) != 0;
             case Visibility visibility:
                 return visibility == Visibility.Visible;
             case GridLength gridLength:


### PR DESCRIPTION
## Summary
- ensure BooleanToVisibilityConverter does not shadow System.Convert when handling Enum values
- use fully qualified System.Convert.ToInt64 for enum conversion to prevent compiler errors

## Testing
- `dotnet build` *(fails: dotnet CLI is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d39ee00a688326a35d2b666d41495d