### PR TITLE
Fix AutoMapper conversions for file DTOs

### DIFF
--- a/Veriado.Mapping/Profiles/FileReadProfiles.cs
+++ b/Veriado.Mapping/Profiles/FileReadProfiles.cs
@@ -20,25 +20,28 @@ public sealed class FileReadProfiles : Profile
     /// </summary>
     public FileReadProfiles()
     {
-        CreateMap<FileDocumentValidityEntity, FileValidityDto>().ConstructUsing(src => new FileValidityDto(
-            src.IssuedAt.Value,
-            src.ValidUntil.Value,
-            src.HasPhysicalCopy,
-            src.HasElectronicCopy));
+        CreateMap<FileDocumentValidityEntity, FileValidityDto>()
+            .ConvertUsing(src => new FileValidityDto(
+                src.IssuedAt.Value,
+                src.ValidUntil.Value,
+                src.HasPhysicalCopy,
+                src.HasElectronicCopy));
 
-        CreateMap<FileSystemMetadata, FileSystemMetadataDto>().ConstructUsing(src => new FileSystemMetadataDto(
-            (int)src.Attributes,
-            src.CreatedUtc.Value,
-            src.LastWriteUtc.Value,
-            src.LastAccessUtc.Value,
-            src.OwnerSid,
-            src.HardLinkCount,
-            src.AlternateDataStreamCount));
+        CreateMap<FileSystemMetadata, FileSystemMetadataDto>()
+            .ConvertUsing(src => new FileSystemMetadataDto(
+                (int)src.Attributes,
+                src.CreatedUtc.Value,
+                src.LastWriteUtc.Value,
+                src.LastAccessUtc.Value,
+                src.OwnerSid,
+                src.HardLinkCount,
+                src.AlternateDataStreamCount));
 
-        CreateMap<FileContentEntity, FileContentDto>().ConstructUsing(src => new FileContentDto(
-            src.Hash.Value,
-            src.Length.Value,
-            null));
+        CreateMap<FileContentEntity, FileContentDto>()
+            .ConvertUsing(src => new FileContentDto(
+                src.Hash.Value,
+                src.Length.Value,
+                null));
 
         CreateMap<FileDocumentValidityReadModel, FileValidityDto>()
             .ConvertUsing(src => new FileValidityDto(


### PR DESCRIPTION
## Summary
- switch AutoMapper configuration to use ConvertUsing for file validity, metadata, and content DTO projections
- ensure AutoMapper constructs DTOs with explicit conversions from value objects to primitive types

## Testing
- dotnet test *(fails: command not found in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d4448ac00c83268102de0760b434b4