### PR TITLE
Guard infrastructure initialization migrations

### DIFF
--- a/Veriado.Infrastructure/Persistence/AppDbContext.cs
+++ b/Veriado.Infrastructure/Persistence/AppDbContext.cs
@@ -55,25 +55,18 @@ public sealed class AppDbContext : DbContext
     }
 
     /// <summary>
-    /// Applies database migrations and runs PRAGMA optimize.
+    /// Runs post-migration maintenance tasks such as PRAGMA optimize.
     /// </summary>
     /// <param name="cancellationToken">The cancellation token.</param>
     public async Task InitializeAsync(CancellationToken cancellationToken = default)
     {
         if (Database.IsSqlite())
         {
-            await EnsureSqliteMigrationsLockClearedAsync(cancellationToken).ConfigureAwait(false);
-        }
-
-        await Database.MigrateAsync(cancellationToken).ConfigureAwait(false);
-
-        if (Database.IsSqlite())
-        {
             await Database.ExecuteSqlRawAsync("PRAGMA optimize;", cancellationToken).ConfigureAwait(false);
         }
     }
 
-    private async Task EnsureSqliteMigrationsLockClearedAsync(CancellationToken cancellationToken)
+    internal async Task EnsureSqliteMigrationsLockClearedAsync(CancellationToken cancellationToken)
     {
         const string createTableSql = "CREATE TABLE IF NOT EXISTS \"__EFMigrationsLock\"(\n  \"Id\" INTEGER NOT NULL CONSTRAINT \"PK___EFMigrationsLock\" PRIMARY KEY,\n  \"Timestamp\" TEXT NOT NULL\n);";
         const string deleteSql = "DELETE FROM \"__EFMigrationsLock\";";


### PR DESCRIPTION
## Summary
- centralize database migration execution inside infrastructure initialization and ensure it only runs once per process
- move SQLite migration lock clearing and PRAGMA maintenance outside of the DbContext migration helper so migrations are not retriggered

## Testing
- dotnet build Veriado.sln *(fails: `dotnet` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d83fb1e0e483269af5f837595ed07d