### PR TITLE
Fix timestamp binding on import log entries

### DIFF
--- a/Veriado.WinUI/Views/Import/ImportPage.xaml
+++ b/Veriado.WinUI/Views/Import/ImportPage.xaml
@@ -117,7 +117,7 @@
                                     <TextBlock
                                         FontSize="12"
                                         Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                        Text="{x:Bind Timestamp.ToString(&quot;HH:mm:ss&quot;), Mode=OneWay}" />
+                                        Text="{x:Bind Timestamp, Mode=OneWay, StringFormat='{}{0:HH:mm:ss}'}" />
                                     <TextBlock FontWeight="SemiBold" Text="{Binding Title}" />
                                     <TextBlock TextWrapping="Wrap" Text="{Binding Message}" />
                                 </StackPanel>


### PR DESCRIPTION
## Summary
- replace the invalid x:Bind expression for the import log timestamp with a StringFormat binding
- ensure log timestamps render without binding parser errors

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6495157608326886789180a36fada