### PR TITLE
Fix MainShell view initialization

### DIFF
--- a/Veriado.WinUI/Views/Shell/MainShell.xaml
+++ b/Veriado.WinUI/Views/Shell/MainShell.xaml
@@ -6,7 +6,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:controls="using:Microsoft.UI.Xaml.Controls"
     mc:Ignorable="d">
-    <Grid>
+    <Grid x:Name="RootGrid">
 
         <ContentPresenter x:Name="ContentHost" />
 

--- a/Veriado.WinUI/Views/Shell/MainShell.xaml.cs
+++ b/Veriado.WinUI/Views/Shell/MainShell.xaml.cs
@@ -24,7 +24,7 @@ public sealed partial class MainShell : Window
     public void Initialize(MainShellViewModel viewModel)
     {
         _viewModel = viewModel ?? throw new ArgumentNullException(nameof(viewModel));
-        DataContext = viewModel;
+        RootGrid.DataContext = viewModel;
         _viewModel.PropertyChanged += OnViewModelPropertyChanged;
         LoadPage(_viewModel.CurrentPage);
     }
@@ -65,9 +65,9 @@ public sealed partial class MainShell : Window
     {
         var content = pageId switch
         {
-            PageId.Files => _serviceProvider.GetRequiredService<Views.Files.FilesPage>(),
-            PageId.Import => _serviceProvider.GetRequiredService<Views.Import.ImportPage>(),
-            PageId.Settings => _serviceProvider.GetRequiredService<Views.Settings.SettingsPage>(),
+            PageId.Files => (Page)_serviceProvider.GetRequiredService<Views.Files.FilesPage>(),
+            PageId.Import => (Page)_serviceProvider.GetRequiredService<Views.Import.ImportPage>(),
+            PageId.Settings => (Page)_serviceProvider.GetRequiredService<Views.Settings.SettingsPage>(),
             _ => throw new ArgumentOutOfRangeException(nameof(pageId), pageId, null),
         };
 


### PR DESCRIPTION
## Summary
- assign the MainShell view model to the root grid so bindings work in WinUI 3
- ensure loaded pages are retrieved as Page instances to satisfy the switch expression

## Testing
- not run (no .NET SDK available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d548d4fc4483268e214e1e032161ed