### PR TITLE
Ensure database file is created during startup

### DIFF
--- a/Veriado.WinUI/Services/InfrastructureConfigProvider.cs
+++ b/Veriado.WinUI/Services/InfrastructureConfigProvider.cs
@@ -15,10 +15,20 @@ public sealed class InfrastructureConfigProvider : IInfrastructureConfigProvider
 
     public void EnsureStorageExists(string path)
     {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return;
+        }
+
         var directory = Path.GetDirectoryName(path);
         if (!string.IsNullOrEmpty(directory))
         {
             Directory.CreateDirectory(directory);
+        }
+
+        if (!File.Exists(path))
+        {
+            using var _ = File.Create(path);
         }
     }
 }


### PR DESCRIPTION
## Summary
- guard against empty database paths when preparing local storage
- create the SQLite database file on first launch so startup succeeds even if it is missing

## Testing
- `dotnet build Veriado.sln` *(fails: dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d5a4069d0483269ba19faa9605c408