### PR TITLE
Register FileDetailView factory

### DIFF
--- a/Veriado.WinUI/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/Veriado.WinUI/DependencyInjection/ServiceCollectionExtensions.cs
@@ -18,6 +18,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<MainWindow>();
         services.AddTransient<FilesView>();
         services.AddTransient<FileDetailView>();
+        services.AddTransient<Func<FileDetailView>>(sp => () => sp.GetRequiredService<FileDetailView>());
         services.AddTransient<ImportView>();
         services.AddTransient<SettingsView>();
 


### PR DESCRIPTION
## Summary
- register a `Func<FileDetailView>` factory so `FilesGridViewModel` can resolve its dependency

## Testing
- ⚠️ `dotnet build Veriado.WinUI/Veriado.WinUI.csproj` *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d439b30c4883269045153a07a562fd