### PR TITLE
Include comments metadata in trigram index

### DIFF
--- a/Veriado.Domain/Files/FileEntity.cs
+++ b/Veriado.Domain/Files/FileEntity.cs
@@ -551,6 +551,7 @@ public sealed class FileEntity : AggregateRoot
             Mime.Value,
             authorText,
             subject,
+            comments,
             CreatedUtc.Value,
             LastModifiedUtc.Value,
             contentText);

--- a/Veriado.Domain/Search/SearchDocument.cs
+++ b/Veriado.Domain/Search/SearchDocument.cs
@@ -11,6 +11,7 @@ public sealed record SearchDocument(
     string Mime,
     string? Author,
     string? Subject,
+    string? Comments,
     DateTimeOffset CreatedUtc,
     DateTimeOffset ModifiedUtc,
     string? ContentText);

--- a/Veriado.Infrastructure/Search/SqliteFts5Transactional.cs
+++ b/Veriado.Infrastructure/Search/SqliteFts5Transactional.cs
@@ -40,7 +40,11 @@ internal sealed class SqliteFts5Transactional
                 await insert.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
             }
 
-            var trigramText = TrigramQueryBuilder.BuildIndexEntry(document.Title, document.Author, document.Subject);
+            var trigramText = TrigramQueryBuilder.BuildIndexEntry(
+                document.Title,
+                document.Author,
+                document.Subject,
+                document.Comments);
 
             await using (var deleteTrgm = connection.CreateCommand())
             {


### PR DESCRIPTION
## Summary
- extend the search document projection with the comments metadata field
- ensure file aggregates populate the new property when building FTS search documents
- include comments in the trigram index payload so fuzzy search covers metadata text

## Testing
- not run (dotnet SDK is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d5b2b00f148326b85a0ce7730e34e8