### PR TITLE
Use partial observable properties for WinUI AOT

### DIFF
--- a/Veriado.WinUI/Services/HotStateService.cs
+++ b/Veriado.WinUI/Services/HotStateService.cs
@@ -16,13 +16,13 @@ public sealed partial class HotStateService : ObservableObject, IHotStateService
     private bool _initialized;
 
     [ObservableProperty]
-    private string? lastQuery;
+    private partial string? lastQuery;
 
     [ObservableProperty]
-    private string? lastFolder;
+    private partial string? lastFolder;
 
     [ObservableProperty]
-    private int pageSize = AppSettings.DefaultPageSize;
+    private partial int pageSize = AppSettings.DefaultPageSize;
 
     public HotStateService(
         ISettingsService settingsService,

--- a/Veriado.WinUI/ViewModels/Base/ViewModelBase.cs
+++ b/Veriado.WinUI/ViewModels/Base/ViewModelBase.cs
@@ -37,10 +37,10 @@ public abstract partial class ViewModelBase : ObservableObject
     protected IDispatcherService Dispatcher => _dispatcher;
 
     [ObservableProperty]
-    private bool isBusy;
+    private partial bool isBusy;
 
     [ObservableProperty]
-    private bool hasError;
+    private partial bool hasError;
 
     /// <summary>
     /// Attempts to cancel the currently running operation, if any.

--- a/Veriado.WinUI/ViewModels/Files/FileDetailViewModel.cs
+++ b/Veriado.WinUI/ViewModels/Files/FileDetailViewModel.cs
@@ -21,37 +21,37 @@ public sealed partial class FileDetailViewModel : ViewModelBase
     private readonly IShareService _shareService;
 
     [ObservableProperty]
-    private FileDetailDto? detail;
+    private partial FileDetailDto? detail;
 
     [ObservableProperty]
-    private DateTimeOffset? validityIssuedAt;
+    private partial DateTimeOffset? validityIssuedAt;
 
     [ObservableProperty]
-    private DateTimeOffset? validityValidUntil;
+    private partial DateTimeOffset? validityValidUntil;
 
     [ObservableProperty]
-    private bool validityHasPhysicalCopy;
+    private partial bool validityHasPhysicalCopy;
 
     [ObservableProperty]
-    private bool validityHasElectronicCopy;
+    private partial bool validityHasElectronicCopy;
 
     [ObservableProperty]
-    private bool editableIsReadOnly;
+    private partial bool editableIsReadOnly;
 
     [ObservableProperty]
-    private bool canEdit = true;
+    private partial bool canEdit = true;
 
     [ObservableProperty]
-    private string? editableName;
+    private partial string? editableName;
 
     [ObservableProperty]
-    private string? editableAuthor;
+    private partial string? editableAuthor;
 
     [ObservableProperty]
-    private string? editableMime;
+    private partial string? editableMime;
 
     [ObservableProperty]
-    private string? contentPreview;
+    private partial string? contentPreview;
 
     public FileDetailViewModel(
         IMessenger messenger,

--- a/Veriado.WinUI/ViewModels/Files/FilesGridViewModel.cs
+++ b/Veriado.WinUI/ViewModels/Files/FilesGridViewModel.cs
@@ -24,25 +24,25 @@ public sealed partial class FilesGridViewModel : ViewModelBase
     private readonly ISearchHistoryService _historyService;
 
     [ObservableProperty]
-    private string? searchText;
+    private partial string? searchText;
 
     [ObservableProperty]
-    private int searchModeIndex;
+    private partial int searchModeIndex;
 
     [ObservableProperty]
-    private DateTimeOffset? createdFrom;
+    private partial DateTimeOffset? createdFrom;
 
     [ObservableProperty]
-    private DateTimeOffset? createdTo;
+    private partial DateTimeOffset? createdTo;
 
     [ObservableProperty]
-    private double? lowerValue;
+    private partial double? lowerValue;
 
     [ObservableProperty]
-    private double? upperValue;
+    private partial double? upperValue;
 
     [ObservableProperty]
-    private int pageSize = AppSettings.DefaultPageSize;
+    private partial int pageSize = AppSettings.DefaultPageSize;
 
     public ObservableCollection<FileSummaryDto> Items { get; } = new();
 

--- a/Veriado.WinUI/ViewModels/Files/FiltersNavViewModel.cs
+++ b/Veriado.WinUI/ViewModels/Files/FiltersNavViewModel.cs
@@ -21,7 +21,7 @@ public sealed partial class FiltersNavViewModel : ViewModelBase
     private readonly IFilesSearchSuggestionsProvider _suggestionsProvider;
 
     [ObservableProperty]
-    private string? searchText;
+    private partial string? searchText;
 
     public ObservableCollection<string> SearchSuggestions { get; } = new();
 

--- a/Veriado.WinUI/ViewModels/Import/ImportViewModel.cs
+++ b/Veriado.WinUI/ViewModels/Import/ImportViewModel.cs
@@ -18,34 +18,34 @@ public sealed partial class ImportViewModel : ViewModelBase
     private readonly IHotStateService _hotState;
 
     [ObservableProperty]
-    private string? selectedFolderPath;
+    private partial string? selectedFolderPath;
 
     [ObservableProperty]
-    private string? defaultAuthor;
+    private partial string? defaultAuthor;
 
     [ObservableProperty]
-    private bool recursive = true;
+    private partial bool recursive = true;
 
     [ObservableProperty]
-    private bool extractContent = true;
+    private partial bool extractContent = true;
 
     [ObservableProperty]
-    private int maxDegreeOfParallelism = 4;
+    private partial int maxDegreeOfParallelism = 4;
 
     [ObservableProperty]
-    private string? lastError;
+    private partial string? lastError;
 
     [ObservableProperty]
-    private bool isImporting;
+    private partial bool isImporting;
 
     [ObservableProperty]
-    private string? searchPattern;
+    private partial string? searchPattern;
 
     [ObservableProperty]
-    private int processed;
+    private partial int processed;
 
     [ObservableProperty]
-    private int total;
+    private partial int total;
 
     [RelayCommand]
     private void UseFolderPath(string? folderPath)

--- a/Veriado.WinUI/ViewModels/Search/HistoryViewModel.cs
+++ b/Veriado.WinUI/ViewModels/Search/HistoryViewModel.cs
@@ -29,7 +29,7 @@ public sealed partial class HistoryViewModel : ViewModelBase
     public ObservableCollection<SearchHistoryEntry> Items { get; } = new();
 
     [ObservableProperty]
-    private int take = 50;
+    private partial int take = 50;
 
     [RelayCommand]
     private async Task LoadAsync()

--- a/Veriado.WinUI/ViewModels/Search/SearchOverlayViewModel.cs
+++ b/Veriado.WinUI/ViewModels/Search/SearchOverlayViewModel.cs
@@ -25,10 +25,10 @@ public sealed partial class SearchOverlayViewModel : ViewModelBase
     private readonly IHotStateService _hotState;
 
     [ObservableProperty]
-    private bool isOpen;
+    private partial bool isOpen;
 
     [ObservableProperty]
-    private string? queryText;
+    private partial string? queryText;
 
     public ObservableCollection<string> Suggestions { get; } = new();
 

--- a/Veriado.WinUI/ViewModels/Settings/SettingsViewModel.cs
+++ b/Veriado.WinUI/ViewModels/Settings/SettingsViewModel.cs
@@ -17,13 +17,13 @@ public sealed partial class SettingsViewModel : ViewModelBase
     public ObservableCollection<AppTheme> Themes { get; } = new(Enum.GetValues<AppTheme>());
 
     [ObservableProperty]
-    private AppTheme selectedTheme;
+    private partial AppTheme selectedTheme;
 
     [ObservableProperty]
-    private int pageSize;
+    private partial int pageSize;
 
     [ObservableProperty]
-    private string? lastFolder;
+    private partial string? lastFolder;
 
     public SettingsViewModel(
         IMessenger messenger,

--- a/Veriado.WinUI/ViewModels/Shell/ShellViewModel.cs
+++ b/Veriado.WinUI/ViewModels/Shell/ShellViewModel.cs
@@ -20,22 +20,22 @@ public sealed partial class ShellViewModel : ViewModelBase, INavigationHost
     private readonly SettingsView _settingsView;
 
     [ObservableProperty]
-    private object? currentContent;
+    private partial object? currentContent;
 
     [ObservableProperty]
-    private object? currentDetail;
+    private partial object? currentDetail;
 
     [ObservableProperty]
-    private object? selectedNavItem;
+    private partial object? selectedNavItem;
 
     [ObservableProperty]
-    private string? statusMessage;
+    private partial string? statusMessage;
 
     [ObservableProperty]
-    private bool isInfoBarOpen;
+    private partial bool isInfoBarOpen;
 
     [ObservableProperty]
-    private bool isNavOpen;
+    private partial bool isNavOpen;
 
     public FilesGridViewModel Files { get; }
 

--- a/Veriado.WinUI/ViewModels/Startup/StartupViewModel.cs
+++ b/Veriado.WinUI/ViewModels/Startup/StartupViewModel.cs
@@ -7,16 +7,16 @@ namespace Veriado.WinUI.ViewModels.Startup;
 public partial class StartupViewModel : ObservableObject
 {
     [ObservableProperty]
-    private bool isLoading;
+    private partial bool isLoading;
 
     [ObservableProperty]
-    private bool hasError;
+    private partial bool hasError;
 
     [ObservableProperty]
-    private string? statusMessage;
+    private partial string? statusMessage;
 
     [ObservableProperty]
-    private string? detailsMessage;
+    private partial string? detailsMessage;
 
     public event EventHandler? RetryRequested;
 


### PR DESCRIPTION
## Summary
- update all MVVM Toolkit observable backing members in WinUI view models and services to use partial properties
- ensure generated properties remain compatible with WinRT AOT scenarios such as WinUI 3

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d503596b8083268fa26f3848a4c228