### PR TITLE
Fix WinUI compiler generated output path

### DIFF
--- a/Veriado.WinUI/Veriado.csproj
+++ b/Veriado.WinUI/Veriado.csproj
@@ -13,7 +13,7 @@
     <Nullable>enable</Nullable>
     <LangVersion>12</LangVersion>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
-    <CompilerGeneratedFilesOutputPath>$(BaseIntermediateOutputPath)Generated</CompilerGeneratedFilesOutputPath>
+    <CompilerGeneratedFilesOutputPath>$(IntermediateOutputPath)Generated\</CompilerGeneratedFilesOutputPath>
   </PropertyGroup>
   <ItemGroup>
     <Content Include="Assets\SplashScreen.scale-200.png" />


### PR DESCRIPTION
## Summary
- update the Veriado.WinUI compiler generated files output path to use the intermediate output directory so CSC receives a valid directory

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d93b2cb2e88326a1a15140472bfc24