### PR TITLE
Fix import log timestamp binding

### DIFF
--- a/Veriado.WinUI/Models/Import/ImportLogItem.cs
+++ b/Veriado.WinUI/Models/Import/ImportLogItem.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 
 namespace Veriado.WinUI.Models.Import;
 
@@ -19,4 +20,6 @@ public sealed class ImportLogItem
     public string Message { get; }
 
     public string Status { get; }
+
+    public string FormattedTimestamp => Timestamp.ToString("HH:mm:ss", CultureInfo.CurrentCulture);
 }

--- a/Veriado.WinUI/Views/Import/ImportPage.xaml
+++ b/Veriado.WinUI/Views/Import/ImportPage.xaml
@@ -117,7 +117,7 @@
                                     <TextBlock
                                         FontSize="12"
                                         Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                        Text="{x:Bind Timestamp, Mode=OneWay, StringFormat='{}{0:HH:mm:ss}'}" />
+                                        Text="{x:Bind FormattedTimestamp, Mode=OneWay}" />
                                     <TextBlock FontWeight="SemiBold" Text="{Binding Title}" />
                                     <TextBlock TextWrapping="Wrap" Text="{Binding Message}" />
                                 </StackPanel>


### PR DESCRIPTION
## Summary
- add a formatted timestamp property to import log entries
- bind the import log timestamp TextBlock to the formatted value instead of relying on StringFormat

## Testing
- dotnet build Veriado.sln *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68d64a3927b8832689d6bfd6fbe77acd