### PR TITLE
Add constructible type discovery for migrations assembly

### DIFF
--- a/Veriado.Infrastructure/Persistence/Migrations/LenientMigrationsAssembly.cs
+++ b/Veriado.Infrastructure/Persistence/Migrations/LenientMigrationsAssembly.cs
@@ -188,3 +188,20 @@ public sealed class LenientMigrationsAssembly : IMigrationsAssembly
         return id[..separatorIndex];
     }
 }
+
+internal static class AssemblyExtensions
+{
+    public static IEnumerable<TypeInfo> GetConstructibleTypes(this Assembly assembly)
+        => assembly
+            .DefinedTypes
+            .Where(type => !type.IsAbstract)
+            .Where(type => !type.IsGenericTypeDefinition)
+            .Where(HasAccessibleConstructor);
+
+    private static bool HasAccessibleConstructor(TypeInfo type)
+        => type.DeclaredConstructors.Any(
+            constructor => !constructor.IsStatic
+                            && (constructor.IsPublic
+                                || constructor.IsFamily
+                                || constructor.IsFamilyOrAssembly));
+}


### PR DESCRIPTION
## Summary
- add an internal assembly extension that mirrors EF Core's constructible type discovery
- use the shared helper to enumerate migrations and snapshots without relying on EF Core internals

## Testing
- `dotnet build Veriado.Infrastructure/Veriado.Infrastructure.csproj` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68d7b05551cc8326ad6ae6c0bebe92ac