### PR TITLE
Align import options with backend and reorganize UI

### DIFF
--- a/Veriado.Contracts/Import/ImportFolderRequest.cs
+++ b/Veriado.Contracts/Import/ImportFolderRequest.cs
@@ -23,6 +23,18 @@ public sealed record class ImportFolderRequest
         = true;
 
     /// <summary>
+    /// Gets or sets a value indicating whether captured file system metadata should be preserved.
+    /// </summary>
+    public bool KeepFsMetadata { get; init; }
+        = true;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether imported files should be marked as read only.
+    /// </summary>
+    public bool SetReadOnly { get; init; }
+        = false;
+
+    /// <summary>
     /// Gets or sets the maximum number of concurrent file imports.
     /// </summary>
     public int MaxDegreeOfParallelism { get; init; }

--- a/Veriado.Services/Import/ImportService.cs
+++ b/Veriado.Services/Import/ImportService.cs
@@ -235,21 +235,28 @@ public sealed class ImportService : IImportService
 
         var author = string.IsNullOrWhiteSpace(options.DefaultAuthor) ? string.Empty : options.DefaultAuthor;
         FileSystemMetadataDto? systemMetadata = null;
-        var isReadOnly = false;
+        var isReadOnly = options.SetReadOnly;
 
         try
         {
             var info = new FileInfo(filePath);
             info.Refresh();
-            systemMetadata = new FileSystemMetadataDto(
-                (int)info.Attributes,
-                CoerceToUtc(info.CreationTimeUtc),
-                CoerceToUtc(info.LastWriteTimeUtc),
-                CoerceToUtc(info.LastAccessTimeUtc),
-                OwnerSid: null,
-                HardLinkCount: null,
-                AlternateDataStreamCount: null);
-            isReadOnly = info.IsReadOnly;
+            if (options.KeepFsMetadata)
+            {
+                systemMetadata = new FileSystemMetadataDto(
+                    (int)info.Attributes,
+                    CoerceToUtc(info.CreationTimeUtc),
+                    CoerceToUtc(info.LastWriteTimeUtc),
+                    CoerceToUtc(info.LastAccessTimeUtc),
+                    OwnerSid: null,
+                    HardLinkCount: null,
+                    AlternateDataStreamCount: null);
+            }
+
+            if (!options.SetReadOnly)
+            {
+                isReadOnly = info.IsReadOnly;
+            }
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or NotSupportedException)
         {

--- a/Veriado.WinUI/ViewModels/Import/ImportPageViewModel.cs
+++ b/Veriado.WinUI/ViewModels/Import/ImportPageViewModel.cs
@@ -288,6 +288,8 @@ public partial class ImportPageViewModel : ViewModelBase
             FolderPath = SelectedFolder!.Trim(),
             Recursive = Recursive,
             ExtractContent = ExtractContent,
+            KeepFsMetadata = KeepFsMetadata,
+            SetReadOnly = SetReadOnly,
             MaxDegreeOfParallelism = maxParallel,
             DefaultAuthor = string.IsNullOrWhiteSpace(DefaultAuthor) ? null : DefaultAuthor,
         };

--- a/Veriado.WinUI/Views/Import/ImportPage.xaml
+++ b/Veriado.WinUI/Views/Import/ImportPage.xaml
@@ -5,7 +5,9 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:models="using:Veriado.WinUI.Models.Import"
-    xmlns:muxc="using:Microsoft.UI.Xaml.Controls" xmlns:import="using:Veriado.WinUI.ViewModels.Import" d:DataContext="{d:DesignInstance Type=import:ImportPageViewModel}"
+    xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+    xmlns:import="using:Veriado.WinUI.ViewModels.Import"
+    d:DataContext="{d:DesignInstance Type=import:ImportPageViewModel}"
     AllowDrop="True"
     DragOver="OnPageDragOver"
     Drop="OnPageDrop"
@@ -16,7 +18,7 @@
         <KeyboardAccelerator Key="O" Modifiers="Control" Invoked="OnOpenAcceleratorInvoked" />
     </Page.KeyboardAccelerators>
 
-    <Grid Padding="24" RowSpacing="16">
+    <Grid Padding="24" RowSpacing="24">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
@@ -24,136 +26,148 @@
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
 
+        <!-- Nadpis a akce -->
+        <StackPanel Grid.Row="0" Spacing="12">
+            <TextBlock Text="Import souborů" FontSize="28" FontWeight="SemiBold" />
+            <Grid ColumnSpacing="16">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+
+                <StackPanel Orientation="Horizontal" Spacing="12">
+                    <Button
+                        Content="Spustit import"
+                        Command="{Binding RunImportCommand}" />
+                    <Button
+                        Content="Zastavit"
+                        Command="{Binding StopImportCommand}"
+                        IsEnabled="{Binding IsImporting}" />
+                    <Button
+                        Content="Vymazat výsledky"
+                        Command="{Binding ClearResultsCommand}" />
+                </StackPanel>
+
+                <StackPanel Grid.Column="1" Orientation="Vertical" Spacing="4">
+                    <ProgressBar
+                        Minimum="0"
+                        Maximum="{Binding Total, Mode=OneWay}"
+                        Value="{Binding Processed, Mode=OneWay}"
+                        IsIndeterminate="{Binding IsIndeterminate}" />
+                    <TextBlock
+                        Margin="0,4,0,0"
+                        Text="{Binding ProgressText}" />
+                </StackPanel>
+            </Grid>
+        </StackPanel>
+
         <!-- Zdroj -->
-        <Grid ColumnSpacing="12">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="Auto" />
-                <ColumnDefinition Width="*" />
-            </Grid.ColumnDefinitions>
-            <Button
-                Grid.Column="0"
-                Content="Vybrat složku"
-                Command="{Binding PickFolderCommand}" />
-            <TextBox
-                Grid.Column="1"
-                MinWidth="320"
-                IsReadOnly="True"
-                Text="{Binding SelectedFolder, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-        </Grid>
+        <StackPanel Grid.Row="1" Spacing="12">
+            <TextBlock Text="Zdroj importu" FontSize="20" FontWeight="SemiBold" />
+            <Grid ColumnSpacing="12">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+                <Button
+                    Grid.Column="0"
+                    Content="Vybrat složku"
+                    Command="{Binding PickFolderCommand}" />
+                <TextBox
+                    Grid.Column="1"
+                    MinWidth="320"
+                    IsReadOnly="True"
+                    Text="{Binding SelectedFolder, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+            </Grid>
+        </StackPanel>
 
         <!-- Volby -->
-        <StackPanel Grid.Row="1" Orientation="Horizontal" Spacing="16">
-            <StackPanel Orientation="Vertical" Spacing="8">
-                <CheckBox Content="Rekurzivně" IsChecked="{Binding Recursive, Mode=TwoWay}" />
-                <CheckBox Content="Extrahovat obsah" IsChecked="{Binding ExtractContent, Mode=TwoWay}" />
-                <CheckBox Content="Zachovat FS metadata" IsChecked="{Binding KeepFsMetadata, Mode=TwoWay}" />
-            </StackPanel>
-            <StackPanel Orientation="Vertical" Spacing="8">
-                <CheckBox Content="Nastavit jen pro čtení" IsChecked="{Binding SetReadOnly, Mode=TwoWay}" />
-                <CheckBox Content="Paralelně" IsChecked="{Binding UseParallel, Mode=TwoWay}" />
-                <NumberBox
-                    Header="Max. paralelních vláken"
-                    Minimum="1"
-                    SpinButtonPlacementMode="Compact"
-                    IsEnabled="{Binding UseParallel}"
-                    Value="{Binding MaxDegreeOfParallelism, Mode=TwoWay}" />
-            </StackPanel>
-            <StackPanel Orientation="Vertical" Spacing="8" Width="200">
-                <TextBox
-                    Header="Výchozí autor"
-                    PlaceholderText="(nevyplněno)"
-                    Text="{Binding DefaultAuthor, Mode=TwoWay}" />
+        <StackPanel Grid.Row="2" Spacing="12">
+            <TextBlock Text="Volby importu" FontSize="20" FontWeight="SemiBold" />
+            <StackPanel Orientation="Horizontal" Spacing="16">
+                <StackPanel Orientation="Vertical" Spacing="8">
+                    <CheckBox Content="Rekurzivně" IsChecked="{Binding Recursive, Mode=TwoWay}" />
+                    <CheckBox Content="Extrahovat obsah" IsChecked="{Binding ExtractContent, Mode=TwoWay}" />
+                    <CheckBox Content="Zachovat FS metadata" IsChecked="{Binding KeepFsMetadata, Mode=TwoWay}" />
+                </StackPanel>
+                <StackPanel Orientation="Vertical" Spacing="8">
+                    <CheckBox Content="Nastavit jen pro čtení" IsChecked="{Binding SetReadOnly, Mode=TwoWay}" />
+                    <CheckBox Content="Paralelně" IsChecked="{Binding UseParallel, Mode=TwoWay}" />
+                    <NumberBox
+                        Header="Max. paralelních vláken"
+                        Minimum="1"
+                        SpinButtonPlacementMode="Compact"
+                        IsEnabled="{Binding UseParallel}"
+                        Value="{Binding MaxDegreeOfParallelism, Mode=TwoWay}" />
+                </StackPanel>
+                <StackPanel Orientation="Vertical" Spacing="8" Width="200">
+                    <TextBox
+                        Header="Výchozí autor"
+                        PlaceholderText="(nevyplněno)"
+                        Text="{Binding DefaultAuthor, Mode=TwoWay}" />
+                </StackPanel>
             </StackPanel>
         </StackPanel>
 
-        <!-- Akce a průběh -->
-        <Grid Grid.Row="2" ColumnSpacing="16">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="Auto" />
-                <ColumnDefinition Width="*" />
-            </Grid.ColumnDefinitions>
+        <!-- Protokol -->
+        <StackPanel Grid.Row="3" Spacing="12">
+            <TextBlock Text="Protokol importu" FontSize="20" FontWeight="SemiBold" />
+            <Grid RowSpacing="12">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="*" />
+                    <RowDefinition Height="Auto" />
+                </Grid.RowDefinitions>
 
-            <StackPanel Orientation="Horizontal" Spacing="12">
-                <Button
-                    Content="Spustit import"
-                    Command="{Binding RunImportCommand}" />
-                <Button
-                    Content="Zastavit"
-                    Command="{Binding StopImportCommand}"
-                    IsEnabled="{Binding IsImporting}" />
-                <Button
-                    Content="Vymazat výsledky"
-                    Command="{Binding ClearResultsCommand}" />
-            </StackPanel>
+                <ScrollViewer Grid.Row="0" VerticalScrollBarVisibility="Auto">
+                    <ItemsRepeater ItemsSource="{Binding Log}">
+                        <ItemsRepeater.Layout>
+                            <muxc:StackLayout Orientation="Vertical" />
+                        </ItemsRepeater.Layout>
+                        <ItemsRepeater.ItemTemplate>
+                            <DataTemplate x:DataType="models:ImportLogItem">
+                                <Border BorderThickness="0,0,0,1" BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}" Padding="8">
+                                    <StackPanel Spacing="2">
+                                        <TextBlock
+                                            FontSize="12"
+                                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                            Text="{x:Bind FormattedTimestamp, Mode=OneWay}" />
+                                        <TextBlock FontWeight="SemiBold" Text="{Binding Title}" />
+                                        <TextBlock TextWrapping="Wrap" Text="{Binding Message}" />
+                                    </StackPanel>
+                                </Border>
+                            </DataTemplate>
+                        </ItemsRepeater.ItemTemplate>
+                    </ItemsRepeater>
+                </ScrollViewer>
 
-            <StackPanel Grid.Column="1" Orientation="Vertical" Spacing="4">
-                <ProgressBar
-                    Minimum="0"
-                    Maximum="{Binding Total, Mode=OneWay}"
-                    Value="{Binding Processed, Mode=OneWay}"
-                    IsIndeterminate="{Binding IsIndeterminate}" />
-                <TextBlock
-                    Margin="0,4,0,0"
-                    Text="{Binding ProgressText}" />
-            </StackPanel>
-        </Grid>
-
-        <!-- Log a chyby -->
-        <Grid Grid.Row="3" RowSpacing="12">
-            <Grid.RowDefinitions>
-                <RowDefinition Height="*" />
-                <RowDefinition Height="Auto" />
-            </Grid.RowDefinitions>
-
-            <ScrollViewer Grid.Row="0" VerticalScrollBarVisibility="Auto">
-                <ItemsRepeater ItemsSource="{Binding Log}">
-                    <ItemsRepeater.Layout>
-                        <muxc:StackLayout Orientation="Vertical" />
-                    </ItemsRepeater.Layout>
-                    <ItemsRepeater.ItemTemplate>
-                        <DataTemplate x:DataType="models:ImportLogItem">
-                            <Border BorderThickness="0,0,0,1" BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}" Padding="8">
-                                <StackPanel Spacing="2">
-                                    <TextBlock
-                                        FontSize="12"
-                                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                        Text="{x:Bind FormattedTimestamp, Mode=OneWay}" />
-                                    <TextBlock FontWeight="SemiBold" Text="{Binding Title}" />
-                                    <TextBlock TextWrapping="Wrap" Text="{Binding Message}" />
-                                </StackPanel>
-                            </Border>
-                        </DataTemplate>
-                    </ItemsRepeater.ItemTemplate>
-                </ItemsRepeater>
-            </ScrollViewer>
-
-            <Expander
-                Grid.Row="1"
-                Header="Chyby"
-                IsExpanded="{Binding HasErrors}"
-                HorizontalAlignment="Stretch">
-                <ItemsControl x:Name="ErrorsItemsControl" ItemsSource="{Binding Errors}">
-                    <ItemsControl.ItemTemplate>
-                        <DataTemplate x:DataType="models:ImportErrorItem">
-                            <Grid Padding="8" ColumnSpacing="12">
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="*" />
-                                    <ColumnDefinition Width="Auto" />
-                                </Grid.ColumnDefinitions>
-                                <StackPanel Orientation="Vertical" Spacing="4">
-                                    <TextBlock FontWeight="SemiBold" Text="{Binding FileName}" />
-                                    <TextBlock TextWrapping="Wrap" Text="{Binding ErrorMessage}" />
-                                </StackPanel>
-                                <Button
-                                    Grid.Column="1"
-                                    Content="Detail"
-                                    Command="{Binding ElementName=ErrorsItemsControl, Path=DataContext.OpenErrorDetailCommand}"
-                                    CommandParameter="{Binding}" />
-                            </Grid>
-                        </DataTemplate>
-                    </ItemsControl.ItemTemplate>
-                </ItemsControl>
-            </Expander>
-        </Grid>
+                <Expander
+                    Grid.Row="1"
+                    Header="Chyby"
+                    IsExpanded="{Binding HasErrors}"
+                    HorizontalAlignment="Stretch">
+                    <ItemsControl x:Name="ErrorsItemsControl" ItemsSource="{Binding Errors}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate x:DataType="models:ImportErrorItem">
+                                <Grid Padding="8" ColumnSpacing="12">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="*" />
+                                        <ColumnDefinition Width="Auto" />
+                                    </Grid.ColumnDefinitions>
+                                    <StackPanel Orientation="Vertical" Spacing="4">
+                                        <TextBlock FontWeight="SemiBold" Text="{Binding FileName}" />
+                                        <TextBlock TextWrapping="Wrap" Text="{Binding ErrorMessage}" />
+                                    </StackPanel>
+                                    <Button
+                                        Grid.Column="1"
+                                        Content="Detail"
+                                        Command="{Binding ElementName=ErrorsItemsControl, Path=DataContext.OpenErrorDetailCommand}"
+                                        CommandParameter="{Binding}" />
+                                </Grid>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </Expander>
+            </Grid>
+        </StackPanel>
     </Grid>
 </Page>


### PR DESCRIPTION
## Summary
- expose KeepFsMetadata and SetReadOnly options on ImportFolderRequest and wire them through the view model
- honor the new options inside ImportService while keeping default behaviors intact
- restructure the import page into clearly labeled sections for source, options, and protocol

## Testing
- dotnet build Veriado.sln *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d64c21228483268ed92984cc0f7028