### PR TITLE
Register DbContext factories for infrastructure contexts

### DIFF
--- a/Veriado.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/Veriado.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
@@ -61,17 +61,18 @@ public static class ServiceCollectionExtensions
         services.AddSingleton(options);
         services.AddSingleton<SqlitePragmaInterceptor>();
 
-        services.AddDbContextPool<AppDbContext>((serviceProvider, builder) =>
-        {
-            builder.UseSqlite(options.ConnectionString, sqlite => sqlite.CommandTimeout(30));
-            builder.AddInterceptors(serviceProvider.GetRequiredService<SqlitePragmaInterceptor>());
-        }, poolSize: 128);
+        services.AddDbContextPool<AppDbContext>(ConfigureDbContext<AppDbContext>, poolSize: 128);
+        services.AddDbContextFactory<AppDbContext>(ConfigureDbContext<AppDbContext>);
 
-        services.AddDbContextPool<ReadOnlyDbContext>((serviceProvider, builder) =>
+        services.AddDbContextPool<ReadOnlyDbContext>(ConfigureDbContext<ReadOnlyDbContext>, poolSize: 256);
+        services.AddDbContextFactory<ReadOnlyDbContext>(ConfigureDbContext<ReadOnlyDbContext>);
+
+        void ConfigureDbContext<TContext>(IServiceProvider serviceProvider, DbContextOptionsBuilder<TContext> builder)
+            where TContext : DbContext
         {
             builder.UseSqlite(options.ConnectionString, sqlite => sqlite.CommandTimeout(30));
             builder.AddInterceptors(serviceProvider.GetRequiredService<SqlitePragmaInterceptor>());
-        }, poolSize: 256);
+        }
 
         services.TryAddSingleton<IClock, SystemClock>();
 


### PR DESCRIPTION
## Summary
- register IDbContextFactory for both AppDbContext and ReadOnlyDbContext
- centralize shared SQLite configuration in a local helper to avoid duplication

## Testing
- no automated tests were run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d3c97401dc83269994c670990bf7b0