### PR TITLE
Set AppHost before resolving UI services

### DIFF
--- a/Veriado.WinUI/App.xaml.cs
+++ b/Veriado.WinUI/App.xaml.cs
@@ -74,6 +74,8 @@ public partial class App : Application
         {
             host = await AppHost.StartAsync().ConfigureAwait(true);
 
+            _appHost = host;
+
             var services = host.Services;
 
             var mainWindow = services.GetRequiredService<MainWindow>();
@@ -100,7 +102,6 @@ public partial class App : Application
             mainWindow.Activate();
             mainWindow.Closed += OnWindowClosed;
 
-            _appHost = host;
             MainWindow = mainWindow;
 
             return true;


### PR DESCRIPTION
## Summary
- assign the application's AppHost before resolving MainWindow dependencies
- prevent XAML controls from accessing App.Services before the host is ready

## Testing
- `dotnet build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d516c25828832690272a71df913b94