### PR TITLE
Fix infrastructure initialization order

### DIFF
--- a/Veriado.WinUI/AppHost.cs
+++ b/Veriado.WinUI/AppHost.cs
@@ -88,8 +88,8 @@ internal sealed class AppHost : IAsyncDisposable
             })
             .Build();
 
-        await host.StartAsync().ConfigureAwait(false);
         await host.Services.InitializeInfrastructureAsync().ConfigureAwait(false);
+        await host.StartAsync().ConfigureAwait(false);
         await host.Services.GetRequiredService<IHotStateService>().InitializeAsync().ConfigureAwait(false);
         return new AppHost(host);
     }


### PR DESCRIPTION
## Summary
- ensure infrastructure initialization completes before the host starts so background workers run against a migrated database

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d50d2909208326856602bd4e8eb427