### PR TITLE
Prefill import author with current Windows user

### DIFF
--- a/Veriado.WinUI/ViewModels/Import/ImportPageViewModel.cs
+++ b/Veriado.WinUI/ViewModels/Import/ImportPageViewModel.cs
@@ -57,6 +57,7 @@ public partial class ImportPageViewModel : ViewModelBase
         Errors.CollectionChanged += OnErrorsCollectionChanged;
 
         RestoreStateFromHotStorage();
+        PopulateDefaultAuthorFromCurrentUser();
 
         _pickFolderCommand = new AsyncRelayCommand(ExecutePickFolderAsync, () => !IsImporting);
         _runImportCommand = new AsyncRelayCommand(ExecuteRunImportAsync, CanRunImport);
@@ -628,6 +629,30 @@ public partial class ImportPageViewModel : ViewModelBase
             : Environment.ProcessorCount;
         DefaultAuthor = _hotStateService.ImportDefaultAuthor;
         MaxFileSizeMegabytes = _hotStateService.ImportMaxFileSizeMegabytes ?? 0;
+    }
+
+    private void PopulateDefaultAuthorFromCurrentUser()
+    {
+        if (!string.IsNullOrWhiteSpace(DefaultAuthor))
+        {
+            return;
+        }
+
+        if (!OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        var userName = Environment.UserName;
+        if (string.IsNullOrWhiteSpace(userName))
+        {
+            return;
+        }
+
+        var domainName = Environment.UserDomainName;
+        DefaultAuthor = string.IsNullOrWhiteSpace(domainName)
+            ? userName
+            : $"{domainName}\\{userName}";
     }
 
     private void OnErrorsCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)


### PR DESCRIPTION
## Summary
- populate the import default author field from the currently signed-in Windows account when no value is stored

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d8f3487ca0832687b93ea2e9241442