### PR TITLE
Embed FTS schema in infrastructure migration

### DIFF
--- a/Veriado.Infrastructure/Veriado.Infrastructure.csproj
+++ b/Veriado.Infrastructure/Veriado.Infrastructure.csproj
@@ -21,13 +21,8 @@
     <PackageReference Include="DocumentFormat.OpenXml" Version="3.3.0" />
   </ItemGroup>
   <ItemGroup>
-    <Page Include="Persistence\Schema\Fts5.sql">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Page>
+    <EmbeddedResource Include="Persistence\Schema\Fts5.sql" />
   </ItemGroup>
-	<ItemGroup>
-		<EmbeddedResource Include="Persistence\Schema\Fts5.sql" />
-	</ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Veriado.Domain\Veriado.Domain.csproj" />
     <ProjectReference Include="..\Veriado.Application\Veriado.Appl.csproj" />


### PR DESCRIPTION
## Summary
- embed the FTS schema SQL file into the infrastructure assembly
- load the embedded script within the initial migration via a helper method

## Testing
- dotnet build Veriado.sln *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d3dcc303c48326acc473dc36fc8f41