### PR TITLE
Fix DbContext registration delegates

### DIFF
--- a/Veriado.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/Veriado.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
@@ -59,19 +59,19 @@ public static class ServiceCollectionExtensions
         options.ConnectionString = connectionStringBuilder.ConnectionString;
 
         services.AddSingleton(options);
-        services.AddSingleton<SqlitePragmaInterceptor>();
+        var sqlitePragmaInterceptor = new SqlitePragmaInterceptor();
+        services.AddSingleton<SqlitePragmaInterceptor>(sqlitePragmaInterceptor);
 
-        services.AddDbContextPool<AppDbContext>(ConfigureDbContext<AppDbContext>, poolSize: 128);
-        services.AddDbContextFactory<AppDbContext>(ConfigureDbContext<AppDbContext>);
+        services.AddDbContextPool<AppDbContext>(ConfigureDbContext, poolSize: 128);
+        services.AddDbContextFactory<AppDbContext>(ConfigureDbContext);
 
-        services.AddDbContextPool<ReadOnlyDbContext>(ConfigureDbContext<ReadOnlyDbContext>, poolSize: 256);
-        services.AddDbContextFactory<ReadOnlyDbContext>(ConfigureDbContext<ReadOnlyDbContext>);
+        services.AddDbContextPool<ReadOnlyDbContext>(ConfigureDbContext, poolSize: 256);
+        services.AddDbContextFactory<ReadOnlyDbContext>(ConfigureDbContext);
 
-        void ConfigureDbContext<TContext>(IServiceProvider serviceProvider, DbContextOptionsBuilder<TContext> builder)
-            where TContext : DbContext
+        void ConfigureDbContext(DbContextOptionsBuilder builder)
         {
             builder.UseSqlite(options.ConnectionString, sqlite => sqlite.CommandTimeout(30));
-            builder.AddInterceptors(serviceProvider.GetRequiredService<SqlitePragmaInterceptor>());
+            builder.AddInterceptors(sqlitePragmaInterceptor);
         }
 
         services.TryAddSingleton<IClock, SystemClock>();


### PR DESCRIPTION
## Summary
- register a single SQLite PRAGMA interceptor instance and reuse it when configuring DbContext options
- update DbContext pool and factory registrations to use the overloads that accept a single DbContextOptionsBuilder parameter

## Testing
- not run (dotnet CLI unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68d3ce777fb883269d27b6a9d01579cb