### PR TITLE
Fix WinUI bindings and accelerators

### DIFF
--- a/Veriado.WinUI/Views/FileDetailView.xaml
+++ b/Veriado.WinUI/Views/FileDetailView.xaml
@@ -12,7 +12,7 @@
         </Grid.RowDefinitions>
 
         <StackPanel Spacing="8">
-            <TextBlock Text="{x:Bind ViewModel.Detail?.Name, Mode=OneWay}" FontSize="18" FontWeight="SemiBold" />
+            <TextBlock Text="{Binding Detail.Name}" FontSize="18" FontWeight="SemiBold" />
             <StackPanel Orientation="Horizontal" Spacing="8">
                 <TextBox Width="220"
                          PlaceholderText="Nový název"

--- a/Veriado.WinUI/Views/FilesView.xaml
+++ b/Veriado.WinUI/Views/FilesView.xaml
@@ -39,20 +39,26 @@
                                       FontSize="24"
                                       VerticalAlignment="Top" />
 
-                            <StackPanel Grid.Column="1" Spacing="4">
-                                <TextBlock Text="{x:Bind Name, Mode=OneWay}" FontSize="18" FontWeight="SemiBold" />
-                                <StackPanel Orientation="Horizontal" Spacing="8">
-                                    <TextBlock Text="{Binding Extension, StringFormat='.{0}'}" />
-                                    <TextBlock Text="•" />
-                                    <TextBlock Text="{Binding Size, Converter={StaticResource SizeConverter}}" />
-                                    <TextBlock Text="•" />
-                                    <TextBlock Text="{Binding LastModifiedUtc, Converter={StaticResource RelativeConverter}}" />
-                                </StackPanel>
-                                <TextBlock Text="{x:Bind Author, Mode=OneWay}" Style="{ThemeResource CaptionTextBlockStyle}" />
-                            </StackPanel>
+                              <StackPanel Grid.Column="1" Spacing="4">
+                                  <TextBlock Text="{x:Bind Name, Mode=OneWay}" FontSize="18" FontWeight="SemiBold" />
+                                  <StackPanel Orientation="Horizontal" Spacing="8">
+                                      <TextBlock>
+                                          <Run Text="." />
+                                          <Run Text="{Binding Extension}" />
+                                      </TextBlock>
+                                      <TextBlock Text="•" />
+                                      <TextBlock Text="{Binding Size, Converter={StaticResource SizeConverter}}" />
+                                      <TextBlock Text="•" />
+                                      <TextBlock Text="{Binding LastModifiedUtc, Converter={StaticResource RelativeConverter}}" />
+                                  </StackPanel>
+                                  <TextBlock Text="{x:Bind Author, Mode=OneWay}" Style="{ThemeResource CaptionTextBlockStyle}" />
+                              </StackPanel>
 
                             <StackPanel Grid.Column="2" HorizontalAlignment="Right" Spacing="4">
-                                <TextBlock Text="{Binding Version, StringFormat='v{0}'}" Style="{ThemeResource CaptionTextBlockStyle}" />
+                                <TextBlock Style="{ThemeResource CaptionTextBlockStyle}">
+                                    <Run Text="v" />
+                                    <Run Text="{Binding Version}" />
+                                </TextBlock>
                                 <Button Content="Detail"
                                         Tag="{x:Bind Id, Mode=OneWay}"
                                         Click="OpenDetail_Click" />

--- a/Veriado.WinUI/Views/MainShell.xaml
+++ b/Veriado.WinUI/Views/MainShell.xaml
@@ -45,7 +45,7 @@
             <KeyboardAccelerator Key="F" Modifiers="Control" Invoked="FocusSearch_Invoked" />
             <KeyboardAccelerator Key="M" Modifiers="Menu" Invoked="ToggleNavigation_Invoked" />
             <KeyboardAccelerator Key="Escape" Invoked="CloseNavigation_Invoked" />
-            <KeyboardAccelerator Key="F5" Command="{Binding Files.RefreshCommand}" />
+            <KeyboardAccelerator Key="F5" Invoked="RefreshAccelerator_Invoked" />
             <KeyboardAccelerator Key="F6" Invoked="ForwardAccelerator_Invoked" />
             <KeyboardAccelerator Key="F7" Invoked="ForwardAccelerator_Invoked" />
             <KeyboardAccelerator Key="F8" Invoked="ForwardAccelerator_Invoked" />

--- a/Veriado.WinUI/Views/MainShell.xaml.cs
+++ b/Veriado.WinUI/Views/MainShell.xaml.cs
@@ -3,6 +3,7 @@ using CommunityToolkit.Mvvm.Messaging;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
+using Veriado.WinUI.Infrastructure;
 using Veriado.WinUI.Services.Messages;
 using Veriado.WinUI.ViewModels;
 
@@ -38,6 +39,15 @@ public sealed partial class MainShell : UserControl
         if (DataContext is ShellViewModel vm && vm.IsNavOpen)
         {
             vm.IsNavOpen = false;
+            args.Handled = true;
+        }
+    }
+
+    private async void RefreshAccelerator_Invoked(KeyboardAccelerator sender, KeyboardAcceleratorInvokedEventArgs args)
+    {
+        if (DataContext is ShellViewModel vm)
+        {
+            await CommandForwarder.TryExecuteAsync(vm.Files.RefreshCommand, null);
             args.Handled = true;
         }
     }


### PR DESCRIPTION
## Summary
- replace unsupported StringFormat bindings in FilesView with inline Run elements to render the prefix characters
- adjust FileDetailView title binding to avoid nullable member syntax that WinUI XAML cannot parse
- wire the F5 keyboard accelerator to an event handler that forwards to the files refresh command

## Testing
- `dotnet build Veriado.sln` *(fails: `dotnet` command is not available in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d501d27eec83268cd9496fcf85960d