### PR TITLE
Qualify validation exception in pipeline behavior

### DIFF
--- a/Veriado.Application/Pipeline/ValidationBehavior.cs
+++ b/Veriado.Application/Pipeline/ValidationBehavior.cs
@@ -1,5 +1,7 @@
 using System.Reflection;
 
+using ValidationException = Veriado.Appl.Common.ValidationException;
+
 namespace Veriado.Appl.Pipeline;
 
 /// <summary>


### PR DESCRIPTION
## Summary
- add an alias in ValidationBehavior to reference the common ValidationException explicitly

## Testing
- `dotnet build Veriado.Application/Veriado.Appl.csproj` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68da54c4fb048326b634755b33b78c12