### PR TITLE
Fix nullable bool pattern matching in visibility converter

### DIFF
--- a/Veriado.WinUI/Converters/BooleanToVisibilityConverter.cs
+++ b/Veriado.WinUI/Converters/BooleanToVisibilityConverter.cs
@@ -87,7 +87,7 @@ public sealed class BooleanToVisibilityConverter : IValueConverter
                 return null;
             case bool boolValue:
                 return boolValue;
-            case bool? nullableBool:
+            case Nullable<bool> nullableBool:
                 return nullableBool;
             case string text:
                 if (bool.TryParse(text, out var parsed))


### PR DESCRIPTION
## Summary
- replace the `bool?` pattern case with `Nullable<bool>` in the boolean-to-visibility converter to avoid compiler errors

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d39fbd87a88326bffe456cc138a13b