### PR TITLE
Add detailed summaries to import log entries

### DIFF
--- a/Veriado.WinUI/Models/Import/ImportLogItem.cs
+++ b/Veriado.WinUI/Models/Import/ImportLogItem.cs
@@ -5,12 +5,13 @@ namespace Veriado.WinUI.Models.Import;
 
 public sealed class ImportLogItem
 {
-    public ImportLogItem(DateTimeOffset timestamp, string title, string message, string status)
+    public ImportLogItem(DateTimeOffset timestamp, string title, string message, string status, string? detail = null)
     {
         Timestamp = timestamp;
         Title = title;
         Message = message;
         Status = status;
+        Detail = detail;
     }
 
     public DateTimeOffset Timestamp { get; }
@@ -21,5 +22,9 @@ public sealed class ImportLogItem
 
     public string Status { get; }
 
+    public string? Detail { get; }
+
     public string FormattedTimestamp => Timestamp.ToString("HH:mm:ss", CultureInfo.CurrentCulture);
+
+    public bool HasDetail => !string.IsNullOrWhiteSpace(Detail);
 }

--- a/Veriado.WinUI/Views/Import/ImportPage.xaml
+++ b/Veriado.WinUI/Views/Import/ImportPage.xaml
@@ -141,6 +141,12 @@
                                             Text="{x:Bind FormattedTimestamp, Mode=OneWay}" />
                                         <TextBlock FontWeight="SemiBold" Text="{Binding Title}" />
                                         <TextBlock TextWrapping="Wrap" Text="{Binding Message}" />
+                                        <TextBlock
+                                            Margin="0,2,0,0"
+                                            TextWrapping="Wrap"
+                                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                            Text="{x:Bind Detail, Mode=OneWay}"
+                                            x:Load="{x:Bind HasDetail, Mode=OneWay}" />
                                     </StackPanel>
                                 </Border>
                             </DataTemplate>


### PR DESCRIPTION
## Summary
- add optional detail text to import log items and surface it in the log view
- augment the import page view model to capture per-file details and aggregate batch results for log entries

## Testing
- dotnet build Veriado.sln *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d8f9c0e39483268f9de604deb40713