### PR TITLE
Log and disable hybrid indexer when prerequisites missing

### DIFF
--- a/Veriado.Infrastructure/Search/HybridSearchIndexer.cs
+++ b/Veriado.Infrastructure/Search/HybridSearchIndexer.cs
@@ -1,8 +1,10 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Veriado.Appl.Abstractions;
 using Veriado.Domain.Search;
+using Veriado.Infrastructure.Persistence.Options;
 
 namespace Veriado.Infrastructure.Search;
 
@@ -13,27 +15,67 @@ internal sealed class HybridSearchIndexer : ISearchIndexer
 {
     private readonly SqliteFts5Indexer _ftsIndexer;
     private readonly LuceneSearchIndexer _luceneIndexer;
+    private readonly InfrastructureOptions _options;
+    private readonly ILogger<HybridSearchIndexer> _logger;
+    private readonly bool _isEnabled;
 
-    public HybridSearchIndexer(SqliteFts5Indexer ftsIndexer, LuceneSearchIndexer luceneIndexer)
+    public HybridSearchIndexer(
+        SqliteFts5Indexer ftsIndexer,
+        LuceneSearchIndexer luceneIndexer,
+        InfrastructureOptions options,
+        ILogger<HybridSearchIndexer> logger)
     {
         _ftsIndexer = ftsIndexer ?? throw new ArgumentNullException(nameof(ftsIndexer));
         _luceneIndexer = luceneIndexer ?? throw new ArgumentNullException(nameof(luceneIndexer));
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+        var luceneEnabled = _options.EnableLuceneIntegration && _luceneIndexer.IsEnabled;
+        _isEnabled = _options.IsFulltextAvailable && (!_options.EnableLuceneIntegration || luceneEnabled);
+
+        if (!_options.IsFulltextAvailable)
+        {
+            _logger.LogWarning(
+                "Hybrid search indexing disabled because SQLite FTS5 support is unavailable: {Reason}",
+                _options.FulltextAvailabilityError ?? "Unknown reason.");
+        }
+        else if (_options.EnableLuceneIntegration && !luceneEnabled)
+        {
+            _logger.LogWarning(
+                "Hybrid search indexing disabled because Lucene.Net integration could not be initialised. Check Lucene configuration settings.");
+        }
     }
 
     public Task IndexAsync(SearchDocument document, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(document);
-        return _ftsIndexer.IndexAsync(
-            document,
-            beforeCommit: ct => _luceneIndexer.IndexAsync(document, ct),
-            cancellationToken);
+        if (!_isEnabled)
+        {
+            return Task.CompletedTask;
+        }
+
+        Func<CancellationToken, Task>? beforeCommit = null;
+        if (_options.EnableLuceneIntegration && _luceneIndexer.IsEnabled)
+        {
+            beforeCommit = ct => _luceneIndexer.IndexAsync(document, ct);
+        }
+
+        return _ftsIndexer.IndexAsync(document, beforeCommit, cancellationToken);
     }
 
     public Task DeleteAsync(Guid fileId, CancellationToken cancellationToken)
     {
-        return _ftsIndexer.DeleteAsync(
-            fileId,
-            beforeCommit: ct => _luceneIndexer.DeleteAsync(fileId, ct),
-            cancellationToken);
+        if (!_isEnabled)
+        {
+            return Task.CompletedTask;
+        }
+
+        Func<CancellationToken, Task>? beforeCommit = null;
+        if (_options.EnableLuceneIntegration && _luceneIndexer.IsEnabled)
+        {
+            beforeCommit = ct => _luceneIndexer.DeleteAsync(fileId, ct);
+        }
+
+        return _ftsIndexer.DeleteAsync(fileId, beforeCommit, cancellationToken);
     }
 }


### PR DESCRIPTION
## Summary
- add infrastructure options and logging dependencies to `HybridSearchIndexer`
- disable hybrid indexing when SQLite FTS5 support or Lucene integration are unavailable and emit warnings

## Testing
- dotnet build Veriado.sln *(fails: `dotnet` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d6a27a16f0832683d7500def0c0f7a