### PR TITLE
Fix Lucene query parser usage and error handling

### DIFF
--- a/Veriado.Infrastructure/Search/LuceneSearchQueryService.cs
+++ b/Veriado.Infrastructure/Search/LuceneSearchQueryService.cs
@@ -22,7 +22,7 @@ namespace Veriado.Infrastructure.Search;
 /// </summary>
 internal sealed class LuceneSearchQueryService
 {
-    private const double ScoreTolerance = 0.0001d;
+    private const float ScoreTolerance = 0.0001f;
 
     private readonly InfrastructureOptions _options;
     private readonly Analyzer? _analyzer;
@@ -243,11 +243,7 @@ internal sealed class LuceneSearchQueryService
 
             return DirectoryReader.Open(_directory);
         }
-        catch (FileNotFoundException)
-        {
-            return null;
-        }
-        catch (DirectoryNotFoundException)
+        catch (IOException)
         {
             return null;
         }
@@ -266,7 +262,7 @@ internal sealed class LuceneSearchQueryService
 
         var parser = new MultiFieldQueryParser(LuceneVersion.LUCENE_48, _searchFields, _analyzer)
         {
-            DefaultOperator = QueryParser.Operator.AND,
+            DefaultOperator = QueryParserBase.Operator.AND,
             AllowLeadingWildcard = true,
         };
 


### PR DESCRIPTION
## Summary
- align score tolerance with Lucene score types to avoid float conversion issues
- set the multi-field query parser's default operator via QueryParserBase
- consolidate file system exception handling when opening the Lucene index reader

## Testing
- dotnet build Veriado.Infrastructure/Veriado.Infrastructure.csproj *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d784917a708326b9bd8417315284cc