### PR TITLE
Update navigation labels and hide filters outside file management

### DIFF
--- a/Veriado.WinUI/ViewModels/Shell/ShellViewModel.cs
+++ b/Veriado.WinUI/ViewModels/Shell/ShellViewModel.cs
@@ -1,6 +1,7 @@
 using System;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Messaging;
+using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Veriado.WinUI.Services.Abstractions;
 using Veriado.WinUI.Services.Messages;
@@ -36,6 +37,12 @@ public sealed partial class ShellViewModel : ViewModelBase, INavigationHost
 
     [ObservableProperty]
     private bool isNavOpen;
+
+    [ObservableProperty]
+    private bool isFiltersPaneVisible = true;
+
+    [ObservableProperty]
+    private GridLength filtersColumnWidth = new(300);
 
     public FilesGridViewModel Files { get; }
 
@@ -86,7 +93,11 @@ public sealed partial class ShellViewModel : ViewModelBase, INavigationHost
 
     private void NavigateTo(object? tag)
     {
-        switch (tag?.ToString())
+        var target = tag?.ToString();
+
+        UpdateFiltersPaneVisibility(string.Equals(target, "Files", StringComparison.Ordinal));
+
+        switch (target)
         {
             case "Files":
                 _navigationService.NavigateTo(_filesView);
@@ -100,5 +111,11 @@ public sealed partial class ShellViewModel : ViewModelBase, INavigationHost
         }
 
         IsNavOpen = false;
+    }
+
+    private void UpdateFiltersPaneVisibility(bool isVisible)
+    {
+        IsFiltersPaneVisible = isVisible;
+        FiltersColumnWidth = isVisible ? new GridLength(300) : new GridLength(0);
     }
 }

--- a/Veriado.WinUI/Views/MainWindow.xaml
+++ b/Veriado.WinUI/Views/MainWindow.xaml
@@ -41,7 +41,7 @@
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
         <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="300" />
+            <ColumnDefinition Width="{Binding FiltersColumnWidth}" />
             <ColumnDefinition Width="*" />
             <ColumnDefinition Width="400" />
         </Grid.ColumnDefinitions>
@@ -75,7 +75,9 @@
                          Grid.Row="1"
                          Grid.Column="0"
                          HorizontalAlignment="Stretch"
-                         VerticalAlignment="Stretch" />
+                         VerticalAlignment="Stretch"
+                         Visibility="{Binding IsFiltersPaneVisible, Converter={StaticResource BoolToVisibility}}"
+                         IsHitTestVisible="{Binding IsFiltersPaneVisible}" />
 
         <ContentPresenter Grid.Row="1"
                           Grid.Column="1"
@@ -108,7 +110,7 @@
               Visibility="{Binding IsNavOpen, Converter={StaticResource BoolToVisibilityEx}}"
               IsHitTestVisible="{Binding IsNavOpen}"
               Tapped="NavigationOverlay_Tapped">
-            <winui:NavigationView x:Name="OverlayNavView"
+                <winui:NavigationView x:Name="OverlayNavView"
                                   Width="320"
                                   HorizontalAlignment="Left"
                                   VerticalAlignment="Stretch"
@@ -117,8 +119,8 @@
                                   IsPaneOpen="{Binding IsNavOpen, Mode=TwoWay}"
                                   SelectedItem="{Binding SelectedNavItem, Mode=TwoWay}">
                 <winui:NavigationView.MenuItems>
-                    <winui:NavigationViewItem Content="Soubory" Icon="Folder" Tag="Files" />
-                    <winui:NavigationViewItem Content="Import" Icon="Upload" Tag="Import" />
+                    <winui:NavigationViewItem Content="Správa souborů" Icon="Folder" Tag="Files" />
+                    <winui:NavigationViewItem Content="Import souborů" Icon="Upload" Tag="Import" />
                     <winui:NavigationViewItem Content="Nastavení" Icon="Setting" Tag="Settings" />
                 </winui:NavigationView.MenuItems>
             </winui:NavigationView>


### PR DESCRIPTION
## Summary
- rename navigation view entries to "Správa souborů", "Import souborů" and keep "Nastavení"
- bind the filters pane visibility and column width to view model state so the panel only appears in file management
- update ShellViewModel to manage filters pane visibility when navigation changes

## Testing
- `dotnet build` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68d522f1e5848326b956995e1346fd72