### PR TITLE
Fix error expander binding mode

### DIFF
--- a/Veriado.WinUI/Views/Import/ImportPage.xaml
+++ b/Veriado.WinUI/Views/Import/ImportPage.xaml
@@ -157,7 +157,7 @@
                 <Expander
                     Grid.Row="1"
                     Header="Chyby"
-                    IsExpanded="{Binding HasErrors}"
+                    IsExpanded="{Binding HasErrors, Mode=OneWay}"
                     HorizontalAlignment="Stretch">
                     <ItemsControl x:Name="ErrorsItemsControl" ItemsSource="{Binding Errors}">
                         <ItemsControl.ItemTemplate>


### PR DESCRIPTION
## Summary
- set the error expander on the import page to use a one-way binding
- ensure collapsing the expander manually does not produce binding warnings

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8fd4ee83483269935df394ec27178