### PR TITLE
Fix nullable int conversion syntax

### DIFF
--- a/Veriado.WinUI/Converters/NullableIntToDoubleConverter.cs
+++ b/Veriado.WinUI/Converters/NullableIntToDoubleConverter.cs
@@ -13,9 +13,9 @@ public sealed class NullableIntToDoubleConverter : IValueConverter
             return (double)intValue;
         }
 
-        if (value is int? nullable && nullable.HasValue)
+        if (value is int? nullable)
         {
-            return (double)nullable.Value;
+            return nullable.HasValue ? (double)nullable.Value : 0d;
         }
 
         return 0d;


### PR DESCRIPTION
## Summary
- adjust the nullable integer handling in the WinUI converter to avoid pattern-matching syntax errors

## Testing
- dotnet build Veriado.sln *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68d92d7766a88326b94666d6fb084915