### PR TITLE
Remove unsupported acrylic brush usage in MainShell

### DIFF
--- a/Veriado.WinUI/Views/Shell/MainShell.xaml
+++ b/Veriado.WinUI/Views/Shell/MainShell.xaml
@@ -7,14 +7,6 @@
     xmlns:controls="using:Microsoft.UI.Xaml.Controls"
     xmlns:media="using:Microsoft.UI.Xaml.Media"
     mc:Ignorable="d">
-    <Window.Resources>
-        <media:AcrylicBrush
-            x:Key="NavigationPaneBrush"
-            BackgroundSource="Backdrop"
-            FallbackColor="{ThemeResource SystemBaseLowColor}"
-            TintColor="{ThemeResource SystemChromeAltLowColor}"
-            TintOpacity="0.6" />
-    </Window.Resources>
     <Grid x:Name="RootGrid">
         <Grid.Resources>
             <media:AcrylicBrush
@@ -44,7 +36,6 @@
             Width="320"
             HorizontalAlignment="Left"
             IsPaneToggleButtonVisible="True"
-            PaneBackground="{StaticResource NavigationPaneBrush}"
             IsPaneOpen="{Binding IsNavOpen, Mode=TwoWay}"
             ItemInvoked="OnNavigationViewItemInvoked">
             <controls:NavigationView.Resources>


### PR DESCRIPTION
## Summary
- remove the unsupported window-level acrylic resource definition from MainShell
- keep the navigation pane styling scoped to the grid resources to avoid compile-time XAML errors

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d63b57a97483269d21d233454c4625