### PR TITLE
Handle SQLite failures in application layer

### DIFF
--- a/Veriado.Application/Veriado.Appl.csproj
+++ b/Veriado.Application/Veriado.Appl.csproj
@@ -9,6 +9,7 @@
     <PackageReference Include="AutoMapper" Version="12.0.1" />
     <PackageReference Include="FluentValidation" Version="11.7.1" />
     <PackageReference Include="MediatR" Version="13.0.0" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.9" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.9" />
   </ItemGroup>
   <ItemGroup>

--- a/Veriado.Services/Files/FileOperationsService.cs
+++ b/Veriado.Services/Files/FileOperationsService.cs
@@ -197,6 +197,7 @@ public sealed class FileOperationsService : IFileOperationsService
             ErrorCode.Validation => "validation_error",
             ErrorCode.Forbidden => "forbidden",
             ErrorCode.TooLarge => "payload_too_large",
+            ErrorCode.Database => "database_error",
             _ => "unexpected_error",
         };
 

--- a/Veriado.Services/Import/ImportService.cs
+++ b/Veriado.Services/Import/ImportService.cs
@@ -318,6 +318,7 @@ public sealed class ImportService : IImportService
             ErrorCode.Validation => "validation_error",
             ErrorCode.Forbidden => "forbidden",
             ErrorCode.TooLarge => "payload_too_large",
+            ErrorCode.Database => "database_error",
             _ => "unexpected_error",
         };
 


### PR DESCRIPTION
## Summary
- add dedicated handling for SqliteException within AppResult to surface database errors consistently
- introduce a database error code and API mapping so services can return explicit database_error responses
- reference Microsoft.Data.Sqlite from the application layer to enable exception detection

## Testing
- dotnet build *(fails: dotnet is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6820edac48326bd6db2cf95d23f01