### PR TITLE
Enable scrollbars on import page data grids

### DIFF
--- a/Veriado.WinUI/Views/Import/ImportPage.xaml
+++ b/Veriado.WinUI/Views/Import/ImportPage.xaml
@@ -233,7 +233,9 @@
                     HeadersVisibility="Column"
                     IsReadOnly="True"
                     SelectionMode="Single"
-                    GridLinesVisibility="All">
+                    GridLinesVisibility="All"
+                    ScrollViewer.VerticalScrollBarVisibility="Auto"
+                    ScrollViewer.HorizontalScrollBarVisibility="Auto">
                     <datagrid:DataGrid.Columns>
                         <datagrid:DataGridTextColumn Header="Čas" Binding="{Binding FormattedTimestamp}" Width="Auto" />
                         <datagrid:DataGridTextColumn Header="Událost" Binding="{Binding Title}" Width="2*">
@@ -312,7 +314,9 @@
                         GridLinesVisibility="All"
                         MinHeight="180"
                         RowDetailsVisibilityMode="VisibleWhenSelected"
-                        Visibility="{Binding HasFilteredErrors, Converter={StaticResource BooleanToVisibilityConverter}}">
+                        Visibility="{Binding HasFilteredErrors, Converter={StaticResource BooleanToVisibilityConverter}}"
+                        ScrollViewer.VerticalScrollBarVisibility="Auto"
+                        ScrollViewer.HorizontalScrollBarVisibility="Auto">
                         <datagrid:DataGrid.Columns>
                             <datagrid:DataGridTextColumn Header="Čas" Binding="{Binding FormattedTimestamp}" Width="Auto" />
                             <datagrid:DataGridTextColumn Header="Soubor" Binding="{Binding FileName}" Width="2*">


### PR DESCRIPTION
## Summary
- enable automatic horizontal and vertical scrollbars for the import log and error data grids so long content stays accessible

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d99c4a31548326a0e29c247f1ed621