### PR TITLE
Prevent duplicate infrastructure initialization

### DIFF
--- a/Veriado.Infrastructure/DependencyInjection/InfrastructureInitializationState.cs
+++ b/Veriado.Infrastructure/DependencyInjection/InfrastructureInitializationState.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Veriado.Infrastructure.DependencyInjection;
+
+internal sealed class InfrastructureInitializationState
+{
+    private readonly SemaphoreSlim _gate = new(1, 1);
+    private bool _initialized;
+
+    public async Task<bool> EnsureInitializedAsync(Func<Task> initializer, CancellationToken cancellationToken)
+    {
+        if (_initialized)
+        {
+            return false;
+        }
+
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            if (_initialized)
+            {
+                return false;
+            }
+
+            await initializer().ConfigureAwait(false);
+            _initialized = true;
+            return true;
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add an initialization state singleton so infrastructure setup only runs once
- log each InitializeInfrastructureAsync invocation with the caller and database path

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d83c1b9eac83268c75130bdc1688c9