### PR TITLE
Align runtime metadata storage default with migrations

### DIFF
--- a/Veriado.Infrastructure/Persistence/Options/InfrastructureOptions.cs
+++ b/Veriado.Infrastructure/Persistence/Options/InfrastructureOptions.cs
@@ -19,7 +19,7 @@ public sealed class InfrastructureOptions
     /// Gets or sets a value indicating whether the key/value metadata store should be used instead of JSON.
     /// </summary>
     public bool UseKvMetadata { get; set; }
-        = false;
+        = true;
 
     /// <summary>
     /// Gets or sets the optional maximum number of bytes allowed for stored file content.


### PR DESCRIPTION
## Summary
- default InfrastructureOptions.UseKvMetadata to true so runtime matches design-time migrations

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d5ae22f3c08326826398c2e54984d4