### PR TITLE
Fix AutoMapper configuration for search and file DTOs

### DIFF
--- a/Veriado.Mapping/Profiles/FileReadProfiles.cs
+++ b/Veriado.Mapping/Profiles/FileReadProfiles.cs
@@ -40,11 +40,12 @@ public sealed class FileReadProfiles : Profile
             src.Length.Value,
             null));
 
-        CreateMap<FileDocumentValidityReadModel, FileValidityDto>().ConstructUsing(src => new FileValidityDto(
-            src.IssuedAtUtc,
-            src.ValidUntilUtc,
-            src.HasPhysicalCopy,
-            src.HasElectronicCopy));
+        CreateMap<FileDocumentValidityReadModel, FileValidityDto>()
+            .ConvertUsing(src => new FileValidityDto(
+                src.IssuedAtUtc,
+                src.ValidUntilUtc,
+                src.HasPhysicalCopy,
+                src.HasElectronicCopy));
 
         CreateMap<FileListItemReadModel, FileListItemDto>().ConstructUsing(src => new FileListItemDto(
             src.Id,
@@ -71,7 +72,8 @@ public sealed class FileReadProfiles : Profile
             .ForMember(dest => dest.LastIndexedUtc, opt => opt.MapFrom(src => src.SearchIndex.LastIndexedUtc))
             .ForMember(dest => dest.IndexedTitle, opt => opt.MapFrom(src => src.SearchIndex.IndexedTitle))
             .ForMember(dest => dest.IndexSchemaVersion, opt => opt.MapFrom(src => src.SearchIndex.SchemaVersion))
-            .ForMember(dest => dest.IndexedContentHash, opt => opt.MapFrom(src => src.SearchIndex.IndexedContentHash));
+            .ForMember(dest => dest.IndexedContentHash, opt => opt.MapFrom(src => src.SearchIndex.IndexedContentHash))
+            .ForMember(dest => dest.Score, opt => opt.Ignore());
 
         CreateMap<FileEntity, FileDetailDto>()
             .ForMember(dest => dest.Name, opt => opt.ConvertUsing(new CommonValueConverters.FileNameToStringConverter(), src => src.Name))

--- a/Veriado.Mapping/Profiles/SearchProfiles.cs
+++ b/Veriado.Mapping/Profiles/SearchProfiles.cs
@@ -22,22 +22,24 @@ public sealed class SearchProfiles : Profile
             src.Score,
             src.LastModifiedUtc));
 
-        CreateMap<SearchHistoryEntryEntity, SearchHistoryEntry>().ConstructUsing(src => new SearchHistoryEntry(
-            src.Id,
-            src.QueryText,
-            src.Match,
-            src.CreatedUtc,
-            src.Executions,
-            src.LastTotalHits,
-            src.IsFuzzy));
+        CreateMap<SearchHistoryEntryEntity, SearchHistoryEntry>()
+            .ConvertUsing(src => new SearchHistoryEntry(
+                src.Id,
+                src.QueryText,
+                src.Match,
+                src.CreatedUtc,
+                src.Executions,
+                src.LastTotalHits,
+                src.IsFuzzy));
 
-        CreateMap<SearchFavoriteEntity, SearchFavoriteItem>().ConstructUsing(src => new SearchFavoriteItem(
-            src.Id,
-            src.Name,
-            src.QueryText,
-            src.Match,
-            src.Position,
-            src.CreatedUtc,
-            src.IsFuzzy));
+        CreateMap<SearchFavoriteEntity, SearchFavoriteItem>()
+            .ConvertUsing(src => new SearchFavoriteItem(
+                src.Id,
+                src.Name,
+                src.QueryText,
+                src.Match,
+                src.Position,
+                src.CreatedUtc,
+                src.IsFuzzy));
     }
 }


### PR DESCRIPTION
## Summary
- ensure read model validity mappings project record constructor arguments explicitly
- ignore unmapped file summary score field in AutoMapper profile to satisfy destination members
- convert search history and favourite mappings to use converters so MatchQuery and LastQueriedUtc map correctly

## Testing
- `dotnet build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d43ffb33e08326b40766627e891542