### PR TITLE
Skip importing duplicate files by hash

### DIFF
--- a/Veriado.Application/UseCases/Files/CheckFileHash/FileHashExistsQuery.cs
+++ b/Veriado.Application/UseCases/Files/CheckFileHash/FileHashExistsQuery.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using Veriado.Appl.Abstractions;
+using Veriado.Domain.ValueObjects;
+
+namespace Veriado.Appl.UseCases.Files.CheckFileHash;
+
+/// <summary>
+/// Represents a query that determines whether a file with a specific content hash already exists.
+/// </summary>
+/// <param name="Hash">The SHA-256 hash in hexadecimal representation.</param>
+public sealed record FileHashExistsQuery(string Hash) : IRequest<bool>;
+
+/// <summary>
+/// Handles <see cref="FileHashExistsQuery"/> instances.
+/// </summary>
+public sealed class FileHashExistsQueryHandler : IRequestHandler<FileHashExistsQuery, bool>
+{
+    private readonly IFileRepository _repository;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FileHashExistsQueryHandler"/> class.
+    /// </summary>
+    public FileHashExistsQueryHandler(IFileRepository repository)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> Handle(FileHashExistsQuery request, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        var fileHash = FileHash.From(request.Hash);
+        return await _repository.ExistsByHashAsync(fileHash, cancellationToken).ConfigureAwait(false);
+    }
+}


### PR DESCRIPTION
## Summary
- skip importing files during folder imports when a matching content hash already exists
- compute and reuse file content hashes while reading from disk to avoid duplicate work
- add an application query handler that checks whether a file hash is already present in the repository

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d99debeb08832693addd3384748d74