### PR TITLE
Add AutoMapper mapping for file content responses

### DIFF
--- a/Veriado.Mapping/Profiles/FileReadProfiles.cs
+++ b/Veriado.Mapping/Profiles/FileReadProfiles.cs
@@ -1,3 +1,4 @@
+using System;
 using AutoMapper;
 using Veriado.Appl.Abstractions;
 using Veriado.Contracts.Files;
@@ -35,6 +36,20 @@ public sealed class FileReadProfiles : Profile
             .ForCtorParam(nameof(FileContentDto.Hash), opt => opt.MapFrom(src => src.Hash))
             .ForCtorParam(nameof(FileContentDto.Length), opt => opt.MapFrom(src => src.Length))
             .ForCtorParam(nameof(FileContentDto.Bytes), opt => opt.MapFrom(_ => (byte[]?)null));
+
+        CreateMap<FileEntity, FileContentResponseDto>()
+            .ForCtorParam(nameof(FileContentResponseDto.Id), opt => opt.MapFrom(src => src.Id))
+            .ForCtorParam(nameof(FileContentResponseDto.Name), opt => opt.MapFrom(src => src.Name))
+            .ForCtorParam(nameof(FileContentResponseDto.Extension), opt => opt.MapFrom(src => src.Extension))
+            .ForCtorParam(nameof(FileContentResponseDto.Mime), opt => opt.MapFrom(src => src.Mime))
+            .ForCtorParam(nameof(FileContentResponseDto.Author), opt => opt.MapFrom(src => src.Author))
+            .ForCtorParam(nameof(FileContentResponseDto.SizeBytes), opt => opt.MapFrom(src => src.Size))
+            .ForCtorParam(nameof(FileContentResponseDto.Version), opt => opt.MapFrom(src => src.Version))
+            .ForCtorParam(nameof(FileContentResponseDto.IsReadOnly), opt => opt.MapFrom(src => src.IsReadOnly))
+            .ForCtorParam(nameof(FileContentResponseDto.CreatedUtc), opt => opt.MapFrom(src => src.CreatedUtc))
+            .ForCtorParam(nameof(FileContentResponseDto.LastModifiedUtc), opt => opt.MapFrom(src => src.LastModifiedUtc))
+            .ForCtorParam(nameof(FileContentResponseDto.Validity), opt => opt.MapFrom(src => src.Validity))
+            .ForCtorParam(nameof(FileContentResponseDto.Content), opt => opt.MapFrom(src => CloneBytes(src.Content.Bytes)));
 
         CreateMap<FileDocumentValidityReadModel, FileValidityDto>()
             .ForCtorParam(nameof(FileValidityDto.IssuedAt), opt => opt.MapFrom(src => src.IssuedAtUtc))
@@ -125,5 +140,17 @@ public sealed class FileReadProfiles : Profile
             .ForMember(dest => dest.Content, opt => opt.MapFrom(src => new FileContentDto(string.Empty, src.SizeBytes, null)))
             .ForMember(dest => dest.SystemMetadata, opt => opt.MapFrom(src => src.SystemMetadata))
             .ForMember(dest => dest.Validity, opt => opt.MapFrom(src => src.Validity));
+    }
+
+    private static byte[] CloneBytes(byte[] source)
+    {
+        if (source is null || source.Length == 0)
+        {
+            return Array.Empty<byte>();
+        }
+
+        var clone = new byte[source.Length];
+        Array.Copy(source, clone, source.Length);
+        return clone;
     }
 }

--- a/Veriado.Services/Files/FileContentService.cs
+++ b/Veriado.Services/Files/FileContentService.cs
@@ -31,22 +31,7 @@ public sealed class FileContentService : IFileContentService
             return null;
         }
 
-        var summary = _mapper.Map<FileSummaryDto>(file);
-        var content = new byte[file.Content.Bytes.Length];
-        Array.Copy(file.Content.Bytes, content, file.Content.Bytes.Length);
-        return new FileContentResponseDto(
-            summary.Id,
-            summary.Name,
-            summary.Extension,
-            summary.Mime,
-            summary.Author,
-            summary.Size,
-            summary.Version,
-            summary.IsReadOnly,
-            summary.CreatedUtc,
-            summary.LastModifiedUtc,
-            summary.Validity,
-            content);
+        return _mapper.Map<FileContentResponseDto>(file);
     }
 
     public async Task<AppResult<Guid>> SaveContentToDiskAsync(Guid fileId, string targetPath, CancellationToken cancellationToken)


### PR DESCRIPTION
## Summary
- add an AutoMapper map from `FileEntity` to `FileContentResponseDto`, including cloning the content bytes
- switch the file content service to rely on AutoMapper for building download payloads

## Testing
- `dotnet test` *(fails: dotnet is not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d8eb444f488326a1c06dc508280d5d