### PR TITLE
Add hybrid Lucene.NET search integration

### DIFF
--- a/Veriado.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/Veriado.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
@@ -50,6 +50,21 @@ public static class ServiceCollectionExtensions
             Directory.CreateDirectory(directory);
         }
 
+        if (options.EnableLuceneIntegration)
+        {
+            if (string.IsNullOrWhiteSpace(options.LuceneIndexPath))
+            {
+                options.LuceneIndexPath = string.IsNullOrWhiteSpace(directory)
+                    ? Path.Combine(AppContext.BaseDirectory, "lucene-index")
+                    : Path.Combine(directory!, "lucene-index");
+            }
+
+            if (!Directory.Exists(options.LuceneIndexPath))
+            {
+                Directory.CreateDirectory(options.LuceneIndexPath);
+            }
+        }
+
         var connectionStringBuilder = new SqliteConnectionStringBuilder
         {
             DataSource = options.DbPath,
@@ -85,10 +100,14 @@ public static class ServiceCollectionExtensions
         services.TryAddSingleton<IClock, SystemClock>();
 
         services.AddSingleton<IWriteQueue, WriteQueue>();
-        services.AddSingleton<ISearchIndexer, SqliteFts5Indexer>();
+        services.AddSingleton<SqliteFts5Indexer>();
+        services.AddSingleton<LuceneSearchIndexer>();
+        services.AddSingleton<ISearchIndexer, HybridSearchIndexer>();
         services.AddSingleton<ISearchIndexCoordinator, SqliteSearchIndexCoordinator>();
         services.AddSingleton<IDatabaseMaintenanceService, SqliteDatabaseMaintenanceService>();
-        services.AddSingleton<ISearchQueryService, SqliteFts5QueryService>();
+        services.AddSingleton<SqliteFts5QueryService>();
+        services.AddSingleton<LuceneSearchQueryService>();
+        services.AddSingleton<ISearchQueryService, HybridSearchQueryService>();
         services.AddSingleton<ISearchHistoryService, SearchHistoryService>();
         services.AddSingleton<ISearchFavoritesService, SearchFavoritesService>();
         services.AddSingleton<IFulltextIntegrityService, FulltextIntegrityService>();

--- a/Veriado.Infrastructure/Persistence/Options/InfrastructureOptions.cs
+++ b/Veriado.Infrastructure/Persistence/Options/InfrastructureOptions.cs
@@ -28,6 +28,16 @@ public sealed class InfrastructureOptions
         = FtsIndexingMode.SameTransaction;
 
     /// <summary>
+    /// Gets or sets a value indicating whether Lucene.Net integration is enabled.
+    /// </summary>
+    public bool EnableLuceneIntegration { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets the absolute path to the Lucene.Net index directory.
+    /// </summary>
+    public string LuceneIndexPath { get; set; } = string.Empty;
+
+    /// <summary>
     /// Gets a value indicating whether the runtime environment provides the required SQLite FTS5 features.
     /// </summary>
     public bool IsFulltextAvailable { get; internal set; } = true;

--- a/Veriado.Infrastructure/Search/HybridSearchIndexer.cs
+++ b/Veriado.Infrastructure/Search/HybridSearchIndexer.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Veriado.Appl.Abstractions;
+using Veriado.Domain.Search;
+
+namespace Veriado.Infrastructure.Search;
+
+/// <summary>
+/// Coordinates updates across the SQLite FTS5 index and the Lucene.Net index.
+/// </summary>
+internal sealed class HybridSearchIndexer : ISearchIndexer
+{
+    private readonly SqliteFts5Indexer _ftsIndexer;
+    private readonly LuceneSearchIndexer _luceneIndexer;
+
+    public HybridSearchIndexer(SqliteFts5Indexer ftsIndexer, LuceneSearchIndexer luceneIndexer)
+    {
+        _ftsIndexer = ftsIndexer ?? throw new ArgumentNullException(nameof(ftsIndexer));
+        _luceneIndexer = luceneIndexer ?? throw new ArgumentNullException(nameof(luceneIndexer));
+    }
+
+    public async Task IndexAsync(SearchDocument document, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+        await _ftsIndexer.IndexAsync(document, cancellationToken).ConfigureAwait(false);
+        await _luceneIndexer.IndexAsync(document, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task DeleteAsync(Guid fileId, CancellationToken cancellationToken)
+    {
+        await _ftsIndexer.DeleteAsync(fileId, cancellationToken).ConfigureAwait(false);
+        await _luceneIndexer.DeleteAsync(fileId, cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/Veriado.Infrastructure/Search/HybridSearchQueryService.cs
+++ b/Veriado.Infrastructure/Search/HybridSearchQueryService.cs
@@ -1,0 +1,213 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Veriado.Appl.Search.Abstractions;
+using Veriado.Domain.Search;
+
+namespace Veriado.Infrastructure.Search;
+
+/// <summary>
+/// Blends results from SQLite FTS5 and Lucene.Net to provide richer search experiences.
+/// </summary>
+internal sealed class HybridSearchQueryService : ISearchQueryService
+{
+    private const double LuceneWeight = 0.85d;
+
+    private readonly SqliteFts5QueryService _ftsQueryService;
+    private readonly LuceneSearchQueryService _luceneQueryService;
+
+    public HybridSearchQueryService(SqliteFts5QueryService ftsQueryService, LuceneSearchQueryService luceneQueryService)
+    {
+        _ftsQueryService = ftsQueryService ?? throw new ArgumentNullException(nameof(ftsQueryService));
+        _luceneQueryService = luceneQueryService ?? throw new ArgumentNullException(nameof(luceneQueryService));
+    }
+
+    public async Task<IReadOnlyList<(Guid Id, double Score)>> SearchWithScoresAsync(
+        string matchQuery,
+        int skip,
+        int take,
+        CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(matchQuery);
+        if (take <= 0)
+        {
+            return Array.Empty<(Guid, double)>();
+        }
+
+        if (skip < 0)
+        {
+            skip = 0;
+        }
+
+        var fetch = Math.Max(skip + take, take);
+        var ftsHits = await _ftsQueryService
+            .SearchWithScoresAsync(matchQuery, 0, fetch, cancellationToken)
+            .ConfigureAwait(false);
+        var luceneHits = await _luceneQueryService
+            .SearchWithScoresAsync(matchQuery, 0, fetch, cancellationToken)
+            .ConfigureAwait(false);
+
+        return MergeScoreResults(ftsHits, luceneHits, skip, take);
+    }
+
+    public async Task<IReadOnlyList<(Guid Id, double Score)>> SearchFuzzyWithScoresAsync(
+        string matchQuery,
+        int skip,
+        int take,
+        CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(matchQuery);
+        if (take <= 0)
+        {
+            return Array.Empty<(Guid, double)>();
+        }
+
+        if (skip < 0)
+        {
+            skip = 0;
+        }
+
+        var fetch = Math.Max(skip + take, take);
+        var ftsHits = await _ftsQueryService
+            .SearchFuzzyWithScoresAsync(matchQuery, 0, fetch, cancellationToken)
+            .ConfigureAwait(false);
+        var luceneHits = await _luceneQueryService
+            .SearchFuzzyWithScoresAsync(matchQuery, 0, fetch, cancellationToken)
+            .ConfigureAwait(false);
+
+        return MergeScoreResults(ftsHits, luceneHits, skip, take);
+    }
+
+    public async Task<int> CountAsync(string matchQuery, CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(matchQuery);
+        var ftsCount = await _ftsQueryService.CountAsync(matchQuery, cancellationToken).ConfigureAwait(false);
+        var luceneCount = await _luceneQueryService.CountAsync(matchQuery, cancellationToken).ConfigureAwait(false);
+        return Math.Max(ftsCount, luceneCount);
+    }
+
+    public async Task<IReadOnlyList<SearchHit>> SearchAsync(string query, int? limit, CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(query);
+        var take = limit.GetValueOrDefault(10);
+        if (take <= 0)
+        {
+            return Array.Empty<SearchHit>();
+        }
+
+        var fetch = take > int.MaxValue / 2 ? take : take * 2;
+        var ftsHits = await _ftsQueryService.SearchAsync(query, fetch, cancellationToken).ConfigureAwait(false);
+        var luceneHits = await _luceneQueryService.SearchAsync(query, fetch, cancellationToken).ConfigureAwait(false);
+
+        if (ftsHits.Count == 0 && luceneHits.Count == 0)
+        {
+            return Array.Empty<SearchHit>();
+        }
+
+        return MergeSearchHits(ftsHits, luceneHits, take);
+    }
+
+    private static IReadOnlyList<(Guid Id, double Score)> MergeScoreResults(
+        IReadOnlyList<(Guid Id, double Score)> ftsHits,
+        IReadOnlyList<(Guid Id, double Score)> luceneHits,
+        int skip,
+        int take)
+    {
+        if (ftsHits.Count == 0 && luceneHits.Count == 0)
+        {
+            return Array.Empty<(Guid, double)>();
+        }
+
+        var combined = new Dictionary<Guid, double>();
+        foreach (var hit in luceneHits)
+        {
+            var weighted = hit.Score * LuceneWeight;
+            if (combined.TryGetValue(hit.Id, out var current))
+            {
+                combined[hit.Id] = Math.Max(current, weighted);
+            }
+            else
+            {
+                combined[hit.Id] = weighted;
+            }
+        }
+
+        foreach (var hit in ftsHits)
+        {
+            if (combined.TryGetValue(hit.Id, out var current))
+            {
+                combined[hit.Id] = Math.Max(current, hit.Score);
+            }
+            else
+            {
+                combined[hit.Id] = hit.Score;
+            }
+        }
+
+        if (combined.Count == 0)
+        {
+            return Array.Empty<(Guid, double)>();
+        }
+
+        var ordered = combined
+            .OrderByDescending(static pair => pair.Value)
+            .ThenBy(static pair => pair.Key)
+            .ToList();
+
+        if (skip >= ordered.Count)
+        {
+            return Array.Empty<(Guid, double)>();
+        }
+
+        return ordered
+            .Skip(skip)
+            .Take(take)
+            .Select(static pair => (pair.Key, pair.Value))
+            .ToList();
+    }
+
+    private static IReadOnlyList<SearchHit> MergeSearchHits(
+        IReadOnlyList<SearchHit> ftsHits,
+        IReadOnlyList<SearchHit> luceneHits,
+        int take)
+    {
+        var combined = new Dictionary<Guid, (SearchHit Hit, double Score)>();
+
+        foreach (var hit in ftsHits)
+        {
+            combined[hit.FileId] = (hit, hit.Score);
+        }
+
+        foreach (var hit in luceneHits)
+        {
+            var weightedScore = hit.Score * LuceneWeight;
+            if (combined.TryGetValue(hit.FileId, out var existing))
+            {
+                var bestScore = Math.Max(existing.Score, weightedScore);
+                var snippet = !string.IsNullOrWhiteSpace(existing.Hit.Snippet)
+                    ? existing.Hit.Snippet
+                    : hit.Snippet;
+                combined[hit.FileId] = (existing.Hit with { Score = bestScore, Snippet = snippet }, bestScore);
+            }
+            else
+            {
+                combined[hit.FileId] = (hit with { Score = weightedScore }, weightedScore);
+            }
+        }
+
+        if (combined.Count == 0)
+        {
+            return Array.Empty<SearchHit>();
+        }
+
+        return combined
+            .Values
+            .OrderByDescending(static item => item.Score)
+            .ThenBy(static item => item.Hit.FileId)
+            .Take(take)
+            .Select(static item => item.Hit with { Score = item.Score })
+            .ToList();
+    }
+}

--- a/Veriado.Infrastructure/Search/LuceneSearchFields.cs
+++ b/Veriado.Infrastructure/Search/LuceneSearchFields.cs
@@ -1,0 +1,15 @@
+namespace Veriado.Infrastructure.Search;
+
+/// <summary>
+/// Defines the field names stored within the Lucene.Net search index.
+/// </summary>
+internal static class LuceneSearchFields
+{
+    public const string Id = "id";
+    public const string Title = "title";
+    public const string Mime = "mime";
+    public const string Author = "author";
+    public const string Created = "created";
+    public const string Modified = "modified";
+    public const string Text = "text";
+}

--- a/Veriado.Infrastructure/Search/LuceneSearchIndexer.cs
+++ b/Veriado.Infrastructure/Search/LuceneSearchIndexer.cs
@@ -1,0 +1,135 @@
+using System;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Lucene.Net.Analysis;
+using Lucene.Net.Analysis.Standard;
+using Lucene.Net.Documents;
+using Lucene.Net.Index;
+using Lucene.Net.Store;
+using Lucene.Net.Util;
+using Veriado.Domain.Search;
+using Veriado.Infrastructure.Persistence.Options;
+
+namespace Veriado.Infrastructure.Search;
+
+/// <summary>
+/// Provides Lucene.Net backed indexing for search documents.
+/// </summary>
+internal sealed class LuceneSearchIndexer
+{
+    private const string GuidFormat = "N";
+
+    private readonly InfrastructureOptions _options;
+    private readonly Analyzer? _analyzer;
+    private readonly FSDirectory? _directory;
+    private readonly object _syncRoot = new();
+
+    public LuceneSearchIndexer(InfrastructureOptions options)
+    {
+        _options = options;
+        if (!options.EnableLuceneIntegration)
+        {
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(options.LuceneIndexPath))
+        {
+            return;
+        }
+
+        var directoryInfo = new DirectoryInfo(options.LuceneIndexPath);
+        if (!directoryInfo.Exists)
+        {
+            directoryInfo.Create();
+        }
+
+        _analyzer = new StandardAnalyzer(LuceneVersion.LUCENE_48);
+        _directory = FSDirectory.Open(directoryInfo);
+
+        // Ensure the index exists so that query services can open it without throwing.
+        using var writer = CreateWriter();
+        writer.Commit();
+    }
+
+    public bool IsEnabled => _options.EnableLuceneIntegration && _directory is not null && _analyzer is not null;
+
+    public Task IndexAsync(SearchDocument document, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+        if (!IsEnabled)
+        {
+            return Task.CompletedTask;
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        lock (_syncRoot)
+        {
+            using var writer = CreateWriter();
+            var luceneDocument = BuildDocument(document);
+            writer.UpdateDocument(new Term(LuceneSearchFields.Id, document.FileId.ToString(GuidFormat, CultureInfo.InvariantCulture)), luceneDocument);
+            writer.Commit();
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task DeleteAsync(Guid fileId, CancellationToken cancellationToken)
+    {
+        if (!IsEnabled)
+        {
+            return Task.CompletedTask;
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        lock (_syncRoot)
+        {
+            using var writer = CreateWriter();
+            writer.DeleteDocuments(new Term(LuceneSearchFields.Id, fileId.ToString(GuidFormat, CultureInfo.InvariantCulture)));
+            writer.Commit();
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private IndexWriter CreateWriter()
+    {
+        if (_directory is null || _analyzer is null)
+        {
+            throw new InvalidOperationException("Lucene index directory has not been initialised.");
+        }
+
+        var config = new IndexWriterConfig(LuceneVersion.LUCENE_48, _analyzer)
+        {
+            OpenMode = OpenMode.CREATE_OR_APPEND,
+        };
+
+        return new IndexWriter(_directory, config);
+    }
+
+    private static Document BuildDocument(SearchDocument document)
+    {
+        var luceneDocument = new Document
+        {
+            new StringField(LuceneSearchFields.Id, document.FileId.ToString(GuidFormat, CultureInfo.InvariantCulture), Field.Store.YES),
+            new TextField(LuceneSearchFields.Title, document.Title ?? string.Empty, Field.Store.YES),
+            new StringField(LuceneSearchFields.Mime, document.Mime ?? string.Empty, Field.Store.YES),
+            new TextField(LuceneSearchFields.Author, document.Author ?? string.Empty, Field.Store.YES),
+            new StringField(LuceneSearchFields.Created, document.CreatedUtc.ToString("O", CultureInfo.InvariantCulture), Field.Store.YES),
+            new StringField(LuceneSearchFields.Modified, document.ModifiedUtc.ToString("O", CultureInfo.InvariantCulture), Field.Store.YES),
+            new TextField(LuceneSearchFields.Text, BuildCombinedText(document), Field.Store.NO),
+        };
+
+        return luceneDocument;
+    }
+
+    private static string BuildCombinedText(SearchDocument document)
+    {
+        var parts = new[] { document.Title, document.Author, document.Mime };
+        return string.Join(' ', parts.Where(static part => !string.IsNullOrWhiteSpace(part)));
+    }
+}

--- a/Veriado.Infrastructure/Search/LuceneSearchQueryService.cs
+++ b/Veriado.Infrastructure/Search/LuceneSearchQueryService.cs
@@ -1,0 +1,318 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Lucene.Net.Analysis;
+using Lucene.Net.Analysis.Standard;
+using Lucene.Net.Documents;
+using Lucene.Net.Index;
+using Lucene.Net.QueryParsers.Classic;
+using Lucene.Net.Search;
+using Lucene.Net.Store;
+using Lucene.Net.Util;
+using Veriado.Domain.Search;
+using Veriado.Infrastructure.Persistence.Options;
+
+namespace Veriado.Infrastructure.Search;
+
+/// <summary>
+/// Provides Lucene.Net backed query capabilities complementing the SQLite FTS index.
+/// </summary>
+internal sealed class LuceneSearchQueryService
+{
+    private const double ScoreTolerance = 0.0001d;
+
+    private readonly InfrastructureOptions _options;
+    private readonly Analyzer? _analyzer;
+    private readonly FSDirectory? _directory;
+    private readonly string[] _searchFields =
+    {
+        LuceneSearchFields.Title,
+        LuceneSearchFields.Author,
+        LuceneSearchFields.Mime,
+        LuceneSearchFields.Text,
+    };
+
+    public LuceneSearchQueryService(InfrastructureOptions options)
+    {
+        _options = options;
+        if (!options.EnableLuceneIntegration)
+        {
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(options.LuceneIndexPath))
+        {
+            return;
+        }
+
+        var directoryInfo = new DirectoryInfo(options.LuceneIndexPath);
+        if (!directoryInfo.Exists)
+        {
+            directoryInfo.Create();
+        }
+
+        _analyzer = new StandardAnalyzer(LuceneVersion.LUCENE_48);
+        _directory = FSDirectory.Open(directoryInfo);
+    }
+
+    public bool IsEnabled => _options.EnableLuceneIntegration && _directory is not null && _analyzer is not null;
+
+    public Task<IReadOnlyList<(Guid Id, double Score)>> SearchWithScoresAsync(
+        string matchQuery,
+        int skip,
+        int take,
+        CancellationToken cancellationToken)
+        => SearchWithScoresInternalAsync(matchQuery, skip, take, allowFuzzy: false, cancellationToken);
+
+    public Task<IReadOnlyList<(Guid Id, double Score)>> SearchFuzzyWithScoresAsync(
+        string matchQuery,
+        int skip,
+        int take,
+        CancellationToken cancellationToken)
+        => SearchWithScoresInternalAsync(matchQuery, skip, take, allowFuzzy: true, cancellationToken);
+
+    public Task<int> CountAsync(string matchQuery, CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(matchQuery);
+        if (!IsEnabled)
+        {
+            return Task.FromResult(0);
+        }
+
+        var query = TryParse(matchQuery, allowFuzzy: false);
+        if (query is null)
+        {
+            return Task.FromResult(0);
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        using var reader = TryOpenReader();
+        if (reader is null)
+        {
+            return Task.FromResult(0);
+        }
+
+        var searcher = new IndexSearcher(reader);
+        var collector = new TotalHitCountCollector();
+        searcher.Search(query, collector);
+        return Task.FromResult(collector.TotalHits);
+    }
+
+    public Task<IReadOnlyList<SearchHit>> SearchAsync(string query, int? limit, CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(query);
+        var take = limit.GetValueOrDefault(10);
+        if (take <= 0)
+        {
+            return Task.FromResult<IReadOnlyList<SearchHit>>(Array.Empty<SearchHit>());
+        }
+
+        if (!IsEnabled)
+        {
+            return Task.FromResult<IReadOnlyList<SearchHit>>(Array.Empty<SearchHit>());
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var parsedQuery = TryParse(query, allowFuzzy: false) ?? TryParse(QueryParserBase.Escape(query), allowFuzzy: false);
+        if (parsedQuery is null)
+        {
+            return Task.FromResult<IReadOnlyList<SearchHit>>(Array.Empty<SearchHit>());
+        }
+
+        using var reader = TryOpenReader();
+        if (reader is null)
+        {
+            return Task.FromResult<IReadOnlyList<SearchHit>>(Array.Empty<SearchHit>());
+        }
+
+        var searcher = new IndexSearcher(reader);
+        var topDocs = searcher.Search(parsedQuery, take);
+        if (topDocs.ScoreDocs.Length == 0)
+        {
+            return Task.FromResult<IReadOnlyList<SearchHit>>(Array.Empty<SearchHit>());
+        }
+
+        var maxScore = Math.Max(topDocs.MaxScore, ScoreTolerance);
+        var hits = new List<SearchHit>(Math.Min(take, topDocs.ScoreDocs.Length));
+        foreach (var scoreDoc in topDocs.ScoreDocs)
+        {
+            var document = searcher.Doc(scoreDoc.Doc);
+            if (!TryExtractIdentifier(document, out var fileId))
+            {
+                continue;
+            }
+
+            var title = document.Get(LuceneSearchFields.Title) ?? string.Empty;
+            var mime = document.Get(LuceneSearchFields.Mime) ?? "application/octet-stream";
+            var author = document.Get(LuceneSearchFields.Author);
+            var modified = TryParseDate(document.Get(LuceneSearchFields.Modified));
+            var score = NormalizeScore(scoreDoc.Score, maxScore);
+            hits.Add(new SearchHit(fileId, title, mime, author, score, modified));
+        }
+
+        return Task.FromResult<IReadOnlyList<SearchHit>>(hits);
+    }
+
+    private Task<IReadOnlyList<(Guid Id, double Score)>> SearchWithScoresInternalAsync(
+        string matchQuery,
+        int skip,
+        int take,
+        bool allowFuzzy,
+        CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(matchQuery);
+        if (take <= 0)
+        {
+            return Task.FromResult<IReadOnlyList<(Guid, double)>>(Array.Empty<(Guid, double)>());
+        }
+
+        if (skip < 0)
+        {
+            skip = 0;
+        }
+
+        if (!IsEnabled)
+        {
+            return Task.FromResult<IReadOnlyList<(Guid, double)>>(Array.Empty<(Guid, double)>());
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var query = TryParse(matchQuery, allowFuzzy) ?? TryParse(QueryParserBase.Escape(matchQuery), allowFuzzy);
+        if (query is null)
+        {
+            return Task.FromResult<IReadOnlyList<(Guid, double)>>(Array.Empty<(Guid, double)>());
+        }
+
+        using var reader = TryOpenReader();
+        if (reader is null)
+        {
+            return Task.FromResult<IReadOnlyList<(Guid, double)>>(Array.Empty<(Guid, double)>());
+        }
+
+        var maxDocs = Math.Max(skip + take, take);
+        var searcher = new IndexSearcher(reader);
+        var topDocs = searcher.Search(query, maxDocs);
+        if (topDocs.ScoreDocs.Length == 0)
+        {
+            return Task.FromResult<IReadOnlyList<(Guid, double)>>(Array.Empty<(Guid, double)>());
+        }
+
+        var maxScore = Math.Max(topDocs.MaxScore, ScoreTolerance);
+        var upperBound = Math.Min(skip + take, topDocs.ScoreDocs.Length);
+        if (skip >= upperBound)
+        {
+            return Task.FromResult<IReadOnlyList<(Guid, double)>>(Array.Empty<(Guid, double)>());
+        }
+
+        var results = new List<(Guid, double)>(Math.Max(upperBound - skip, 0));
+        for (var index = skip; index < upperBound; index++)
+        {
+            var scoreDoc = topDocs.ScoreDocs[index];
+            var document = searcher.Doc(scoreDoc.Doc);
+            if (!TryExtractIdentifier(document, out var fileId))
+            {
+                continue;
+            }
+
+            var score = NormalizeScore(scoreDoc.Score, maxScore);
+            results.Add((fileId, score));
+        }
+
+        return Task.FromResult<IReadOnlyList<(Guid, double)>>(results);
+    }
+
+    private DirectoryReader? TryOpenReader()
+    {
+        if (_directory is null)
+        {
+            return null;
+        }
+
+        try
+        {
+            if (!DirectoryReader.IndexExists(_directory))
+            {
+                return null;
+            }
+
+            return DirectoryReader.Open(_directory);
+        }
+        catch (FileNotFoundException)
+        {
+            return null;
+        }
+        catch (DirectoryNotFoundException)
+        {
+            return null;
+        }
+        catch (IndexNotFoundException)
+        {
+            return null;
+        }
+    }
+
+    private Query? TryParse(string text, bool allowFuzzy)
+    {
+        if (string.IsNullOrWhiteSpace(text) || _analyzer is null)
+        {
+            return null;
+        }
+
+        var parser = new MultiFieldQueryParser(LuceneVersion.LUCENE_48, _searchFields, _analyzer)
+        {
+            DefaultOperator = QueryParser.Operator.AND,
+            AllowLeadingWildcard = true,
+        };
+
+        if (allowFuzzy)
+        {
+            parser.FuzzyMinSim = 0.6f;
+            parser.FuzzyPrefixLength = 1;
+        }
+
+        try
+        {
+            return parser.Parse(text);
+        }
+        catch (ParseException)
+        {
+            return null;
+        }
+    }
+
+    private static bool TryExtractIdentifier(Document document, out Guid fileId)
+    {
+        fileId = default;
+        var identifier = document.Get(LuceneSearchFields.Id);
+        return identifier is not null && Guid.TryParseExact(identifier, "N", out fileId);
+    }
+
+    private static DateTimeOffset TryParseDate(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return DateTimeOffset.MinValue;
+        }
+
+        return DateTimeOffset.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var parsed)
+            ? parsed
+            : DateTimeOffset.MinValue;
+    }
+
+    private static double NormalizeScore(float score, float maxScore)
+    {
+        if (maxScore <= ScoreTolerance || score <= ScoreTolerance)
+        {
+            return 0d;
+        }
+
+        var normalised = score / maxScore;
+        return Math.Clamp(normalised, 0d, 1d);
+    }
+}

--- a/Veriado.Infrastructure/Veriado.Infrastructure.csproj
+++ b/Veriado.Infrastructure/Veriado.Infrastructure.csproj
@@ -9,6 +9,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="MediatR" Version="13.0.0" />
+    <PackageReference Include="Lucene.Net" Version="4.8.0-beta00016" />
+    <PackageReference Include="Lucene.Net.Analysis.Common" Version="4.8.0-beta00016" />
+    <PackageReference Include="Lucene.Net.Highlighter" Version="4.8.0-beta00016" />
+    <PackageReference Include="Lucene.Net.QueryParser" Version="4.8.0-beta00016" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.9" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.9" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.9">


### PR DESCRIPTION
## Summary
- introduce Lucene.NET indexer and query services and blend them with the existing SQLite FTS5 pipeline
- extend infrastructure options and dependency registration to configure and bootstrap the Lucene index
- add Lucene.NET package references to the infrastructure project

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d69831406c8326a14d98b3a1050746