### PR TITLE
Remove invalid partial modifiers from observable fields

### DIFF
--- a/Veriado.WinUI/Services/HotStateService.cs
+++ b/Veriado.WinUI/Services/HotStateService.cs
@@ -16,13 +16,13 @@ public sealed partial class HotStateService : ObservableObject, IHotStateService
     private bool _initialized;
 
     [ObservableProperty]
-    private partial string? lastQuery;
+    private string? lastQuery;
 
     [ObservableProperty]
-    private partial string? lastFolder;
+    private string? lastFolder;
 
     [ObservableProperty]
-    private partial int pageSize = AppSettings.DefaultPageSize;
+    private int pageSize = AppSettings.DefaultPageSize;
 
     public HotStateService(
         ISettingsService settingsService,

--- a/Veriado.WinUI/ViewModels/Base/ViewModelBase.cs
+++ b/Veriado.WinUI/ViewModels/Base/ViewModelBase.cs
@@ -37,10 +37,10 @@ public abstract partial class ViewModelBase : ObservableObject
     protected IDispatcherService Dispatcher => _dispatcher;
 
     [ObservableProperty]
-    private partial bool isBusy;
+    private bool isBusy;
 
     [ObservableProperty]
-    private partial bool hasError;
+    private bool hasError;
 
     /// <summary>
     /// Attempts to cancel the currently running operation, if any.

--- a/Veriado.WinUI/ViewModels/Files/FileDetailViewModel.cs
+++ b/Veriado.WinUI/ViewModels/Files/FileDetailViewModel.cs
@@ -21,37 +21,37 @@ public sealed partial class FileDetailViewModel : ViewModelBase
     private readonly IShareService _shareService;
 
     [ObservableProperty]
-    private partial FileDetailDto? detail;
+    private FileDetailDto? detail;
 
     [ObservableProperty]
-    private partial DateTimeOffset? validityIssuedAt;
+    private DateTimeOffset? validityIssuedAt;
 
     [ObservableProperty]
-    private partial DateTimeOffset? validityValidUntil;
+    private DateTimeOffset? validityValidUntil;
 
     [ObservableProperty]
-    private partial bool validityHasPhysicalCopy;
+    private bool validityHasPhysicalCopy;
 
     [ObservableProperty]
-    private partial bool validityHasElectronicCopy;
+    private bool validityHasElectronicCopy;
 
     [ObservableProperty]
-    private partial bool editableIsReadOnly;
+    private bool editableIsReadOnly;
 
     [ObservableProperty]
-    private partial bool canEdit = true;
+    private bool canEdit = true;
 
     [ObservableProperty]
-    private partial string? editableName;
+    private string? editableName;
 
     [ObservableProperty]
-    private partial string? editableAuthor;
+    private string? editableAuthor;
 
     [ObservableProperty]
-    private partial string? editableMime;
+    private string? editableMime;
 
     [ObservableProperty]
-    private partial string? contentPreview;
+    private string? contentPreview;
 
     public FileDetailViewModel(
         IMessenger messenger,

--- a/Veriado.WinUI/ViewModels/Files/FilesGridViewModel.cs
+++ b/Veriado.WinUI/ViewModels/Files/FilesGridViewModel.cs
@@ -24,25 +24,25 @@ public sealed partial class FilesGridViewModel : ViewModelBase
     private readonly ISearchHistoryService _historyService;
 
     [ObservableProperty]
-    private partial string? searchText;
+    private string? searchText;
 
     [ObservableProperty]
-    private partial int searchModeIndex;
+    private int searchModeIndex;
 
     [ObservableProperty]
-    private partial DateTimeOffset? createdFrom;
+    private DateTimeOffset? createdFrom;
 
     [ObservableProperty]
-    private partial DateTimeOffset? createdTo;
+    private DateTimeOffset? createdTo;
 
     [ObservableProperty]
-    private partial double? lowerValue;
+    private double? lowerValue;
 
     [ObservableProperty]
-    private partial double? upperValue;
+    private double? upperValue;
 
     [ObservableProperty]
-    private partial int pageSize = AppSettings.DefaultPageSize;
+    private int pageSize = AppSettings.DefaultPageSize;
 
     public ObservableCollection<FileSummaryDto> Items { get; } = new();
 

--- a/Veriado.WinUI/ViewModels/Files/FiltersNavViewModel.cs
+++ b/Veriado.WinUI/ViewModels/Files/FiltersNavViewModel.cs
@@ -21,7 +21,7 @@ public sealed partial class FiltersNavViewModel : ViewModelBase
     private readonly IFilesSearchSuggestionsProvider _suggestionsProvider;
 
     [ObservableProperty]
-    private partial string? searchText;
+    private string? searchText;
 
     public ObservableCollection<string> SearchSuggestions { get; } = new();
 

--- a/Veriado.WinUI/ViewModels/Import/ImportViewModel.cs
+++ b/Veriado.WinUI/ViewModels/Import/ImportViewModel.cs
@@ -18,34 +18,34 @@ public sealed partial class ImportViewModel : ViewModelBase
     private readonly IHotStateService _hotState;
 
     [ObservableProperty]
-    private partial string? selectedFolderPath;
+    private string? selectedFolderPath;
 
     [ObservableProperty]
-    private partial string? defaultAuthor;
+    private string? defaultAuthor;
 
     [ObservableProperty]
-    private partial bool recursive = true;
+    private bool recursive = true;
 
     [ObservableProperty]
-    private partial bool extractContent = true;
+    private bool extractContent = true;
 
     [ObservableProperty]
-    private partial int maxDegreeOfParallelism = 4;
+    private int maxDegreeOfParallelism = 4;
 
     [ObservableProperty]
-    private partial string? lastError;
+    private string? lastError;
 
     [ObservableProperty]
-    private partial bool isImporting;
+    private bool isImporting;
 
     [ObservableProperty]
-    private partial string? searchPattern;
+    private string? searchPattern;
 
     [ObservableProperty]
-    private partial int processed;
+    private int processed;
 
     [ObservableProperty]
-    private partial int total;
+    private int total;
 
     [RelayCommand]
     private void UseFolderPath(string? folderPath)

--- a/Veriado.WinUI/ViewModels/Search/HistoryViewModel.cs
+++ b/Veriado.WinUI/ViewModels/Search/HistoryViewModel.cs
@@ -29,7 +29,7 @@ public sealed partial class HistoryViewModel : ViewModelBase
     public ObservableCollection<SearchHistoryEntry> Items { get; } = new();
 
     [ObservableProperty]
-    private partial int take = 50;
+    private int take = 50;
 
     [RelayCommand]
     private async Task LoadAsync()

--- a/Veriado.WinUI/ViewModels/Search/SearchOverlayViewModel.cs
+++ b/Veriado.WinUI/ViewModels/Search/SearchOverlayViewModel.cs
@@ -25,10 +25,10 @@ public sealed partial class SearchOverlayViewModel : ViewModelBase
     private readonly IHotStateService _hotState;
 
     [ObservableProperty]
-    private partial bool isOpen;
+    private bool isOpen;
 
     [ObservableProperty]
-    private partial string? queryText;
+    private string? queryText;
 
     public ObservableCollection<string> Suggestions { get; } = new();
 

--- a/Veriado.WinUI/ViewModels/Settings/SettingsViewModel.cs
+++ b/Veriado.WinUI/ViewModels/Settings/SettingsViewModel.cs
@@ -17,13 +17,13 @@ public sealed partial class SettingsViewModel : ViewModelBase
     public ObservableCollection<AppTheme> Themes { get; } = new(Enum.GetValues<AppTheme>());
 
     [ObservableProperty]
-    private partial AppTheme selectedTheme;
+    private AppTheme selectedTheme;
 
     [ObservableProperty]
-    private partial int pageSize;
+    private int pageSize;
 
     [ObservableProperty]
-    private partial string? lastFolder;
+    private string? lastFolder;
 
     public SettingsViewModel(
         IMessenger messenger,

--- a/Veriado.WinUI/ViewModels/Shell/ShellViewModel.cs
+++ b/Veriado.WinUI/ViewModels/Shell/ShellViewModel.cs
@@ -20,22 +20,22 @@ public sealed partial class ShellViewModel : ViewModelBase, INavigationHost
     private readonly SettingsView _settingsView;
 
     [ObservableProperty]
-    private partial object? currentContent;
+    private object? currentContent;
 
     [ObservableProperty]
-    private partial object? currentDetail;
+    private object? currentDetail;
 
     [ObservableProperty]
-    private partial object? selectedNavItem;
+    private object? selectedNavItem;
 
     [ObservableProperty]
-    private partial string? statusMessage;
+    private string? statusMessage;
 
     [ObservableProperty]
-    private partial bool isInfoBarOpen;
+    private bool isInfoBarOpen;
 
     [ObservableProperty]
-    private partial bool isNavOpen;
+    private bool isNavOpen;
 
     public FilesGridViewModel Files { get; }
 

--- a/Veriado.WinUI/ViewModels/Startup/StartupViewModel.cs
+++ b/Veriado.WinUI/ViewModels/Startup/StartupViewModel.cs
@@ -7,16 +7,16 @@ namespace Veriado.WinUI.ViewModels.Startup;
 public partial class StartupViewModel : ObservableObject
 {
     [ObservableProperty]
-    private partial bool isLoading;
+    private bool isLoading;
 
     [ObservableProperty]
-    private partial bool hasError;
+    private bool hasError;
 
     [ObservableProperty]
-    private partial string? statusMessage;
+    private string? statusMessage;
 
     [ObservableProperty]
-    private partial string? detailsMessage;
+    private string? detailsMessage;
 
     public event EventHandler? RetryRequested;
 


### PR DESCRIPTION
## Summary
- remove the erroneous `partial` modifiers from CommunityToolkit observable property backing fields across WinUI view models and services

## Testing
- dotnet build *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d50512d240832696e82835bdc87234