### PR TITLE
Improve visibility of import error summary and details

### DIFF
--- a/Veriado.WinUI/ViewModels/Import/ImportPageViewModel.cs
+++ b/Veriado.WinUI/ViewModels/Import/ImportPageViewModel.cs
@@ -76,6 +76,7 @@ public partial class ImportPageViewModel : ViewModelBase
         RestoreStateFromHotStorage();
         PopulateDefaultAuthorFromCurrentUser();
         UpdateFilteredErrors();
+        UpdateErrorSummary();
     }
 
     [ObservableProperty]
@@ -162,6 +163,18 @@ public partial class ImportPageViewModel : ViewModelBase
     [ObservableProperty]
     private ImportErrorSeverity _selectedErrorFilter = ImportErrorSeverity.All;
 
+    [ObservableProperty]
+    private InfoBarSeverity _errorSummarySeverity = InfoBarSeverity.Informational;
+
+    [ObservableProperty]
+    private string? _errorSummaryTitle;
+
+    [ObservableProperty]
+    private string? _errorSummaryMessage;
+
+    [ObservableProperty]
+    private string? _errorSummaryDetail;
+
     public ObservableCollection<ImportLogItem> Log { get; }
 
     public ObservableCollection<ImportErrorItem> Errors { get; }
@@ -219,6 +232,12 @@ public partial class ImportPageViewModel : ViewModelBase
         $"Zpracováno {Processed}/{(Total > 0 ? Total : 0)} • OK {OkCount} • Chyby {ErrorCount} • Skip {SkipCount}";
 
     public bool HasErrors => Errors.Count > 0;
+
+    public bool HasFilteredErrors => _filteredErrors.Count > 0;
+
+    public bool HasNoFilteredErrors => !HasFilteredErrors;
+
+    public bool HasErrorSummaryDetail => !string.IsNullOrWhiteSpace(ErrorSummaryDetail);
 
     public IAsyncRelayCommand PickFolderCommand => _pickFolderCommand;
 
@@ -1237,6 +1256,7 @@ public partial class ImportPageViewModel : ViewModelBase
         OnPropertyChanged(nameof(HasErrors));
         _clearResultsCommand.NotifyCanExecuteChanged();
         UpdateFilteredErrors();
+        UpdateErrorSummary();
     }
 
     private void OnLogCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
@@ -1385,6 +1405,63 @@ public partial class ImportPageViewModel : ViewModelBase
         {
             _filteredErrors.Add(item);
         }
+
+        OnPropertyChanged(nameof(HasFilteredErrors));
+        OnPropertyChanged(nameof(HasNoFilteredErrors));
+    }
+
+    private void UpdateErrorSummary()
+    {
+        if (Errors.Count == 0)
+        {
+            ErrorSummarySeverity = InfoBarSeverity.Informational;
+            ErrorSummaryTitle = null;
+            ErrorSummaryMessage = null;
+            ErrorSummaryDetail = null;
+            return;
+        }
+
+        var fatalCount = Errors.Count(static item => item.Severity == ImportErrorSeverity.Fatal);
+        var errorCount = Errors.Count(static item => item.Severity == ImportErrorSeverity.Error);
+        var warningCount = Errors.Count(static item => item.Severity == ImportErrorSeverity.Warning);
+
+        ErrorSummarySeverity = fatalCount > 0 || errorCount > 0
+            ? InfoBarSeverity.Error
+            : InfoBarSeverity.Warning;
+
+        ErrorSummaryTitle = fatalCount > 0
+            ? "Import obsahuje fatální chyby"
+            : errorCount > 0
+                ? "Import obsahuje chyby"
+                : "Import dokončen s varováními";
+
+        var summaryParts = new List<string>();
+
+        if (fatalCount > 0)
+        {
+            summaryParts.Add($"{fatalCount}× fatální chyba");
+        }
+
+        if (errorCount > 0)
+        {
+            summaryParts.Add($"{errorCount}× chyba");
+        }
+
+        if (warningCount > 0)
+        {
+            summaryParts.Add($"{warningCount}× varování");
+        }
+
+        ErrorSummaryMessage = summaryParts.Count > 0
+            ? $"Celkem {Errors.Count} problémů: {string.Join(", ", summaryParts)}."
+            : $"Celkem {Errors.Count} problémů.";
+
+        ErrorSummaryDetail = "Vyberte řádek v tabulce, chcete-li zobrazit doporučení a další detaily. Chyby můžete filtrovat podle závažnosti.";
+    }
+
+    partial void OnErrorSummaryDetailChanged(string? value)
+    {
+        OnPropertyChanged(nameof(HasErrorSummaryDetail));
     }
 
     private bool MatchesSelectedFilter(ImportErrorItem item)

--- a/Veriado.WinUI/Views/Import/ImportPage.xaml
+++ b/Veriado.WinUI/Views/Import/ImportPage.xaml
@@ -279,78 +279,125 @@
                     </toolkit:DataGrid.Columns>
                 </toolkit:DataGrid>
 
-                <Expander
-                    Grid.Row="1"
-                    Header="Chyby"
-                    IsExpanded="{Binding HasErrors, Mode=OneWay}"
-                    HorizontalAlignment="Stretch">
-                    <StackPanel Spacing="8">
-                        <StackPanel.Transitions>
-                            <TransitionCollection>
-                                <animations:EntranceThemeTransition IsStaggeringEnabled="True" />
-                            </TransitionCollection>
-                        </StackPanel.Transitions>
-                        <StackPanel Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
+                <Grid Grid.Row="1" RowSpacing="8">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="*" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+
+                    <muxc:InfoBar
+                        Grid.Row="0"
+                        IsClosable="False"
+                        IsOpen="{Binding HasErrors}"
+                        Visibility="{Binding HasErrors, Converter={StaticResource BooleanToVisibilityConverter}}"
+                        Severity="{Binding ErrorSummarySeverity}"
+                        Title="{Binding ErrorSummaryTitle}"
+                        Message="{Binding ErrorSummaryMessage}">
+                        <muxc:InfoBar.Content>
                             <TextBlock
-                                VerticalAlignment="Center"
-                                Text="Filtrovat:" />
-                            <ComboBox
-                                Width="180"
-                                ItemsSource="{Binding ErrorFilterOptions}"
-                                SelectedItem="{Binding SelectedErrorFilter, Mode=TwoWay}">
-                                <ComboBox.ItemTemplate>
-                                    <DataTemplate x:DataType="models:ImportErrorSeverity">
-                                        <TextBlock Text="{Binding Converter={StaticResource ErrorSeverityToStringConverter}}" />
-                                    </DataTemplate>
-                                </ComboBox.ItemTemplate>
-                            </ComboBox>
-                        </StackPanel>
-                        <ItemsControl x:Name="ErrorsItemsControl" ItemsSource="{Binding FilteredErrors}">
-                            <ItemsControl.ItemContainerTransitions>
-                                <TransitionCollection>
-                                    <animations:EntranceThemeTransition IsStaggeringEnabled="True" />
-                                </TransitionCollection>
-                            </ItemsControl.ItemContainerTransitions>
-                            <ItemsControl.ItemTemplate>
-                                <DataTemplate x:DataType="models:ImportErrorItem">
-                                    <Grid Padding="8" ColumnSpacing="12">
-                                        <Grid.ColumnDefinitions>
-                                            <ColumnDefinition Width="*" />
-                                            <ColumnDefinition Width="Auto" />
-                                        </Grid.ColumnDefinitions>
-                                        <StackPanel Orientation="Vertical" Spacing="4">
-                                            <TextBlock
-                                                FontSize="12"
-                                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                                Text="{Binding FormattedTimestamp}" />
-                                            <TextBlock FontWeight="SemiBold" Text="{Binding FileName}" />
-                                            <TextBlock
-                                                FontSize="12"
-                                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                                Text="{Binding Code}"
-                                                Visibility="{Binding HasCode, Converter={StaticResource BooleanToVisibilityConverter}}" />
-                                            <TextBlock TextWrapping="Wrap" Text="{Binding ErrorMessage}" />
-                                            <TextBlock
-                                                FontSize="12"
-                                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                                Text="{Binding FilePath}"
-                                                Visibility="{Binding HasFilePath, Converter={StaticResource BooleanToVisibilityConverter}}" />
-                                            <TextBlock
-                                                TextWrapping="Wrap"
-                                                Text="{Binding Suggestion}"
-                                                Visibility="{Binding HasSuggestion, Converter={StaticResource BooleanToVisibilityConverter}}" />
-                                        </StackPanel>
-                                        <Button
-                                            Grid.Column="1"
-                                            Content="Detail"
-                                            Command="{Binding ElementName=ErrorsItemsControl, Path=DataContext.OpenErrorDetailCommand}"
-                                            CommandParameter="{Binding Source}" />
-                                    </Grid>
+                                Text="{Binding ErrorSummaryDetail}"
+                                TextWrapping="Wrap"
+                                Visibility="{Binding HasErrorSummaryDetail, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                        </muxc:InfoBar.Content>
+                    </muxc:InfoBar>
+
+                    <StackPanel Grid.Row="1" Orientation="Horizontal" Spacing="8" VerticalAlignment="Center" IsEnabled="{Binding HasErrors}">
+                        <TextBlock
+                            VerticalAlignment="Center"
+                            Text="Filtrovat:" />
+                        <ComboBox
+                            Width="180"
+                            ItemsSource="{Binding ErrorFilterOptions}"
+                            SelectedItem="{Binding SelectedErrorFilter, Mode=TwoWay}">
+                            <ComboBox.ItemTemplate>
+                                <DataTemplate x:DataType="models:ImportErrorSeverity">
+                                    <TextBlock Text="{Binding Converter={StaticResource ErrorSeverityToStringConverter}}" />
                                 </DataTemplate>
-                            </ItemsControl.ItemTemplate>
-                        </ItemsControl>
+                            </ComboBox.ItemTemplate>
+                        </ComboBox>
                     </StackPanel>
-                </Expander>
+
+                    <toolkit:DataGrid
+                        x:Name="ErrorsDataGrid"
+                        Grid.Row="2"
+                        ItemsSource="{Binding FilteredErrors}"
+                        AutoGenerateColumns="False"
+                        CanUserReorderColumns="False"
+                        CanUserResizeColumns="True"
+                        CanUserSortColumns="False"
+                        HeadersVisibility="Column"
+                        IsReadOnly="True"
+                        SelectionMode="Single"
+                        GridLinesVisibility="All"
+                        RowHeight="Auto"
+                        MinHeight="180"
+                        RowDetailsVisibilityMode="VisibleWhenSelected"
+                        Visibility="{Binding HasFilteredErrors, Converter={StaticResource BooleanToVisibilityConverter}}">
+                        <toolkit:DataGrid.Columns>
+                            <toolkit:DataGridTextColumn
+                                Header="Čas"
+                                Binding="{Binding FormattedTimestamp}"
+                                Width="Auto" />
+                            <toolkit:DataGridTextColumn
+                                Header="Soubor"
+                                Binding="{Binding FileName}"
+                                Width="2*">
+                                <toolkit:DataGridTextColumn.ElementStyle>
+                                    <Style TargetType="TextBlock" BasedOn="{StaticResource WrapTextBlockStyle}">
+                                        <Setter Property="ToolTipService.ToolTip" Value="{Binding FilePath}" />
+                                    </Style>
+                                </toolkit:DataGridTextColumn.ElementStyle>
+                            </toolkit:DataGridTextColumn>
+                            <toolkit:DataGridTextColumn
+                                Header="Kód"
+                                Binding="{Binding Code}"
+                                Width="Auto" />
+                            <toolkit:DataGridTextColumn
+                                Header="Závažnost"
+                                Binding="{Binding Severity, Converter={StaticResource ErrorSeverityToStringConverter}}"
+                                Width="Auto" />
+                            <toolkit:DataGridTextColumn
+                                Header="Zpráva"
+                                Binding="{Binding ErrorMessage}"
+                                Width="3*">
+                                <toolkit:DataGridTextColumn.ElementStyle>
+                                    <Style TargetType="TextBlock" BasedOn="{StaticResource WrapTextBlockStyle}" />
+                                </toolkit:DataGridTextColumn.ElementStyle>
+                            </toolkit:DataGridTextColumn>
+                        </toolkit:DataGrid.Columns>
+                        <toolkit:DataGrid.RowDetailsTemplate>
+                            <DataTemplate x:DataType="models:ImportErrorItem">
+                                <StackPanel Margin="0,8,0,8" Spacing="4">
+                                    <TextBlock
+                                        FontSize="12"
+                                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                        Text="{Binding FilePath}"
+                                        TextWrapping="Wrap"
+                                        Visibility="{Binding HasFilePath, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                                    <TextBlock
+                                        FontWeight="SemiBold"
+                                        Text="{Binding Suggestion}"
+                                        TextWrapping="Wrap"
+                                        Visibility="{Binding HasSuggestion, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                                    <Button
+                                        Content="Otevřít detail"
+                                        HorizontalAlignment="Left"
+                                        Command="{Binding ElementName=ErrorsDataGrid, Path=DataContext.OpenErrorDetailCommand}"
+                                        CommandParameter="{Binding Source}" />
+                                </StackPanel>
+                            </DataTemplate>
+                        </toolkit:DataGrid.RowDetailsTemplate>
+                    </toolkit:DataGrid>
+
+                    <TextBlock
+                        Grid.Row="3"
+                        Margin="0,8,0,0"
+                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                        Text="Žádné chyby neodpovídají vybranému filtru."
+                        Visibility="{Binding HasNoFilteredErrors, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                </Grid>
             </Grid>
         </StackPanel>
 


### PR DESCRIPTION
## Summary
- add observable properties to surface aggregated error severity and counts for the import page
- refresh the error summary whenever results change so the UI can highlight fatal issues and guidance
- replace the collapsible error list with an always-visible info bar, severity filter, and DataGrid row details for clearer inspection

## Testing
- `dotnet build Veriado.sln` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68d952c17b10832692d6d3f4c86f4db6