### PR TITLE
Add x:Name for import detail text block

### DIFF
--- a/Veriado.WinUI/Views/Import/ImportPage.xaml
+++ b/Veriado.WinUI/Views/Import/ImportPage.xaml
@@ -142,6 +142,7 @@
                                         <TextBlock FontWeight="SemiBold" Text="{Binding Title}" />
                                         <TextBlock TextWrapping="Wrap" Text="{Binding Message}" />
                                         <TextBlock
+                                            x:Name="DetailTextBlock"
                                             Margin="0,2,0,0"
                                             TextWrapping="Wrap"
                                             Foreground="{ThemeResource TextFillColorSecondaryBrush}"


### PR DESCRIPTION
## Summary
- assign a name to the import detail TextBlock so it can be used with x:Load without triggering WMC0907

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8fdc923e48326bdb5998f12c22b2d