### PR TITLE
Enhance import status handling

### DIFF
--- a/Veriado.Contracts/Import/ImportBatchResult.cs
+++ b/Veriado.Contracts/Import/ImportBatchResult.cs
@@ -5,11 +5,13 @@ namespace Veriado.Contracts.Import;
 /// <summary>
 /// Represents the aggregated outcome of a folder import operation.
 /// </summary>
+/// <param name="Status">The resulting status of the batch import.</param>
 /// <param name="Total">The total number of processed files.</param>
 /// <param name="Succeeded">The number of files imported successfully.</param>
 /// <param name="Failed">The number of files that failed to import.</param>
 /// <param name="Errors">The collection of import errors captured during processing.</param>
 public sealed record ImportBatchResult(
+    ImportBatchStatus Status,
     int Total,
     int Succeeded,
     int Failed,

--- a/Veriado.Contracts/Import/ImportBatchStatus.cs
+++ b/Veriado.Contracts/Import/ImportBatchStatus.cs
@@ -1,0 +1,27 @@
+namespace Veriado.Contracts.Import;
+
+/// <summary>
+/// Represents the high level outcome of a batch import operation.
+/// </summary>
+public enum ImportBatchStatus
+{
+    /// <summary>
+    /// All files were imported successfully.
+    /// </summary>
+    Success,
+
+    /// <summary>
+    /// At least one file was imported successfully and at least one failed.
+    /// </summary>
+    PartialSuccess,
+
+    /// <summary>
+    /// All files failed to import.
+    /// </summary>
+    Failure,
+
+    /// <summary>
+    /// A fatal error prevented the import from completing.
+    /// </summary>
+    FatalError,
+}

--- a/Veriado.WinUI/ViewModels/Import/ImportPageViewModel.cs
+++ b/Veriado.WinUI/ViewModels/Import/ImportPageViewModel.cs
@@ -100,8 +100,33 @@ public partial class ImportPageViewModel : ViewModelBase
                     return;
                 }
 
+                if (response.Data is null)
+                {
+                    StatusService.Error("Import vrátil neplatnou odpověď.");
+                    return;
+                }
+
+                var result = response.Data;
+                switch (result.Status)
+                {
+                    case ImportBatchStatus.Success:
+                        StatusService.Info($"Import dokončen. Importováno {result.Succeeded} z {result.Total} souborů.");
+                        break;
+                    case ImportBatchStatus.PartialSuccess:
+                        StatusService.Error($"Import dokončen s chybami. Úspěšně importováno {result.Succeeded} z {result.Total} souborů.");
+                        break;
+                    case ImportBatchStatus.Failure:
+                        StatusService.Error("Import se nezdařil. Zkontrolujte protokol chyb.");
+                        break;
+                    case ImportBatchStatus.FatalError:
+                        StatusService.Error("Import byl přerušen kvůli fatální chybě. Zkontrolujte protokol chyb.");
+                        break;
+                    default:
+                        StatusService.Info("Import dokončen.");
+                        break;
+                }
+
                 _hotStateService.LastFolder = SelectedFolder;
-                StatusService.Info("Import dokončen.");
             }
             finally
             {


### PR DESCRIPTION
## Summary
- introduce an `ImportBatchStatus` enum to describe success, partial success, failure, and fatal outcomes
- compute the batch status during folder imports and return it alongside the batch metrics
- update the WinUI import page to surface user messaging for each import result status

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d629275900832699fcaf3b5073fd68