### PR TITLE
Fix HasErrorSummaryDetail updates without partial method

### DIFF
--- a/Veriado.WinUI/ViewModels/Import/ImportPageViewModel.cs
+++ b/Veriado.WinUI/ViewModels/Import/ImportPageViewModel.cs
@@ -1376,11 +1376,6 @@ public partial class ImportPageViewModel : ViewModelBase
         UpdateFilteredErrors();
     }
 
-    partial void OnErrorSummaryDetailChanged(string? value)
-    {
-        OnPropertyChanged(nameof(HasErrorSummaryDetail));
-    }
-
     partial void OnIsImportingChanged(bool value)
     {
         _runImportCommand.NotifyCanExecuteChanged();
@@ -1435,6 +1430,7 @@ public partial class ImportPageViewModel : ViewModelBase
             ErrorSummaryTitle = null;
             ErrorSummaryMessage = null;
             ErrorSummaryDetail = null;
+            OnPropertyChanged(nameof(HasErrorSummaryDetail));
             return;
         }
 
@@ -1474,6 +1470,7 @@ public partial class ImportPageViewModel : ViewModelBase
             : $"Celkem {Errors.Count} problémů.";
 
         ErrorSummaryDetail = "Vyberte řádek v tabulce, chcete-li zobrazit doporučení a další detaily. Chyby můžete filtrovat podle závažnosti.";
+        OnPropertyChanged(nameof(HasErrorSummaryDetail));
     }
 
     private bool MatchesSelectedFilter(ImportErrorItem item)


### PR DESCRIPTION
## Summary
- remove the unused partial method implementation for ErrorSummaryDetail changes
- manually notify HasErrorSummaryDetail updates when the summary detail text is assigned

## Testing
- dotnet build Veriado.sln *(fails: dotnet command not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d965a4e9b88326802a8ce106e67240