### PR TITLE
Include title metadata in domain events

### DIFF
--- a/Veriado.Domain/Audit/FileAuditEntity.cs
+++ b/Veriado.Domain/Audit/FileAuditEntity.cs
@@ -67,11 +67,17 @@ public sealed class FileAuditEntity
     /// <param name="fileId">The file identifier.</param>
     /// <param name="mime">The MIME type after the update.</param>
     /// <param name="author">The author after the update.</param>
+    /// <param name="title">The optional title after the update.</param>
     /// <param name="occurredUtc">The timestamp when the event occurred.</param>
     /// <returns>The created audit entry.</returns>
-    public static FileAuditEntity MetadataUpdated(Guid fileId, MimeType mime, string author, UtcTimestamp occurredUtc)
+    public static FileAuditEntity MetadataUpdated(Guid fileId, MimeType mime, string author, string? title, UtcTimestamp occurredUtc)
     {
-        return new FileAuditEntity(fileId, FileAuditAction.MetadataUpdated, $"Metadata updated (MIME: {mime.Value}, Author: {author})", occurredUtc);
+        var titleText = string.IsNullOrWhiteSpace(title) ? "(none)" : $"'{title}'";
+        return new FileAuditEntity(
+            fileId,
+            FileAuditAction.MetadataUpdated,
+            $"Metadata updated (MIME: {mime.Value}, Author: {author}, Title: {titleText})",
+            occurredUtc);
     }
 
     /// <summary>

--- a/Veriado.Domain/Files/Events/FileMetadataUpdated.cs
+++ b/Veriado.Domain/Files/Events/FileMetadataUpdated.cs
@@ -16,13 +16,21 @@ public sealed class FileMetadataUpdated : IDomainEvent
     /// <param name="fileId">The identifier of the file.</param>
     /// <param name="mime">The updated MIME type.</param>
     /// <param name="author">The updated author.</param>
+    /// <param name="title">The updated title, if any.</param>
     /// <param name="systemMetadata">The updated file system metadata snapshot.</param>
     /// <param name="occurredUtc">The timestamp when the update was recorded.</param>
-    public FileMetadataUpdated(Guid fileId, MimeType mime, string author, FileSystemMetadata systemMetadata, UtcTimestamp occurredUtc)
+    public FileMetadataUpdated(
+        Guid fileId,
+        MimeType mime,
+        string author,
+        string? title,
+        FileSystemMetadata systemMetadata,
+        UtcTimestamp occurredUtc)
     {
         FileId = fileId;
         Mime = mime;
         Author = author;
+        Title = title;
         SystemMetadata = systemMetadata;
         EventId = Guid.NewGuid();
         OccurredOnUtc = occurredUtc.ToDateTimeOffset();
@@ -42,6 +50,11 @@ public sealed class FileMetadataUpdated : IDomainEvent
     /// Gets the author after the update.
     /// </summary>
     public string Author { get; }
+
+    /// <summary>
+    /// Gets the optional title after the update.
+    /// </summary>
+    public string? Title { get; }
 
     /// <summary>
     /// Gets the file system metadata snapshot after the update.

--- a/Veriado.Domain/Files/FileEntity.cs
+++ b/Veriado.Domain/Files/FileEntity.cs
@@ -168,7 +168,7 @@ public sealed class FileEntity : AggregateRoot
         Name = newName;
         Touch(whenUtc);
         RaiseDomainEvent(new FileRenamed(Id, previous, newName, whenUtc));
-        RaiseDomainEvent(new FileMetadataUpdated(Id, Mime, Author, SystemMetadata, whenUtc));
+        RaiseDomainEvent(new FileMetadataUpdated(Id, Mime, Author, Title, SystemMetadata, whenUtc));
         MarkSearchDirty(whenUtc, ReindexReason.MetadataChanged);
     }
 
@@ -204,7 +204,7 @@ public sealed class FileEntity : AggregateRoot
         }
 
         Touch(whenUtc);
-        RaiseDomainEvent(new FileMetadataUpdated(Id, Mime, Author, SystemMetadata, whenUtc));
+        RaiseDomainEvent(new FileMetadataUpdated(Id, Mime, Author, Title, SystemMetadata, whenUtc));
         MarkSearchDirty(whenUtc, ReindexReason.MetadataChanged);
     }
 
@@ -319,7 +319,7 @@ public sealed class FileEntity : AggregateRoot
 
         SystemMetadata = metadata;
         Touch(whenUtc);
-        RaiseDomainEvent(new FileMetadataUpdated(Id, Mime, Author, SystemMetadata, whenUtc));
+        RaiseDomainEvent(new FileMetadataUpdated(Id, Mime, Author, Title, SystemMetadata, whenUtc));
         MarkSearchDirty(whenUtc, ReindexReason.MetadataChanged);
     }
 
@@ -338,7 +338,7 @@ public sealed class FileEntity : AggregateRoot
 
         Title = normalized;
         Touch(whenUtc);
-        RaiseDomainEvent(new FileMetadataUpdated(Id, Mime, Author, SystemMetadata, whenUtc));
+        RaiseDomainEvent(new FileMetadataUpdated(Id, Mime, Author, Title, SystemMetadata, whenUtc));
         MarkSearchDirty(whenUtc, ReindexReason.MetadataChanged);
     }
 
@@ -357,7 +357,7 @@ public sealed class FileEntity : AggregateRoot
 
         Author = normalized;
         Touch(whenUtc);
-        RaiseDomainEvent(new FileMetadataUpdated(Id, Mime, Author, SystemMetadata, whenUtc));
+        RaiseDomainEvent(new FileMetadataUpdated(Id, Mime, Author, Title, SystemMetadata, whenUtc));
         MarkSearchDirty(whenUtc, ReindexReason.MetadataChanged);
     }
 

--- a/Veriado.Infrastructure/Events/AuditEventPublisher.cs
+++ b/Veriado.Infrastructure/Events/AuditEventPublisher.cs
@@ -60,7 +60,12 @@ internal sealed class AuditEventPublisher : IEventPublisher
                     break;
 
                 case FileMetadataUpdated metadata:
-                    context.FileAudits.Add(FileAuditEntity.MetadataUpdated(metadata.FileId, metadata.Mime, metadata.Author, UtcTimestamp.From(metadata.OccurredOnUtc)));
+                    context.FileAudits.Add(FileAuditEntity.MetadataUpdated(
+                        metadata.FileId,
+                        metadata.Mime,
+                        metadata.Author,
+                        metadata.Title,
+                        UtcTimestamp.From(metadata.OccurredOnUtc)));
                     hasChanges = true;
                     break;
 


### PR DESCRIPTION
## Summary
- extend the FileMetadataUpdated domain event to carry the optional title
- propagate the title through aggregate updates and audit publishing
- enrich file metadata audit entries with the updated title information

## Testing
- `dotnet build Veriado.sln` *(fails: dotnet not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d7bd913178832688ec72f76450783d