### PR TITLE
Refine import streaming resource contracts

### DIFF
--- a/Veriado.Contracts/Import/ImportOptions.cs
+++ b/Veriado.Contracts/Import/ImportOptions.cs
@@ -1,39 +1,12 @@
 namespace Veriado.Contracts.Import;
 
 /// <summary>
-/// Represents configurable import behavior and resource limits.
+/// Represents configurable resource limits for the streaming import pipeline.
 /// </summary>
 public sealed record class ImportOptions
 {
     /// <summary>
-    /// Gets or sets the search pattern applied when enumerating files within the folder.
-    /// </summary>
-    public string SearchPattern { get; init; } = "*";
-
-    /// <summary>
-    /// Gets or sets a value indicating whether nested folders should be processed.
-    /// </summary>
-    public bool Recursive { get; init; } = true;
-
-    /// <summary>
-    /// Gets or sets the default author applied when the source file does not specify one.
-    /// </summary>
-    public string? DefaultAuthor { get; init; }
-        = null;
-
-    /// <summary>
-    /// Gets or sets a value indicating whether captured file system metadata should be preserved.
-    /// </summary>
-    public bool KeepFileSystemMetadata { get; init; } = true;
-
-    /// <summary>
-    /// Gets or sets a value indicating whether the imported file should be marked read-only.
-    /// </summary>
-    public bool SetReadOnly { get; init; }
-        = false;
-
-    /// <summary>
-    /// Gets or sets the optional maximum allowed size of an imported file in bytes.
+    /// Gets or sets the maximum allowed size of an imported file in bytes.
     /// A non-positive value or <c>null</c> disables the limit.
     /// </summary>
     public long? MaxFileSizeBytes { get; init; }

--- a/Veriado.WinUI/ViewModels/Import/ImportPageViewModel.cs
+++ b/Veriado.WinUI/ViewModels/Import/ImportPageViewModel.cs
@@ -315,10 +315,6 @@ public partial class ImportPageViewModel : ViewModelBase
 
         return new ImportOptions
         {
-            Recursive = Recursive,
-            DefaultAuthor = string.IsNullOrWhiteSpace(DefaultAuthor) ? null : DefaultAuthor,
-            KeepFileSystemMetadata = KeepFsMetadata,
-            SetReadOnly = SetReadOnly,
             MaxFileSizeBytes = CalculateMaxFileSizeBytes(),
             MaxDegreeOfParallelism = maxParallel,
         };


### PR DESCRIPTION
## Summary
- restrict `ImportOptions` to buffer size, file size and parallelism controls for the streaming pipeline
- provide default normalization for removed settings while honoring folder request configuration
- update the WinUI import page to build the streamlined option contract

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d9102535548326a49ba13eed078a73