### PR TITLE
Add search messaging and filters navigation

### DIFF
--- a/Veriado.WinUI/AppHost.cs
+++ b/Veriado.WinUI/AppHost.cs
@@ -64,6 +64,7 @@ internal sealed class AppHost : IAsyncDisposable
                 services.AddSingleton<ShellViewModel>();
                 services.AddSingleton<SearchOverlayViewModel>();
                 services.AddTransient<FilesGridViewModel>();
+                services.AddSingleton<FiltersNavViewModel>();
                 services.AddTransient<FileDetailViewModel>();
                 services.AddTransient<ImportViewModel>();
                 services.AddSingleton<FavoritesViewModel>();
@@ -83,6 +84,7 @@ internal sealed class AppHost : IAsyncDisposable
                 });
                 services.AddApplication();
                 services.AddVeriadoServices();
+                services.AddSingleton<IFilesSearchSuggestionsProvider, FilesSearchSuggestionsProvider>();
             })
             .Build();
 

--- a/Veriado.WinUI/Services/Abstractions/IFilesSearchSuggestionsProvider.cs
+++ b/Veriado.WinUI/Services/Abstractions/IFilesSearchSuggestionsProvider.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Veriado.WinUI.Services.Abstractions;
+
+public interface IFilesSearchSuggestionsProvider
+{
+    Task<IReadOnlyList<string>> GetSuggestionsAsync(CancellationToken cancellationToken);
+}

--- a/Veriado.WinUI/Services/FilesSearchSuggestionsProvider.cs
+++ b/Veriado.WinUI/Services/FilesSearchSuggestionsProvider.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Veriado.Appl.Search.Abstractions;
+using Veriado.WinUI.Services.Abstractions;
+
+namespace Veriado.WinUI.Services;
+
+public sealed class FilesSearchSuggestionsProvider : IFilesSearchSuggestionsProvider
+{
+    private const int SuggestionLimit = 50;
+    private readonly ISearchFavoritesService _favoritesService;
+    private readonly ISearchHistoryService _historyService;
+
+    public FilesSearchSuggestionsProvider(
+        ISearchFavoritesService favoritesService,
+        ISearchHistoryService historyService)
+    {
+        _favoritesService = favoritesService ?? throw new ArgumentNullException(nameof(favoritesService));
+        _historyService = historyService ?? throw new ArgumentNullException(nameof(historyService));
+    }
+
+    public async Task<IReadOnlyList<string>> GetSuggestionsAsync(CancellationToken cancellationToken)
+    {
+        var favoritesTask = _favoritesService.GetAllAsync(cancellationToken);
+        var historyTask = _historyService.GetRecentAsync(SuggestionLimit, cancellationToken);
+
+        await Task.WhenAll(favoritesTask, historyTask).ConfigureAwait(false);
+
+        var favorites = favoritesTask.Result
+            .Select(item => item.QueryText ?? item.MatchQuery)
+            .Where(text => !string.IsNullOrWhiteSpace(text))
+            .Select(text => text!.Trim());
+
+        var history = historyTask.Result
+            .Select(item => item.QueryText ?? item.MatchQuery)
+            .Where(text => !string.IsNullOrWhiteSpace(text))
+            .Select(text => text!.Trim());
+
+        var suggestions = favorites
+            .Concat(history)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Take(SuggestionLimit)
+            .ToArray();
+
+        return suggestions;
+    }
+}

--- a/Veriado.WinUI/Services/Messages/SearchMessages.cs
+++ b/Veriado.WinUI/Services/Messages/SearchMessages.cs
@@ -1,0 +1,13 @@
+using SavedViewDto = Veriado.Contracts.Search.SearchFavoriteItem;
+
+namespace Veriado.WinUI.Services.Messages;
+
+public sealed record QuerySubmittedMessage(string Text);
+
+public sealed record ApplySavedViewMessage(SavedViewDto Saved);
+
+public sealed record SaveCurrentQueryRequestedMessage(string? Text);
+
+public sealed record ClearSearchHistoryRequestedMessage();
+
+public sealed record FocusSearchRequestedMessage;

--- a/Veriado.WinUI/ViewModels/Files/FilesGridViewModel.SearchMessaging.cs
+++ b/Veriado.WinUI/ViewModels/Files/FilesGridViewModel.SearchMessaging.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.Messaging;
+using Veriado.Contracts.Search;
+using Veriado.WinUI.Services.Messages;
+using SavedViewDto = Veriado.Contracts.Search.SearchFavoriteItem;
+
+namespace Veriado.WinUI.ViewModels.Files;
+
+public sealed partial class FilesGridViewModel :
+    IRecipient<QuerySubmittedMessage>,
+    IRecipient<ApplySavedViewMessage>,
+    IRecipient<SaveCurrentQueryRequestedMessage>,
+    IRecipient<ClearSearchHistoryRequestedMessage>,
+    IRecipient<FocusSearchRequestedMessage>
+{
+    public void Receive(QuerySubmittedMessage message)
+    {
+        if (string.IsNullOrWhiteSpace(message?.Text))
+        {
+            return;
+        }
+
+        SearchText = message.Text;
+        _ = RefreshCommand.ExecuteAsync(null);
+    }
+
+    public void Receive(ApplySavedViewMessage message)
+    {
+        if (message?.Saved is null)
+        {
+            return;
+        }
+
+        SearchText = ResolveSearchText(message.Saved);
+        _ = RefreshCommand.ExecuteAsync(null);
+    }
+
+    public void Receive(SaveCurrentQueryRequestedMessage message)
+    {
+        _ = SaveCurrentQueryAsync(message?.Text);
+    }
+
+    public void Receive(ClearSearchHistoryRequestedMessage message)
+    {
+        _ = ClearSearchHistoryAsync();
+    }
+
+    public void Receive(FocusSearchRequestedMessage message)
+    {
+        // Intentionally left blank. The view listens for this message to focus the search box.
+    }
+
+    private async Task SaveCurrentQueryAsync(string? requestedName)
+    {
+        if (string.IsNullOrWhiteSpace(SearchText))
+        {
+            return;
+        }
+
+        var favoriteName = string.IsNullOrWhiteSpace(requestedName)
+            ? SearchText!.Trim()
+            : requestedName.Trim();
+
+        if (string.IsNullOrWhiteSpace(favoriteName))
+        {
+            StatusService.Error("Název uloženého filtru je povinný.");
+            return;
+        }
+
+        await SafeExecuteAsync(async ct =>
+        {
+            var definition = new SearchFavoriteDefinition(
+                favoriteName!,
+                SearchText!,
+                SearchText,
+                false);
+
+            await _queryService.AddFavoriteAsync(definition, ct).ConfigureAwait(false);
+            StatusService.Info("Aktuální filtr byl uložen mezi oblíbené.");
+        }, "Ukládám aktuální filtr…");
+    }
+
+    private async Task ClearSearchHistoryAsync()
+    {
+        await SafeExecuteAsync(async ct =>
+        {
+            await _historyService.ClearAsync(null, ct).ConfigureAwait(false);
+            StatusService.Info("Historie vyhledávání byla vymazána.");
+        }, "Mažu historii vyhledávání…");
+    }
+
+    private static string? ResolveSearchText(SavedViewDto saved)
+    {
+        if (!string.IsNullOrWhiteSpace(saved.QueryText))
+        {
+            return saved.QueryText;
+        }
+
+        return string.IsNullOrWhiteSpace(saved.MatchQuery)
+            ? saved.Name
+            : saved.MatchQuery;
+    }
+}

--- a/Veriado.WinUI/ViewModels/Files/FilesGridViewModel.cs
+++ b/Veriado.WinUI/ViewModels/Files/FilesGridViewModel.cs
@@ -12,6 +12,7 @@ using Veriado.WinUI.Services.Abstractions;
 using Veriado.Services.Files;
 using Veriado.WinUI.ViewModels.Base;
 using Veriado.WinUI.Views;
+using Veriado.Appl.Search.Abstractions;
 
 namespace Veriado.WinUI.ViewModels.Files;
 
@@ -21,6 +22,7 @@ public sealed partial class FilesGridViewModel : ViewModelBase
     private readonly INavigationService _navigationService;
     private readonly Func<FileDetailView> _detailViewFactory;
     private readonly IHotStateService _hotState;
+    private readonly ISearchHistoryService _historyService;
 
     [ObservableProperty]
     private string? searchText;
@@ -61,16 +63,20 @@ public sealed partial class FilesGridViewModel : ViewModelBase
         IFileQueryService queryService,
         INavigationService navigationService,
         IHotStateService hotState,
-        Func<FileDetailView> detailViewFactory)
+        Func<FileDetailView> detailViewFactory,
+        ISearchHistoryService historyService)
         : base(messenger, statusService, dispatcher, exceptionHandler)
     {
         _queryService = queryService ?? throw new ArgumentNullException(nameof(queryService));
         _navigationService = navigationService ?? throw new ArgumentNullException(nameof(navigationService));
         _detailViewFactory = detailViewFactory ?? throw new ArgumentNullException(nameof(detailViewFactory));
         _hotState = hotState ?? throw new ArgumentNullException(nameof(hotState));
+        _historyService = historyService ?? throw new ArgumentNullException(nameof(historyService));
 
         PageSize = Math.Max(1, _hotState.PageSize);
         SearchText = _hotState.LastQuery;
+
+        Messenger.RegisterAll(this);
     }
 
     [RelayCommand]

--- a/Veriado.WinUI/ViewModels/Files/FiltersNavViewModel.cs
+++ b/Veriado.WinUI/ViewModels/Files/FiltersNavViewModel.cs
@@ -1,0 +1,152 @@
+using System;
+using System.Collections.ObjectModel;
+using System.Threading;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using CommunityToolkit.Mvvm.Messaging;
+using Veriado.Appl.Search.Abstractions;
+using Veriado.WinUI.Services.Abstractions;
+using Veriado.WinUI.Services.Messages;
+using Veriado.WinUI.ViewModels.Base;
+using SavedViewDto = Veriado.Contracts.Search.SearchFavoriteItem;
+using SearchHistoryItemDto = Veriado.Contracts.Search.SearchHistoryEntry;
+
+namespace Veriado.WinUI.ViewModels.Files;
+
+public sealed partial class FiltersNavViewModel : ViewModelBase
+{
+    private readonly ISearchFavoritesService _favoritesService;
+    private readonly ISearchHistoryService _historyService;
+    private readonly IFilesSearchSuggestionsProvider _suggestionsProvider;
+
+    [ObservableProperty]
+    private string? searchText;
+
+    public ObservableCollection<string> SearchSuggestions { get; } = new();
+
+    public ObservableCollection<SavedViewDto> Favorites { get; } = new();
+
+    public ObservableCollection<SearchHistoryItemDto> History { get; } = new();
+
+    public FiltersNavViewModel(
+        IMessenger messenger,
+        IStatusService statusService,
+        IDispatcherService dispatcher,
+        IExceptionHandler exceptionHandler,
+        ISearchFavoritesService favoritesService,
+        ISearchHistoryService historyService,
+        IFilesSearchSuggestionsProvider suggestionsProvider)
+        : base(messenger, statusService, dispatcher, exceptionHandler)
+    {
+        _favoritesService = favoritesService ?? throw new ArgumentNullException(nameof(favoritesService));
+        _historyService = historyService ?? throw new ArgumentNullException(nameof(historyService));
+        _suggestionsProvider = suggestionsProvider ?? throw new ArgumentNullException(nameof(suggestionsProvider));
+    }
+
+    [RelayCommand]
+    private async Task LoadAsync()
+    {
+        await SafeExecuteAsync(async ct =>
+        {
+            await LoadFavoritesAsync(ct).ConfigureAwait(false);
+            await LoadHistoryAsync(ct).ConfigureAwait(false);
+            await LoadSuggestionsAsync(ct).ConfigureAwait(false);
+        });
+    }
+
+    [RelayCommand]
+    private void SubmitQueryFromAutoSuggest(string? query)
+    {
+        if (string.IsNullOrWhiteSpace(query))
+        {
+            return;
+        }
+
+        SearchText = query;
+        Messenger.Send(new QuerySubmittedMessage(query));
+    }
+
+    [RelayCommand]
+    private void SaveCurrentQuery()
+    {
+        Messenger.Send(new SaveCurrentQueryRequestedMessage(SearchText));
+    }
+
+    [RelayCommand]
+    private void ClearHistory()
+    {
+        Messenger.Send(new ClearSearchHistoryRequestedMessage());
+    }
+
+    [RelayCommand]
+    private void ApplySavedView(SavedViewDto? saved)
+    {
+        if (saved is null)
+        {
+            return;
+        }
+
+        Messenger.Send(new ApplySavedViewMessage(saved));
+    }
+
+    [RelayCommand]
+    private void ApplyHistoryItem(SearchHistoryItemDto? historyItem)
+    {
+        if (historyItem is null)
+        {
+            return;
+        }
+
+        var query = historyItem.QueryText ?? historyItem.MatchQuery;
+        if (string.IsNullOrWhiteSpace(query))
+        {
+            return;
+        }
+
+        SearchText = query;
+        Messenger.Send(new QuerySubmittedMessage(query));
+    }
+
+    private async Task LoadFavoritesAsync(CancellationToken cancellationToken)
+    {
+        var favorites = await _favoritesService.GetAllAsync(cancellationToken).ConfigureAwait(false);
+
+        await Dispatcher.Enqueue(() =>
+        {
+            Favorites.Clear();
+            foreach (var favorite in favorites)
+            {
+                Favorites.Add(favorite);
+            }
+        });
+    }
+
+    private async Task LoadHistoryAsync(CancellationToken cancellationToken)
+    {
+        var history = await _historyService.GetRecentAsync(50, cancellationToken).ConfigureAwait(false);
+
+        await Dispatcher.Enqueue(() =>
+        {
+            History.Clear();
+            foreach (var item in history)
+            {
+                History.Add(item);
+            }
+        });
+    }
+
+    private async Task LoadSuggestionsAsync(CancellationToken cancellationToken)
+    {
+        var suggestions = await _suggestionsProvider.GetSuggestionsAsync(cancellationToken).ConfigureAwait(false);
+
+        await Dispatcher.Enqueue(() =>
+        {
+            SearchSuggestions.Clear();
+            foreach (var suggestion in suggestions)
+            {
+                SearchSuggestions.Add(suggestion);
+            }
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- add dedicated search messages for query submission, saved views, and history actions
- introduce a filters navigation view model backed by favorites, history, and suggestions services
- provide a files search suggestions provider and extend files grid messaging plus dependency registrations

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d4f1d4f8908326a9a712138da769b6