### PR TITLE
Fix FTS deletion to avoid table scan errors

### DIFF
--- a/Veriado.Infrastructure/Search/SqliteFts5Transactional.cs
+++ b/Veriado.Infrastructure/Search/SqliteFts5Transactional.cs
@@ -21,7 +21,7 @@ internal sealed class SqliteFts5Transactional
         await using (var delete = connection.CreateCommand())
         {
             delete.Transaction = transaction;
-            delete.CommandText = "DELETE FROM file_search WHERE rowid = $rowid;";
+            delete.CommandText = "INSERT INTO file_search(file_search, rowid) VALUES ('delete', $rowid);";
             delete.Parameters.Add("$rowid", SqliteType.Integer).Value = searchRowId;
             await delete.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
         }
@@ -43,7 +43,7 @@ internal sealed class SqliteFts5Transactional
         await using (var deleteTrgm = connection.CreateCommand())
         {
             deleteTrgm.Transaction = transaction;
-            deleteTrgm.CommandText = "DELETE FROM file_trgm WHERE rowid = $rowid;";
+            deleteTrgm.CommandText = "INSERT INTO file_trgm(file_trgm, rowid) VALUES ('delete', $rowid);";
             deleteTrgm.Parameters.Add("$rowid", SqliteType.Integer).Value = trigramRowId;
             await deleteTrgm.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
         }
@@ -69,7 +69,7 @@ internal sealed class SqliteFts5Transactional
         {
             await using var deleteFts = connection.CreateCommand();
             deleteFts.Transaction = transaction;
-            deleteFts.CommandText = "DELETE FROM file_search WHERE rowid = $rowid;";
+            deleteFts.CommandText = "INSERT INTO file_search(file_search, rowid) VALUES ('delete', $rowid);";
             deleteFts.Parameters.Add("$rowid", SqliteType.Integer).Value = searchRowId.Value;
             await deleteFts.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
         }
@@ -79,7 +79,7 @@ internal sealed class SqliteFts5Transactional
         {
             await using var deleteTrgm = connection.CreateCommand();
             deleteTrgm.Transaction = transaction;
-            deleteTrgm.CommandText = "DELETE FROM file_trgm WHERE rowid = $rowid;";
+            deleteTrgm.CommandText = "INSERT INTO file_trgm(file_trgm, rowid) VALUES ('delete', $rowid);";
             deleteTrgm.Parameters.Add("$rowid", SqliteType.Integer).Value = trigramRowId.Value;
             await deleteTrgm.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
         }


### PR DESCRIPTION
## Summary
- replace direct DELETE statements against the FTS5 tables with the recommended control insert
- prevent SQLite from attempting unsupported table scans when refreshing search and trigram entries

## Testing
- `dotnet test` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d599153ab883269de3c34c59b16540