### PR TITLE
Prevent duplicate file content inserts

### DIFF
--- a/Veriado.Application/Abstractions/IFileRepository.cs
+++ b/Veriado.Application/Abstractions/IFileRepository.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Veriado.Domain.Files;
+using Veriado.Domain.ValueObjects;
 
 namespace Veriado.Appl.Abstractions;
 
@@ -33,6 +34,14 @@ public interface IFileRepository
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>An asynchronous sequence of file aggregates.</returns>
     IAsyncEnumerable<FileEntity> StreamAllAsync(CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Checks whether a file with the specified content hash already exists.
+    /// </summary>
+    /// <param name="hash">The content hash to look up.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns><see langword="true"/> when a file with the given hash exists; otherwise <see langword="false"/>.</returns>
+    Task<bool> ExistsByHashAsync(FileHash hash, CancellationToken cancellationToken);
 
     /// <summary>
     /// Adds a newly created file aggregate to the persistence store.

--- a/Veriado.Application/UseCases/Files/CreateFile/CreateFileHandler.cs
+++ b/Veriado.Application/UseCases/Files/CreateFile/CreateFileHandler.cs
@@ -46,6 +46,11 @@ public sealed class CreateFileHandler : FileWriteHandlerBase, IRequestHandler<Cr
             var createdAt = CurrentTimestamp();
             var file = FileEntity.CreateNew(name, extension, mime, request.Author, request.Content, createdAt, _importPolicy.MaxContentLengthBytes);
 
+            if (await Repository.ExistsByHashAsync(file.Content.Hash, cancellationToken).ConfigureAwait(false))
+            {
+                return AppResult<Guid>.Conflict("A file with identical content already exists.");
+            }
+
             var options = new FilePersistenceOptions { ExtractContent = true };
             await PersistNewAsync(file, options, cancellationToken);
             return AppResult<Guid>.Success(file.Id);

--- a/Veriado.Infrastructure/Repositories/FileRepository.cs
+++ b/Veriado.Infrastructure/Repositories/FileRepository.cs
@@ -95,7 +95,7 @@ internal sealed class FileRepository : IFileRepository
         }
     }
 
-    public async Task<bool> ExistsByHashAsync(FileHash hash, CancellationToken cancellationToken = default)
+    public async Task<bool> ExistsByHashAsync(FileHash hash, CancellationToken cancellationToken)
     {
         await using var context = await _readFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
         return await context.Files.AnyAsync(f => f.Content.Hash == hash, cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
## Summary
- expose a repository method for checking whether a content hash already exists
- short-circuit CreateFileCommand handling when an identical file hash is detected to avoid persistence failures

## Testing
- not run (dotnet CLI not available in environment)


------
https://chatgpt.com/codex/tasks/task_e_68d64fa2276c83269a30aa25d47869cb