### PR TITLE
Remove unsupported nullable bool pattern

### DIFF
--- a/Veriado.WinUI/Converters/BooleanToVisibilityConverter.cs
+++ b/Veriado.WinUI/Converters/BooleanToVisibilityConverter.cs
@@ -87,8 +87,6 @@ public sealed class BooleanToVisibilityConverter : IValueConverter
                 return null;
             case bool boolValue:
                 return boolValue;
-            case Nullable<bool> nullableBool:
-                return nullableBool;
             case string text:
                 if (bool.TryParse(text, out var parsed))
                 {


### PR DESCRIPTION
## Summary
- remove the `Nullable<bool>` pattern from `BooleanToVisibilityConverter` to avoid the CS8116 compiler error

## Testing
- dotnet build Veriado.sln *(fails: `dotnet` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d3a0ecd1c48326908a227c855d8eca