### PR TITLE
Fix nullable handling in BooleanToVisibilityConverterEx

### DIFF
--- a/Veriado.WinUI/Converters/Converters.cs
+++ b/Veriado.WinUI/Converters/Converters.cs
@@ -120,10 +120,15 @@ public sealed class BooleanToVisibilityConverterEx : IValueConverter
             return flag ? Visibility.Visible : Visibility.Collapsed;
         }
 
-        if (value is bool? nullable && nullable.HasValue)
+        if (value is bool?)
         {
-            var flagValue = invert ? !nullable.Value : nullable.Value;
-            return flagValue ? Visibility.Visible : Visibility.Collapsed;
+            var nullable = (bool?)value;
+
+            if (nullable.HasValue)
+            {
+                var flagValue = invert ? !nullable.Value : nullable.Value;
+                return flagValue ? Visibility.Visible : Visibility.Collapsed;
+            }
         }
 
         return Visibility.Collapsed;


### PR DESCRIPTION
## Summary
- replace nullable boolean pattern matching with explicit nullable cast
- ensure the converter gracefully handles null values in older C# language versions

## Testing
- `dotnet build` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68d50634f2548326be162031ee0e0cc7