### PR TITLE
Trim author whitespace during backend import normalization

### DIFF
--- a/Veriado.Services/Import/ImportService.cs
+++ b/Veriado.Services/Import/ImportService.cs
@@ -583,12 +583,14 @@ public sealed class ImportService : IImportService
             ? MimeMap.GetMimeType(normalizedExtension)
             : request.Mime!;
 
+        var normalizedAuthor = request.Author is null ? string.Empty : request.Author.Trim();
+
         return new CreateFileRequest
         {
             Name = request.Name ?? string.Empty,
             Extension = normalizedExtension,
             Mime = mime,
-            Author = request.Author ?? string.Empty,
+            Author = normalizedAuthor,
             Content = request.Content ?? Array.Empty<byte>(),
             MaxContentLength = request.MaxContentLength,
             SystemMetadata = request.SystemMetadata,


### PR DESCRIPTION
## Summary
- trim the author field when normalizing import requests so accidental whitespace from clients no longer propagates into the backend

## Testing
- dotnet test *(fails: `dotnet` CLI not available in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d952f4b4ec8326ab0194de612b6020