### PR TITLE
Fix ImportPage WinUI binding errors

### DIFF
--- a/Veriado.WinUI/Views/Import/ImportPage.xaml
+++ b/Veriado.WinUI/Views/Import/ImportPage.xaml
@@ -30,10 +30,6 @@
             <models:ImportErrorSeverity>Error</models:ImportErrorSeverity>
             <models:ImportErrorSeverity>Fatal</models:ImportErrorSeverity>
         </x:Array>
-        <CollectionViewSource
-            x:Key="ErrorsViewSource"
-            Source="{Binding Errors}"
-            Filter="OnErrorsFilter" />
     </Page.Resources>
 
     <Grid Padding="24" RowSpacing="24">
@@ -73,12 +69,12 @@
                     <muxc:ProgressBar
                         Minimum="0"
                         Maximum="100"
-                        Value="{Binding ProgressPercent, Mode=OneWay, TargetNullValue=0}"
+                        Value="{Binding ProgressPercentValue, Mode=OneWay}"
                         IsIndeterminate="{Binding IsIndeterminate}" />
                     <StackPanel Orientation="Horizontal" Spacing="8">
                         <TextBlock
                             FontWeight="SemiBold"
-                            Text="{Binding ProgressPercent, Mode=OneWay, StringFormat='{}{0:0.##} %', TargetNullValue='0 %'}" />
+                            Text="{Binding ProgressPercentDisplay, Mode=OneWay}" />
                         <TextBlock Text="{Binding ProgressText}" />
                     </StackPanel>
                     <TextBlock
@@ -86,10 +82,9 @@
                         Text="{Binding CurrentFileName, TargetNullValue='(Žádný soubor)'}" />
                     <TextBlock
                         Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                        Text="{Binding CurrentFilePath}"
+                        Text="{Binding CurrentFilePath, TargetNullValue=''}"
                         TextTrimming="CharacterEllipsis"
-                        MaxLines="2"
-                        TargetNullValue="" />
+                        MaxLines="2" />
                     <TextBlock>
                         <Run Text="Zpracováno: " />
                         <Run Text="{Binding ProcessedBytes, Converter={StaticResource SizeToHumanConverter}}" />
@@ -231,7 +226,7 @@
                                 </ComboBox.ItemTemplate>
                             </ComboBox>
                         </StackPanel>
-                        <ItemsControl x:Name="ErrorsItemsControl" ItemsSource="{Binding Source={StaticResource ErrorsViewSource}}">
+                        <ItemsControl x:Name="ErrorsItemsControl" ItemsSource="{Binding FilteredErrors}">
                             <ItemsControl.ItemTemplate>
                                 <DataTemplate x:DataType="models:ImportErrorItem">
                                     <Grid Padding="8" ColumnSpacing="12">

--- a/Veriado.WinUI/Views/Import/ImportPage.xaml.cs
+++ b/Veriado.WinUI/Views/Import/ImportPage.xaml.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Specialized;
 using System.IO;
 using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
@@ -9,8 +7,6 @@ using Windows.ApplicationModel.DataTransfer;
 using Windows.Storage;
 using Veriado.WinUI.ViewModels.Import;
 using Microsoft.UI.Xaml;
-using Microsoft.UI.Xaml.Data;
-using Veriado.WinUI.Models.Import;
 
 namespace Veriado.WinUI.Views.Import;
 
@@ -20,8 +16,6 @@ public sealed partial class ImportPage : Page
     {
         InitializeComponent();
         DataContext = App.Services.GetRequiredService<ImportPageViewModel>();
-        Loaded += OnPageLoaded;
-        Unloaded += OnPageUnloaded;
     }
 
     private ImportPageViewModel? ViewModel => DataContext as ImportPageViewModel;
@@ -139,72 +133,4 @@ public sealed partial class ImportPage : Page
         }
     }
 
-    private void OnPageLoaded(object sender, RoutedEventArgs e)
-    {
-        if (ViewModel is null)
-        {
-            return;
-        }
-
-        if (GetErrorsViewSource() is { } viewSource)
-        {
-            viewSource.Source = ViewModel.Errors;
-            RefreshErrorsView();
-        }
-
-        ViewModel.ErrorFilterChanged += OnErrorFilterChanged;
-        ViewModel.Errors.CollectionChanged += OnErrorsCollectionChanged;
-    }
-
-    private void OnPageUnloaded(object sender, RoutedEventArgs e)
-    {
-        if (ViewModel is null)
-        {
-            return;
-        }
-
-        ViewModel.ErrorFilterChanged -= OnErrorFilterChanged;
-        ViewModel.Errors.CollectionChanged -= OnErrorsCollectionChanged;
-    }
-
-    private void OnErrorFilterChanged(object? sender, EventArgs e)
-    {
-        RefreshErrorsView();
-    }
-
-    private void OnErrorsCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
-    {
-        RefreshErrorsView();
-    }
-
-    private void RefreshErrorsView()
-    {
-        var view = GetErrorsViewSource()?.View;
-        view?.Refresh();
-    }
-
-    private void OnErrorsFilter(object sender, FilterEventArgs e)
-    {
-        if (ViewModel is null || e.Item is not ImportErrorItem item)
-        {
-            e.Accepted = false;
-            return;
-        }
-
-        e.Accepted = ViewModel.SelectedErrorFilter switch
-        {
-            ImportErrorSeverity.All => true,
-            ImportErrorSeverity.Warning => item.Severity == ImportErrorSeverity.Warning,
-            ImportErrorSeverity.Error => item.Severity == ImportErrorSeverity.Error,
-            ImportErrorSeverity.Fatal => item.Severity == ImportErrorSeverity.Fatal,
-            _ => true,
-        };
-    }
-
-    private CollectionViewSource? GetErrorsViewSource()
-    {
-        return Resources.TryGetValue("ErrorsViewSource", out var resource)
-            ? resource as CollectionViewSource
-            : null;
-    }
 }


### PR DESCRIPTION
## Summary
- manage filtered import errors inside the view model and add progress display helpers for null-safe bindings
- update ImportPage XAML to consume the filtered collection and avoid unsupported binding attributes
- simplify ImportPage code-behind by removing CollectionViewSource wiring that is no longer needed

## Testing
- dotnet build Veriado.sln *(fails: `dotnet` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d916f8db2883269a3d4d68c80f10a7