### PR TITLE
Handle automatic repair when FTS index is corrupted

### DIFF
--- a/Veriado.Infrastructure/Search/Outbox/OutboxWorker.cs
+++ b/Veriado.Infrastructure/Search/Outbox/OutboxWorker.cs
@@ -28,6 +28,7 @@ internal sealed class OutboxWorker : BackgroundService
     private readonly ILogger<OutboxWorker> _logger;
     private readonly InfrastructureOptions _options;
     private readonly IClock _clock;
+    private readonly IFulltextIntegrityService _integrityService;
 
     public OutboxWorker(
         IDbContextFactory<AppDbContext> writeFactory,
@@ -36,7 +37,8 @@ internal sealed class OutboxWorker : BackgroundService
         ITextExtractor textExtractor,
         ILogger<OutboxWorker> logger,
         InfrastructureOptions options,
-        IClock clock)
+        IClock clock,
+        IFulltextIntegrityService integrityService)
     {
         _writeFactory = writeFactory;
         _readFactory = readFactory;
@@ -45,6 +47,7 @@ internal sealed class OutboxWorker : BackgroundService
         _logger = logger;
         _options = options;
         _clock = clock;
+        _integrityService = integrityService;
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -90,39 +93,74 @@ internal sealed class OutboxWorker : BackgroundService
 
         foreach (var outbox in pendingEvents)
         {
-            try
+            var repairAttempted = false;
+            while (true)
             {
-                using var payload = JsonDocument.Parse(outbox.Payload);
-                if (!payload.RootElement.TryGetProperty("FileId", out var fileIdElement) || !Guid.TryParse(fileIdElement.GetString(), out var fileId))
+                try
                 {
-                    _logger.LogWarning("Outbox event {EventId} missing file identifier", outbox.Id);
-                    outbox.ProcessedUtc = _clock.UtcNow;
-                    continue;
+                    await ProcessOutboxEventAsync(writeContext, outbox, cancellationToken).ConfigureAwait(false);
+                    break;
                 }
-
-                var extractContent = true;
-                if (payload.RootElement.TryGetProperty("ExtractContent", out var extractElement) && extractElement.ValueKind == JsonValueKind.False)
+                catch (SearchIndexCorruptedException ex)
                 {
-                    extractContent = false;
-                }
+                    if (repairAttempted)
+                    {
+                        _logger.LogCritical(ex, "Full-text search index is corrupted. Please run the integrity repair operation before retrying outbox event {EventId}.", outbox.Id);
+                        throw;
+                    }
 
-                await ReindexFileAsync(writeContext, fileId, extractContent, cancellationToken).ConfigureAwait(false);
-                outbox.ProcessedUtc = _clock.UtcNow;
-            }
-            catch (SearchIndexCorruptedException ex)
-            {
-                _logger.LogCritical(ex, "Full-text search index is corrupted. Please run the integrity repair operation before retrying outbox event {EventId}.", outbox.Id);
-                throw;
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Failed to process outbox event {EventId}", outbox.Id);
-                // Leave the event unprocessed for retry.
+                    repairAttempted = true;
+                    _logger.LogWarning(ex, "Full-text search index corruption detected while processing outbox event {EventId}. Initiating automatic repair.", outbox.Id);
+
+                    await AttemptIntegrityRepairAsync(cancellationToken).ConfigureAwait(false);
+                    _logger.LogInformation("Retrying outbox event {EventId} after repairing the full-text search index.", outbox.Id);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Failed to process outbox event {EventId}", outbox.Id);
+                    break;
+                }
             }
         }
 
         await writeContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
         return true;
+    }
+
+    private async Task ProcessOutboxEventAsync(AppDbContext writeContext, OutboxEvent outbox, CancellationToken cancellationToken)
+    {
+        using var payload = JsonDocument.Parse(outbox.Payload);
+        if (!payload.RootElement.TryGetProperty("FileId", out var fileIdElement) || !Guid.TryParse(fileIdElement.GetString(), out var fileId))
+        {
+            _logger.LogWarning("Outbox event {EventId} missing file identifier", outbox.Id);
+            outbox.ProcessedUtc = _clock.UtcNow;
+            return;
+        }
+
+        var extractContent = true;
+        if (payload.RootElement.TryGetProperty("ExtractContent", out var extractElement) && extractElement.ValueKind == JsonValueKind.False)
+        {
+            extractContent = false;
+        }
+
+        await ReindexFileAsync(writeContext, fileId, extractContent, cancellationToken).ConfigureAwait(false);
+        outbox.ProcessedUtc = _clock.UtcNow;
+    }
+
+    private async Task AttemptIntegrityRepairAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            _logger.LogWarning("Attempting automatic full rebuild of the full-text search index due to detected corruption.");
+            var repaired = await _integrityService.RepairAsync(reindexAll: true, extractContent: true, cancellationToken)
+                .ConfigureAwait(false);
+            _logger.LogInformation("Automatic full-text index repair completed ({Repaired} entries updated).", repaired);
+        }
+        catch (Exception repairEx)
+        {
+            _logger.LogCritical(repairEx, "Automatic full-text index repair failed. Manual intervention is required.");
+            throw;
+        }
     }
 
     private async Task ReindexFileAsync(AppDbContext writeContext, Guid fileId, bool extractContent, CancellationToken cancellationToken)


### PR DESCRIPTION
## Summary
- attempt an automatic full rebuild of the SQLite full-text index when corruption is detected during outbox processing
- retry the affected outbox event after a successful repair and log detailed progress
- refactor outbox processing logic into dedicated helpers for reuse

## Testing
- dotnet test *(fails: `dotnet` is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d59f4bddb883269862fc4cadaa2b79