### PR TITLE
Fix FileDetail read model mapping optional argument usage

### DIFF
--- a/Veriado.Mapping/Profiles/FileReadProfiles.cs
+++ b/Veriado.Mapping/Profiles/FileReadProfiles.cs
@@ -122,7 +122,7 @@ public sealed class FileReadProfiles : Profile
         CreateMap<FileDetailReadModel, FileDetailDto>()
             .ForMember(dest => dest.Size, opt => opt.MapFrom(src => src.SizeBytes))
             // The read model does not surface hashes; expose metadata only.
-            .ForMember(dest => dest.Content, opt => opt.MapFrom(src => new FileContentDto(string.Empty, src.SizeBytes)))
+            .ForMember(dest => dest.Content, opt => opt.MapFrom(src => new FileContentDto(string.Empty, src.SizeBytes, null)))
             .ForMember(dest => dest.SystemMetadata, opt => opt.MapFrom(src => src.SystemMetadata))
             .ForMember(dest => dest.Validity, opt => opt.MapFrom(src => src.Validity));
     }


### PR DESCRIPTION
## Summary
- provide the FileContentDto constructor with an explicit bytes argument when mapping FileDetailReadModel instances to avoid optional argument usage in expression trees

## Testing
- ⚠️ `dotnet build Veriado.sln` *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d8eabafa388326a1574bff988e8fc5