### PR TITLE
Fix Lucene query parser default operator assignment

### DIFF
--- a/Veriado.Infrastructure/Search/LuceneSearchQueryService.cs
+++ b/Veriado.Infrastructure/Search/LuceneSearchQueryService.cs
@@ -258,7 +258,7 @@ internal sealed class LuceneSearchQueryService
 
         var parser = new MultiFieldQueryParser(LuceneVersion.LUCENE_48, _searchFields, _analyzer)
         {
-            DefaultOperator = QueryParserBase.Operator.AND,
+            DefaultOperator = QueryParser.Operator.AND,
             AllowLeadingWildcard = true,
         };
 


### PR DESCRIPTION
## Summary
- update the Lucene query parser default operator assignment to use the available enum

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d7865799888326966d4535146a1127