### PR TITLE
Ensure theme changes run on UI thread

### DIFF
--- a/Veriado.WinUI/AppHost.cs
+++ b/Veriado.WinUI/AppHost.cs
@@ -46,8 +46,8 @@ internal sealed class AppHost : IAsyncDisposable
 
                 services.AddSingleton<IWindowProvider, WindowProvider>();
                 services.AddSingleton<ISettingsService, JsonSettingsService>();
-                services.AddSingleton<IThemeService, ThemeService>();
                 services.AddSingleton<IDispatcherService, DispatcherService>();
+                services.AddSingleton<IThemeService, ThemeService>();
                 services.AddSingleton<IExceptionHandler, ExceptionHandler>();
                 services.AddSingleton<IKeyboardShortcutsService, KeyboardShortcutsService>();
                 services.AddSingleton<IClipboardService, ClipboardService>();

--- a/Veriado.WinUI/Services/ThemeService.cs
+++ b/Veriado.WinUI/Services/ThemeService.cs
@@ -10,12 +10,17 @@ public sealed class ThemeService : IThemeService
 {
     private readonly ISettingsService _settingsService;
     private readonly IWindowProvider _windowProvider;
+    private readonly IDispatcherService _dispatcherService;
     private AppTheme _currentTheme = AppTheme.Default;
 
-    public ThemeService(ISettingsService settingsService, IWindowProvider windowProvider)
+    public ThemeService(
+        ISettingsService settingsService,
+        IWindowProvider windowProvider,
+        IDispatcherService dispatcherService)
     {
         _settingsService = settingsService ?? throw new ArgumentNullException(nameof(settingsService));
         _windowProvider = windowProvider ?? throw new ArgumentNullException(nameof(windowProvider));
+        _dispatcherService = dispatcherService ?? throw new ArgumentNullException(nameof(dispatcherService));
     }
 
     public AppTheme CurrentTheme => _currentTheme;
@@ -24,17 +29,39 @@ public sealed class ThemeService : IThemeService
     {
         var settings = await _settingsService.GetAsync(cancellationToken).ConfigureAwait(false);
         _currentTheme = settings.Theme;
-        ApplyTheme(_currentTheme);
+        await ApplyThemeAsync(_currentTheme, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task SetThemeAsync(AppTheme theme, CancellationToken cancellationToken = default)
     {
         _currentTheme = theme;
-        ApplyTheme(theme);
+        await ApplyThemeAsync(theme, cancellationToken).ConfigureAwait(false);
         await _settingsService.UpdateAsync(settings => settings.Theme = theme, cancellationToken).ConfigureAwait(false);
     }
 
-    private void ApplyTheme(AppTheme theme)
+    private async Task ApplyThemeAsync(AppTheme theme, CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return;
+        }
+
+        if (_dispatcherService.HasThreadAccess)
+        {
+            ApplyThemeCore(theme);
+            return;
+        }
+
+        await _dispatcherService.Enqueue(() =>
+        {
+            if (!cancellationToken.IsCancellationRequested)
+            {
+                ApplyThemeCore(theme);
+            }
+        }).ConfigureAwait(false);
+    }
+
+    private void ApplyThemeCore(AppTheme theme)
     {
         if (!_windowProvider.TryGetWindow(out var window) || window?.Content is not FrameworkElement root)
         {


### PR DESCRIPTION
## Summary
- update ThemeService to marshal theme changes to the UI dispatcher before accessing the window content
- inject the dispatcher service into ThemeService and reorder dependency registrations to satisfy the new dependency

## Testing
- dotnet build Veriado.sln *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d44834127083268b1b47ab52b7a143