### PR TITLE
Fix nullable int pattern matching in converter

### DIFF
--- a/Veriado.WinUI/Converters/NullableIntToDoubleConverter.cs
+++ b/Veriado.WinUI/Converters/NullableIntToDoubleConverter.cs
@@ -13,8 +13,9 @@ public sealed class NullableIntToDoubleConverter : IValueConverter
             return (double)intValue;
         }
 
-        if (value is int? nullable)
+        if (value is int?)
         {
+            var nullable = (int?)value;
             return nullable.HasValue ? (double)nullable.Value : 0d;
         }
 


### PR DESCRIPTION
## Summary
- adjust the nullable int conversion logic to avoid disallowed pattern matching
- ensure nullable conversions still return the expected double values

## Testing
- `dotnet build Veriado.sln` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68d92e07bc608326bc4dc84e22b3a47d