### PR TITLE
Ensure import streaming respects UI options

### DIFF
--- a/Veriado.Contracts/Import/ImportOptions.cs
+++ b/Veriado.Contracts/Import/ImportOptions.cs
@@ -1,7 +1,7 @@
 namespace Veriado.Contracts.Import;
 
 /// <summary>
-/// Represents configurable resource limits for the streaming import pipeline.
+/// Represents configurable behaviour and resource limits for the streaming import pipeline.
 /// </summary>
 public sealed record class ImportOptions
 {
@@ -25,4 +25,34 @@ public sealed record class ImportOptions
     /// </summary>
     public int BufferSize { get; init; }
         = 64 * 1024;
+
+    /// <summary>
+    /// Gets or sets the default author applied when file metadata does not specify one.
+    /// </summary>
+    public string? DefaultAuthor { get; init; }
+        = null;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether captured file system metadata should be preserved.
+    /// </summary>
+    public bool KeepFileSystemMetadata { get; init; }
+        = true;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether imported files should be marked as read only.
+    /// </summary>
+    public bool SetReadOnly { get; init; }
+        = false;
+
+    /// <summary>
+    /// Gets or sets the search pattern applied when enumerating files.
+    /// </summary>
+    public string? SearchPattern { get; init; }
+        = "*";
+
+    /// <summary>
+    /// Gets or sets a value indicating whether sub-folders should be traversed.
+    /// </summary>
+    public bool Recursive { get; init; }
+        = true;
 }

--- a/Veriado.Services/Import/ImportService.cs
+++ b/Veriado.Services/Import/ImportService.cs
@@ -675,12 +675,18 @@ public sealed class ImportService : IImportService
             bufferSize = 4096;
         }
 
+        var searchPattern = string.IsNullOrWhiteSpace(options?.SearchPattern) ? "*" : options!.SearchPattern!;
+        var recursive = options?.Recursive ?? true;
+        var defaultAuthor = (options?.DefaultAuthor ?? string.Empty).Trim();
+        var keepMetadata = options?.KeepFileSystemMetadata ?? true;
+        var setReadOnly = options?.SetReadOnly ?? false;
+
         return new NormalizedImportOptions(
-            "*",
-            true,
-            string.Empty,
-            true,
-            false,
+            searchPattern,
+            recursive,
+            defaultAuthor,
+            keepMetadata,
+            setReadOnly,
             maxFileSize,
             maxDegree,
             bufferSize);
@@ -688,23 +694,16 @@ public sealed class ImportService : IImportService
 
     private static NormalizedImportOptions NormalizeOptions(ImportFolderRequest request)
     {
-        var sanitized = NormalizeOptions(new ImportOptions
+        return NormalizeOptions(new ImportOptions
         {
             MaxFileSizeBytes = request.MaxFileSizeBytes,
             MaxDegreeOfParallelism = request.MaxDegreeOfParallelism,
-        });
-
-        var searchPattern = string.IsNullOrWhiteSpace(request.SearchPattern) ? "*" : request.SearchPattern!;
-        var defaultAuthor = (request.DefaultAuthor ?? string.Empty).Trim();
-
-        return sanitized with
-        {
-            SearchPattern = searchPattern,
-            Recursive = request.Recursive,
-            DefaultAuthor = defaultAuthor,
+            DefaultAuthor = request.DefaultAuthor,
             KeepFileSystemMetadata = request.KeepFsMetadata,
             SetReadOnly = request.SetReadOnly,
-        };
+            SearchPattern = request.SearchPattern,
+            Recursive = request.Recursive,
+        });
     }
 
     private void LogApiErrors(string? descriptor, IReadOnlyList<ApiError> errors)

--- a/Veriado.WinUI/ViewModels/Import/ImportPageViewModel.cs
+++ b/Veriado.WinUI/ViewModels/Import/ImportPageViewModel.cs
@@ -489,6 +489,11 @@ public partial class ImportPageViewModel : ViewModelBase
         {
             MaxFileSizeBytes = CalculateMaxFileSizeBytes(),
             MaxDegreeOfParallelism = ResolveParallelism(),
+            KeepFileSystemMetadata = KeepFsMetadata,
+            SetReadOnly = SetReadOnly,
+            Recursive = Recursive,
+            DefaultAuthor = string.IsNullOrWhiteSpace(DefaultAuthor) ? null : DefaultAuthor,
+            SearchPattern = "*",
         };
     }
 

--- a/docs/import-analysis.md
+++ b/docs/import-analysis.md
@@ -1,0 +1,12 @@
+# Import pipeline analysis
+
+## Backend findings
+- **Configuration loss in streaming imports** – `ImportService.NormalizeOptions(ImportOptions?)` previously reset the search pattern, recursion, metadata preservation and read-only options to hard-coded defaults, so the WinUI client could not influence these behaviours when using the streaming API. This made the UI toggles for "recursive", "keep file-system metadata" and "set read only" ineffective. The normalization now carries through user-specified values, ensuring the streaming pipeline honours the selected settings.
+- **Default author trimming** – The normalization step now trims the optional author value instead of replacing it with an empty string, preventing accidental spaces from propagating to the domain.
+
+## Frontend findings
+- **Incomplete option projection** – `ImportPageViewModel.BuildImportOptions` only forwarded resource limits to the service, so metadata-related toggles never reached the backend. The builder now mirrors the full request so both streaming and fallback batch imports receive consistent input.
+
+## Suggested follow-up improvements
+- Surface an optional search-pattern picker in the UI to allow narrowing imports without editing files manually.
+- Consider exposing the buffer-size limit in advanced settings so power users can tune throughput on slow disks.


### PR DESCRIPTION
## Summary
- extend `ImportOptions` so streaming imports can receive metadata-related settings
- update the import service normalization to preserve user-provided configuration
- align the WinUI view-model with the new options and document the audit findings

## Testing
- `dotnet build Veriado.sln` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d94e7dfa0883268340c49010a67f11