### PR TITLE
Ensure SQLite database file exists on startup

### DIFF
--- a/Veriado.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/Veriado.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
@@ -58,6 +58,12 @@ public static class ServiceCollectionExtensions
         };
         options.ConnectionString = connectionStringBuilder.ConnectionString;
 
+        if (!File.Exists(options.DbPath))
+        {
+            using var connection = new SqliteConnection(options.ConnectionString);
+            connection.Open();
+        }
+
         services.AddSingleton(options);
         var sqlitePragmaInterceptor = new SqlitePragmaInterceptor();
         services.AddSingleton<SqlitePragmaInterceptor>(sqlitePragmaInterceptor);


### PR DESCRIPTION
## Summary
- ensure the infrastructure bootstrapper creates the SQLite database file when missing before registering EF contexts

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d5a1d53c5083268fb03a18cbe4604c