### PR TITLE
Handle null search index during file mapping

### DIFF
--- a/Veriado.Mapping/Profiles/FileReadProfiles.cs
+++ b/Veriado.Mapping/Profiles/FileReadProfiles.cs
@@ -69,11 +69,11 @@ public sealed class FileReadProfiles : Profile
             .ForMember(dest => dest.CreatedUtc, opt => opt.MapFrom(src => src.CreatedUtc.Value))
             .ForMember(dest => dest.LastModifiedUtc, opt => opt.MapFrom(src => src.LastModifiedUtc.Value))
             .ForMember(dest => dest.Validity, opt => opt.MapFrom(src => src.Validity))
-            .ForMember(dest => dest.IsIndexStale, opt => opt.MapFrom(src => src.SearchIndex.IsStale))
-            .ForMember(dest => dest.LastIndexedUtc, opt => opt.MapFrom(src => src.SearchIndex.LastIndexedUtc))
-            .ForMember(dest => dest.IndexedTitle, opt => opt.MapFrom(src => src.SearchIndex.IndexedTitle))
-            .ForMember(dest => dest.IndexSchemaVersion, opt => opt.MapFrom(src => src.SearchIndex.SchemaVersion))
-            .ForMember(dest => dest.IndexedContentHash, opt => opt.MapFrom(src => src.SearchIndex.IndexedContentHash))
+            .ForMember(dest => dest.IsIndexStale, opt => opt.MapFrom(src => src.SearchIndex?.IsStale ?? false))
+            .ForMember(dest => dest.LastIndexedUtc, opt => opt.MapFrom(src => src.SearchIndex?.LastIndexedUtc))
+            .ForMember(dest => dest.IndexedTitle, opt => opt.MapFrom(src => src.SearchIndex?.IndexedTitle))
+            .ForMember(dest => dest.IndexSchemaVersion, opt => opt.MapFrom(src => src.SearchIndex?.SchemaVersion ?? 0))
+            .ForMember(dest => dest.IndexedContentHash, opt => opt.MapFrom(src => src.SearchIndex?.IndexedContentHash))
             .ForMember(dest => dest.Score, opt => opt.Ignore());
 
         CreateMap<FileEntity, FileDetailDto>()
@@ -87,11 +87,11 @@ public sealed class FileReadProfiles : Profile
             .ForMember(dest => dest.Content, opt => opt.MapFrom(src => src.Content))
             .ForMember(dest => dest.SystemMetadata, opt => opt.MapFrom(src => src.SystemMetadata))
             .ForMember(dest => dest.Validity, opt => opt.MapFrom(src => src.Validity))
-            .ForMember(dest => dest.IsIndexStale, opt => opt.MapFrom(src => src.SearchIndex.IsStale))
-            .ForMember(dest => dest.LastIndexedUtc, opt => opt.MapFrom(src => src.SearchIndex.LastIndexedUtc))
-            .ForMember(dest => dest.IndexedTitle, opt => opt.MapFrom(src => src.SearchIndex.IndexedTitle))
-            .ForMember(dest => dest.IndexSchemaVersion, opt => opt.MapFrom(src => src.SearchIndex.SchemaVersion))
-            .ForMember(dest => dest.IndexedContentHash, opt => opt.MapFrom(src => src.SearchIndex.IndexedContentHash));
+            .ForMember(dest => dest.IsIndexStale, opt => opt.MapFrom(src => src.SearchIndex?.IsStale ?? false))
+            .ForMember(dest => dest.LastIndexedUtc, opt => opt.MapFrom(src => src.SearchIndex?.LastIndexedUtc))
+            .ForMember(dest => dest.IndexedTitle, opt => opt.MapFrom(src => src.SearchIndex?.IndexedTitle))
+            .ForMember(dest => dest.IndexSchemaVersion, opt => opt.MapFrom(src => src.SearchIndex?.SchemaVersion ?? 0))
+            .ForMember(dest => dest.IndexedContentHash, opt => opt.MapFrom(src => src.SearchIndex?.IndexedContentHash));
 
         CreateMap<FileDetailReadModel, FileDetailDto>()
             .ForMember(dest => dest.Id, opt => opt.MapFrom(src => src.Id))


### PR DESCRIPTION
## Summary
- update AutoMapper configuration for file summaries and details to tolerate missing search index state
- default search-related values when the entity lacks an initialized SearchIndex

## Testing
- dotnet test *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d8de37c8348326ad763df340b0cb49