### PR TITLE
Fix compiler generated files output path

### DIFF
--- a/Veriado.WinUI/Veriado.csproj
+++ b/Veriado.WinUI/Veriado.csproj
@@ -13,7 +13,7 @@
     <Nullable>enable</Nullable>
     <LangVersion>12</LangVersion>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
-    <CompilerGeneratedFilesOutputPath>$(IntermediateOutputPath)Generated\</CompilerGeneratedFilesOutputPath>
+    <CompilerGeneratedFilesOutputPath>$(IntermediateOutputPath)Generated</CompilerGeneratedFilesOutputPath>
   </PropertyGroup>
   <ItemGroup>
     <Content Include="Assets\SplashScreen.scale-200.png" />


### PR DESCRIPTION
## Summary
- ensure the compiler generated files output path does not end with a trailing slash to avoid invalid file names on Windows builds

## Testing
- no automated tests were run (not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d93dfa0674832683d2086371b2e4bf