### PR TITLE
feat(import): improve progress display and error handling

### DIFF
--- a/Veriado.WinUI/Converters/ImportErrorSeverityToStringConverter.cs
+++ b/Veriado.WinUI/Converters/ImportErrorSeverityToStringConverter.cs
@@ -1,0 +1,31 @@
+using System;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Data;
+using Veriado.WinUI.Models.Import;
+
+namespace Veriado.WinUI.Converters;
+
+public sealed class ImportErrorSeverityToStringConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, string language)
+    {
+        if (value is not ImportErrorSeverity severity)
+        {
+            return string.Empty;
+        }
+
+        return severity switch
+        {
+            ImportErrorSeverity.All => "Vše",
+            ImportErrorSeverity.Warning => "Varování",
+            ImportErrorSeverity.Error => "Chyby",
+            ImportErrorSeverity.Fatal => "Fatální",
+            _ => severity.ToString(),
+        };
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, string language)
+    {
+        return DependencyProperty.UnsetValue;
+    }
+}

--- a/Veriado.WinUI/Converters/NullableIntToDoubleConverter.cs
+++ b/Veriado.WinUI/Converters/NullableIntToDoubleConverter.cs
@@ -1,0 +1,39 @@
+using System;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Data;
+
+namespace Veriado.WinUI.Converters;
+
+public sealed class NullableIntToDoubleConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, string language)
+    {
+        if (value is int intValue)
+        {
+            return (double)intValue;
+        }
+
+        if (value is int? nullable && nullable.HasValue)
+        {
+            return (double)nullable.Value;
+        }
+
+        return 0d;
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, string language)
+    {
+        if (value is double doubleValue)
+        {
+            if (double.IsNaN(doubleValue) || double.IsInfinity(doubleValue))
+            {
+                return null;
+            }
+
+            var rounded = (int)Math.Round(doubleValue);
+            return rounded;
+        }
+
+        return DependencyProperty.UnsetValue;
+    }
+}

--- a/Veriado.WinUI/Models/Import/ImportErrorSeverity.cs
+++ b/Veriado.WinUI/Models/Import/ImportErrorSeverity.cs
@@ -1,0 +1,9 @@
+namespace Veriado.WinUI.Models.Import;
+
+public enum ImportErrorSeverity
+{
+    All = 0,
+    Warning,
+    Error,
+    Fatal,
+}

--- a/Veriado.WinUI/Services/Abstractions/IDialogService.cs
+++ b/Veriado.WinUI/Services/Abstractions/IDialogService.cs
@@ -1,4 +1,5 @@
 using System.Threading.Tasks;
+using Microsoft.UI.Xaml;
 
 namespace Veriado.WinUI.Services.Abstractions;
 
@@ -7,4 +8,5 @@ public interface IDialogService
     Task<bool> ConfirmAsync(string title, string message, string confirmText = "OK", string cancelText = "Cancel");
     Task ShowInfoAsync(string title, string message);
     Task ShowErrorAsync(string title, string message);
+    Task ShowAsync(string title, FrameworkElement content, string primaryButtonText = "OK");
 }

--- a/Veriado.WinUI/Services/DialogService.cs
+++ b/Veriado.WinUI/Services/DialogService.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Threading.Tasks;
+using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Veriado.WinUI.Services.Abstractions;
 
@@ -40,5 +41,23 @@ public sealed class DialogService : IDialogService
     public Task ShowErrorAsync(string title, string message)
     {
         return ConfirmAsync(title, message, "OK", string.Empty);
+    }
+
+    public async Task ShowAsync(string title, FrameworkElement content, string primaryButtonText = "OK")
+    {
+        ArgumentNullException.ThrowIfNull(content);
+
+        var window = _window.GetActiveWindow();
+        var hwnd = _window.GetHwnd(window);
+        var dialog = new ContentDialog
+        {
+            Title = title,
+            Content = content,
+            PrimaryButtonText = primaryButtonText,
+            XamlRoot = _window.GetXamlRoot(window),
+        };
+
+        WinRT.Interop.InitializeWithWindow.Initialize(dialog, hwnd);
+        await dialog.ShowAsync();
     }
 }

--- a/Veriado.WinUI/ViewModels/Import/ErrorDetailViewModel.cs
+++ b/Veriado.WinUI/ViewModels/Import/ErrorDetailViewModel.cs
@@ -1,0 +1,51 @@
+using System;
+using Veriado.Contracts.Import;
+using Veriado.WinUI.Models.Import;
+
+namespace Veriado.WinUI.ViewModels.Import;
+
+public sealed class ErrorDetailViewModel
+{
+    public ErrorDetailViewModel(ImportError error)
+    {
+        ArgumentNullException.ThrowIfNull(error);
+
+        Error = error;
+        Item = new ImportErrorItem(error);
+    }
+
+    public ImportError Error { get; }
+
+    public ImportErrorItem Item { get; }
+
+    public string Title => Item.FileName;
+
+    public string Message => Item.ErrorMessage;
+
+    public string? Code => Item.Code;
+
+    public string? Suggestion => Item.Suggestion;
+
+    public string? FilePath => Item.FilePath;
+
+    public string FormattedTimestamp => Item.FormattedTimestamp;
+
+    public string? StackTrace => Item.StackTrace;
+
+    public bool HasStackTrace => Item.HasStackTrace;
+
+    public bool HasSuggestion => Item.HasSuggestion;
+
+    public bool HasCode => Item.HasCode;
+
+    public bool HasFilePath => Item.HasFilePath;
+
+    public ImportErrorSeverity Severity => Item.Severity;
+
+    public string SeverityText => Severity switch
+    {
+        ImportErrorSeverity.Fatal => "Fatální chyba",
+        ImportErrorSeverity.Warning => "Varování",
+        _ => "Chyba",
+    };
+}

--- a/Veriado.WinUI/Views/Import/ErrorDetailView.xaml
+++ b/Veriado.WinUI/Views/Import/ErrorDetailView.xaml
@@ -1,0 +1,45 @@
+<UserControl
+    x:Class="Veriado.WinUI.Views.Import.ErrorDetailView"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+    <ScrollViewer VerticalScrollBarVisibility="Auto">
+        <StackPanel Padding="12" Spacing="12">
+            <TextBlock
+                FontSize="20"
+                FontWeight="SemiBold"
+                Text="{Binding Title}" />
+            <TextBlock
+                FontStyle="Italic"
+                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                Text="{Binding SeverityText}" />
+            <StackPanel Orientation="Horizontal" Spacing="4">
+                <TextBlock
+                    FontWeight="SemiBold"
+                    Text="Čas:" />
+                <TextBlock Text="{Binding FormattedTimestamp}" />
+            </StackPanel>
+            <StackPanel Orientation="Horizontal" Spacing="4" x:Load="{Binding HasCode}">
+                <TextBlock FontWeight="SemiBold" Text="Kód:" />
+                <TextBlock Text="{Binding Code}" />
+            </StackPanel>
+            <StackPanel Orientation="Horizontal" Spacing="4" x:Load="{Binding HasFilePath}">
+                <TextBlock FontWeight="SemiBold" Text="Cesta:" />
+                <TextBlock TextWrapping="Wrap" Text="{Binding FilePath}" />
+            </StackPanel>
+            <TextBlock TextWrapping="Wrap" Text="{Binding Message}" />
+            <StackPanel x:Load="{Binding HasSuggestion}" Spacing="4">
+                <TextBlock FontWeight="SemiBold" Text="Doporučení" />
+                <TextBlock TextWrapping="Wrap" Text="{Binding Suggestion}" />
+            </StackPanel>
+            <StackPanel x:Load="{Binding HasStackTrace}" Spacing="4">
+                <TextBlock FontWeight="SemiBold" Text="Stack trace" />
+                <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}" Padding="8">
+                    <TextBlock FontFamily="Consolas" TextWrapping="Wrap" Text="{Binding StackTrace}" />
+                </Border>
+            </StackPanel>
+        </StackPanel>
+    </ScrollViewer>
+</UserControl>

--- a/Veriado.WinUI/Views/Import/ErrorDetailView.xaml.cs
+++ b/Veriado.WinUI/Views/Import/ErrorDetailView.xaml.cs
@@ -1,0 +1,11 @@
+using Microsoft.UI.Xaml.Controls;
+
+namespace Veriado.WinUI.Views.Import;
+
+public sealed partial class ErrorDetailView : UserControl
+{
+    public ErrorDetailView()
+    {
+        InitializeComponent();
+    }
+}

--- a/Veriado.WinUI/Views/Import/ImportPage.xaml
+++ b/Veriado.WinUI/Views/Import/ImportPage.xaml
@@ -7,16 +7,34 @@
     xmlns:models="using:Veriado.WinUI.Models.Import"
     xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
     xmlns:import="using:Veriado.WinUI.ViewModels.Import"
+    xmlns:converters="using:Veriado.WinUI.Converters"
     d:DataContext="{d:DesignInstance Type=import:ImportPageViewModel}"
     AllowDrop="True"
     DragOver="OnPageDragOver"
     Drop="OnPageDrop"
+    DragLeave="OnPageDragLeave"
     mc:Ignorable="d">
     <Page.KeyboardAccelerators>
         <KeyboardAccelerator Key="Enter" Invoked="OnEnterAcceleratorInvoked" />
         <KeyboardAccelerator Key="Escape" Invoked="OnEscapeAcceleratorInvoked" />
         <KeyboardAccelerator Key="O" Modifiers="Control" Invoked="OnOpenAcceleratorInvoked" />
     </Page.KeyboardAccelerators>
+
+    <Page.Resources>
+        <converters:SizeToHumanConverter x:Key="SizeToHumanConverter" />
+        <converters:ImportErrorSeverityToStringConverter x:Key="ErrorSeverityToStringConverter" />
+        <converters:NullableIntToDoubleConverter x:Key="NullableIntToDoubleConverter" />
+        <x:Array x:Key="ErrorFilterOptions" Type="models:ImportErrorSeverity">
+            <models:ImportErrorSeverity>All</models:ImportErrorSeverity>
+            <models:ImportErrorSeverity>Warning</models:ImportErrorSeverity>
+            <models:ImportErrorSeverity>Error</models:ImportErrorSeverity>
+            <models:ImportErrorSeverity>Fatal</models:ImportErrorSeverity>
+        </x:Array>
+        <CollectionViewSource
+            x:Key="ErrorsViewSource"
+            Source="{Binding Errors}"
+            Filter="OnErrorsFilter" />
+    </Page.Resources>
 
     <Grid Padding="24" RowSpacing="24">
         <Grid.RowDefinitions>
@@ -46,17 +64,38 @@
                     <Button
                         Content="Vymazat výsledky"
                         Command="{Binding ClearResultsCommand}" />
+                    <Button
+                        Content="Exportovat protokol"
+                        Command="{Binding ExportLogCommand}" />
                 </StackPanel>
 
                 <StackPanel Grid.Column="1" Orientation="Vertical" Spacing="4">
-                    <ProgressBar
+                    <muxc:ProgressBar
                         Minimum="0"
-                        Maximum="{Binding Total, Mode=OneWay}"
-                        Value="{Binding Processed, Mode=OneWay}"
+                        Maximum="100"
+                        Value="{Binding ProgressPercent, Mode=OneWay, TargetNullValue=0}"
                         IsIndeterminate="{Binding IsIndeterminate}" />
+                    <StackPanel Orientation="Horizontal" Spacing="8">
+                        <TextBlock
+                            FontWeight="SemiBold"
+                            Text="{Binding ProgressPercent, Mode=OneWay, StringFormat='{}{0:0.##} %', TargetNullValue='0 %'}" />
+                        <TextBlock Text="{Binding ProgressText}" />
+                    </StackPanel>
                     <TextBlock
-                        Margin="0,4,0,0"
-                        Text="{Binding ProgressText}" />
+                        FontWeight="SemiBold"
+                        Text="{Binding CurrentFileName, TargetNullValue='(Žádný soubor)'}" />
+                    <TextBlock
+                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                        Text="{Binding CurrentFilePath}"
+                        TextTrimming="CharacterEllipsis"
+                        MaxLines="2"
+                        TargetNullValue="" />
+                    <TextBlock>
+                        <Run Text="Zpracováno: " />
+                        <Run Text="{Binding ProcessedBytes, Converter={StaticResource SizeToHumanConverter}}" />
+                        <Run Text=" / " />
+                        <Run Text="{Binding TotalBytes, Converter={StaticResource SizeToHumanConverter}}" />
+                    </TextBlock>
                 </StackPanel>
             </Grid>
         </StackPanel>
@@ -98,7 +137,14 @@
                         SpinButtonPlacementMode="Compact"
                         IsEnabled="{Binding UseParallel}"
                         ValidationMode="InvalidInputOverwritten"
-                        Value="{Binding MaxDegreeOfParallelism, Mode=TwoWay}" />
+                        Value="{Binding MaxDegreeOfParallelism, Mode=TwoWay, Converter={StaticResource NullableIntToDoubleConverter}, TargetNullValue=1}" />
+                    <muxc:InfoBar
+                        Margin="0,4,0,0"
+                        IsOpen="{Binding HasParallelismError}"
+                        Severity="Error"
+                        Title="Neplatný počet vláken"
+                        Message="Zadejte kladné celé číslo větší než nula."
+                        IsClosable="False" />
                 </StackPanel>
                 <StackPanel Orientation="Vertical" Spacing="8" Width="200">
                     <TextBox
@@ -110,7 +156,14 @@
                         Minimum="0"
                         SpinButtonPlacementMode="Compact"
                         ValidationMode="InvalidInputOverwritten"
-                        Value="{Binding MaxFileSizeMegabytes, Mode=TwoWay}" />
+                        Value="{Binding MaxFileSizeMegabytes, Mode=TwoWay, TargetNullValue=0}" />
+                    <muxc:InfoBar
+                        Margin="0,4,0,0"
+                        IsOpen="{Binding HasMaxFileSizeError}"
+                        Severity="Warning"
+                        Title="Neplatná velikost souboru"
+                        Message="Zadejte nezápornou hodnotu nebo ponechte 0 pro bez limitu."
+                        IsClosable="False" />
                     <TextBlock
                         FontSize="12"
                         Foreground="{ThemeResource TextFillColorSecondaryBrush}"
@@ -162,47 +215,82 @@
                     Header="Chyby"
                     IsExpanded="{Binding HasErrors, Mode=OneWay}"
                     HorizontalAlignment="Stretch">
-                    <ItemsControl x:Name="ErrorsItemsControl" ItemsSource="{Binding Errors}">
-                        <ItemsControl.ItemTemplate>
-                            <DataTemplate x:DataType="models:ImportErrorItem">
-                                <Grid Padding="8" ColumnSpacing="12">
-                                    <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="*" />
-                                        <ColumnDefinition Width="Auto" />
-                                    </Grid.ColumnDefinitions>
-                                    <StackPanel Orientation="Vertical" Spacing="4">
-                                        <TextBlock
-                                            FontSize="12"
-                                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                            Text="{Binding FormattedTimestamp}" />
-                                        <TextBlock FontWeight="SemiBold" Text="{Binding FileName}" />
-                                        <TextBlock
-                                            FontSize="12"
-                                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                            Text="{Binding Code}"
-                                            x:Load="{Binding HasCode}" />
-                                        <TextBlock TextWrapping="Wrap" Text="{Binding ErrorMessage}" />
-                                        <TextBlock
-                                            FontSize="12"
-                                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                            Text="{Binding FilePath}"
-                                            x:Load="{Binding HasFilePath}" />
-                                        <TextBlock
-                                            TextWrapping="Wrap"
-                                            Text="{Binding Suggestion}"
-                                            x:Load="{Binding HasSuggestion}" />
-                                    </StackPanel>
-                                    <Button
-                                        Grid.Column="1"
-                                        Content="Detail"
-                                        Command="{Binding ElementName=ErrorsItemsControl, Path=DataContext.OpenErrorDetailCommand}"
-                                        CommandParameter="{Binding}" />
-                                </Grid>
-                            </DataTemplate>
-                        </ItemsControl.ItemTemplate>
-                    </ItemsControl>
+                    <StackPanel Spacing="8">
+                        <StackPanel Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
+                            <TextBlock
+                                VerticalAlignment="Center"
+                                Text="Filtrovat:" />
+                            <ComboBox
+                                Width="180"
+                                ItemsSource="{StaticResource ErrorFilterOptions}"
+                                SelectedItem="{Binding SelectedErrorFilter, Mode=TwoWay}">
+                                <ComboBox.ItemTemplate>
+                                    <DataTemplate x:DataType="models:ImportErrorSeverity">
+                                        <TextBlock Text="{Binding Converter={StaticResource ErrorSeverityToStringConverter}}" />
+                                    </DataTemplate>
+                                </ComboBox.ItemTemplate>
+                            </ComboBox>
+                        </StackPanel>
+                        <ItemsControl x:Name="ErrorsItemsControl" ItemsSource="{Binding Source={StaticResource ErrorsViewSource}}">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate x:DataType="models:ImportErrorItem">
+                                    <Grid Padding="8" ColumnSpacing="12">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="*" />
+                                            <ColumnDefinition Width="Auto" />
+                                        </Grid.ColumnDefinitions>
+                                        <StackPanel Orientation="Vertical" Spacing="4">
+                                            <TextBlock
+                                                FontSize="12"
+                                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                                Text="{Binding FormattedTimestamp}" />
+                                            <TextBlock FontWeight="SemiBold" Text="{Binding FileName}" />
+                                            <TextBlock
+                                                FontSize="12"
+                                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                                Text="{Binding Code}"
+                                                x:Load="{Binding HasCode}" />
+                                            <TextBlock TextWrapping="Wrap" Text="{Binding ErrorMessage}" />
+                                            <TextBlock
+                                                FontSize="12"
+                                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                                Text="{Binding FilePath}"
+                                                x:Load="{Binding HasFilePath}" />
+                                            <TextBlock
+                                                TextWrapping="Wrap"
+                                                Text="{Binding Suggestion}"
+                                                x:Load="{Binding HasSuggestion}" />
+                                        </StackPanel>
+                                        <Button
+                                            Grid.Column="1"
+                                            Content="Detail"
+                                            Command="{Binding ElementName=ErrorsItemsControl, Path=DataContext.OpenErrorDetailCommand}"
+                                            CommandParameter="{Binding Source}" />
+                                    </Grid>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                    </StackPanel>
                 </Expander>
             </Grid>
         </StackPanel>
+
+        <Grid
+            x:Name="DragOverlay"
+            Background="#66000000"
+            Visibility="Collapsed"
+            IsHitTestVisible="False">
+            <Border
+                Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                CornerRadius="12"
+                Padding="24"
+                HorizontalAlignment="Center"
+                VerticalAlignment="Center">
+                <StackPanel Spacing="8" HorizontalAlignment="Center">
+                    <TextBlock Text="Pusťte složku pro import" FontSize="24" FontWeight="SemiBold" HorizontalAlignment="Center" />
+                    <TextBlock Text="Složku můžete také vybrat pomocí tlačítka." HorizontalAlignment="Center" />
+                </StackPanel>
+            </Border>
+        </Grid>
     </Grid>
 </Page>


### PR DESCRIPTION
## Summary
- track streaming import progress in `ImportPageViewModel`, add log export support, and surface validation flags for parallelism and file size
- introduce an error detail dialog with dedicated view/model and extend the dialog service to host custom content
- refresh the import page UI with detailed progress metrics, validation info bars, drag-and-drop overlay, and severity filtering for errors

## Testing
- dotnet build Veriado.sln *(fails: dotnet not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d9118e55208326b1f38ea89c58e1d4