### PR TITLE
Initialize extended metadata to avoid null access

### DIFF
--- a/Veriado.Domain/Files/FileEntity.cs
+++ b/Veriado.Domain/Files/FileEntity.cs
@@ -112,7 +112,7 @@ public sealed class FileEntity : AggregateRoot
     /// <summary>
     /// Gets the extended metadata collection.
     /// </summary>
-    public ExtendedMetadata ExtendedMetadata { get; private set; } = null!;
+    public ExtendedMetadata ExtendedMetadata { get; private set; } = ExtendedMetadata.Empty;
 
     /// <summary>
     /// Gets the search index state.


### PR DESCRIPTION
## Summary
- default FileEntity.ExtendedMetadata to ExtendedMetadata.Empty to avoid null dereferences when metadata is loaded later

## Testing
- dotnet test *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d5877c13088326a2ceb55de17c8c5f