### PR TITLE
Propagate index corruption during repair

### DIFF
--- a/Veriado.Infrastructure/Integrity/FulltextIntegrityService.cs
+++ b/Veriado.Infrastructure/Integrity/FulltextIntegrityService.cs
@@ -202,6 +202,12 @@ internal sealed class FulltextIntegrityService : IFulltextIntegrityService
                     processed++;
                 }
             }
+            catch (SearchIndexCorruptedException)
+            {
+                // Bubble the corruption signal back to the caller so that automated repair routines can
+                // escalate the failure instead of reporting a successful repair.
+                throw;
+            }
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Failed to repair search index for file {FileId}", fileId);


### PR DESCRIPTION
## Summary
- rethrow search index corruption exceptions during full-text repair so automated recovery can detect failure

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d99b10679c8326a0330f456aece63c