### PR TITLE
Refine AutoMapper projections and value object conversions

### DIFF
--- a/Veriado.Mapping/DependencyInjection/MappingServiceCollectionExtensions.cs
+++ b/Veriado.Mapping/DependencyInjection/MappingServiceCollectionExtensions.cs
@@ -34,13 +34,14 @@ public static class MappingServiceCollectionExtensions
         {
             var configuration = new MapperConfiguration(cfg =>
             {
+                CommonValueConverters.Register(cfg);
                 cfg.AddProfile<FileReadProfiles>();
                 cfg.AddProfile<FileWriteProfiles>();
                 cfg.AddProfile<SearchProfiles>();
             });
-#if DEBUG
+
             configuration.AssertConfigurationIsValid();
-#endif
+            configuration.CompileMappings();
             return configuration;
         });
 

--- a/Veriado.Mapping/Profiles/CommonValueConverters.cs
+++ b/Veriado.Mapping/Profiles/CommonValueConverters.cs
@@ -6,28 +6,65 @@ using Veriado.Domain.ValueObjects;
 namespace Veriado.Mapping.Profiles;
 
 /// <summary>
-/// Provides reusable AutoMapper value converters for domain primitives.
+/// Provides reusable AutoMapper value converters for domain primitives and value objects.
 /// </summary>
 public static class CommonValueConverters
 {
+    /// <summary>
+    /// Registers the shared converters on the provided profile.
+    /// </summary>
+    /// <param name="profile">The profile on which to register the converters.</param>
+    public static void Register(IProfileExpression profile)
+    {
+        ArgumentNullException.ThrowIfNull(profile);
+
+        profile.CreateMap<FileName, string>().ConvertUsing<FileNameToStringConverter>();
+        profile.CreateMap<FileExtension, string>().ConvertUsing<FileExtensionToStringConverter>();
+        profile.CreateMap<MimeType, string>().ConvertUsing<MimeTypeToStringConverter>();
+        profile.CreateMap<FileHash, string>().ConvertUsing<FileHashToStringConverter>();
+        profile.CreateMap<ByteSize, long>().ConvertUsing<ByteSizeToLongConverter>();
+        profile.CreateMap<FileAttributesFlags, int>().ConvertUsing<FileAttributesToIntConverter>();
+
+        profile.CreateMap<UtcTimestamp, DateTimeOffset>().ConvertUsing<UtcTimestampToDateTimeOffsetConverter>();
+        profile.CreateMap<UtcTimestamp?, DateTimeOffset?>().ConvertUsing<NullableUtcTimestampToNullableDateTimeOffsetConverter>();
+        profile.CreateMap<DateTimeOffset, UtcTimestamp>().ConvertUsing<DateTimeOffsetToUtcTimestampConverter>();
+        profile.CreateMap<DateTimeOffset?, UtcTimestamp?>().ConvertUsing<NullableDateTimeOffsetToNullableUtcTimestampConverter>();
+        profile.CreateMap<int, FileAttributesFlags>().ConvertUsing<IntToFileAttributesFlagsConverter>();
+    }
+
     public sealed class FileNameToStringConverter : IValueConverter<FileName, string>
     {
-        public string Convert(FileName sourceMember, ResolutionContext context) => sourceMember.Value;
+        public string Convert(FileName sourceMember, ResolutionContext context) => sourceMember.Value ?? string.Empty;
     }
 
     public sealed class FileExtensionToStringConverter : IValueConverter<FileExtension, string>
     {
-        public string Convert(FileExtension sourceMember, ResolutionContext context) => sourceMember.Value;
+        public string Convert(FileExtension sourceMember, ResolutionContext context) => sourceMember.Value ?? string.Empty;
     }
 
     public sealed class MimeTypeToStringConverter : IValueConverter<MimeType, string>
     {
-        public string Convert(MimeType sourceMember, ResolutionContext context) => sourceMember.Value;
+        public string Convert(MimeType sourceMember, ResolutionContext context) => sourceMember.Value ?? string.Empty;
+    }
+
+    public sealed class FileHashToStringConverter : IValueConverter<FileHash, string>
+    {
+        public string Convert(FileHash sourceMember, ResolutionContext context) => sourceMember.Value ?? string.Empty;
     }
 
     public sealed class ByteSizeToLongConverter : IValueConverter<ByteSize, long>
     {
         public long Convert(ByteSize sourceMember, ResolutionContext context) => sourceMember.Value;
+    }
+
+    public sealed class FileAttributesToIntConverter : IValueConverter<FileAttributesFlags, int>
+    {
+        public int Convert(FileAttributesFlags sourceMember, ResolutionContext context) => (int)sourceMember;
+    }
+
+    public sealed class IntToFileAttributesFlagsConverter : IValueConverter<int, FileAttributesFlags>
+    {
+        public FileAttributesFlags Convert(int sourceMember, ResolutionContext context) => (FileAttributesFlags)sourceMember;
     }
 
     public sealed class UtcTimestampToDateTimeOffsetConverter : IValueConverter<UtcTimestamp, DateTimeOffset>
@@ -40,13 +77,14 @@ public static class CommonValueConverters
         public DateTimeOffset? Convert(UtcTimestamp? sourceMember, ResolutionContext context) => sourceMember?.Value;
     }
 
-    public sealed class FileHashToStringConverter : IValueConverter<FileHash, string>
+    public sealed class DateTimeOffsetToUtcTimestampConverter : IValueConverter<DateTimeOffset, UtcTimestamp>
     {
-        public string Convert(FileHash sourceMember, ResolutionContext context) => sourceMember.Value;
+        public UtcTimestamp Convert(DateTimeOffset sourceMember, ResolutionContext context) => UtcTimestamp.From(sourceMember);
     }
 
-    public sealed class FileAttributesToIntConverter : IValueConverter<FileAttributesFlags, int>
+    public sealed class NullableDateTimeOffsetToNullableUtcTimestampConverter : IValueConverter<DateTimeOffset?, UtcTimestamp?>
     {
-        public int Convert(FileAttributesFlags sourceMember, ResolutionContext context) => (int)sourceMember;
+        public UtcTimestamp? Convert(DateTimeOffset? sourceMember, ResolutionContext context) =>
+            sourceMember.HasValue ? UtcTimestamp.From(sourceMember.Value) : null;
     }
 }

--- a/Veriado.Mapping/Profiles/FileReadProfiles.cs
+++ b/Veriado.Mapping/Profiles/FileReadProfiles.cs
@@ -1,4 +1,3 @@
-using System;
 using AutoMapper;
 using Veriado.Appl.Abstractions;
 using Veriado.Contracts.Files;
@@ -8,7 +7,7 @@ using Veriado.Domain.Metadata;
 namespace Veriado.Mapping.Profiles;
 
 /// <summary>
-/// Configures mappings used when projecting domain entities to read DTOs.
+/// Configures mappings used when projecting domain entities and read models to read DTOs.
 /// </summary>
 public sealed class FileReadProfiles : Profile
 {
@@ -18,100 +17,113 @@ public sealed class FileReadProfiles : Profile
     public FileReadProfiles()
     {
         CreateMap<FileDocumentValidityEntity, FileValidityDto>()
-            .ConvertUsing(src => new FileValidityDto(
-                src.IssuedAt.Value,
-                src.ValidUntil.Value,
-                src.HasPhysicalCopy,
-                src.HasElectronicCopy));
+            .ForCtorParam(nameof(FileValidityDto.IssuedAt), opt => opt.MapFrom(src => src.IssuedAt))
+            .ForCtorParam(nameof(FileValidityDto.ValidUntil), opt => opt.MapFrom(src => src.ValidUntil))
+            .ForCtorParam(nameof(FileValidityDto.HasPhysicalCopy), opt => opt.MapFrom(src => src.HasPhysicalCopy))
+            .ForCtorParam(nameof(FileValidityDto.HasElectronicCopy), opt => opt.MapFrom(src => src.HasElectronicCopy));
 
         CreateMap<FileSystemMetadata, FileSystemMetadataDto>()
-            .ConvertUsing(src => new FileSystemMetadataDto(
-                (int)src.Attributes,
-                src.CreatedUtc.Value,
-                src.LastWriteUtc.Value,
-                src.LastAccessUtc.Value,
-                src.OwnerSid,
-                src.HardLinkCount,
-                src.AlternateDataStreamCount));
+            .ForCtorParam(nameof(FileSystemMetadataDto.Attributes), opt => opt.MapFrom(src => src.Attributes))
+            .ForCtorParam(nameof(FileSystemMetadataDto.CreatedUtc), opt => opt.MapFrom(src => src.CreatedUtc))
+            .ForCtorParam(nameof(FileSystemMetadataDto.LastWriteUtc), opt => opt.MapFrom(src => src.LastWriteUtc))
+            .ForCtorParam(nameof(FileSystemMetadataDto.LastAccessUtc), opt => opt.MapFrom(src => src.LastAccessUtc))
+            .ForCtorParam(nameof(FileSystemMetadataDto.OwnerSid), opt => opt.MapFrom(src => src.OwnerSid))
+            .ForCtorParam(nameof(FileSystemMetadataDto.HardLinkCount), opt => opt.MapFrom(src => src.HardLinkCount))
+            .ForCtorParam(nameof(FileSystemMetadataDto.AlternateDataStreamCount), opt => opt.MapFrom(src => src.AlternateDataStreamCount));
 
         CreateMap<FileContentEntity, FileContentDto>()
-            .ConvertUsing(src => new FileContentDto(
-                src.Hash.Value,
-                src.Length.Value,
-                null));
+            .ForCtorParam(nameof(FileContentDto.Hash), opt => opt.MapFrom(src => src.Hash))
+            .ForCtorParam(nameof(FileContentDto.Length), opt => opt.MapFrom(src => src.Length))
+            .ForCtorParam(nameof(FileContentDto.Bytes), opt => opt.MapFrom(_ => (byte[]?)null));
 
         CreateMap<FileDocumentValidityReadModel, FileValidityDto>()
-            .ConvertUsing(src => new FileValidityDto(
-                src.IssuedAtUtc,
-                src.ValidUntilUtc,
-                src.HasPhysicalCopy,
-                src.HasElectronicCopy));
+            .ForCtorParam(nameof(FileValidityDto.IssuedAt), opt => opt.MapFrom(src => src.IssuedAtUtc))
+            .ForCtorParam(nameof(FileValidityDto.ValidUntil), opt => opt.MapFrom(src => src.ValidUntilUtc))
+            .ForCtorParam(nameof(FileValidityDto.HasPhysicalCopy), opt => opt.MapFrom(src => src.HasPhysicalCopy))
+            .ForCtorParam(nameof(FileValidityDto.HasElectronicCopy), opt => opt.MapFrom(src => src.HasElectronicCopy));
 
-        CreateMap<FileListItemReadModel, FileListItemDto>().ConstructUsing(src => new FileListItemDto(
-            src.Id,
-            src.Name,
-            src.Extension,
-            src.Mime,
-            src.Author,
-            src.SizeBytes,
-            src.Version,
-            src.IsReadOnly,
-            src.CreatedUtc,
-            src.LastModifiedUtc,
-            src.ValidUntilUtc));
+        CreateMap<FileListItemReadModel, FileListItemDto>();
 
         CreateMap<FileEntity, FileSummaryDto>()
-            .ForMember(dest => dest.Name, opt => opt.MapFrom(src => src.Name.Value))
-            .ForMember(dest => dest.Extension, opt => opt.MapFrom(src => src.Extension.Value))
-            .ForMember(dest => dest.Mime, opt => opt.MapFrom(src => src.Mime.Value))
-            .ForMember(dest => dest.Title, opt => opt.MapFrom(src => src.Title ?? src.Name.Value))
-            .ForMember(dest => dest.Size, opt => opt.MapFrom(src => src.Size.Value))
-            .ForMember(dest => dest.CreatedUtc, opt => opt.MapFrom(src => src.CreatedUtc.Value))
-            .ForMember(dest => dest.LastModifiedUtc, opt => opt.MapFrom(src => src.LastModifiedUtc.Value))
-            .ForMember(dest => dest.Validity, opt => opt.MapFrom(src => src.Validity))
-            .ForMember(dest => dest.IsIndexStale, opt => opt.MapFrom(src => src.SearchIndex?.IsStale ?? false))
-            .ForMember(dest => dest.LastIndexedUtc, opt => opt.MapFrom(src => src.SearchIndex?.LastIndexedUtc))
-            .ForMember(dest => dest.IndexedTitle, opt => opt.MapFrom(src => src.SearchIndex?.IndexedTitle))
-            .ForMember(dest => dest.IndexSchemaVersion, opt => opt.MapFrom(src => src.SearchIndex?.SchemaVersion ?? 0))
-            .ForMember(dest => dest.IndexedContentHash, opt => opt.MapFrom(src => src.SearchIndex?.IndexedContentHash))
-            .ForMember(dest => dest.Score, opt => opt.Ignore());
-
-        CreateMap<FileEntity, FileDetailDto>()
-            .ForMember(dest => dest.Name, opt => opt.MapFrom(src => src.Name.Value))
-            .ForMember(dest => dest.Extension, opt => opt.MapFrom(src => src.Extension.Value))
-            .ForMember(dest => dest.Mime, opt => opt.MapFrom(src => src.Mime.Value))
-            .ForMember(dest => dest.Title, opt => opt.MapFrom(src => src.Title ?? src.Name.Value))
-            .ForMember(dest => dest.Size, opt => opt.MapFrom(src => src.Size.Value))
-            .ForMember(dest => dest.CreatedUtc, opt => opt.MapFrom(src => src.CreatedUtc.Value))
-            .ForMember(dest => dest.LastModifiedUtc, opt => opt.MapFrom(src => src.LastModifiedUtc.Value))
-            .ForMember(dest => dest.Content, opt => opt.MapFrom(src => src.Content))
-            .ForMember(dest => dest.SystemMetadata, opt => opt.MapFrom(src => src.SystemMetadata))
-            .ForMember(dest => dest.Validity, opt => opt.MapFrom(src => src.Validity))
-            .ForMember(dest => dest.IsIndexStale, opt => opt.MapFrom(src => src.SearchIndex?.IsStale ?? false))
-            .ForMember(dest => dest.LastIndexedUtc, opt => opt.MapFrom(src => src.SearchIndex?.LastIndexedUtc))
-            .ForMember(dest => dest.IndexedTitle, opt => opt.MapFrom(src => src.SearchIndex?.IndexedTitle))
-            .ForMember(dest => dest.IndexSchemaVersion, opt => opt.MapFrom(src => src.SearchIndex?.SchemaVersion ?? 0))
-            .ForMember(dest => dest.IndexedContentHash, opt => opt.MapFrom(src => src.SearchIndex?.IndexedContentHash));
-
-        CreateMap<FileDetailReadModel, FileDetailDto>()
-            .ForMember(dest => dest.Id, opt => opt.MapFrom(src => src.Id))
             .ForMember(dest => dest.Name, opt => opt.MapFrom(src => src.Name))
             .ForMember(dest => dest.Extension, opt => opt.MapFrom(src => src.Extension))
             .ForMember(dest => dest.Mime, opt => opt.MapFrom(src => src.Mime))
-            .ForMember(dest => dest.Author, opt => opt.MapFrom(src => src.Author))
-            .ForMember(dest => dest.Size, opt => opt.MapFrom(src => src.SizeBytes))
+            .ForMember(dest => dest.Title, opt => opt.MapFrom(src => src.Title ?? src.Name.Value))
+            .ForMember(dest => dest.Size, opt => opt.MapFrom(src => src.Size))
             .ForMember(dest => dest.CreatedUtc, opt => opt.MapFrom(src => src.CreatedUtc))
             .ForMember(dest => dest.LastModifiedUtc, opt => opt.MapFrom(src => src.LastModifiedUtc))
-            .ForMember(dest => dest.IsReadOnly, opt => opt.MapFrom(src => src.IsReadOnly))
-            .ForMember(dest => dest.Version, opt => opt.MapFrom(src => src.Version))
-            .ForMember(dest => dest.Content, opt => opt.MapFrom(src => new FileContentDto(string.Empty, src.SizeBytes, null)))
-            .ForMember(dest => dest.SystemMetadata, opt => opt.MapFrom(src => src.SystemMetadata))
-            .ForMember(dest => dest.Title, opt => opt.MapFrom(src => src.Title))
             .ForMember(dest => dest.Validity, opt => opt.MapFrom(src => src.Validity))
-            .ForMember(dest => dest.IsIndexStale, opt => opt.MapFrom(_ => false))
-            .ForMember(dest => dest.LastIndexedUtc, opt => opt.MapFrom(_ => (DateTimeOffset?)null))
-            .ForMember(dest => dest.IndexedTitle, opt => opt.MapFrom(_ => (string?)null))
-            .ForMember(dest => dest.IndexSchemaVersion, opt => opt.MapFrom(_ => 0))
-            .ForMember(dest => dest.IndexedContentHash, opt => opt.MapFrom(_ => (string?)null));
+            // Search index state is optional; guard members to avoid null dereferences and preserve defaults.
+            .ForMember(dest => dest.IsIndexStale, opt =>
+            {
+                opt.PreCondition(src => src.SearchIndex is not null);
+                opt.MapFrom(src => src.SearchIndex!.IsStale);
+            })
+            .ForMember(dest => dest.LastIndexedUtc, opt =>
+            {
+                opt.PreCondition(src => src.SearchIndex is not null);
+                opt.MapFrom(src => src.SearchIndex!.LastIndexedUtc);
+            })
+            .ForMember(dest => dest.IndexedTitle, opt =>
+            {
+                opt.PreCondition(src => src.SearchIndex is not null);
+                opt.MapFrom(src => src.SearchIndex!.IndexedTitle);
+            })
+            .ForMember(dest => dest.IndexSchemaVersion, opt =>
+            {
+                opt.PreCondition(src => src.SearchIndex is not null);
+                opt.MapFrom(src => src.SearchIndex!.SchemaVersion);
+            })
+            .ForMember(dest => dest.IndexedContentHash, opt =>
+            {
+                opt.PreCondition(src => src.SearchIndex is not null);
+                opt.MapFrom(src => src.SearchIndex!.IndexedContentHash);
+            })
+            .ForMember(dest => dest.Score, opt => opt.Ignore());
+
+        CreateMap<FileEntity, FileDetailDto>()
+            .ForMember(dest => dest.Name, opt => opt.MapFrom(src => src.Name))
+            .ForMember(dest => dest.Extension, opt => opt.MapFrom(src => src.Extension))
+            .ForMember(dest => dest.Mime, opt => opt.MapFrom(src => src.Mime))
+            .ForMember(dest => dest.Title, opt => opt.MapFrom(src => src.Title ?? src.Name.Value))
+            .ForMember(dest => dest.Size, opt => opt.MapFrom(src => src.Size))
+            .ForMember(dest => dest.CreatedUtc, opt => opt.MapFrom(src => src.CreatedUtc))
+            .ForMember(dest => dest.LastModifiedUtc, opt => opt.MapFrom(src => src.LastModifiedUtc))
+            .ForMember(dest => dest.Content, opt => opt.MapFrom(src => src.Content))
+            .ForMember(dest => dest.SystemMetadata, opt => opt.MapFrom(src => src.SystemMetadata))
+            .ForMember(dest => dest.Validity, opt => opt.MapFrom(src => src.Validity))
+            // Avoid forcing default values when search indexing has not run yet.
+            .ForMember(dest => dest.IsIndexStale, opt =>
+            {
+                opt.PreCondition(src => src.SearchIndex is not null);
+                opt.MapFrom(src => src.SearchIndex!.IsStale);
+            })
+            .ForMember(dest => dest.LastIndexedUtc, opt =>
+            {
+                opt.PreCondition(src => src.SearchIndex is not null);
+                opt.MapFrom(src => src.SearchIndex!.LastIndexedUtc);
+            })
+            .ForMember(dest => dest.IndexedTitle, opt =>
+            {
+                opt.PreCondition(src => src.SearchIndex is not null);
+                opt.MapFrom(src => src.SearchIndex!.IndexedTitle);
+            })
+            .ForMember(dest => dest.IndexSchemaVersion, opt =>
+            {
+                opt.PreCondition(src => src.SearchIndex is not null);
+                opt.MapFrom(src => src.SearchIndex!.SchemaVersion);
+            })
+            .ForMember(dest => dest.IndexedContentHash, opt =>
+            {
+                opt.PreCondition(src => src.SearchIndex is not null);
+                opt.MapFrom(src => src.SearchIndex!.IndexedContentHash);
+            });
+
+        CreateMap<FileDetailReadModel, FileDetailDto>()
+            .ForMember(dest => dest.Size, opt => opt.MapFrom(src => src.SizeBytes))
+            // The read model does not surface hashes; expose metadata only.
+            .ForMember(dest => dest.Content, opt => opt.MapFrom(src => new FileContentDto(string.Empty, src.SizeBytes)))
+            .ForMember(dest => dest.SystemMetadata, opt => opt.MapFrom(src => src.SystemMetadata))
+            .ForMember(dest => dest.Validity, opt => opt.MapFrom(src => src.Validity));
     }
 }

--- a/Veriado.Mapping/Profiles/FileWriteProfiles.cs
+++ b/Veriado.Mapping/Profiles/FileWriteProfiles.cs
@@ -1,7 +1,6 @@
 using AutoMapper;
 using Veriado.Contracts.Files;
 using Veriado.Domain.Metadata;
-using Veriado.Domain.ValueObjects;
 
 namespace Veriado.Mapping.Profiles;
 
@@ -15,13 +14,13 @@ public sealed class FileWriteProfiles : Profile
     /// </summary>
     public FileWriteProfiles()
     {
-        CreateMap<FileSystemMetadataDto, FileSystemMetadata>().ConvertUsing(dto => new FileSystemMetadata(
-            (FileAttributesFlags)dto.Attributes,
-            UtcTimestamp.From(dto.CreatedUtc),
-            UtcTimestamp.From(dto.LastWriteUtc),
-            UtcTimestamp.From(dto.LastAccessUtc),
-            dto.OwnerSid,
-            dto.HardLinkCount,
-            dto.AlternateDataStreamCount));
+        CreateMap<FileSystemMetadataDto, FileSystemMetadata>()
+            .ForCtorParam("attributes", opt => opt.MapFrom(src => src.Attributes))
+            .ForCtorParam("createdUtc", opt => opt.MapFrom(src => src.CreatedUtc))
+            .ForCtorParam("lastWriteUtc", opt => opt.MapFrom(src => src.LastWriteUtc))
+            .ForCtorParam("lastAccessUtc", opt => opt.MapFrom(src => src.LastAccessUtc))
+            .ForCtorParam("ownerSid", opt => opt.MapFrom(src => src.OwnerSid))
+            .ForCtorParam("hardLinkCount", opt => opt.MapFrom(src => src.HardLinkCount))
+            .ForCtorParam("alternateDataStreamCount", opt => opt.MapFrom(src => src.AlternateDataStreamCount));
     }
 }

--- a/Veriado.Mapping/Profiles/SearchProfiles.cs
+++ b/Veriado.Mapping/Profiles/SearchProfiles.cs
@@ -14,32 +14,24 @@ public sealed class SearchProfiles : Profile
     /// </summary>
     public SearchProfiles()
     {
-        CreateMap<SearchHit, SearchHitDto>().ConstructUsing(src => new SearchHitDto(
-            src.FileId,
-            src.Title,
-            src.Mime,
-            src.Snippet,
-            src.Score,
-            src.LastModifiedUtc));
+        CreateMap<SearchHit, SearchHitDto>();
 
         CreateMap<SearchHistoryEntryEntity, SearchHistoryEntry>()
-            .ConvertUsing(src => new SearchHistoryEntry(
-                src.Id,
-                src.QueryText,
-                src.Match,
-                src.CreatedUtc,
-                src.Executions,
-                src.LastTotalHits,
-                src.IsFuzzy));
+            .ForCtorParam(nameof(SearchHistoryEntry.Id), opt => opt.MapFrom(src => src.Id))
+            .ForCtorParam(nameof(SearchHistoryEntry.QueryText), opt => opt.MapFrom(src => src.QueryText))
+            .ForCtorParam(nameof(SearchHistoryEntry.MatchQuery), opt => opt.MapFrom(src => src.Match))
+            .ForCtorParam(nameof(SearchHistoryEntry.LastQueriedUtc), opt => opt.MapFrom(src => src.CreatedUtc))
+            .ForCtorParam(nameof(SearchHistoryEntry.Executions), opt => opt.MapFrom(src => src.Executions))
+            .ForCtorParam(nameof(SearchHistoryEntry.LastTotalHits), opt => opt.MapFrom(src => src.LastTotalHits))
+            .ForCtorParam(nameof(SearchHistoryEntry.IsFuzzy), opt => opt.MapFrom(src => src.IsFuzzy));
 
         CreateMap<SearchFavoriteEntity, SearchFavoriteItem>()
-            .ConvertUsing(src => new SearchFavoriteItem(
-                src.Id,
-                src.Name,
-                src.QueryText,
-                src.Match,
-                src.Position,
-                src.CreatedUtc,
-                src.IsFuzzy));
+            .ForCtorParam(nameof(SearchFavoriteItem.Id), opt => opt.MapFrom(src => src.Id))
+            .ForCtorParam(nameof(SearchFavoriteItem.Name), opt => opt.MapFrom(src => src.Name))
+            .ForCtorParam(nameof(SearchFavoriteItem.QueryText), opt => opt.MapFrom(src => src.QueryText))
+            .ForCtorParam(nameof(SearchFavoriteItem.MatchQuery), opt => opt.MapFrom(src => src.Match))
+            .ForCtorParam(nameof(SearchFavoriteItem.Position), opt => opt.MapFrom(src => src.Position))
+            .ForCtorParam(nameof(SearchFavoriteItem.CreatedUtc), opt => opt.MapFrom(src => src.CreatedUtc))
+            .ForCtorParam(nameof(SearchFavoriteItem.IsFuzzy), opt => opt.MapFrom(src => src.IsFuzzy));
     }
 }


### PR DESCRIPTION
## Summary
- centralize reusable value-object converters to avoid null dereferences and enable symmetric DTO-domain projections
- refactor file and search profiles to use constructor mapping/PreCondition for EF-friendly ProjectTo expressions
- warm up mapper configuration at startup with validation and compiled mappings for better runtime diagnostics

## Testing
- `dotnet build Veriado.sln` *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d8e840a08c8326bff7dee4984a60f8