### PR TITLE
Make navigation menu fluent with acrylic background

### DIFF
--- a/Veriado.WinUI/Views/Shell/MainShell.xaml
+++ b/Veriado.WinUI/Views/Shell/MainShell.xaml
@@ -5,7 +5,16 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:controls="using:Microsoft.UI.Xaml.Controls"
+    xmlns:media="using:Microsoft.UI.Xaml.Media"
     mc:Ignorable="d">
+    <Window.Resources>
+        <media:AcrylicBrush
+            x:Key="NavigationPaneBrush"
+            BackgroundSource="Backdrop"
+            FallbackColor="{ThemeResource SystemBaseLowColor}"
+            TintColor="{ThemeResource SystemChromeAltLowColor}"
+            TintOpacity="0.6" />
+    </Window.Resources>
     <Grid x:Name="RootGrid">
 
         <ContentPresenter
@@ -27,6 +36,7 @@
             Width="320"
             HorizontalAlignment="Left"
             IsPaneToggleButtonVisible="True"
+            PaneBackground="{StaticResource NavigationPaneBrush}"
             IsPaneOpen="{Binding IsNavOpen, Mode=TwoWay}"
             ItemInvoked="OnNavigationViewItemInvoked">
             <controls:NavigationView.MenuItems>


### PR DESCRIPTION
## Summary
- add an acrylic brush resource to the main shell
- apply the brush to the navigation view pane to give it a fluent appearance

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d63760ae908326a4c3aae9ae7faac3