### PR TITLE
Fix ObservableProperty setter access usage

### DIFF
--- a/Veriado.WinUI/ViewModels/Import/ImportPageViewModel.cs
+++ b/Veriado.WinUI/ViewModels/Import/ImportPageViewModel.cs
@@ -138,25 +138,25 @@ public partial class ImportPageViewModel : ViewModelBase
     [ObservableProperty]
     private bool _isActiveStatusVisible;
 
-    [ObservableProperty(Setter = SetterAccessModifier.Private)]
+    [ObservableProperty(Setter = AccessModifier.Private)]
     private string? _activeStatusTitle;
 
-    [ObservableProperty(Setter = SetterAccessModifier.Private)]
+    [ObservableProperty(Setter = AccessModifier.Private)]
     private string? _activeStatusMessage;
 
-    [ObservableProperty(Setter = SetterAccessModifier.Private)]
+    [ObservableProperty(Setter = AccessModifier.Private)]
     private InfoBarSeverity _activeStatusSeverity = InfoBarSeverity.Informational;
 
     [ObservableProperty]
     private bool _isDynamicStatusVisible;
 
-    [ObservableProperty(Setter = SetterAccessModifier.Private)]
+    [ObservableProperty(Setter = AccessModifier.Private)]
     private string? _dynamicStatusTitle;
 
-    [ObservableProperty(Setter = SetterAccessModifier.Private)]
+    [ObservableProperty(Setter = AccessModifier.Private)]
     private string? _dynamicStatusMessage;
 
-    [ObservableProperty(Setter = SetterAccessModifier.Private)]
+    [ObservableProperty(Setter = AccessModifier.Private)]
     private InfoBarSeverity _dynamicStatusSeverity = InfoBarSeverity.Informational;
 
     [ObservableProperty]


### PR DESCRIPTION
## Summary
- replace obsolete SetterAccessModifier usage with AccessModifier on CommunityToolkit observable properties to restore generated properties

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d92017467c8326b273162833bbde22