### PR TITLE
Fix import response handling and shell initialization

### DIFF
--- a/Veriado.WinUI/ViewModels/Import/ImportPageViewModel.cs
+++ b/Veriado.WinUI/ViewModels/Import/ImportPageViewModel.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
@@ -89,11 +90,12 @@ public partial class ImportPageViewModel : ViewModelBase
                 };
 
                 var response = await _importService.ImportFolderAsync(request, cancellationToken).ConfigureAwait(false);
-                if (!response.Success)
+                if (!response.IsSuccess)
                 {
-                    var message = string.IsNullOrWhiteSpace(response.Message)
+                    var errorMessage = response.Errors.FirstOrDefault()?.Message;
+                    var message = string.IsNullOrWhiteSpace(errorMessage)
                         ? "Import se nezdařil."
-                        : response.Message;
+                        : errorMessage;
                     StatusService.Error(message);
                     return;
                 }

--- a/Veriado.WinUI/Views/Shell/MainShell.xaml.cs
+++ b/Veriado.WinUI/Views/Shell/MainShell.xaml.cs
@@ -26,7 +26,7 @@ public sealed partial class MainShell : Window, INavigationHost
         _navigationService.AttachHost(this);
 
         _viewModel.PropertyChanged += OnViewModelPropertyChanged;
-        Loaded += OnLoaded;
+        RootGrid.Loaded += OnLoaded;
         Closed += OnClosed;
     }
 
@@ -38,7 +38,7 @@ public sealed partial class MainShell : Window, INavigationHost
 
     private void OnLoaded(object sender, RoutedEventArgs e)
     {
-        Loaded -= OnLoaded;
+        RootGrid.Loaded -= OnLoaded;
         _viewModel.Initialize();
         UpdateNavigationSelection(_viewModel.CurrentPage);
     }


### PR DESCRIPTION
## Summary
- adjust the import page view model to evaluate ApiResponse success correctly and surface error messages from the response payload
- attach the shell initialization logic to the RootGrid.Loaded event so it compiles against WinUI's Window API

## Testing
- dotnet build Veriado.sln *(fails: dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d582a7b4748326af4e43d543303fea