### PR TITLE
Fix StartupWindow bindings causing generated member errors

### DIFF
--- a/Veriado.WinUI/Views/StartupWindow.xaml
+++ b/Veriado.WinUI/Views/StartupWindow.xaml
@@ -4,30 +4,30 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:winui="using:Microsoft.UI.Xaml.Controls"
     Title="Veriado">
-    <Grid x:Name="ContentRoot">
+    <Grid>
         <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="12" Width="320">
             <winui:ProgressRing
                 Width="48"
                 Height="48"
-                IsActive="{x:Bind ViewModel.IsLoading, Mode=OneWay}"
-                Visibility="{x:Bind ViewModel.IsLoading, Mode=OneWay, Converter={StaticResource BoolToVisibility}}" />
+                IsActive="{Binding IsLoading}"
+                Visibility="{Binding IsLoading, Converter={StaticResource BoolToVisibility}}" />
             <TextBlock
-                Text="{x:Bind ViewModel.StatusMessage, Mode=OneWay}"
+                Text="{Binding StatusMessage}"
                 TextAlignment="Center"
                 TextWrapping="Wrap"
                 Style="{ThemeResource BodyStrongTextBlockStyle}" />
             <TextBlock
                 Margin="0,0,0,8"
-                Text="{x:Bind ViewModel.DetailsMessage, Mode=OneWay}"
+                Text="{Binding DetailsMessage}"
                 TextAlignment="Center"
                 TextWrapping="Wrap"
-                Visibility="{x:Bind ViewModel.HasError, Mode=OneWay, Converter={StaticResource BoolToVisibility}}" />
+                Visibility="{Binding HasError, Converter={StaticResource BoolToVisibility}}" />
             <Button
                 Width="160"
                 HorizontalAlignment="Center"
                 Content="Zkusit znovu"
-                Command="{x:Bind ViewModel.RetryCommand, Mode=OneWay}"
-                Visibility="{x:Bind ViewModel.HasError, Mode=OneWay, Converter={StaticResource BoolToVisibility}}" />
+                Command="{Binding RetryCommand}"
+                Visibility="{Binding HasError, Converter={StaticResource BoolToVisibility}}" />
         </StackPanel>
     </Grid>
 </Window>

--- a/Veriado.WinUI/Views/StartupWindow.xaml.cs
+++ b/Veriado.WinUI/Views/StartupWindow.xaml.cs
@@ -11,7 +11,11 @@ public sealed partial class StartupWindow : Window
         InitializeComponent();
 
         ViewModel = viewModel ?? throw new ArgumentNullException(nameof(viewModel));
-        ContentRoot.DataContext = ViewModel;
+
+        if (Content is FrameworkElement contentRoot)
+        {
+            contentRoot.DataContext = ViewModel;
+        }
     }
 
     public StartupViewModel ViewModel { get; }


### PR DESCRIPTION
## Summary
- switch StartupWindow bindings from x:Bind to classic bindings so the generated partial class no longer expects missing members
- set the DataContext for the window content in code-behind without relying on a named root element

## Testing
- not run (dotnet CLI not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68d3bbb07e7c8326a1f8f4d13693304f