### PR TITLE
Fail fulltext repair on persistent corruption

### DIFF
--- a/Veriado.Infrastructure/Integrity/FulltextIntegrityService.cs
+++ b/Veriado.Infrastructure/Integrity/FulltextIntegrityService.cs
@@ -202,6 +202,11 @@ internal sealed class FulltextIntegrityService : IFulltextIntegrityService
                     processed++;
                 }
             }
+            catch (SearchIndexCorruptedException ex)
+            {
+                _logger.LogError(ex, "Failed to repair search index for file {FileId}", fileId);
+                throw;
+            }
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Failed to repair search index for file {FileId}", fileId);


### PR DESCRIPTION
## Summary
- propagate search index corruption errors during repair so automatic recovery can escalate when reindexing still fails

## Testing
- N/A

------
https://chatgpt.com/codex/tasks/task_e_68d99b3b72508326994cb49718376a45