### PR TITLE
Fix design-time AppDbContextFactory logger dependency

### DIFF
--- a/Veriado.Infrastructure/Persistence/DesignTime/AppDbContextFactory.cs
+++ b/Veriado.Infrastructure/Persistence/DesignTime/AppDbContextFactory.cs
@@ -3,6 +3,7 @@ using System.IO;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Design;
+using Microsoft.Extensions.Logging.Abstractions;
 using Veriado.Infrastructure.Persistence;
 using Veriado.Infrastructure.Persistence.Interceptors;
 using Veriado.Infrastructure.Persistence.Options;
@@ -26,7 +27,7 @@ public sealed class AppDbContextFactory : IDesignTimeDbContextFactory<AppDbConte
         builder.UseSqlite(connectionString, sqlite => sqlite.CommandTimeout(30));
         builder.AddInterceptors(pragmaInterceptor);
 
-        return new AppDbContext(builder.Options, infrastructureOptions);
+        return new AppDbContext(builder.Options, infrastructureOptions, NullLogger<AppDbContext>.Instance);
     }
 
     private static InfrastructureOptions BuildInfrastructureOptions()

--- a/Veriado.Infrastructure/Veriado.Infrastructure.csproj
+++ b/Veriado.Infrastructure/Veriado.Infrastructure.csproj
@@ -15,6 +15,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.9" />
     <PackageReference Include="PdfPig" Version="0.1.11" />
     <PackageReference Include="System.Text.Json" Version="9.0.9" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.9" />


### PR DESCRIPTION
## Summary
- update the design-time AppDbContextFactory to pass a NullLogger when creating AppDbContext instances
- add Microsoft.Extensions.Logging.Abstractions to the infrastructure project to supply the NullLogger implementation

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d5152ca68483268bfc336bc758ab01