### PR TITLE
Refactor main shell layout and add filters pane

### DIFF
--- a/Veriado.WinUI/App.xaml.cs
+++ b/Veriado.WinUI/App.xaml.cs
@@ -91,6 +91,11 @@ public partial class App : Application
             var settingsViewModel = services.GetRequiredService<SettingsViewModel>();
             settingsViewModel.SelectedTheme = themeService.CurrentTheme;
 
+            var shellViewModel = services.GetRequiredService<ShellViewModel>();
+            var shellView = services.GetRequiredService<MainShell>();
+            shellView.DataContext = shellViewModel;
+            mainWindow.Content = shellView;
+
             mainWindow.Activate();
             mainWindow.Closed += OnWindowClosed;
 

--- a/Veriado.WinUI/AppHost.cs
+++ b/Veriado.WinUI/AppHost.cs
@@ -64,7 +64,7 @@ internal sealed class AppHost : IAsyncDisposable
                 services.AddSingleton<ShellViewModel>();
                 services.AddSingleton<SearchOverlayViewModel>();
                 services.AddTransient<FilesGridViewModel>();
-                services.AddSingleton<FiltersNavViewModel>();
+                services.AddTransient<FiltersNavViewModel>();
                 services.AddTransient<FileDetailViewModel>();
                 services.AddTransient<ImportViewModel>();
                 services.AddSingleton<FavoritesViewModel>();

--- a/Veriado.WinUI/Converters/Converters.cs
+++ b/Veriado.WinUI/Converters/Converters.cs
@@ -1,0 +1,210 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Globalization;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Data;
+
+namespace Veriado.WinUI.Converters;
+
+public sealed class SizeToHumanReadableConverter : IValueConverter
+{
+    private static readonly string[] Units = ["B", "KB", "MB", "GB", "TB", "PB"];
+
+    public object Convert(object value, Type targetType, object parameter, string language)
+    {
+        if (value is null)
+        {
+            return string.Empty;
+        }
+
+        double bytes;
+        try
+        {
+            bytes = System.Convert.ToDouble(value, CultureInfo.InvariantCulture);
+        }
+        catch (Exception)
+        {
+            return string.Empty;
+        }
+
+        if (bytes <= 0)
+        {
+            return "0 B";
+        }
+
+        var order = (int)Math.Min(Units.Length - 1, Math.Log(bytes, 1024));
+        var scaled = bytes / Math.Pow(1024, order);
+        return string.Create(CultureInfo.GetCultureInfo("cs-CZ"), $"{scaled:0.##} {Units[order]}");
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, string language) => DependencyProperty.UnsetValue;
+}
+
+public sealed class DateTimeToRelativeConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, string language)
+    {
+        if (value is null)
+        {
+            return string.Empty;
+        }
+
+        DateTimeOffset timestamp = value switch
+        {
+            DateTimeOffset dto => dto,
+            DateTime dt => new DateTimeOffset(dt),
+            _ => default
+        };
+
+        if (timestamp == default)
+        {
+            return string.Empty;
+        }
+
+        var now = DateTimeOffset.UtcNow;
+        var delta = now - timestamp.ToUniversalTime();
+
+        if (delta.TotalSeconds < 60)
+        {
+            var seconds = Math.Max(1, (int)Math.Round(delta.TotalSeconds));
+            return seconds == 1 ? "před sekundou" : $"před {seconds} sekundami";
+        }
+
+        if (delta.TotalMinutes < 60)
+        {
+            var minutes = Math.Max(1, (int)Math.Round(delta.TotalMinutes));
+            return minutes == 1 ? "před minutou" : $"před {minutes} minutami";
+        }
+
+        if (delta.TotalHours < 24)
+        {
+            var hours = Math.Max(1, (int)Math.Round(delta.TotalHours));
+            return hours == 1 ? "před hodinou" : $"před {hours} hodinami";
+        }
+
+        if (delta.TotalDays < 7)
+        {
+            var days = Math.Max(1, (int)Math.Round(delta.TotalDays));
+            return days == 1 ? "včera" : $"před {days} dny";
+        }
+
+        if (delta.TotalDays < 30)
+        {
+            var weeks = Math.Max(1, (int)Math.Round(delta.TotalDays / 7));
+            return weeks == 1 ? "před týdnem" : $"před {weeks} týdny";
+        }
+
+        if (delta.TotalDays < 365)
+        {
+            var months = Math.Max(1, (int)Math.Round(delta.TotalDays / 30));
+            return months == 1 ? "před měsícem" : $"před {months} měsíci";
+        }
+
+        var years = Math.Max(1, (int)Math.Round(delta.TotalDays / 365));
+        return years == 1 ? "před rokem" : $"před {years} lety";
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, string language) => DependencyProperty.UnsetValue;
+}
+
+public sealed class BooleanToVisibilityConverterEx : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, string language)
+    {
+        var invert = parameter is string s && s.Equals("Invert", StringComparison.OrdinalIgnoreCase);
+
+        if (value is bool flag)
+        {
+            flag = invert ? !flag : flag;
+            return flag ? Visibility.Visible : Visibility.Collapsed;
+        }
+
+        if (value is bool? nullable && nullable.HasValue)
+        {
+            var flagValue = invert ? !nullable.Value : nullable.Value;
+            return flagValue ? Visibility.Visible : Visibility.Collapsed;
+        }
+
+        return Visibility.Collapsed;
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, string language)
+    {
+        if (value is not Visibility visibility)
+        {
+            return DependencyProperty.UnsetValue;
+        }
+
+        var invert = parameter is string s && s.Equals("Invert", StringComparison.OrdinalIgnoreCase);
+        var result = visibility == Visibility.Visible;
+        return invert ? !result : result;
+    }
+}
+
+public sealed class SelectionCountToStatusConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, string language)
+    {
+        if (value is int count)
+        {
+            return count switch
+            {
+                < 0 => string.Empty,
+                0 => "Žádná položka není vybrána.",
+                1 => "1 položka vybrána.",
+                _ => $"Vybráno {count} položek."
+            };
+        }
+
+        return string.Empty;
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, string language) => DependencyProperty.UnsetValue;
+}
+
+public sealed class SortDirectionToGlyphConverter : IValueConverter
+{
+    private static readonly IReadOnlyDictionary<ListSortDirection, string> Glyphs = new Dictionary<ListSortDirection, string>
+    {
+        [ListSortDirection.Ascending] = "\uE74A",
+        [ListSortDirection.Descending] = "\uE74B",
+    };
+
+    public object Convert(object value, Type targetType, object parameter, string language)
+    {
+        if (value is ListSortDirection direction && Glyphs.TryGetValue(direction, out var glyph))
+        {
+            return glyph;
+        }
+
+        return string.Empty;
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, string language) => DependencyProperty.UnsetValue;
+}
+
+public sealed class MimeToIconConverter : IValueConverter
+{
+    private static readonly IReadOnlyDictionary<string, string> MimeGlyphs = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+    {
+        ["application/pdf"] = "\uE8A5",
+        ["image/png"] = "\uEB9F",
+        ["image/jpeg"] = "\uEB9F",
+        ["text/plain"] = "\uE8A5",
+        ["application/vnd.openxmlformats-officedocument.wordprocessingml.document"] = "\uE8A5",
+        ["application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"] = "\uE8A5",
+    };
+
+    public object Convert(object value, Type targetType, object parameter, string language)
+    {
+        if (value is string mime && MimeGlyphs.TryGetValue(mime, out var glyph))
+        {
+            return glyph;
+        }
+
+        return "\uE7C3"; // Generic document glyph
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, string language) => DependencyProperty.UnsetValue;
+}

--- a/Veriado.WinUI/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/Veriado.WinUI/DependencyInjection/ServiceCollectionExtensions.cs
@@ -17,6 +17,8 @@ public static class ServiceCollectionExtensions
     public static IServiceCollection AddWinUiShell(this IServiceCollection services)
     {
         services.AddSingleton<MainWindow>();
+        services.AddTransient<MainShell>();
+        services.AddTransient<FiltersNavPane>();
         services.AddTransient<FilesView>();
         services.AddTransient<FileDetailView>();
         services.AddTransient<Func<FileDetailView>>(sp => () => sp.GetRequiredService<FileDetailView>());

--- a/Veriado.WinUI/Services/KeyboardShortcutsService.cs
+++ b/Veriado.WinUI/Services/KeyboardShortcutsService.cs
@@ -40,7 +40,7 @@ public sealed class KeyboardShortcutsService : IKeyboardShortcutsService
         };
         openSearch.Invoked += (_, args) =>
         {
-            _messenger.Send(new OpenSearchOverlayMessage());
+            _messenger.Send(new FocusSearchRequestedMessage());
             args.Handled = true;
         };
 

--- a/Veriado.WinUI/ViewModels/Shell/ShellViewModel.cs
+++ b/Veriado.WinUI/ViewModels/Shell/ShellViewModel.cs
@@ -34,6 +34,9 @@ public sealed partial class ShellViewModel : ViewModelBase, INavigationHost
     [ObservableProperty]
     private bool isInfoBarOpen;
 
+    [ObservableProperty]
+    private bool isNavOpen;
+
     public FilesGridViewModel Files { get; }
 
     public ImportViewModel Import { get; }
@@ -95,5 +98,7 @@ public sealed partial class ShellViewModel : ViewModelBase, INavigationHost
                 _navigationService.NavigateTo(_settingsView);
                 break;
         }
+
+        IsNavOpen = false;
     }
 }

--- a/Veriado.WinUI/Views/FilesView.xaml
+++ b/Veriado.WinUI/Views/FilesView.xaml
@@ -3,44 +3,64 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:contracts="using:Veriado.Contracts.Files"
+    xmlns:conv="using:Veriado.WinUI.Converters"
     xmlns:winui="using:Microsoft.UI.Xaml.Controls">
 
     <Grid x:Name="Root" Loaded="Root_Loaded">
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="*" />
-        </Grid.RowDefinitions>
+        <Grid.Resources>
+            <conv:SizeToHumanReadableConverter x:Key="SizeConverter" />
+            <conv:DateTimeToRelativeConverter x:Key="RelativeConverter" />
+            <conv:MimeToIconConverter x:Key="MimeToIconConverter" />
+        </Grid.Resources>
 
-        <StackPanel Orientation="Horizontal" Spacing="8">
-            <TextBox Width="320"
-                     PlaceholderText="Hledat"
-                     Text="{Binding SearchText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-            <Button Content="Hledat"
-                    Click="SearchButton_Click" />
-            <winui:NumberBox Width="140"
-                             Header="Položek na stránku"
-                             Value="{Binding PageSize, Mode=TwoWay}"
-                             Minimum="1"
-                             Maximum="500" />
-        </StackPanel>
-
-        <winui:ItemsRepeater Grid.Row="1" ItemsSource="{Binding Items}">
-            <winui:ItemsRepeater.ItemTemplate>
+        <winui:ListView x:Name="FilesList"
+                        ItemsSource="{Binding Items}"
+                        IsItemClickEnabled="True"
+                        SelectionMode="Extended"
+                        ItemClick="FilesList_ItemClick"
+                        DoubleTapped="FilesList_DoubleTapped"
+                        HorizontalAlignment="Stretch"
+                        VerticalAlignment="Stretch">
+            <winui:ListView.ItemTemplate>
                 <DataTemplate x:DataType="contracts:FileSummaryDto">
-                    <Border Padding="12">
-                        <StackPanel>
-                            <TextBlock Text="{x:Bind Name, Mode=OneWay}" FontWeight="SemiBold" />
-                            <TextBlock Text="{x:Bind Mime, Mode=OneWay}" />
-                            <Button Content="Otevřít detail"
-                                    Click="OpenDetail_Click"
-                                    Tag="{x:Bind Id, Mode=OneWay}" />
-                        </StackPanel>
+                    <Border Margin="0,0,0,12"
+                            Padding="12"
+                            Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                            CornerRadius="8">
+                        <Grid ColumnSpacing="12">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto" />
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="Auto" />
+                            </Grid.ColumnDefinitions>
+
+                            <FontIcon FontFamily="Segoe Fluent Icons"
+                                      Glyph="{Binding Mime, Converter={StaticResource MimeToIconConverter}}"
+                                      FontSize="24"
+                                      VerticalAlignment="Top" />
+
+                            <StackPanel Grid.Column="1" Spacing="4">
+                                <TextBlock Text="{x:Bind Name, Mode=OneWay}" FontSize="18" FontWeight="SemiBold" />
+                                <StackPanel Orientation="Horizontal" Spacing="8">
+                                    <TextBlock Text="{Binding Extension, StringFormat='.{0}'}" />
+                                    <TextBlock Text="•" />
+                                    <TextBlock Text="{Binding Size, Converter={StaticResource SizeConverter}}" />
+                                    <TextBlock Text="•" />
+                                    <TextBlock Text="{Binding LastModifiedUtc, Converter={StaticResource RelativeConverter}}" />
+                                </StackPanel>
+                                <TextBlock Text="{x:Bind Author, Mode=OneWay}" Style="{ThemeResource CaptionTextBlockStyle}" />
+                            </StackPanel>
+
+                            <StackPanel Grid.Column="2" HorizontalAlignment="Right" Spacing="4">
+                                <TextBlock Text="{Binding Version, StringFormat='v{0}'}" Style="{ThemeResource CaptionTextBlockStyle}" />
+                                <Button Content="Detail"
+                                        Tag="{x:Bind Id, Mode=OneWay}"
+                                        Click="OpenDetail_Click" />
+                            </StackPanel>
+                        </Grid>
                     </Border>
                 </DataTemplate>
-            </winui:ItemsRepeater.ItemTemplate>
-            <winui:ItemsRepeater.Layout>
-                <winui:UniformGridLayout MaximumRowsOrColumns="3" />
-            </winui:ItemsRepeater.Layout>
-        </winui:ItemsRepeater>
+            </winui:ListView.ItemTemplate>
+        </winui:ListView>
     </Grid>
 </UserControl>

--- a/Veriado.WinUI/Views/FilesView.xaml.cs
+++ b/Veriado.WinUI/Views/FilesView.xaml.cs
@@ -3,6 +3,8 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Input;
+using Veriado.Contracts.Files;
 using Veriado.WinUI.Infrastructure;
 using Veriado.WinUI.ViewModels.Files;
 
@@ -28,17 +30,28 @@ public sealed partial class FilesView : UserControl
             .ConfigureAwait(false);
     }
 
-    private async void SearchButton_Click(object sender, RoutedEventArgs e)
-    {
-        await CommandForwarder.TryExecuteAsync(ViewModel.RefreshCommand, null, _logger)
-            .ConfigureAwait(false);
-    }
-
     private void OpenDetail_Click(object sender, RoutedEventArgs e)
     {
         if (sender is Button { Tag: Guid id })
         {
             CommandForwarder.TryExecute(ViewModel.OpenDetailCommand, id, _logger);
+        }
+    }
+
+    private void FilesList_ItemClick(object sender, ItemClickEventArgs e)
+    {
+        if (e?.ClickedItem is FileSummaryDto summary)
+        {
+            CommandForwarder.TryExecute(ViewModel.OpenDetailCommand, summary.Id, _logger);
+        }
+    }
+
+    private void FilesList_DoubleTapped(object sender, DoubleTappedRoutedEventArgs e)
+    {
+        if (sender is ListView { SelectedItem: FileSummaryDto summary })
+        {
+            CommandForwarder.TryExecute(ViewModel.OpenDetailCommand, summary.Id, _logger);
+            e.Handled = true;
         }
     }
 }

--- a/Veriado.WinUI/Views/FiltersNavPane.xaml
+++ b/Veriado.WinUI/Views/FiltersNavPane.xaml
@@ -1,0 +1,76 @@
+<UserControl
+    x:Class="Veriado.WinUI.Views.FiltersNavPane"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:contracts="using:Veriado.Contracts.Search"
+    xmlns:conv="using:Veriado.WinUI.Converters"
+    xmlns:winui="using:Microsoft.UI.Xaml.Controls">
+
+    <UserControl.Resources>
+        <conv:DateTimeToRelativeConverter x:Key="RelativeConverter" />
+    </UserControl.Resources>
+
+    <Grid x:Name="Root"
+          Padding="16"
+          RowSpacing="12"
+          Loaded="Root_Loaded"
+          Unloaded="Root_Unloaded">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <StackPanel Spacing="12">
+            <AutoSuggestBox x:Name="SearchBox"
+                            PlaceholderText="Hledat dokumenty"
+                            QueryIcon="Find"
+                            Text="{Binding SearchText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                            ItemsSource="{Binding SearchSuggestions}"
+                            QuerySubmitted="SearchBox_QuerySubmitted"
+                            SuggestionChosen="SearchBox_SuggestionChosen" />
+
+            <StackPanel Orientation="Horizontal" Spacing="8">
+                <Button Content="Uložit pohled"
+                        Command="{Binding SaveCurrentQueryCommand}" />
+                <Button Content="Vymazat historii"
+                        Command="{Binding ClearHistoryCommand}" />
+            </StackPanel>
+        </StackPanel>
+
+        <winui:Expander Grid.Row="1" Header="Oblíbené" IsExpanded="True">
+            <winui:ListView x:Name="FavoritesList"
+                            ItemsSource="{Binding Favorites}"
+                            SelectionMode="None"
+                            IsItemClickEnabled="True"
+                            ItemClick="FavoritesList_ItemClick">
+                <winui:ListView.ItemTemplate>
+                    <DataTemplate x:DataType="contracts:SearchFavoriteItem">
+                        <StackPanel Spacing="4">
+                            <TextBlock Text="{x:Bind Name, Mode=OneWay}" FontWeight="SemiBold" />
+                            <TextBlock Text="{x:Bind QueryText, Mode=OneWay}" Style="{ThemeResource CaptionTextBlockStyle}" />
+                        </StackPanel>
+                    </DataTemplate>
+                </winui:ListView.ItemTemplate>
+            </winui:ListView>
+        </winui:Expander>
+
+        <winui:Expander Grid.Row="2" Header="Historie" IsExpanded="False">
+            <winui:ListView x:Name="HistoryList"
+                            ItemsSource="{Binding History}"
+                            SelectionMode="None"
+                            IsItemClickEnabled="True"
+                            ItemClick="HistoryList_ItemClick">
+                <winui:ListView.ItemTemplate>
+                    <DataTemplate x:DataType="contracts:SearchHistoryEntry">
+                        <StackPanel Spacing="4">
+                            <TextBlock Text="{x:Bind QueryText, Mode=OneWay}" FontWeight="SemiBold" />
+                            <TextBlock Text="{Binding LastQueriedUtc, Converter={StaticResource RelativeConverter}}"
+                                       Style="{ThemeResource CaptionTextBlockStyle}" />
+                        </StackPanel>
+                    </DataTemplate>
+                </winui:ListView.ItemTemplate>
+            </winui:ListView>
+        </winui:Expander>
+    </Grid>
+</UserControl>

--- a/Veriado.WinUI/Views/FiltersNavPane.xaml.cs
+++ b/Veriado.WinUI/Views/FiltersNavPane.xaml.cs
@@ -1,0 +1,80 @@
+using System;
+using CommunityToolkit.Mvvm.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Veriado.Contracts.Search;
+using Veriado.WinUI.Infrastructure;
+using Veriado.WinUI.Services.Messages;
+using Veriado.WinUI.ViewModels.Files;
+
+namespace Veriado.WinUI.Views;
+
+public sealed partial class FiltersNavPane : UserControl, IRecipient<FocusSearchRequestedMessage>
+{
+    private readonly ILogger<FiltersNavPane> _logger;
+    private readonly IMessenger _messenger;
+
+    public FiltersNavPane()
+    {
+        InitializeComponent();
+
+        var services = App.Services;
+        DataContext = services.GetRequiredService<FiltersNavViewModel>();
+        _logger = services.GetRequiredService<ILogger<FiltersNavPane>>();
+        _messenger = services.GetRequiredService<IMessenger>();
+
+        _messenger.Register<FiltersNavPane, FocusSearchRequestedMessage>(this, static (recipient, message) => recipient.Receive(message));
+    }
+
+    public FiltersNavViewModel ViewModel => (FiltersNavViewModel)DataContext!;
+
+    public void Receive(FocusSearchRequestedMessage message)
+    {
+        _ = DispatcherQueue.TryEnqueue(() => SearchBox.Focus(FocusState.Programmatic));
+    }
+
+    private async void Root_Loaded(object sender, RoutedEventArgs e)
+    {
+        await CommandForwarder.TryExecuteAsync(ViewModel.LoadCommand, null, _logger).ConfigureAwait(false);
+    }
+
+    private void Root_Unloaded(object sender, RoutedEventArgs e)
+    {
+        _messenger.Unregister<FocusSearchRequestedMessage>(this);
+    }
+
+    private async void SearchBox_QuerySubmitted(AutoSuggestBox sender, AutoSuggestBoxQuerySubmittedEventArgs args)
+    {
+        var query = args?.QueryText;
+        await CommandForwarder.TryExecuteAsync(ViewModel.SubmitQueryFromAutoSuggestCommand, query, _logger)
+            .ConfigureAwait(false);
+    }
+
+    private void SearchBox_SuggestionChosen(AutoSuggestBox sender, AutoSuggestBoxSuggestionChosenEventArgs args)
+    {
+        if (args?.SelectedItem is string suggestion)
+        {
+            ViewModel.SearchText = suggestion;
+        }
+    }
+
+    private async void FavoritesList_ItemClick(object sender, ItemClickEventArgs e)
+    {
+        if (e?.ClickedItem is SearchFavoriteItem favorite)
+        {
+            await CommandForwarder.TryExecuteAsync(ViewModel.ApplySavedViewCommand, favorite, _logger)
+                .ConfigureAwait(false);
+        }
+    }
+
+    private async void HistoryList_ItemClick(object sender, ItemClickEventArgs e)
+    {
+        if (e?.ClickedItem is SearchHistoryEntry history)
+        {
+            await CommandForwarder.TryExecuteAsync(ViewModel.ApplyHistoryItemCommand, history, _logger)
+                .ConfigureAwait(false);
+        }
+    }
+}

--- a/Veriado.WinUI/Views/MainShell.xaml
+++ b/Veriado.WinUI/Views/MainShell.xaml
@@ -1,0 +1,109 @@
+<UserControl
+    x:Class="Veriado.WinUI.Views.MainShell"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:conv="using:Veriado.WinUI.Converters"
+    xmlns:views="using:Veriado.WinUI.Views"
+    xmlns:winui="using:Microsoft.UI.Xaml.Controls">
+
+    <UserControl.Resources>
+        <conv:BooleanToVisibilityConverterEx x:Key="BoolToVisibilityEx" />
+    </UserControl.Resources>
+
+    <Grid x:Name="LayoutRoot">
+        <VisualStateManager.VisualStateGroups>
+            <VisualStateGroup>
+                <VisualState x:Name="Narrow">
+                    <VisualState.StateTriggers>
+                        <AdaptiveTrigger MinWindowWidth="0" />
+                    </VisualState.StateTriggers>
+                    <VisualState.Setters>
+                        <Setter Target="PreviewDetailPane.Visibility" Value="Collapsed" />
+                    </VisualState.Setters>
+                </VisualState>
+                <VisualState x:Name="Wide">
+                    <VisualState.StateTriggers>
+                        <AdaptiveTrigger MinWindowWidth="1200" />
+                    </VisualState.StateTriggers>
+                    <VisualState.Setters>
+                        <Setter Target="PreviewDetailPane.Visibility" Value="Visible" />
+                    </VisualState.Setters>
+                </VisualState>
+            </VisualStateGroup>
+        </VisualStateManager.VisualStateGroups>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="300" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="400" />
+        </Grid.ColumnDefinitions>
+
+        <Grid.KeyboardAccelerators>
+            <KeyboardAccelerator Key="F" Modifiers="Control" Invoked="FocusSearch_Invoked" />
+            <KeyboardAccelerator Key="M" Modifiers="Menu" Invoked="ToggleNavigation_Invoked" />
+            <KeyboardAccelerator Key="Escape" Invoked="CloseNavigation_Invoked" />
+            <KeyboardAccelerator Key="F5" Command="{Binding Files.RefreshCommand}" />
+            <KeyboardAccelerator Key="F6" Invoked="ForwardAccelerator_Invoked" />
+            <KeyboardAccelerator Key="F7" Invoked="ForwardAccelerator_Invoked" />
+            <KeyboardAccelerator Key="F8" Invoked="ForwardAccelerator_Invoked" />
+            <KeyboardAccelerator Key="Delete" Invoked="ForwardAccelerator_Invoked" />
+            <KeyboardAccelerator Key="F6" Modifiers="Shift" Invoked="ForwardAccelerator_Invoked" />
+            <KeyboardAccelerator Key="R" Modifiers="Control" Invoked="ForwardAccelerator_Invoked" />
+            <KeyboardAccelerator Key="Q" Modifiers="Control" Invoked="ForwardAccelerator_Invoked" />
+            <KeyboardAccelerator Key="Tab" Invoked="ForwardAccelerator_Invoked" />
+        </Grid.KeyboardAccelerators>
+
+        <views:FiltersNavPane Grid.Row="0"
+                              Grid.Column="0"
+                              HorizontalAlignment="Stretch"
+                              VerticalAlignment="Stretch" />
+
+        <ContentPresenter Grid.Row="0"
+                          Grid.Column="1"
+                          Margin="12"
+                          Content="{Binding CurrentContent}" />
+
+        <Border x:Name="PreviewDetailPane"
+                Grid.Row="0"
+                Grid.Column="2"
+                Margin="12"
+                Padding="12"
+                Background="{ThemeResource CardBackgroundFillColorDefaultBrush}">
+            <ContentPresenter Content="{Binding CurrentDetail}" />
+        </Border>
+
+        <Grid x:Name="StatusBar"
+              Grid.Row="1"
+              Grid.ColumnSpan="3"
+              Background="{ThemeResource LayerOnAcrylicFillColorDefaultBrush}"
+              Padding="8">
+            <winui:InfoBar IsOpen="{Binding IsInfoBarOpen}"
+                           Severity="{Binding HasError, Converter={StaticResource BoolToSeverityConverter}}"
+                           Message="{Binding StatusMessage}" />
+        </Grid>
+
+        <Grid x:Name="NavigationOverlay"
+              Background="{ThemeResource LayerOnAcrylicDefaultBrush}"
+              Visibility="{Binding IsNavOpen, Converter={StaticResource BoolToVisibilityEx}}"
+              IsHitTestVisible="{Binding IsNavOpen}"
+              Tapped="NavigationOverlay_Tapped">
+            <winui:NavigationView x:Name="OverlayNavView"
+                                  Width="320"
+                                  HorizontalAlignment="Left"
+                                  VerticalAlignment="Stretch"
+                                  IsSettingsVisible="True"
+                                  PaneDisplayMode="LeftMinimal"
+                                  IsPaneOpen="{Binding IsNavOpen, Mode=TwoWay}"
+                                  SelectedItem="{Binding SelectedNavItem, Mode=TwoWay}">
+                <winui:NavigationView.MenuItems>
+                    <winui:NavigationViewItem Content="Soubory" Icon="Folder" Tag="Files" />
+                    <winui:NavigationViewItem Content="Import" Icon="Upload" Tag="Import" />
+                    <winui:NavigationViewItem Content="Nastavení" Icon="Setting" Tag="Settings" />
+                </winui:NavigationView.MenuItems>
+            </winui:NavigationView>
+        </Grid>
+    </Grid>
+</UserControl>

--- a/Veriado.WinUI/Views/MainShell.xaml.cs
+++ b/Veriado.WinUI/Views/MainShell.xaml.cs
@@ -1,0 +1,82 @@
+using System;
+using CommunityToolkit.Mvvm.Messaging;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Input;
+using Veriado.WinUI.Services.Messages;
+using Veriado.WinUI.ViewModels;
+
+namespace Veriado.WinUI.Views;
+
+public sealed partial class MainShell : UserControl
+{
+    public MainShell()
+    {
+        InitializeComponent();
+    }
+
+    public ShellViewModel ViewModel => (ShellViewModel)DataContext!;
+
+    private void FocusSearch_Invoked(KeyboardAccelerator sender, KeyboardAcceleratorInvokedEventArgs args)
+    {
+        WeakReferenceMessenger.Default.Send(new FocusSearchRequestedMessage());
+        args.Handled = true;
+    }
+
+    private void ToggleNavigation_Invoked(KeyboardAccelerator sender, KeyboardAcceleratorInvokedEventArgs args)
+    {
+        if (DataContext is ShellViewModel vm)
+        {
+            vm.IsNavOpen = !vm.IsNavOpen;
+        }
+
+        args.Handled = true;
+    }
+
+    private void CloseNavigation_Invoked(KeyboardAccelerator sender, KeyboardAcceleratorInvokedEventArgs args)
+    {
+        if (DataContext is ShellViewModel vm && vm.IsNavOpen)
+        {
+            vm.IsNavOpen = false;
+            args.Handled = true;
+        }
+    }
+
+    private void NavigationOverlay_Tapped(object sender, TappedRoutedEventArgs e)
+    {
+        if (sender is not FrameworkElement overlay || DataContext is not ShellViewModel vm)
+        {
+            return;
+        }
+
+        if (e.OriginalSource is FrameworkElement element && IsInsideNavigationView(element))
+        {
+            return;
+        }
+
+        vm.IsNavOpen = false;
+        e.Handled = true;
+    }
+
+    private static bool IsInsideNavigationView(FrameworkElement element)
+    {
+        var current = element;
+        while (current is not null)
+        {
+            if (current is NavigationView)
+            {
+                return true;
+            }
+
+            current = current.Parent as FrameworkElement;
+        }
+
+        return false;
+    }
+
+    private void ForwardAccelerator_Invoked(KeyboardAccelerator sender, KeyboardAcceleratorInvokedEventArgs args)
+    {
+        // Allow child controls to handle these accelerators.
+        args.Handled = false;
+    }
+}


### PR DESCRIPTION
## Summary
- add a FiltersNavPane control with autosuggest search, favorites, and history lists wired to focus requests and view-model commands
- replace the window content with a new MainShell layout that hosts the filters pane, files view, detail pane, overlay navigation, and status bar with updated keyboard accelerators
- provide reusable converters and update dependency injection, startup wiring, keyboard shortcuts, and files listing to leverage the new experience

## Testing
- not run (dotnet CLI is unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68d4f78c2d7c832696b97fd642260854