### PR TITLE
Fix WinUI import views without x:Load bindings

### DIFF
--- a/Veriado.WinUI/ViewModels/Import/ImportPageViewModel.cs
+++ b/Veriado.WinUI/ViewModels/Import/ImportPageViewModel.cs
@@ -168,6 +168,14 @@ public partial class ImportPageViewModel : ViewModelBase
 
     public ReadOnlyObservableCollection<ImportErrorItem> FilteredErrors { get; }
 
+    public IReadOnlyList<ImportErrorSeverity> ErrorFilterOptions { get; } = new[]
+    {
+        ImportErrorSeverity.All,
+        ImportErrorSeverity.Warning,
+        ImportErrorSeverity.Error,
+        ImportErrorSeverity.Fatal,
+    };
+
     public int OkCount
     {
         get => _okCount;

--- a/Veriado.WinUI/Views/Import/ErrorDetailView.xaml
+++ b/Veriado.WinUI/Views/Import/ErrorDetailView.xaml
@@ -21,20 +21,30 @@
                     Text="Čas:" />
                 <TextBlock Text="{Binding FormattedTimestamp}" />
             </StackPanel>
-            <StackPanel Orientation="Horizontal" Spacing="4" x:Load="{Binding HasCode}">
+            <StackPanel
+                Orientation="Horizontal"
+                Spacing="4"
+                Visibility="{Binding HasCode, Converter={StaticResource BooleanToVisibilityConverter}}">
                 <TextBlock FontWeight="SemiBold" Text="Kód:" />
                 <TextBlock Text="{Binding Code}" />
             </StackPanel>
-            <StackPanel Orientation="Horizontal" Spacing="4" x:Load="{Binding HasFilePath}">
+            <StackPanel
+                Orientation="Horizontal"
+                Spacing="4"
+                Visibility="{Binding HasFilePath, Converter={StaticResource BooleanToVisibilityConverter}}">
                 <TextBlock FontWeight="SemiBold" Text="Cesta:" />
                 <TextBlock TextWrapping="Wrap" Text="{Binding FilePath}" />
             </StackPanel>
             <TextBlock TextWrapping="Wrap" Text="{Binding Message}" />
-            <StackPanel x:Load="{Binding HasSuggestion}" Spacing="4">
+            <StackPanel
+                Spacing="4"
+                Visibility="{Binding HasSuggestion, Converter={StaticResource BooleanToVisibilityConverter}}">
                 <TextBlock FontWeight="SemiBold" Text="Doporučení" />
                 <TextBlock TextWrapping="Wrap" Text="{Binding Suggestion}" />
             </StackPanel>
-            <StackPanel x:Load="{Binding HasStackTrace}" Spacing="4">
+            <StackPanel
+                Spacing="4"
+                Visibility="{Binding HasStackTrace, Converter={StaticResource BooleanToVisibilityConverter}}">
                 <TextBlock FontWeight="SemiBold" Text="Stack trace" />
                 <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}" Padding="8">
                     <TextBlock FontFamily="Consolas" TextWrapping="Wrap" Text="{Binding StackTrace}" />

--- a/Veriado.WinUI/Views/Import/ImportPage.xaml
+++ b/Veriado.WinUI/Views/Import/ImportPage.xaml
@@ -25,12 +25,6 @@
         <converters:SizeToHumanConverter x:Key="SizeToHumanConverter" />
         <converters:ImportErrorSeverityToStringConverter x:Key="ErrorSeverityToStringConverter" />
         <converters:NullableIntToDoubleConverter x:Key="NullableIntToDoubleConverter" />
-        <x:Array x:Key="ErrorFilterOptions" Type="models:ImportErrorSeverity">
-            <models:ImportErrorSeverity>All</models:ImportErrorSeverity>
-            <models:ImportErrorSeverity>Warning</models:ImportErrorSeverity>
-            <models:ImportErrorSeverity>Error</models:ImportErrorSeverity>
-            <models:ImportErrorSeverity>Fatal</models:ImportErrorSeverity>
-        </x:Array>
     </Page.Resources>
 
     <Grid Padding="24" RowSpacing="24">
@@ -279,7 +273,7 @@
                                 Text="Filtrovat:" />
                             <ComboBox
                                 Width="180"
-                                ItemsSource="{StaticResource ErrorFilterOptions}"
+                                ItemsSource="{Binding ErrorFilterOptions}"
                                 SelectedItem="{Binding SelectedErrorFilter, Mode=TwoWay}">
                                 <ComboBox.ItemTemplate>
                                     <DataTemplate x:DataType="models:ImportErrorSeverity">
@@ -311,17 +305,17 @@
                                                 FontSize="12"
                                                 Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                                 Text="{Binding Code}"
-                                                x:Load="{Binding HasCode}" />
+                                                Visibility="{Binding HasCode, Converter={StaticResource BooleanToVisibilityConverter}}" />
                                             <TextBlock TextWrapping="Wrap" Text="{Binding ErrorMessage}" />
                                             <TextBlock
                                                 FontSize="12"
                                                 Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                                 Text="{Binding FilePath}"
-                                                x:Load="{Binding HasFilePath}" />
+                                                Visibility="{Binding HasFilePath, Converter={StaticResource BooleanToVisibilityConverter}}" />
                                             <TextBlock
                                                 TextWrapping="Wrap"
                                                 Text="{Binding Suggestion}"
-                                                x:Load="{Binding HasSuggestion}" />
+                                                Visibility="{Binding HasSuggestion, Converter={StaticResource BooleanToVisibilityConverter}}" />
                                         </StackPanel>
                                         <Button
                                             Grid.Column="1"


### PR DESCRIPTION
## Summary
- replace unsupported x:Load bindings in import views with visibility bindings that use the existing BooleanToVisibilityConverter
- expose the list of error filter options from ImportPageViewModel instead of using an x:Array resource so the ComboBox can bind to it

## Testing
- dotnet build *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d926ef05c4832698e8269de9051066