### PR TITLE
Configure infrastructure options for kv metadata

### DIFF
--- a/Veriado.WinUI/AppHost.cs
+++ b/Veriado.WinUI/AppHost.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Veriado.WinUI.DependencyInjection;
 using Veriado.Infrastructure.DependencyInjection;
+using Veriado.Infrastructure.Persistence.Options;
 using Veriado.Mapping.DependencyInjection;
 using Veriado.Services;
 using Veriado.WinUI.Services.Abstractions;
@@ -77,6 +78,8 @@ internal sealed class AppHost : IAsyncDisposable
                     var databasePath = infrastructureConfig.GetDatabasePath();
                     infrastructureConfig.EnsureStorageExists(databasePath);
                     options.DbPath = databasePath;
+                    options.UseKvMetadata = true;
+                    options.FtsIndexingMode = FtsIndexingMode.Outbox;
                 });
                 services.AddApplication();
                 services.AddVeriadoServices();


### PR DESCRIPTION
## Summary
- configure the WinUI host to enable the KV metadata store and outbox indexing mode when wiring infrastructure services
- ensure runtime EF Core model matches the migrations snapshot to eliminate pending model change warnings

## Testing
- dotnet build Veriado.sln *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d44cbe64b48326b9c5d7aadc0c161e