### PR TITLE
Add WinUI import page with persistent import options

### DIFF
--- a/Veriado.WinUI/Models/Import/ImportErrorItem.cs
+++ b/Veriado.WinUI/Models/Import/ImportErrorItem.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace Veriado.WinUI.Models.Import;
+
+public sealed class ImportErrorItem
+{
+    public ImportErrorItem(string fileName, string errorMessage, Guid? fileId)
+    {
+        FileName = fileName;
+        ErrorMessage = errorMessage;
+        FileId = fileId;
+    }
+
+    public string FileName { get; }
+
+    public string ErrorMessage { get; }
+
+    public Guid? FileId { get; }
+}

--- a/Veriado.WinUI/Models/Import/ImportLogItem.cs
+++ b/Veriado.WinUI/Models/Import/ImportLogItem.cs
@@ -1,0 +1,22 @@
+using System;
+
+namespace Veriado.WinUI.Models.Import;
+
+public sealed class ImportLogItem
+{
+    public ImportLogItem(DateTimeOffset timestamp, string title, string message, string status)
+    {
+        Timestamp = timestamp;
+        Title = title;
+        Message = message;
+        Status = status;
+    }
+
+    public DateTimeOffset Timestamp { get; }
+
+    public string Title { get; }
+
+    public string Message { get; }
+
+    public string Status { get; }
+}

--- a/Veriado.WinUI/Services/Abstractions/IHotStateService.cs
+++ b/Veriado.WinUI/Services/Abstractions/IHotStateService.cs
@@ -6,10 +6,24 @@ namespace Veriado.WinUI.Services.Abstractions;
 public interface IHotStateService
 {
     string? LastQuery { get; set; }
-    
+
     string? LastFolder { get; set; }
 
     int PageSize { get; set; }
+
+    bool ImportRecursive { get; set; }
+
+    bool ImportExtractContent { get; set; }
+
+    bool ImportKeepFsMetadata { get; set; }
+
+    bool ImportSetReadOnly { get; set; }
+
+    bool ImportUseParallel { get; set; }
+
+    int ImportMaxDegreeOfParallelism { get; set; }
+
+    string? ImportDefaultAuthor { get; set; }
 
     Task InitializeAsync(CancellationToken cancellationToken = default);
 }

--- a/Veriado.WinUI/Services/Abstractions/ISettingsService.cs
+++ b/Veriado.WinUI/Services/Abstractions/ISettingsService.cs
@@ -26,4 +26,30 @@ public sealed class AppSettings
 
     public string? LastQuery { get; set; }
         = null;
+
+    public ImportPreferences Import { get; set; } = new();
+}
+
+public sealed class ImportPreferences
+{
+    public bool? Recursive { get; set; }
+        = null;
+
+    public bool? ExtractContent { get; set; }
+        = null;
+
+    public bool? KeepFsMetadata { get; set; }
+        = null;
+
+    public bool? SetReadOnly { get; set; }
+        = null;
+
+    public bool? UseParallel { get; set; }
+        = null;
+
+    public int? MaxDegreeOfParallelism { get; set; }
+        = null;
+
+    public string? DefaultAuthor { get; set; }
+        = null;
 }

--- a/Veriado.WinUI/Services/NavigationService.cs
+++ b/Veriado.WinUI/Services/NavigationService.cs
@@ -48,10 +48,19 @@ public sealed class NavigationService : INavigationService
 
         if (registration.ViewModelType is not null)
         {
-            viewModel = _serviceProvider.GetRequiredService(registration.ViewModelType);
+            if (view is FrameworkElement existingElement
+                && existingElement.DataContext is not null
+                && registration.ViewModelType.IsInstanceOfType(existingElement.DataContext))
+            {
+                viewModel = existingElement.DataContext;
+            }
+            else
+            {
+                viewModel = _serviceProvider.GetRequiredService(registration.ViewModelType);
+            }
         }
 
-        if (view is FrameworkElement frameworkElement && viewModel is not null)
+        if (view is FrameworkElement frameworkElement && viewModel is not null && !ReferenceEquals(frameworkElement.DataContext, viewModel))
         {
             frameworkElement.DataContext = viewModel;
         }

--- a/Veriado.WinUI/ViewModels/Import/ImportPageViewModel.cs
+++ b/Veriado.WinUI/ViewModels/Import/ImportPageViewModel.cs
@@ -1,11 +1,19 @@
 using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.IO;
 using System.Linq;
+using System.Reflection;
+using System.Threading;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.Mvvm.Messaging;
+using Veriado.Contracts.Common;
 using Veriado.Contracts.Import;
 using Veriado.Services.Import;
+using Veriado.WinUI.Models.Import;
 using Veriado.WinUI.Services.Abstractions;
 using Veriado.WinUI.ViewModels.Base;
 
@@ -13,51 +21,153 @@ namespace Veriado.WinUI.ViewModels.Import;
 
 public partial class ImportPageViewModel : ViewModelBase
 {
+    private const int MaxLogEntries = 250;
+
     private readonly IImportService _importService;
-    private readonly IHotStateService _hotStateService;
+    private readonly IHotStateService? _hotStateService;
     private readonly IPickerService? _pickerService;
     private readonly AsyncRelayCommand _pickFolderCommand;
     private readonly AsyncRelayCommand _runImportCommand;
+    private readonly RelayCommand _stopImportCommand;
+    private readonly RelayCommand _clearResultsCommand;
+    private readonly RelayCommand<ImportErrorItem> _openErrorDetailCommand;
+    private CancellationTokenSource? _importCancellation;
+
+    private int _okCount;
+    private int _errorCount;
+    private int _skipCount;
 
     public ImportPageViewModel(
         IImportService importService,
-        IHotStateService hotStateService,
         IMessenger messenger,
         IStatusService statusService,
         IDispatcherService dispatcher,
         IExceptionHandler exceptionHandler,
+        IHotStateService? hotStateService = null,
         IPickerService? pickerService = null)
         : base(messenger, statusService, dispatcher, exceptionHandler)
     {
         _importService = importService ?? throw new ArgumentNullException(nameof(importService));
-        _hotStateService = hotStateService ?? throw new ArgumentNullException(nameof(hotStateService));
+        _hotStateService = hotStateService;
         _pickerService = pickerService;
 
-        SelectedFolder = string.IsNullOrWhiteSpace(_hotStateService.LastFolder)
-            ? null
-            : _hotStateService.LastFolder;
+        Log = new ObservableCollection<ImportLogItem>();
+        Errors = new ObservableCollection<ImportErrorItem>();
+        Log.CollectionChanged += OnLogCollectionChanged;
+        Errors.CollectionChanged += OnErrorsCollectionChanged;
 
-        _pickFolderCommand = new AsyncRelayCommand(PickFolderAsync);
-        _runImportCommand = new AsyncRelayCommand(RunImportAsync, CanRunImport);
+        RestoreStateFromHotStorage();
+
+        _pickFolderCommand = new AsyncRelayCommand(ExecutePickFolderAsync, () => !IsImporting);
+        _runImportCommand = new AsyncRelayCommand(ExecuteRunImportAsync, CanRunImport);
+        _stopImportCommand = new RelayCommand(ExecuteStopImport, () => IsImporting);
+        _clearResultsCommand = new RelayCommand(ExecuteClearResults, CanClearResults);
+        _openErrorDetailCommand = new RelayCommand<ImportErrorItem>(ExecuteOpenErrorDetail);
     }
 
     [ObservableProperty]
     private string? selectedFolder;
 
     [ObservableProperty]
+    private bool recursive = true;
+
+    [ObservableProperty]
+    private bool extractContent = true;
+
+    [ObservableProperty]
+    private bool keepFsMetadata = true;
+
+    [ObservableProperty]
+    private bool setReadOnly;
+
+    [ObservableProperty]
+    private bool useParallel = true;
+
+    [ObservableProperty]
+    private int maxDegreeOfParallelism = Environment.ProcessorCount;
+
+    [ObservableProperty]
+    private string? defaultAuthor;
+
+    [ObservableProperty]
     private bool isImporting;
+
+    [ObservableProperty]
+    private bool isIndeterminate;
+
+    [ObservableProperty]
+    private int processed;
+
+    [ObservableProperty]
+    private int total;
+
+    public ObservableCollection<ImportLogItem> Log { get; }
+
+    public ObservableCollection<ImportErrorItem> Errors { get; }
+
+    public int OkCount
+    {
+        get => _okCount;
+        private set
+        {
+            if (SetProperty(ref _okCount, value))
+            {
+                OnPropertyChanged(nameof(ProgressText));
+                _clearResultsCommand.NotifyCanExecuteChanged();
+            }
+        }
+    }
+
+    public int ErrorCount
+    {
+        get => _errorCount;
+        private set
+        {
+            if (SetProperty(ref _errorCount, value))
+            {
+                OnPropertyChanged(nameof(ProgressText));
+                _clearResultsCommand.NotifyCanExecuteChanged();
+            }
+        }
+    }
+
+    public int SkipCount
+    {
+        get => _skipCount;
+        private set
+        {
+            if (SetProperty(ref _skipCount, value))
+            {
+                OnPropertyChanged(nameof(ProgressText));
+                _clearResultsCommand.NotifyCanExecuteChanged();
+            }
+        }
+    }
+
+    public string ProgressText =>
+        $"Zpracováno {Processed}/{(Total > 0 ? Total : 0)} • OK {OkCount} • Chyby {ErrorCount} • Skip {SkipCount}";
+
+    public bool HasErrors => Errors.Count > 0;
 
     public IAsyncRelayCommand PickFolderCommand => _pickFolderCommand;
 
     public IAsyncRelayCommand RunImportCommand => _runImportCommand;
 
+    public IRelayCommand StopImportCommand => _stopImportCommand;
+
+    public IRelayCommand ClearResultsCommand => _clearResultsCommand;
+
+    public IRelayCommand<ImportErrorItem> OpenErrorDetailCommand => _openErrorDetailCommand;
+
     private bool CanRunImport() => !IsImporting && !string.IsNullOrWhiteSpace(SelectedFolder);
 
-    private Task PickFolderAsync()
+    private bool CanClearResults() => Log.Count > 0 || Errors.Count > 0 || Processed > 0 || Total > 0 || OkCount > 0 || ErrorCount > 0 || SkipCount > 0;
+
+    private Task ExecutePickFolderAsync()
     {
         if (_pickerService is null)
         {
-            StatusService.Error("Výběr složky není v této konfiguraci podporován.");
+            StatusService.Info("Výběr složky není v této konfiguraci podporován.");
             return Task.CompletedTask;
         }
 
@@ -66,12 +176,12 @@ public partial class ImportPageViewModel : ViewModelBase
             var folder = await _pickerService.PickFolderAsync().ConfigureAwait(false);
             if (!string.IsNullOrWhiteSpace(folder))
             {
-                SelectedFolder = folder;
+                await Dispatcher.Enqueue(() => SelectedFolder = folder);
             }
-        });
+        }, "Otevírám dialog výběru složky...");
     }
 
-    private Task RunImportAsync()
+    private Task ExecuteRunImportAsync()
     {
         if (string.IsNullOrWhiteSpace(SelectedFolder))
         {
@@ -79,70 +189,485 @@ public partial class ImportPageViewModel : ViewModelBase
             return Task.CompletedTask;
         }
 
-        return SafeExecuteAsync(async cancellationToken =>
+        return SafeExecuteAsync(RunImportInternalAsync, "Importuji…");
+    }
+
+    private void ExecuteStopImport()
+    {
+        _importCancellation?.Cancel();
+        TryCancelRunning();
+    }
+
+    private void ExecuteClearResults()
+    {
+        Log.Clear();
+        Errors.Clear();
+        Processed = 0;
+        Total = 0;
+        OkCount = 0;
+        ErrorCount = 0;
+        SkipCount = 0;
+        IsIndeterminate = false;
+        StatusService.Info("Výsledky importu byly vymazány.");
+    }
+
+    private void ExecuteOpenErrorDetail(ImportErrorItem? item)
+    {
+        if (item is null)
         {
-            IsImporting = true;
-            try
+            return;
+        }
+
+        // TODO: Implement navigation to import error detail page.
+    }
+
+    private async Task RunImportInternalAsync(CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(SelectedFolder))
+        {
+            StatusService.Error("Vyberte složku pro import.");
+            return;
+        }
+
+        _importCancellation?.Dispose();
+        _importCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+
+        try
+        {
+            await Dispatcher.Enqueue(() =>
             {
-                var request = new ImportFolderRequest
-                {
-                    FolderPath = SelectedFolder!,
-                };
+                IsImporting = true;
+                IsIndeterminate = true;
+            });
 
-                var response = await _importService.ImportFolderAsync(request, cancellationToken).ConfigureAwait(false);
-                if (!response.IsSuccess)
-                {
-                    var errorMessage = response.Errors.FirstOrDefault()?.Message;
-                    var message = string.IsNullOrWhiteSpace(errorMessage)
-                        ? "Import se nezdařil."
-                        : errorMessage;
-                    StatusService.Error(message);
-                    return;
-                }
+            await ResetProgressAsync().ConfigureAwait(false);
+            await AddLogAsync("Import", $"Spouštím import ze složky '{SelectedFolder}'.", "info").ConfigureAwait(false);
 
-                if (response.Data is null)
-                {
-                    StatusService.Error("Import vrátil neplatnou odpověď.");
-                    return;
-                }
+            var request = BuildRequest();
 
-                var result = response.Data;
-                switch (result.Status)
-                {
-                    case ImportBatchStatus.Success:
-                        StatusService.Info($"Import dokončen. Importováno {result.Succeeded} z {result.Total} souborů.");
-                        break;
-                    case ImportBatchStatus.PartialSuccess:
-                        StatusService.Error($"Import dokončen s chybami. Úspěšně importováno {result.Succeeded} z {result.Total} souborů.");
-                        break;
-                    case ImportBatchStatus.Failure:
-                        StatusService.Error("Import se nezdařil. Zkontrolujte protokol chyb.");
-                        break;
-                    case ImportBatchStatus.FatalError:
-                        StatusService.Error("Import byl přerušen kvůli fatální chybě. Zkontrolujte protokol chyb.");
-                        break;
-                    default:
-                        StatusService.Info("Import dokončen.");
-                        break;
-                }
+            var handledStreaming = await TryProcessStreamingAsync(request, _importCancellation.Token).ConfigureAwait(false);
+            var statusReported = false;
 
-                _hotStateService.LastFolder = SelectedFolder;
+            if (handledStreaming)
+            {
+                statusReported = true;
+                StatusService.Info("Import dokončen.");
             }
-            finally
+            else
+            {
+                statusReported = await ProcessBatchImportAsync(request, _importCancellation.Token).ConfigureAwait(false);
+            }
+
+            await Dispatcher.Enqueue(() => IsIndeterminate = false);
+
+            if (!statusReported)
+            {
+                StatusService.Info("Import dokončen.");
+            }
+        }
+        finally
+        {
+            _importCancellation?.Dispose();
+            _importCancellation = null;
+            await Dispatcher.Enqueue(() =>
             {
                 IsImporting = false;
+                IsIndeterminate = false;
+            });
+        }
+    }
+
+    private ImportFolderRequest BuildRequest()
+    {
+        var maxParallel = UseParallel
+            ? Math.Max(1, MaxDegreeOfParallelism)
+            : 1;
+
+        return new ImportFolderRequest
+        {
+            FolderPath = SelectedFolder!.Trim(),
+            Recursive = Recursive,
+            ExtractContent = ExtractContent,
+            MaxDegreeOfParallelism = maxParallel,
+            DefaultAuthor = string.IsNullOrWhiteSpace(DefaultAuthor) ? null : DefaultAuthor,
+        };
+    }
+
+    private async Task<bool> TryProcessStreamingAsync(ImportFolderRequest request, CancellationToken cancellationToken)
+    {
+        var method = _importService
+            .GetType()
+            .GetMethod("ImportFolderStreamAsync", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+
+        if (method is null)
+        {
+            return false;
+        }
+
+        var returnType = method.ReturnType;
+        object? invocationResult = method.Invoke(_importService, new object[] { request, cancellationToken });
+
+        if (invocationResult is Task task)
+        {
+            await task.ConfigureAwait(false);
+            invocationResult = GetTaskResult(task);
+            returnType = invocationResult?.GetType() ?? returnType;
+        }
+        else if (invocationResult is not null)
+        {
+            returnType = invocationResult.GetType();
+        }
+
+        if (invocationResult is null)
+        {
+            return false;
+        }
+
+        var asyncEnumerableInterface = returnType
+            .GetInterfaces()
+            .FirstOrDefault(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IAsyncEnumerable<>));
+
+        if (asyncEnumerableInterface is null)
+        {
+            return false;
+        }
+
+        var eventType = asyncEnumerableInterface.GetGenericArguments()[0];
+        var processMethod = typeof(ImportPageViewModel)
+            .GetMethod(nameof(ProcessStreamingEventsAsync), BindingFlags.Instance | BindingFlags.NonPublic)!
+            .MakeGenericMethod(eventType);
+
+        var taskResult = (Task<bool>)processMethod.Invoke(this, new object[] { invocationResult, cancellationToken })!;
+        return await taskResult.ConfigureAwait(false);
+    }
+
+    private async Task<bool> ProcessStreamingEventsAsync<TEvent>(IAsyncEnumerable<TEvent> events, CancellationToken cancellationToken)
+        where TEvent : class
+    {
+        try
+        {
+            await foreach (var evt in events.WithCancellation(cancellationToken).ConfigureAwait(false))
+            {
+                if (evt is null)
+                {
+                    continue;
+                }
+
+                await HandleStreamingEventAsync(evt).ConfigureAwait(false);
             }
+
+            return true;
+        }
+        catch (NotSupportedException)
+        {
+            return false;
+        }
+    }
+
+    private async Task HandleStreamingEventAsync(object evt)
+    {
+        var typeName = evt.GetType().Name;
+
+        switch (typeName)
+        {
+            case "ImportStartedEvent":
+            case "ImportStarted":
+                await AddLogAsync("Import", "Import byl spuštěn.", "info").ConfigureAwait(false);
+                break;
+            case "ImportTotalKnownEvent":
+            case "ImportTotalKnown":
+                var totalProperty = evt.GetType().GetProperty("Total") ?? evt.GetType().GetProperty("Count");
+                if (totalProperty?.GetValue(evt) is int totalCount)
+                {
+                    await Dispatcher.Enqueue(() =>
+                    {
+                        Total = totalCount;
+                        IsIndeterminate = false;
+                    });
+                }
+
+                break;
+            case "ImportFileSucceededEvent":
+            case "ImportFileOkEvent":
+            case "ImportFileOk":
+                await HandleFileProgressAsync(evt, status: "success").ConfigureAwait(false);
+                break;
+            case "ImportFileFailedEvent":
+            case "ImportFileFailed":
+                await HandleFileProgressAsync(evt, status: "error").ConfigureAwait(false);
+                break;
+            case "ImportFileSkippedEvent":
+            case "ImportFileSkipped":
+                await HandleFileProgressAsync(evt, status: "skip").ConfigureAwait(false);
+                break;
+            case "ImportCompletedEvent":
+            case "ImportCompleted":
+                await AddLogAsync("Import", "Import byl dokončen.", "success").ConfigureAwait(false);
+                break;
+            default:
+                await HandleUnknownEventAsync(evt).ConfigureAwait(false);
+                break;
+        }
+    }
+
+    private async Task HandleFileProgressAsync(object evt, string status)
+    {
+        var fileProperty = evt.GetType().GetProperty("FilePath") ?? evt.GetType().GetProperty("Path");
+        var messageProperty = evt.GetType().GetProperty("Message");
+        var errorProperty = evt.GetType().GetProperty("Error");
+        var fileName = fileProperty?.GetValue(evt) as string;
+        var message = messageProperty?.GetValue(evt) as string ?? errorProperty?.GetValue(evt) as string;
+
+        switch (status)
+        {
+            case "success":
+                await Dispatcher.Enqueue(() =>
+                {
+                    OkCount++;
+                    Processed++;
+                });
+                await AddLogAsync("OK", fileName ?? "Soubor", status).ConfigureAwait(false);
+                break;
+            case "error":
+                await Dispatcher.Enqueue(() =>
+                {
+                    ErrorCount++;
+                    Processed++;
+                    Errors.Add(new ImportErrorItem(fileName ?? "Soubor", message ?? "Import se nezdařil.", null));
+                });
+                await AddLogAsync("Chyba", message ?? "Import se nezdařil.", status).ConfigureAwait(false);
+                break;
+            case "skip":
+                await Dispatcher.Enqueue(() =>
+                {
+                    SkipCount++;
+                    Processed++;
+                });
+                await AddLogAsync("Přeskočeno", fileName ?? "Soubor", status).ConfigureAwait(false);
+                break;
+        }
+    }
+
+    private async Task HandleUnknownEventAsync(object evt)
+    {
+        await AddLogAsync("Událost", evt.ToString() ?? evt.GetType().Name, "info").ConfigureAwait(false);
+    }
+
+    private static object? GetTaskResult(Task task)
+    {
+        var type = task.GetType();
+        if (!type.IsGenericType)
+        {
+            return null;
+        }
+
+        return type.GetProperty("Result")?.GetValue(task);
+    }
+
+    private async Task<bool> ProcessBatchImportAsync(ImportFolderRequest request, CancellationToken cancellationToken)
+    {
+        var response = await _importService.ImportFolderAsync(request, cancellationToken).ConfigureAwait(false);
+        if (!response.IsSuccess || response.Data is null)
+        {
+            var message = ExtractErrorMessage(response);
+            await AddLogAsync("Import selhal", message, "error").ConfigureAwait(false);
+            StatusService.Error(message);
+            return true;
+        }
+
+        var result = response.Data;
+
+        await Dispatcher.Enqueue(() =>
+        {
+            Total = result.Total;
+            Processed = result.Total;
+            OkCount = result.Succeeded;
+            ErrorCount = result.Failed;
+            SkipCount = Math.Max(0, result.Total - result.Succeeded - result.Failed);
         });
+
+        if (result.Errors?.Count > 0)
+        {
+            await Dispatcher.Enqueue(() =>
+            {
+                foreach (var error in result.Errors)
+                {
+                    Errors.Add(new ImportErrorItem(
+                        Path.GetFileName(error.FilePath),
+                        error.Message,
+                        null));
+                    Log.Add(new ImportLogItem(DateTimeOffset.Now, "Chyba", error.Message, "error"));
+                    TrimLog();
+                }
+
+                _clearResultsCommand.NotifyCanExecuteChanged();
+            });
+        }
+
+        var summary = result.Status switch
+        {
+            ImportBatchStatus.Success => $"Import dokončen. Úspěšně importováno {result.Succeeded} z {result.Total} souborů.",
+            ImportBatchStatus.PartialSuccess => $"Import dokončen s částečným úspěchem ({result.Succeeded}/{result.Total}).",
+            ImportBatchStatus.Failure => "Import se nezdařil. Zkontrolujte chyby.",
+            ImportBatchStatus.FatalError => "Import skončil fatální chybou.",
+            _ => "Import dokončen.",
+        };
+
+        await AddLogAsync("Výsledek", summary, result.Status == ImportBatchStatus.Success ? "success" : "warning").ConfigureAwait(false);
+
+        if (result.Status == ImportBatchStatus.Success)
+        {
+            StatusService.Info("Import dokončen.");
+        }
+        else
+        {
+            StatusService.Info(summary);
+        }
+
+        return true;
+    }
+
+    private static string ExtractErrorMessage(ApiResponse<ImportBatchResult> response)
+    {
+        var error = response.Errors.FirstOrDefault();
+        if (error is null)
+        {
+            return "Import se nezdařil.";
+        }
+
+        return string.IsNullOrWhiteSpace(error.Message)
+            ? "Import se nezdařil."
+            : error.Message;
+    }
+
+    private async Task ResetProgressAsync()
+    {
+        await Dispatcher.Enqueue(() =>
+        {
+            Processed = 0;
+            Total = 0;
+            OkCount = 0;
+            ErrorCount = 0;
+            SkipCount = 0;
+            Log.Clear();
+            Errors.Clear();
+            _clearResultsCommand.NotifyCanExecuteChanged();
+        });
+    }
+
+    private async Task AddLogAsync(string title, string message, string status)
+    {
+        await Dispatcher.Enqueue(() =>
+        {
+            Log.Add(new ImportLogItem(DateTimeOffset.Now, title, message, status));
+            TrimLog();
+            _clearResultsCommand.NotifyCanExecuteChanged();
+        });
+    }
+
+    private void TrimLog()
+    {
+        while (Log.Count > MaxLogEntries)
+        {
+            Log.RemoveAt(0);
+        }
+    }
+
+    private void RestoreStateFromHotStorage()
+    {
+        if (_hotStateService is null)
+        {
+            return;
+        }
+
+        SelectedFolder = _hotStateService.LastFolder;
+        Recursive = _hotStateService.ImportRecursive;
+        ExtractContent = _hotStateService.ImportExtractContent;
+        KeepFsMetadata = _hotStateService.ImportKeepFsMetadata;
+        SetReadOnly = _hotStateService.ImportSetReadOnly;
+        UseParallel = _hotStateService.ImportUseParallel;
+        MaxDegreeOfParallelism = _hotStateService.ImportMaxDegreeOfParallelism > 0
+            ? _hotStateService.ImportMaxDegreeOfParallelism
+            : Environment.ProcessorCount;
+        DefaultAuthor = _hotStateService.ImportDefaultAuthor;
+    }
+
+    private void OnErrorsCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    {
+        OnPropertyChanged(nameof(HasErrors));
+        _clearResultsCommand.NotifyCanExecuteChanged();
+    }
+
+    private void OnLogCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    {
+        _clearResultsCommand.NotifyCanExecuteChanged();
     }
 
     partial void OnSelectedFolderChanged(string? value)
     {
-        _hotStateService.LastFolder = value;
+        _hotStateService?.LastFolder = value;
         _runImportCommand.NotifyCanExecuteChanged();
+    }
+
+    partial void OnRecursiveChanged(bool value)
+    {
+        _hotStateService?.ImportRecursive = value;
+    }
+
+    partial void OnExtractContentChanged(bool value)
+    {
+        _hotStateService?.ImportExtractContent = value;
+    }
+
+    partial void OnKeepFsMetadataChanged(bool value)
+    {
+        _hotStateService?.ImportKeepFsMetadata = value;
+    }
+
+    partial void OnSetReadOnlyChanged(bool value)
+    {
+        _hotStateService?.ImportSetReadOnly = value;
+    }
+
+    partial void OnUseParallelChanged(bool value)
+    {
+        _hotStateService?.ImportUseParallel = value;
+    }
+
+    partial void OnMaxDegreeOfParallelismChanged(int value)
+    {
+        var normalized = value <= 0 ? Environment.ProcessorCount : value;
+        if (value != normalized)
+        {
+            maxDegreeOfParallelism = normalized;
+            OnPropertyChanged(nameof(MaxDegreeOfParallelism));
+        }
+
+        _hotStateService?.ImportMaxDegreeOfParallelism = normalized;
+    }
+
+    partial void OnDefaultAuthorChanged(string? value)
+    {
+        _hotStateService?.ImportDefaultAuthor = value;
     }
 
     partial void OnIsImportingChanged(bool value)
     {
         _runImportCommand.NotifyCanExecuteChanged();
+        _stopImportCommand.NotifyCanExecuteChanged();
+        _pickFolderCommand.NotifyCanExecuteChanged();
+        _clearResultsCommand.NotifyCanExecuteChanged();
+    }
+
+    partial void OnProcessedChanged(int value)
+    {
+        OnPropertyChanged(nameof(ProgressText));
+        _clearResultsCommand.NotifyCanExecuteChanged();
+    }
+
+    partial void OnTotalChanged(int value)
+    {
+        OnPropertyChanged(nameof(ProgressText));
+        _clearResultsCommand.NotifyCanExecuteChanged();
     }
 }

--- a/Veriado.WinUI/Views/Import/ImportPage.xaml
+++ b/Veriado.WinUI/Views/Import/ImportPage.xaml
@@ -4,22 +4,155 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:models="using:Veriado.WinUI.Models.Import"
+    AllowDrop="True"
+    DragOver="OnPageDragOver"
+    Drop="OnPageDrop"
     mc:Ignorable="d">
-    <StackPanel Padding="24" Spacing="12">
-        <TextBlock Text="Import souborů" FontSize="20" FontWeight="SemiBold" />
+    <Page.KeyboardAccelerators>
+        <KeyboardAccelerator Key="Enter" Invoked="OnEnterAcceleratorInvoked" />
+        <KeyboardAccelerator Key="Escape" Invoked="OnEscapeAcceleratorInvoked" />
+        <KeyboardAccelerator Key="O" Modifiers="Control" Invoked="OnOpenAcceleratorInvoked" />
+    </Page.KeyboardAccelerators>
 
-        <TextBox
-            IsReadOnly="True"
-            PlaceholderText="Vybraná složka"
-            Text="{Binding SelectedFolder, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+    <Grid Padding="24" RowSpacing="16">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
 
-        <StackPanel Orientation="Horizontal" Spacing="8">
-            <Button Content="Vybrat složku" Command="{Binding PickFolderCommand}" />
-            <Button Content="Spustit import" Command="{Binding RunImportCommand}" />
+        <!-- Zdroj -->
+        <Grid ColumnSpacing="12">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+            <Button
+                Grid.Column="0"
+                Content="Vybrat složku"
+                Command="{Binding PickFolderCommand}" />
+            <TextBox
+                Grid.Column="1"
+                MinWidth="320"
+                IsReadOnly="True"
+                Text="{Binding SelectedFolder, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+        </Grid>
+
+        <!-- Volby -->
+        <StackPanel Grid.Row="1" Orientation="Horizontal" Spacing="16">
+            <StackPanel Orientation="Vertical" Spacing="8">
+                <CheckBox Content="Rekurzivně" IsChecked="{Binding Recursive, Mode=TwoWay}" />
+                <CheckBox Content="Extrahovat obsah" IsChecked="{Binding ExtractContent, Mode=TwoWay}" />
+                <CheckBox Content="Zachovat FS metadata" IsChecked="{Binding KeepFsMetadata, Mode=TwoWay}" />
+            </StackPanel>
+            <StackPanel Orientation="Vertical" Spacing="8">
+                <CheckBox Content="Nastavit jen pro čtení" IsChecked="{Binding SetReadOnly, Mode=TwoWay}" />
+                <CheckBox Content="Paralelně" IsChecked="{Binding UseParallel, Mode=TwoWay}" />
+                <NumberBox
+                    Header="Max. paralelních vláken"
+                    Minimum="1"
+                    SpinButtonPlacementMode="Compact"
+                    IsEnabled="{Binding UseParallel}"
+                    Value="{Binding MaxDegreeOfParallelism, Mode=TwoWay}" />
+            </StackPanel>
+            <StackPanel Orientation="Vertical" Spacing="8" Width="200">
+                <TextBox
+                    Header="Výchozí autor"
+                    PlaceholderText="(nevyplněno)"
+                    Text="{Binding DefaultAuthor, Mode=TwoWay}" />
+            </StackPanel>
         </StackPanel>
 
-        <ProgressBar
-            IsIndeterminate="{Binding IsImporting}"
-            Visibility="{Binding IsImporting, Converter={StaticResource BooleanToVisibilityConverter}}" />
-    </StackPanel>
+        <!-- Akce a průběh -->
+        <Grid Grid.Row="2" ColumnSpacing="16">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+
+            <StackPanel Orientation="Horizontal" Spacing="12">
+                <Button
+                    Content="Spustit import"
+                    Command="{Binding RunImportCommand}" />
+                <Button
+                    Content="Zastavit"
+                    Command="{Binding StopImportCommand}"
+                    IsEnabled="{Binding IsImporting}" />
+                <Button
+                    Content="Vymazat výsledky"
+                    Command="{Binding ClearResultsCommand}" />
+            </StackPanel>
+
+            <StackPanel Grid.Column="1" Orientation="Vertical" Spacing="4">
+                <ProgressBar
+                    Minimum="0"
+                    Maximum="{Binding Total, Mode=OneWay}"
+                    Value="{Binding Processed, Mode=OneWay}"
+                    IsIndeterminate="{Binding IsIndeterminate}" />
+                <TextBlock
+                    Margin="0,4,0,0"
+                    Text="{Binding ProgressText}" />
+            </StackPanel>
+        </Grid>
+
+        <!-- Log a chyby -->
+        <Grid Grid.Row="3" RowSpacing="12">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="*" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+
+            <ScrollViewer Grid.Row="0" VerticalScrollBarVisibility="Auto">
+                <ItemsRepeater ItemsSource="{Binding Log}">
+                    <ItemsRepeater.Layout>
+                        <ItemsStackLayout Orientation="Vertical" />
+                    </ItemsRepeater.Layout>
+                    <ItemsRepeater.ItemTemplate>
+                        <DataTemplate x:DataType="models:ImportLogItem">
+                            <Border BorderThickness="0,0,0,1" BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}" Padding="8">
+                                <StackPanel Spacing="2">
+                                    <TextBlock
+                                        FontSize="12"
+                                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                        Text="{Binding Timestamp, StringFormat='{}{0:HH:mm:ss}'}" />
+                                    <TextBlock FontWeight="SemiBold" Text="{Binding Title}" />
+                                    <TextBlock TextWrapping="Wrap" Text="{Binding Message}" />
+                                </StackPanel>
+                            </Border>
+                        </DataTemplate>
+                    </ItemsRepeater.ItemTemplate>
+                </ItemsRepeater>
+            </ScrollViewer>
+
+            <Expander
+                Grid.Row="1"
+                Header="Chyby"
+                IsExpanded="{Binding HasErrors}"
+                HorizontalAlignment="Stretch">
+                <ItemsControl ItemsSource="{Binding Errors}">
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate x:DataType="models:ImportErrorItem">
+                            <Grid Padding="8" ColumnSpacing="12">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*" />
+                                    <ColumnDefinition Width="Auto" />
+                                </Grid.ColumnDefinitions>
+                                <StackPanel Orientation="Vertical" Spacing="4">
+                                    <TextBlock FontWeight="SemiBold" Text="{Binding FileName}" />
+                                    <TextBlock TextWrapping="Wrap" Text="{Binding ErrorMessage}" />
+                                </StackPanel>
+                                <Button
+                                    Grid.Column="1"
+                                    Content="Detail"
+                                    Command="{Binding DataContext.OpenErrorDetailCommand, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
+                                    CommandParameter="{Binding}" />
+                            </Grid>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+            </Expander>
+        </Grid>
+    </Grid>
 </Page>

--- a/Veriado.WinUI/Views/Import/ImportPage.xaml.cs
+++ b/Veriado.WinUI/Views/Import/ImportPage.xaml.cs
@@ -1,4 +1,12 @@
+using System;
+using System.IO;
+using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Input;
+using Windows.ApplicationModel.DataTransfer;
+using Windows.Storage;
+using Veriado.WinUI.ViewModels.Import;
 
 namespace Veriado.WinUI.Views.Import;
 
@@ -7,5 +15,104 @@ public sealed partial class ImportPage : Page
     public ImportPage()
     {
         InitializeComponent();
+        DataContext = App.Services.GetRequiredService<ImportPageViewModel>();
+    }
+
+    private ImportPageViewModel? ViewModel => DataContext as ImportPageViewModel;
+
+    private void OnPageDragOver(object sender, DragEventArgs e)
+    {
+        e.AcceptedOperation = DataPackageOperation.Copy;
+        if (e.DragUIOverride is not null)
+        {
+            e.DragUIOverride.IsCaptionVisible = true;
+            e.DragUIOverride.Caption = "Pustit pro výběr složky";
+        }
+
+        e.Handled = true;
+    }
+
+    private async void OnPageDrop(object sender, DragEventArgs e)
+    {
+        if (ViewModel is null)
+        {
+            return;
+        }
+
+        string? path = null;
+
+        if (e.DataView.Contains(StandardDataFormats.StorageItems))
+        {
+            var items = await e.DataView.GetStorageItemsAsync();
+            path = ResolvePathFromStorageItems(items);
+        }
+        else if (e.DataView.Contains(StandardDataFormats.Text))
+        {
+            var text = await e.DataView.GetTextAsync();
+            path = text;
+        }
+
+        if (!string.IsNullOrWhiteSpace(path))
+        {
+            path = path.Trim();
+            if (Directory.Exists(path))
+            {
+                ViewModel.SelectedFolder = path;
+            }
+            else if (File.Exists(path))
+            {
+                var directory = Path.GetDirectoryName(path);
+                if (!string.IsNullOrWhiteSpace(directory))
+                {
+                    ViewModel.SelectedFolder = directory;
+                }
+            }
+        }
+
+        e.Handled = true;
+    }
+
+    private static string? ResolvePathFromStorageItems(System.Collections.Generic.IReadOnlyList<IStorageItem> items)
+    {
+        if (items.Count == 0)
+        {
+            return null;
+        }
+
+        var folder = items.OfType<StorageFolder>().FirstOrDefault();
+        if (folder is not null)
+        {
+            return folder.Path;
+        }
+
+        var file = items.OfType<StorageFile>().FirstOrDefault();
+        return file?.Path;
+    }
+
+    private async void OnEnterAcceleratorInvoked(KeyboardAccelerator sender, KeyboardAcceleratorInvokedEventArgs args)
+    {
+        if (ViewModel?.RunImportCommand.CanExecute(null) == true)
+        {
+            await ViewModel.RunImportCommand.ExecuteAsync(null);
+            args.Handled = true;
+        }
+    }
+
+    private void OnEscapeAcceleratorInvoked(KeyboardAccelerator sender, KeyboardAcceleratorInvokedEventArgs args)
+    {
+        if (ViewModel?.StopImportCommand.CanExecute(null) == true)
+        {
+            ViewModel.StopImportCommand.Execute(null);
+            args.Handled = true;
+        }
+    }
+
+    private async void OnOpenAcceleratorInvoked(KeyboardAccelerator sender, KeyboardAcceleratorInvokedEventArgs args)
+    {
+        if (ViewModel?.PickFolderCommand.CanExecute(null) == true)
+        {
+            await ViewModel.PickFolderCommand.ExecuteAsync(null);
+            args.Handled = true;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- create a WinUI 3 import page with folder selection, configurable options, drag & drop, and progress logging
- add view models and models for logging and error reporting while persisting import preferences via the hot state service
- update navigation service to respect view-managed data contexts when navigating to pages

## Testing
- dotnet build Veriado.sln *(fails: `dotnet` not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d64119c5dc83269c1a96b485f60abc