### PR TITLE
Stabilize full-text index storage paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Veriado
 
 ## Úvod
-Veriado je desktopová aplikace pro Windows, která katalogizuje dokumenty, ukládá jejich binární obsah a metadata do lokální databáze a staví nad nimi plnotextové vyhledávání s moderním WinUI rozhraním.【F:Veriado.Domain/Files/FileEntity.cs†L13-L177】【F:Veriado.Domain/Files/FileContentEntity.cs†L6-L57】【F:Veriado.Infrastructure/Persistence/Options/InfrastructureOptions.cs†L13-L34】【F:Veriado.Infrastructure/Search/SqliteFts5Indexer.cs†L11-L50】【F:Veriado.WinUI/Views/FilesView.xaml†L1-L45】
+Veriado je desktopová aplikace pro Windows, která katalogizuje dokumenty, ukládá jejich binární obsah a metadata do lokální databáze a staví nad nimi plnotextové vyhledávání s moderním WinUI rozhraním.【F:Veriado.Domain/Files/FileEntity.cs†L13-L177】【F:Veriado.Domain/Files/FileContentEntity.cs†L6-L57】【F:Veriado.Infrastructure/Persistence/Options/InfrastructureOptions.cs†L13-L34】【F:Veriado.Infrastructure/Search/SqliteFts5Indexer.cs†L11-L50】【F:Veriado.WinUI/Views/FilesView.xaml†L1-L45】 Výchozí umístění databáze i Lucene indexu nyní spadá do `%LocalAppData%\Veriado`, takže při restartu aplikace zůstane index stabilní i mimo adresář s binárkami; v prostředích bez dostupného profilu se použije bezpečný fallback v adresáři aplikace.【F:Veriado.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs†L41-L87】
 
 ## Popis aplikace
 ### Klíčové vlastnosti

--- a/Veriado.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/Veriado.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
@@ -43,7 +43,8 @@ public static class ServiceCollectionExtensions
 
         if (string.IsNullOrWhiteSpace(options.DbPath))
         {
-            options.DbPath = Path.Combine(AppContext.BaseDirectory, "veriado.db");
+            var dataDirectory = ResolveDefaultDataDirectory();
+            options.DbPath = Path.Combine(dataDirectory, "veriado.db");
         }
 
         var directory = Path.GetDirectoryName(options.DbPath);
@@ -56,9 +57,8 @@ public static class ServiceCollectionExtensions
         {
             if (string.IsNullOrWhiteSpace(options.LuceneIndexPath))
             {
-                options.LuceneIndexPath = string.IsNullOrWhiteSpace(directory)
-                    ? Path.Combine(AppContext.BaseDirectory, "lucene-index")
-                    : Path.Combine(directory!, "lucene-index");
+                var dataDirectory = ResolveDefaultDataDirectory();
+                options.LuceneIndexPath = Path.Combine(dataDirectory, "lucene-index");
             }
 
             if (!Directory.Exists(options.LuceneIndexPath))
@@ -130,6 +130,17 @@ public static class ServiceCollectionExtensions
         }
 
         return services;
+    }
+
+    private static string ResolveDefaultDataDirectory()
+    {
+        var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+        if (!string.IsNullOrWhiteSpace(localAppData))
+        {
+            return Path.Combine(localAppData, "Veriado");
+        }
+
+        return Path.Combine(AppContext.BaseDirectory, "veriado-data");
     }
 
     public static async Task InitializeInfrastructureAsync(this IServiceProvider serviceProvider, CancellationToken cancellationToken = default, [CallerMemberName] string? callerName = null)


### PR DESCRIPTION
## Summary
- ensure the default SQLite database and Lucene index live under %LocalAppData%\Veriado for stable persistence across restarts
- document the new persistent storage location in the README

## Testing
- not run (dotnet CLI unavailable in environment)


------
https://chatgpt.com/codex/tasks/task_e_68d90e976c3c8326b824abbdc8b84569