### PR TITLE
Fix ImportPage filter enablement binding

### DIFF
--- a/Veriado.WinUI/Views/Import/ImportPage.xaml
+++ b/Veriado.WinUI/Views/Import/ImportPage.xaml
@@ -303,21 +303,23 @@
                         </muxc:InfoBar.Content>
                     </muxc:InfoBar>
 
-                    <StackPanel Grid.Row="1" Orientation="Horizontal" Spacing="8" VerticalAlignment="Center" IsEnabled="{Binding HasErrors}">
-                        <TextBlock
-                            VerticalAlignment="Center"
-                            Text="Filtrovat:" />
-                        <ComboBox
-                            Width="180"
-                            ItemsSource="{Binding ErrorFilterOptions}"
-                            SelectedItem="{Binding SelectedErrorFilter, Mode=TwoWay}">
-                            <ComboBox.ItemTemplate>
-                                <DataTemplate x:DataType="models:ImportErrorSeverity">
-                                    <TextBlock Text="{Binding Converter={StaticResource ErrorSeverityToStringConverter}}" />
-                                </DataTemplate>
-                            </ComboBox.ItemTemplate>
-                        </ComboBox>
-                    </StackPanel>
+                    <ContentControl Grid.Row="1" VerticalAlignment="Center" IsEnabled="{Binding HasErrors}">
+                        <StackPanel Orientation="Horizontal" Spacing="8">
+                            <TextBlock
+                                VerticalAlignment="Center"
+                                Text="Filtrovat:" />
+                            <ComboBox
+                                Width="180"
+                                ItemsSource="{Binding ErrorFilterOptions}"
+                                SelectedItem="{Binding SelectedErrorFilter, Mode=TwoWay}">
+                                <ComboBox.ItemTemplate>
+                                    <DataTemplate x:DataType="models:ImportErrorSeverity">
+                                        <TextBlock Text="{Binding Converter={StaticResource ErrorSeverityToStringConverter}}" />
+                                    </DataTemplate>
+                                </ComboBox.ItemTemplate>
+                            </ComboBox>
+                        </StackPanel>
+                    </ContentControl>
 
                     <toolkit:DataGrid
                         x:Name="ErrorsDataGrid"


### PR DESCRIPTION
## Summary
- replace the StackPanel filter container with a ContentControl wrapper so IsEnabled can be bound
- keep the existing StackPanel layout inside the ContentControl to preserve spacing and alignment

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d978da1770832686bd7da35410296d