### PR TITLE
Fix WinUI shell XAML keyboard accelerators

### DIFF
--- a/Veriado.WinUI/Views/Shell/MainShell.xaml
+++ b/Veriado.WinUI/Views/Shell/MainShell.xaml
@@ -7,8 +7,8 @@
     xmlns:controls="using:Microsoft.UI.Xaml.Controls"
     mc:Ignorable="d">
     <Window.KeyboardAccelerators>
-        <KeyboardAccelerator Key="M" Modifiers="Alt" Command="{Binding ToggleNavCommand}" />
-        <KeyboardAccelerator Key="Escape" Command="{Binding CloseNavCommand}" />
+        <KeyboardAccelerator Key="M" Modifiers="Alt" Invoked="OnToggleNavAcceleratorInvoked" />
+        <KeyboardAccelerator Key="Escape" Invoked="OnCloseNavAcceleratorInvoked" />
     </Window.KeyboardAccelerators>
 
     <Grid>
@@ -16,14 +16,14 @@
 
         <Rectangle
             Fill="Transparent"
-            Panel.ZIndex="998"
+            Canvas.ZIndex="998"
             IsHitTestVisible="{Binding IsNavOpen}"
             Visibility="{Binding IsNavOpen, Converter={StaticResource BooleanToVisibilityConverter}}"
             Tapped="OnOverlayTapped" />
 
         <controls:NavigationView
             x:Name="RootNavigation"
-            Panel.ZIndex="999"
+            Canvas.ZIndex="999"
             IsSettingsVisible="False"
             PaneDisplayMode="LeftMinimal"
             Width="320"

--- a/Veriado.WinUI/Views/Shell/MainShell.xaml.cs
+++ b/Veriado.WinUI/Views/Shell/MainShell.xaml.cs
@@ -48,6 +48,24 @@ public sealed partial class MainShell : Window
         }
     }
 
+    private void OnToggleNavAcceleratorInvoked(KeyboardAccelerator sender, KeyboardAcceleratorInvokedEventArgs args)
+    {
+        if (_viewModel?.ToggleNavCommand.CanExecute(null) == true)
+        {
+            _viewModel.ToggleNavCommand.Execute(null);
+            args.Handled = true;
+        }
+    }
+
+    private void OnCloseNavAcceleratorInvoked(KeyboardAccelerator sender, KeyboardAcceleratorInvokedEventArgs args)
+    {
+        if (_viewModel?.CloseNavCommand.CanExecute(null) == true)
+        {
+            _viewModel.CloseNavCommand.Execute(null);
+            args.Handled = true;
+        }
+    }
+
     private void OnViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
     {
         if (_viewModel is null)


### PR DESCRIPTION
## Summary
- replace unsupported keyboard accelerator command bindings with code-behind event handlers to trigger the shell view model commands
- switch the overlay elements to use Canvas.ZIndex so the XAML compiles under WinUI

## Testing
- not run (dotnet CLI is unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68d53eacad5c83269fc927abbb9fdd2d