### PR TITLE
Refactor WinUI front-end to MVVM navigation pattern

### DIFF
--- a/Veriado.WinUI/App.xaml.cs
+++ b/Veriado.WinUI/App.xaml.cs
@@ -5,7 +5,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.UI.Xaml;
 using Veriado.WinUI.Services.Abstractions;
-using Veriado.WinUI.ViewModels.Shell;
 using Veriado.WinUI.ViewModels.Startup;
 using Veriado.WinUI.Views.Shell;
 
@@ -78,8 +77,6 @@ public partial class App : Application
             var services = host.Services;
 
             var shell = services.GetRequiredService<MainShell>();
-            var shellViewModel = services.GetRequiredService<MainShellViewModel>();
-            shell.Initialize(shellViewModel);
 
             var windowProvider = services.GetRequiredService<IWindowProvider>();
             windowProvider.SetWindow(shell);

--- a/Veriado.WinUI/Services/Abstractions/INavigationService.cs
+++ b/Veriado.WinUI/Services/Abstractions/INavigationService.cs
@@ -1,17 +1,15 @@
+using Veriado.WinUI.Navigation;
+
 namespace Veriado.WinUI.Services.Abstractions;
 
 public interface INavigationService
 {
     void AttachHost(INavigationHost host);
 
-    void NavigateTo(object view, object? viewModel = null);
-
-    void NavigateDetail(object view, object? viewModel = null);
+    void Navigate(PageId pageId);
 }
 
 public interface INavigationHost
 {
     object? CurrentContent { get; set; }
-
-    object? CurrentDetail { get; set; }
 }

--- a/Veriado.WinUI/Services/NavigationService.cs
+++ b/Veriado.WinUI/Services/NavigationService.cs
@@ -1,47 +1,73 @@
 using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.UI.Xaml;
+using Veriado.WinUI.Navigation;
 using Veriado.WinUI.Services.Abstractions;
+using Veriado.WinUI.ViewModels.Files;
+using Veriado.WinUI.ViewModels.Import;
+using Veriado.WinUI.ViewModels.Settings;
+using Veriado.WinUI.Views.Files;
+using Veriado.WinUI.Views.Import;
+using Veriado.WinUI.Views.Settings;
 
 namespace Veriado.WinUI.Services;
 
 public sealed class NavigationService : INavigationService
 {
+    private readonly IServiceProvider _serviceProvider;
+    private readonly IReadOnlyDictionary<PageId, NavigationRegistration> _registrations;
     private INavigationHost? _host;
+
+    public NavigationService(IServiceProvider serviceProvider)
+    {
+        _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
+        _registrations = new Dictionary<PageId, NavigationRegistration>
+        {
+            [PageId.Files] = new NavigationRegistration(typeof(FilesPage), typeof(FilesPageViewModel)),
+            [PageId.Import] = new NavigationRegistration(typeof(ImportPage), typeof(ImportPageViewModel)),
+            [PageId.Settings] = new NavigationRegistration(typeof(SettingsPage), typeof(SettingsPageViewModel)),
+        };
+    }
 
     public void AttachHost(INavigationHost host)
     {
         _host = host ?? throw new ArgumentNullException(nameof(host));
     }
 
-    public void NavigateTo(object view, object? viewModel = null)
+    public void Navigate(PageId pageId)
     {
-        ArgumentNullException.ThrowIfNull(view);
         if (_host is null)
         {
             throw new InvalidOperationException("Navigation host has not been attached.");
         }
 
-        if (view is Microsoft.UI.Xaml.FrameworkElement frameworkElement && viewModel is not null)
+        var registration = ResolveRegistration(pageId);
+        var view = _serviceProvider.GetRequiredService(registration.ViewType);
+        object? viewModel = null;
+
+        if (registration.ViewModelType is not null)
+        {
+            viewModel = _serviceProvider.GetRequiredService(registration.ViewModelType);
+        }
+
+        if (view is FrameworkElement frameworkElement && viewModel is not null)
         {
             frameworkElement.DataContext = viewModel;
         }
 
-        _host.CurrentDetail = null;
         _host.CurrentContent = view;
     }
 
-    public void NavigateDetail(object view, object? viewModel = null)
+    private NavigationRegistration ResolveRegistration(PageId pageId)
     {
-        ArgumentNullException.ThrowIfNull(view);
-        if (_host is null)
+        if (_registrations.TryGetValue(pageId, out var registration))
         {
-            throw new InvalidOperationException("Navigation host has not been attached.");
+            return registration;
         }
 
-        if (view is Microsoft.UI.Xaml.FrameworkElement frameworkElement && viewModel is not null)
-        {
-            frameworkElement.DataContext = viewModel;
-        }
-
-        _host.CurrentDetail = view;
+        throw new ArgumentOutOfRangeException(nameof(pageId), pageId, "Unknown navigation target.");
     }
+
+    private sealed record NavigationRegistration(Type ViewType, Type? ViewModelType);
 }

--- a/Veriado.WinUI/ViewModels/Shell/MainShellViewModel.cs
+++ b/Veriado.WinUI/ViewModels/Shell/MainShellViewModel.cs
@@ -1,11 +1,21 @@
+using System;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Veriado.WinUI.Navigation;
+using Veriado.WinUI.Services.Abstractions;
 
 namespace Veriado.WinUI.ViewModels.Shell;
 
 public partial class MainShellViewModel : ObservableObject
 {
+    private readonly INavigationService _navigationService;
+    private bool _isInitialized;
+
+    public MainShellViewModel(INavigationService navigationService)
+    {
+        _navigationService = navigationService ?? throw new ArgumentNullException(nameof(navigationService));
+    }
+
     [ObservableProperty]
     private bool isNavOpen;
 
@@ -40,7 +50,42 @@ public partial class MainShellViewModel : ObservableObject
             _ => CurrentPage,
         };
 
-        CurrentPage = target;
-        CloseNav();
+        NavigateInternal(target);
+    }
+
+    public void Initialize()
+    {
+        if (_isInitialized)
+        {
+            return;
+        }
+
+        NavigateInternal(PageId.Files, closePane: false, forceNavigation: true);
+    }
+
+    public void Navigate(PageId pageId)
+    {
+        NavigateInternal(pageId);
+    }
+
+    private void NavigateInternal(PageId pageId, bool closePane = true, bool forceNavigation = false)
+    {
+        var isDifferentPage = CurrentPage != pageId;
+
+        if (isDifferentPage)
+        {
+            CurrentPage = pageId;
+        }
+
+        if (forceNavigation || isDifferentPage || !_isInitialized)
+        {
+            _navigationService.Navigate(pageId);
+            _isInitialized = true;
+        }
+
+        if (closePane)
+        {
+            CloseNav();
+        }
     }
 }

--- a/Veriado.WinUI/Views/Files/FilesPage.xaml.cs
+++ b/Veriado.WinUI/Views/Files/FilesPage.xaml.cs
@@ -1,5 +1,4 @@
 using System.Threading.Tasks;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Veriado.WinUI.ViewModels.Files;
@@ -11,11 +10,10 @@ public sealed partial class FilesPage : Page
     public FilesPage()
     {
         InitializeComponent();
-        DataContext = App.Services.GetRequiredService<FilesPageViewModel>();
         Loaded += OnLoaded;
     }
 
-    private FilesPageViewModel ViewModel => (FilesPageViewModel)DataContext;
+    private FilesPageViewModel? ViewModel => DataContext as FilesPageViewModel;
 
     private async void OnLoaded(object sender, RoutedEventArgs e)
     {
@@ -25,6 +23,8 @@ public sealed partial class FilesPage : Page
 
     private Task ExecuteInitialRefreshAsync()
     {
-        return ViewModel.RefreshCommand.ExecuteAsync(null);
+        return ViewModel is not null
+            ? ViewModel.RefreshCommand.ExecuteAsync(null)
+            : Task.CompletedTask;
     }
 }

--- a/Veriado.WinUI/Views/Import/ImportPage.xaml.cs
+++ b/Veriado.WinUI/Views/Import/ImportPage.xaml.cs
@@ -1,6 +1,4 @@
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.UI.Xaml.Controls;
-using Veriado.WinUI.ViewModels.Import;
 
 namespace Veriado.WinUI.Views.Import;
 
@@ -9,6 +7,5 @@ public sealed partial class ImportPage : Page
     public ImportPage()
     {
         InitializeComponent();
-        DataContext = App.Services.GetRequiredService<ImportPageViewModel>();
     }
 }

--- a/Veriado.WinUI/Views/Settings/SettingsPage.xaml.cs
+++ b/Veriado.WinUI/Views/Settings/SettingsPage.xaml.cs
@@ -1,6 +1,4 @@
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.UI.Xaml.Controls;
-using Veriado.WinUI.ViewModels.Settings;
 
 namespace Veriado.WinUI.Views.Settings;
 
@@ -9,6 +7,5 @@ public sealed partial class SettingsPage : Page
     public SettingsPage()
     {
         InitializeComponent();
-        DataContext = App.Services.GetRequiredService<SettingsPageViewModel>();
     }
 }

--- a/Veriado.WinUI/Views/Shell/MainShell.xaml
+++ b/Veriado.WinUI/Views/Shell/MainShell.xaml
@@ -8,7 +8,9 @@
     mc:Ignorable="d">
     <Grid x:Name="RootGrid">
 
-        <ContentPresenter x:Name="ContentHost" />
+        <ContentPresenter
+            x:Name="ContentHost"
+            Content="{x:Bind CurrentContent, Mode=OneWay}" />
 
         <Rectangle
             Fill="Transparent"


### PR DESCRIPTION
## Summary
- add a navigation service that resolves WinUI pages and view models through dependency injection
- update the main shell window and view model to drive navigation without manually creating views
- remove direct `App.Services` lookups from pages so their data contexts are provided by navigation

## Testing
- `dotnet build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d54fbae0588326928c30dcce872503