### PR TITLE
Adjust shell navigation pane layout

### DIFF
--- a/Veriado.WinUI/Views/Shell/MainShell.xaml
+++ b/Veriado.WinUI/Views/Shell/MainShell.xaml
@@ -5,50 +5,39 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:controls="using:Microsoft.UI.Xaml.Controls"
-    xmlns:media="using:Microsoft.UI.Xaml.Media"
     mc:Ignorable="d">
-    <Grid x:Name="RootGrid">
-        <Grid.Resources>
-            <media:AcrylicBrush
-                x:Key="NavigationPaneBrush"
-                FallbackColor="{ThemeResource SystemBaseLowColor}"
-                TintColor="{ThemeResource SystemChromeAltLowColor}"
-                TintOpacity="0.6"
-                AlwaysUseFallback="False" />
-        </Grid.Resources>
-
-        <ContentPresenter
-            x:Name="ContentHost"
-            Content="{x:Bind CurrentContent, Mode=OneWay}" />
-
-        <Rectangle
-            Fill="Transparent"
-            Canvas.ZIndex="998"
-            IsHitTestVisible="{Binding IsNavOpen}"
-            Visibility="{Binding IsNavOpen, Converter={StaticResource BooleanToVisibilityConverter}}"
-            Tapped="OnOverlayTapped" />
-
-        <controls:NavigationView
-            x:Name="RootNavigation"
-            Canvas.ZIndex="999"
-            IsSettingsVisible="False"
-            PaneDisplayMode="LeftMinimal"
-            Width="320"
-            HorizontalAlignment="Left"
-            IsPaneToggleButtonVisible="True"
-            IsPaneOpen="{Binding IsNavOpen, Mode=TwoWay}"
-            ItemInvoked="OnNavigationViewItemInvoked">
-            <controls:NavigationView.Resources>
-                <StaticResource x:Key="NavigationViewDefaultPaneBackground" ResourceKey="NavigationPaneBrush" />
-                <StaticResource x:Key="NavigationViewExpandedPaneBackground" ResourceKey="NavigationPaneBrush" />
-                <StaticResource x:Key="NavigationViewMinimalPaneBackground" ResourceKey="NavigationPaneBrush" />
-                <StaticResource x:Key="NavigationViewTopPaneBackground" ResourceKey="NavigationPaneBrush" />
-            </controls:NavigationView.Resources>
-            <controls:NavigationView.MenuItems>
-                <controls:NavigationViewItem Tag="files" Content="Správa souborů" Icon="Document" />
-                <controls:NavigationViewItem Tag="import" Content="Import souborů" Icon="OpenFile" />
-                <controls:NavigationViewItem Tag="settings" Content="Nastavení" Icon="Setting" />
-            </controls:NavigationView.MenuItems>
-        </controls:NavigationView>
-    </Grid>
+    <controls:NavigationView
+        x:Name="RootNavigation"
+        IsSettingsVisible="False"
+        PaneDisplayMode="LeftCompact"
+        CompactPaneLength="56"
+        OpenPaneLength="320"
+        IsPaneToggleButtonVisible="True"
+        IsPaneOpen="{Binding IsNavOpen, Mode=TwoWay}"
+        ItemInvoked="OnNavigationViewItemInvoked">
+        <controls:NavigationView.Resources>
+            <SolidColorBrush
+                x:Key="NavigationViewDefaultPaneBackground"
+                Color="{ThemeResource SystemChromeHighColor}" />
+            <SolidColorBrush
+                x:Key="NavigationViewExpandedPaneBackground"
+                Color="{ThemeResource SystemChromeHighColor}" />
+            <SolidColorBrush
+                x:Key="NavigationViewMinimalPaneBackground"
+                Color="{ThemeResource SystemChromeHighColor}" />
+            <SolidColorBrush
+                x:Key="NavigationViewTopPaneBackground"
+                Color="{ThemeResource SystemChromeHighColor}" />
+        </controls:NavigationView.Resources>
+        <controls:NavigationView.MenuItems>
+            <controls:NavigationViewItem Tag="files" Content="Správa souborů" Icon="Document" />
+            <controls:NavigationViewItem Tag="import" Content="Import souborů" Icon="OpenFile" />
+            <controls:NavigationViewItem Tag="settings" Content="Nastavení" Icon="Setting" />
+        </controls:NavigationView.MenuItems>
+        <controls:NavigationView.Content>
+            <ContentPresenter
+                x:Name="ContentHost"
+                Content="{x:Bind CurrentContent, Mode=OneWay}" />
+        </controls:NavigationView.Content>
+    </controls:NavigationView>
 </Window>

--- a/Veriado.WinUI/Views/Shell/MainShell.xaml.cs
+++ b/Veriado.WinUI/Views/Shell/MainShell.xaml.cs
@@ -3,7 +3,6 @@ using System.ComponentModel;
 using System.Linq;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml.Input;
 using Veriado.WinUI.Navigation;
 using Veriado.WinUI.Services.Abstractions;
 using Veriado.WinUI.ViewModels.Shell;
@@ -22,11 +21,11 @@ public sealed partial class MainShell : Window, INavigationHost
         _viewModel = viewModel ?? throw new ArgumentNullException(nameof(viewModel));
         _navigationService = navigationService ?? throw new ArgumentNullException(nameof(navigationService));
 
-        RootGrid.DataContext = _viewModel;
+        RootNavigation.DataContext = _viewModel;
         _navigationService.AttachHost(this);
 
         _viewModel.PropertyChanged += OnViewModelPropertyChanged;
-        RootGrid.Loaded += OnLoaded;
+        RootNavigation.Loaded += OnLoaded;
         Closed += OnClosed;
     }
 
@@ -38,7 +37,7 @@ public sealed partial class MainShell : Window, INavigationHost
 
     private void OnLoaded(object sender, RoutedEventArgs e)
     {
-        RootGrid.Loaded -= OnLoaded;
+        RootNavigation.Loaded -= OnLoaded;
         _viewModel.Initialize();
         UpdateNavigationSelection(_viewModel.CurrentPage);
     }
@@ -53,14 +52,6 @@ public sealed partial class MainShell : Window, INavigationHost
     {
         var tag = args.InvokedItemContainer?.Tag as string;
         _viewModel.NavigateToTag(tag);
-    }
-
-    private void OnOverlayTapped(object sender, TappedRoutedEventArgs e)
-    {
-        if (_viewModel.CloseNavCommand.CanExecute(null))
-        {
-            _viewModel.CloseNavCommand.Execute(null);
-        }
     }
 
     private void OnViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)


### PR DESCRIPTION
## Summary
- convert the shell window to host the navigation view directly so the pane expands alongside the app content
- replace the acrylic menu background and overlay handling with an opaque brush to avoid transparency and overlays

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d63ea0b5bc832683acf8f6c2ef9405