### PR TITLE
Fix keyboard accelerators placement in shell

### DIFF
--- a/Veriado.WinUI/Views/Shell/MainShell.xaml
+++ b/Veriado.WinUI/Views/Shell/MainShell.xaml
@@ -6,12 +6,12 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:controls="using:Microsoft.UI.Xaml.Controls"
     mc:Ignorable="d">
-    <Window.KeyboardAccelerators>
-        <KeyboardAccelerator Key="M" Modifiers="Alt" Invoked="OnToggleNavAcceleratorInvoked" />
-        <KeyboardAccelerator Key="Escape" Invoked="OnCloseNavAcceleratorInvoked" />
-    </Window.KeyboardAccelerators>
-
     <Grid>
+        <Grid.KeyboardAccelerators>
+            <KeyboardAccelerator Key="M" Modifiers="Alt" Invoked="OnToggleNavAcceleratorInvoked" />
+            <KeyboardAccelerator Key="Escape" Invoked="OnCloseNavAcceleratorInvoked" />
+        </Grid.KeyboardAccelerators>
+
         <ContentPresenter x:Name="ContentHost" />
 
         <Rectangle


### PR DESCRIPTION
## Summary
- move keyboard accelerators from the window element to the root grid so the markup compiler recognizes the generated fields

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d546082b908326b042073ac3b19e27