### PR TITLE
Handle corrupted SQLite full-text index errors

### DIFF
--- a/Veriado.Infrastructure/Search/SearchIndexCorruptedException.cs
+++ b/Veriado.Infrastructure/Search/SearchIndexCorruptedException.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace Veriado.Infrastructure.Search;
+
+/// <summary>
+/// Represents a failure caused by SQLite reporting that the full-text index is corrupted.
+/// </summary>
+internal sealed class SearchIndexCorruptedException : Exception
+{
+    public SearchIndexCorruptedException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}

--- a/Veriado.Infrastructure/Search/SqliteExceptionExtensions.cs
+++ b/Veriado.Infrastructure/Search/SqliteExceptionExtensions.cs
@@ -1,0 +1,28 @@
+using System;
+using Microsoft.Data.Sqlite;
+
+namespace Veriado.Infrastructure.Search;
+
+internal static class SqliteExceptionExtensions
+{
+    private const int SqliteCorrupt = 11;
+    private const int SqliteNotADatabase = 26;
+
+    public static bool IndicatesDatabaseCorruption(this SqliteException exception)
+    {
+        ArgumentNullException.ThrowIfNull(exception);
+
+        if (exception.SqliteErrorCode is SqliteCorrupt or SqliteNotADatabase)
+        {
+            return true;
+        }
+
+        if (exception.SqliteExtendedErrorCode is SqliteCorrupt or SqliteNotADatabase)
+        {
+            return true;
+        }
+
+        return exception.Message.Contains("database disk image is malformed", StringComparison.OrdinalIgnoreCase)
+            || exception.Message.Contains("malformed", StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/Veriado.Infrastructure/Search/SqliteFts5Transactional.cs
+++ b/Veriado.Infrastructure/Search/SqliteFts5Transactional.cs
@@ -14,90 +14,104 @@ internal sealed class SqliteFts5Transactional
 {
     public async Task IndexAsync(SearchDocument document, SqliteConnection connection, SqliteTransaction transaction, CancellationToken cancellationToken)
     {
-        ArgumentNullException.ThrowIfNull(document);
-        var searchRowId = await EnsureMapRowIdAsync("file_search_map", document.FileId, connection, transaction, cancellationToken).ConfigureAwait(false);
-        var trigramRowId = await EnsureMapRowIdAsync("file_trgm_map", document.FileId, connection, transaction, cancellationToken).ConfigureAwait(false);
-
-        await using (var delete = connection.CreateCommand())
+        try
         {
-            delete.Transaction = transaction;
-            delete.CommandText = "INSERT INTO file_search(file_search, rowid) VALUES ('delete', $rowid);";
-            delete.Parameters.Add("$rowid", SqliteType.Integer).Value = searchRowId;
-            await delete.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            ArgumentNullException.ThrowIfNull(document);
+            var searchRowId = await EnsureMapRowIdAsync("file_search_map", document.FileId, connection, transaction, cancellationToken).ConfigureAwait(false);
+            var trigramRowId = await EnsureMapRowIdAsync("file_trgm_map", document.FileId, connection, transaction, cancellationToken).ConfigureAwait(false);
+
+            await using (var delete = connection.CreateCommand())
+            {
+                delete.Transaction = transaction;
+                delete.CommandText = "INSERT INTO file_search(file_search, rowid) VALUES ('delete', $rowid);";
+                delete.Parameters.Add("$rowid", SqliteType.Integer).Value = searchRowId;
+                await delete.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            }
+
+            await using (var insert = connection.CreateCommand())
+            {
+                insert.Transaction = transaction;
+                insert.CommandText = "INSERT INTO file_search(rowid, title, mime, author, content) VALUES ($rowid, $title, $mime, $author, $content);";
+                insert.Parameters.Add("$rowid", SqliteType.Integer).Value = searchRowId;
+                insert.Parameters.AddWithValue("$title", (object?)document.Title ?? DBNull.Value);
+                insert.Parameters.AddWithValue("$mime", document.Mime);
+                insert.Parameters.AddWithValue("$author", (object?)document.Author ?? DBNull.Value);
+                insert.Parameters.AddWithValue("$content", (object?)document.ContentText ?? DBNull.Value);
+                await insert.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            }
+
+            var trigramText = TrigramQueryBuilder.BuildIndexEntry(document.Title, document.Author, document.Subject);
+
+            await using (var deleteTrgm = connection.CreateCommand())
+            {
+                deleteTrgm.Transaction = transaction;
+                deleteTrgm.CommandText = "INSERT INTO file_trgm(file_trgm, rowid) VALUES ('delete', $rowid);";
+                deleteTrgm.Parameters.Add("$rowid", SqliteType.Integer).Value = trigramRowId;
+                await deleteTrgm.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            }
+
+            await using (var insertTrgm = connection.CreateCommand())
+            {
+                insertTrgm.Transaction = transaction;
+                insertTrgm.CommandText = "INSERT INTO file_trgm(rowid, trgm) VALUES ($rowid, $trgm);";
+                insertTrgm.Parameters.Add("$rowid", SqliteType.Integer).Value = trigramRowId;
+                insertTrgm.Parameters.AddWithValue("$trgm", trigramText);
+                await insertTrgm.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            }
         }
-
-        await using (var insert = connection.CreateCommand())
+        catch (SqliteException ex) when (ex.IndicatesDatabaseCorruption())
         {
-            insert.Transaction = transaction;
-            insert.CommandText = "INSERT INTO file_search(rowid, title, mime, author, content) VALUES ($rowid, $title, $mime, $author, $content);";
-            insert.Parameters.Add("$rowid", SqliteType.Integer).Value = searchRowId;
-            insert.Parameters.AddWithValue("$title", (object?)document.Title ?? DBNull.Value);
-            insert.Parameters.AddWithValue("$mime", document.Mime);
-            insert.Parameters.AddWithValue("$author", (object?)document.Author ?? DBNull.Value);
-            insert.Parameters.AddWithValue("$content", (object?)document.ContentText ?? DBNull.Value);
-            await insert.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
-        }
-
-        var trigramText = TrigramQueryBuilder.BuildIndexEntry(document.Title, document.Author, document.Subject);
-
-        await using (var deleteTrgm = connection.CreateCommand())
-        {
-            deleteTrgm.Transaction = transaction;
-            deleteTrgm.CommandText = "INSERT INTO file_trgm(file_trgm, rowid) VALUES ('delete', $rowid);";
-            deleteTrgm.Parameters.Add("$rowid", SqliteType.Integer).Value = trigramRowId;
-            await deleteTrgm.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
-        }
-
-        await using (var insertTrgm = connection.CreateCommand())
-        {
-            insertTrgm.Transaction = transaction;
-            insertTrgm.CommandText = "INSERT INTO file_trgm(rowid, trgm) VALUES ($rowid, $trgm);";
-            insertTrgm.Parameters.Add("$rowid", SqliteType.Integer).Value = trigramRowId;
-            insertTrgm.Parameters.AddWithValue("$trgm", trigramText);
-            await insertTrgm.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            throw new SearchIndexCorruptedException("SQLite full-text index is corrupted and needs to be repaired.", ex);
         }
     }
 
     public async Task DeleteAsync(Guid fileId, SqliteConnection connection, SqliteTransaction transaction, CancellationToken cancellationToken)
     {
-        ArgumentNullException.ThrowIfNull(connection);
-        ArgumentNullException.ThrowIfNull(transaction);
-        var fileKey = fileId.ToByteArray();
-
-        var searchRowId = await TryGetRowIdAsync("file_search_map", fileId, connection, transaction, cancellationToken).ConfigureAwait(false);
-        if (searchRowId.HasValue)
+        try
         {
-            await using var deleteFts = connection.CreateCommand();
-            deleteFts.Transaction = transaction;
-            deleteFts.CommandText = "INSERT INTO file_search(file_search, rowid) VALUES ('delete', $rowid);";
-            deleteFts.Parameters.Add("$rowid", SqliteType.Integer).Value = searchRowId.Value;
-            await deleteFts.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            ArgumentNullException.ThrowIfNull(connection);
+            ArgumentNullException.ThrowIfNull(transaction);
+            var fileKey = fileId.ToByteArray();
+
+            var searchRowId = await TryGetRowIdAsync("file_search_map", fileId, connection, transaction, cancellationToken).ConfigureAwait(false);
+            if (searchRowId.HasValue)
+            {
+                await using var deleteFts = connection.CreateCommand();
+                deleteFts.Transaction = transaction;
+                deleteFts.CommandText = "INSERT INTO file_search(file_search, rowid) VALUES ('delete', $rowid);";
+                deleteFts.Parameters.Add("$rowid", SqliteType.Integer).Value = searchRowId.Value;
+                await deleteFts.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            }
+
+            var trigramRowId = await TryGetRowIdAsync("file_trgm_map", fileId, connection, transaction, cancellationToken).ConfigureAwait(false);
+            if (trigramRowId.HasValue)
+            {
+                await using var deleteTrgm = connection.CreateCommand();
+                deleteTrgm.Transaction = transaction;
+                deleteTrgm.CommandText = "INSERT INTO file_trgm(file_trgm, rowid) VALUES ('delete', $rowid);";
+                deleteTrgm.Parameters.Add("$rowid", SqliteType.Integer).Value = trigramRowId.Value;
+                await deleteTrgm.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            }
+
+            await using (var deleteSearchMap = connection.CreateCommand())
+            {
+                deleteSearchMap.Transaction = transaction;
+                deleteSearchMap.CommandText = "DELETE FROM file_search_map WHERE file_id = $fileId;";
+                deleteSearchMap.Parameters.Add("$fileId", SqliteType.Blob).Value = fileKey;
+                await deleteSearchMap.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            }
+
+            await using (var deleteTrgmMap = connection.CreateCommand())
+            {
+                deleteTrgmMap.Transaction = transaction;
+                deleteTrgmMap.CommandText = "DELETE FROM file_trgm_map WHERE file_id = $fileId;";
+                deleteTrgmMap.Parameters.Add("$fileId", SqliteType.Blob).Value = fileKey;
+                await deleteTrgmMap.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            }
         }
-
-        var trigramRowId = await TryGetRowIdAsync("file_trgm_map", fileId, connection, transaction, cancellationToken).ConfigureAwait(false);
-        if (trigramRowId.HasValue)
+        catch (SqliteException ex) when (ex.IndicatesDatabaseCorruption())
         {
-            await using var deleteTrgm = connection.CreateCommand();
-            deleteTrgm.Transaction = transaction;
-            deleteTrgm.CommandText = "INSERT INTO file_trgm(file_trgm, rowid) VALUES ('delete', $rowid);";
-            deleteTrgm.Parameters.Add("$rowid", SqliteType.Integer).Value = trigramRowId.Value;
-            await deleteTrgm.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
-        }
-
-        await using (var deleteSearchMap = connection.CreateCommand())
-        {
-            deleteSearchMap.Transaction = transaction;
-            deleteSearchMap.CommandText = "DELETE FROM file_search_map WHERE file_id = $fileId;";
-            deleteSearchMap.Parameters.Add("$fileId", SqliteType.Blob).Value = fileKey;
-            await deleteSearchMap.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
-        }
-
-        await using (var deleteTrgmMap = connection.CreateCommand())
-        {
-            deleteTrgmMap.Transaction = transaction;
-            deleteTrgmMap.CommandText = "DELETE FROM file_trgm_map WHERE file_id = $fileId;";
-            deleteTrgmMap.Parameters.Add("$fileId", SqliteType.Blob).Value = fileKey;
-            await deleteTrgmMap.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            throw new SearchIndexCorruptedException("SQLite full-text index is corrupted and needs to be repaired.", ex);
         }
     }
 


### PR DESCRIPTION
## Summary
- add a dedicated `SearchIndexCorruptedException` that is thrown when SQLite reports a corrupt full-text index
- detect common corruption error codes/messages with a helper extension for `SqliteException`
- surface the corruption failure in the outbox worker so processing stops with a clear instruction to repair the index

## Testing
- Unable to run `dotnet build` in the provided environment because the `dotnet` CLI is not installed

------
https://chatgpt.com/codex/tasks/task_e_68d59bf04c2c8326b6a77c88bc15de5e