### PR TITLE
Baseline legacy SQLite databases before migrations

### DIFF
--- a/Veriado.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/Veriado.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
@@ -147,6 +147,13 @@ public static class ServiceCollectionExtensions
             if (dbContext.Database.IsSqlite())
             {
                 await dbContext.EnsureSqliteMigrationsLockClearedAsync(cancellationToken).ConfigureAwait(false);
+
+                var needsBaseline = await dbContext.NeedsSqliteMigrationsHistoryBaselineAsync(cancellationToken)
+                    .ConfigureAwait(false);
+                if (needsBaseline)
+                {
+                    await dbContext.EnsureSqliteMigrationsHistoryBaselinedAsync(cancellationToken).ConfigureAwait(false);
+                }
             }
 
             await dbContext.Database.MigrateAsync(cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
## Summary
- detect legacy SQLite databases that have core tables but no migrations history
- add an AppDbContext helper to create the history table and seed the initial migration baseline
- invoke the helper during infrastructure initialization before running migrations

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d84245b4888326adde380f66f5051e