### PR TITLE
Fix import page initialization order to avoid null reference

### DIFF
--- a/Veriado.WinUI/ViewModels/Import/ImportPageViewModel.cs
+++ b/Veriado.WinUI/ViewModels/Import/ImportPageViewModel.cs
@@ -56,14 +56,14 @@ public partial class ImportPageViewModel : ViewModelBase
         Log.CollectionChanged += OnLogCollectionChanged;
         Errors.CollectionChanged += OnErrorsCollectionChanged;
 
-        RestoreStateFromHotStorage();
-        PopulateDefaultAuthorFromCurrentUser();
-
         _pickFolderCommand = new AsyncRelayCommand(ExecutePickFolderAsync, () => !IsImporting);
         _runImportCommand = new AsyncRelayCommand(ExecuteRunImportAsync, CanRunImport);
         _stopImportCommand = new RelayCommand(ExecuteStopImport, () => IsImporting);
         _clearResultsCommand = new RelayCommand(ExecuteClearResults, CanClearResults);
         _openErrorDetailCommand = new RelayCommand<ImportErrorItem>(ExecuteOpenErrorDetail);
+
+        RestoreStateFromHotStorage();
+        PopulateDefaultAuthorFromCurrentUser();
     }
 
     [ObservableProperty]


### PR DESCRIPTION
## Summary
- initialize import commands before restoring hot state
- prevent the import page from throwing a NullReferenceException when the last folder is restored

## Testing
- not run (UI change)

------
https://chatgpt.com/codex/tasks/task_e_68d8f6fdc14c8326b075223cd7a6b83d