### PR TITLE
Fix error summary properties in import view model

### DIFF
--- a/Veriado.WinUI/ViewModels/Import/ImportPageViewModel.cs
+++ b/Veriado.WinUI/ViewModels/Import/ImportPageViewModel.cs
@@ -163,17 +163,43 @@ public partial class ImportPageViewModel : ViewModelBase
     [ObservableProperty]
     private ImportErrorSeverity _selectedErrorFilter = ImportErrorSeverity.All;
 
-    [ObservableProperty]
     private InfoBarSeverity _errorSummarySeverity = InfoBarSeverity.Informational;
 
-    [ObservableProperty]
     private string? _errorSummaryTitle;
 
-    [ObservableProperty]
     private string? _errorSummaryMessage;
 
-    [ObservableProperty]
     private string? _errorSummaryDetail;
+
+    public InfoBarSeverity ErrorSummarySeverity
+    {
+        get => _errorSummarySeverity;
+        private set => SetProperty(ref _errorSummarySeverity, value);
+    }
+
+    public string? ErrorSummaryTitle
+    {
+        get => _errorSummaryTitle;
+        private set => SetProperty(ref _errorSummaryTitle, value);
+    }
+
+    public string? ErrorSummaryMessage
+    {
+        get => _errorSummaryMessage;
+        private set => SetProperty(ref _errorSummaryMessage, value);
+    }
+
+    public string? ErrorSummaryDetail
+    {
+        get => _errorSummaryDetail;
+        private set
+        {
+            if (SetProperty(ref _errorSummaryDetail, value))
+            {
+                OnPropertyChanged(nameof(HasErrorSummaryDetail));
+            }
+        }
+    }
 
     public ObservableCollection<ImportLogItem> Log { get; }
 
@@ -1457,11 +1483,6 @@ public partial class ImportPageViewModel : ViewModelBase
             : $"Celkem {Errors.Count} problémů.";
 
         ErrorSummaryDetail = "Vyberte řádek v tabulce, chcete-li zobrazit doporučení a další detaily. Chyby můžete filtrovat podle závažnosti.";
-    }
-
-    partial void OnErrorSummaryDetailChanged(string? value)
-    {
-        OnPropertyChanged(nameof(HasErrorSummaryDetail));
     }
 
     private bool MatchesSelectedFilter(ImportErrorItem item)


### PR DESCRIPTION
## Summary
- replace the error summary observable properties with explicit implementations
- ensure the HasErrorSummaryDetail flag updates when the detail text changes

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d957d992ec8326b1c6b87c4724929b