### PR TITLE
Avoid duplicate AutoMapper profile registration

### DIFF
--- a/Veriado.Mapping/DependencyInjection/MappingServiceCollectionExtensions.cs
+++ b/Veriado.Mapping/DependencyInjection/MappingServiceCollectionExtensions.cs
@@ -32,9 +32,7 @@ public static class MappingServiceCollectionExtensions
             // cfg.LicenseKey = "<tvůj_licenční_klíč>";
 
             CommonValueConverters.Register(cfg);
-            cfg.AddProfile<FileReadProfiles>();
-            cfg.AddProfile<FileWriteProfiles>();
-            cfg.AddProfile<SearchProfiles>();
+            // Profily se načítají automaticky ze zadaného assembly, není potřeba je přidávat ručně.
         }, typeof(FileReadProfiles).Assembly);
 
         // (Volitelné) Validace konfigurace po startu


### PR DESCRIPTION
## Summary
- rely on AutoMapper's assembly scanning to pick up mapping profiles
- document that profiles are loaded automatically to avoid double registration

## Testing
- `dotnet build` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68d98dbd121083269adcaa2b8a234009