### PR TITLE
Add filter sidebar and debounced search to files page

### DIFF
--- a/Veriado.WinUI/Converters/NullableLongToDoubleConverter.cs
+++ b/Veriado.WinUI/Converters/NullableLongToDoubleConverter.cs
@@ -1,0 +1,40 @@
+using System;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Data;
+
+namespace Veriado.WinUI.Converters;
+
+public sealed class NullableLongToDoubleConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, string language)
+    {
+        if (value is long longValue)
+        {
+            return (double)longValue;
+        }
+
+        if (value is long?)
+        {
+            var nullable = (long?)value;
+            return nullable.HasValue ? (double)nullable.Value : 0d;
+        }
+
+        return 0d;
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, string language)
+    {
+        if (value is double doubleValue)
+        {
+            if (double.IsNaN(doubleValue) || double.IsInfinity(doubleValue))
+            {
+                return null;
+            }
+
+            var rounded = (long)Math.Round(doubleValue);
+            return rounded;
+        }
+
+        return DependencyProperty.UnsetValue;
+    }
+}

--- a/Veriado.WinUI/ViewModels/Files/FilesPageViewModel.cs
+++ b/Veriado.WinUI/ViewModels/Files/FilesPageViewModel.cs
@@ -1,16 +1,34 @@
+using System;
 using System.Collections.ObjectModel;
+using System.Globalization;
+using System.Threading;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using CommunityToolkit.Mvvm.Messaging;
 using Veriado.Contracts.Files;
 using Veriado.Services.Files;
+using Veriado.WinUI.Services.Abstractions;
 using Veriado.WinUI.ViewModels.Base;
 
 namespace Veriado.WinUI.ViewModels.Files;
 
 public partial class FilesPageViewModel : ViewModelBase
 {
+    private const int DefaultPageSize = 50;
+    private const int DebounceDelayMilliseconds = 300;
+
     private readonly IFileQueryService _fileQueryService;
+    private readonly IHotStateService _hotStateService;
+    private CancellationTokenSource? _searchDebounceSource;
+
+    private int _currentPage;
+    private int _totalPages;
+    private int _totalCount;
 
     public FilesPageViewModel(
         IFileQueryService fileQueryService,
+        IHotStateService hotStateService,
         IMessenger messenger,
         IStatusService statusService,
         IDispatcherService dispatcher,
@@ -18,40 +36,253 @@ public partial class FilesPageViewModel : ViewModelBase
         : base(messenger, statusService, dispatcher, exceptionHandler)
     {
         _fileQueryService = fileQueryService ?? throw new ArgumentNullException(nameof(fileQueryService));
+        _hotStateService = hotStateService ?? throw new ArgumentNullException(nameof(hotStateService));
+
         Items = new ObservableCollection<FileSummaryDto>();
         RefreshCommand = new AsyncRelayCommand(RefreshAsync);
-    }
+        ClearFiltersCommand = new AsyncRelayCommand(ClearFiltersAsync);
 
-    [ObservableProperty]
-    private string? searchText;
+        PageSize = Math.Clamp(_hotStateService.PageSize <= 0 ? DefaultPageSize : _hotStateService.PageSize, 1, 200);
+        SearchText = _hotStateService.LastQuery;
+    }
 
     public ObservableCollection<FileSummaryDto> Items { get; }
 
     public IAsyncRelayCommand RefreshCommand { get; }
 
-    private Task RefreshAsync()
-    {
-        return SafeExecuteAsync(async cancellationToken =>
-        {
-            var query = new FileGridQueryDto
-            {
-                Text = SearchText,
-                Page = 1,
-                PageSize = 50,
-            };
+    public IAsyncRelayCommand ClearFiltersCommand { get; }
 
+    [ObservableProperty]
+    private string? searchText;
+
+    [ObservableProperty]
+    private bool fuzzy;
+
+    [ObservableProperty]
+    private string? extensionFilter;
+
+    [ObservableProperty]
+    private string? mimeFilter;
+
+    [ObservableProperty]
+    private string? authorFilter;
+
+    [ObservableProperty]
+    private string? versionFilter;
+
+    [ObservableProperty]
+    private bool? readOnlyFilter;
+
+    [ObservableProperty]
+    private bool? isIndexStaleFilter;
+
+    [ObservableProperty]
+    private bool? hasValidityFilter;
+
+    [ObservableProperty]
+    private bool? currentlyValidFilter;
+
+    [ObservableProperty]
+    private int? expiringInDaysFilter;
+
+    [ObservableProperty]
+    private long? sizeMinFilter;
+
+    [ObservableProperty]
+    private long? sizeMaxFilter;
+
+    [ObservableProperty]
+    private DateTimeOffset? createdFromFilter;
+
+    [ObservableProperty]
+    private DateTimeOffset? createdToFilter;
+
+    [ObservableProperty]
+    private DateTimeOffset? modifiedFromFilter;
+
+    [ObservableProperty]
+    private DateTimeOffset? modifiedToFilter;
+
+    [ObservableProperty]
+    private int pageSize = DefaultPageSize;
+
+    [ObservableProperty]
+    private string statusText = string.Empty;
+
+    partial void OnSearchTextChanged(string? value)
+    {
+        _hotStateService.LastQuery = value;
+        DebounceRefresh();
+    }
+
+    partial void OnFuzzyChanged(bool value)
+    {
+        DebounceRefresh();
+    }
+
+    partial void OnPageSizeChanged(int value)
+    {
+        var clamped = Math.Clamp(value <= 0 ? DefaultPageSize : value, 1, 200);
+        if (clamped != value)
+        {
+            PageSize = clamped;
+            return;
+        }
+
+        _hotStateService.PageSize = clamped;
+    }
+
+    private void DebounceRefresh()
+    {
+        CancelPendingDebounce();
+
+        var cts = new CancellationTokenSource();
+        _searchDebounceSource = cts;
+
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                await Task.Delay(DebounceDelayMilliseconds, cts.Token).ConfigureAwait(false);
+                cts.Token.ThrowIfCancellationRequested();
+                await RefreshAsync(true).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                // Intentionally ignored.
+            }
+            finally
+            {
+                if (ReferenceEquals(_searchDebounceSource, cts))
+                {
+                    _searchDebounceSource = null;
+                }
+
+                cts.Dispose();
+            }
+        });
+    }
+
+    private void CancelPendingDebounce()
+    {
+        if (_searchDebounceSource is null)
+        {
+            return;
+        }
+
+        _searchDebounceSource.Cancel();
+        _searchDebounceSource.Dispose();
+        _searchDebounceSource = null;
+    }
+
+    private Task RefreshAsync() => RefreshAsync(true);
+
+    private async Task RefreshAsync(bool resetPage)
+    {
+        CancelPendingDebounce();
+
+        if (!resetPage && _totalPages != 0 && _currentPage >= _totalPages)
+        {
+            return;
+        }
+
+        var page = resetPage ? 1 : Math.Max(1, _currentPage + 1);
+
+        await SafeExecuteAsync(async cancellationToken =>
+        {
+            var query = BuildQuery(page);
             var result = await _fileQueryService.GetGridAsync(query, cancellationToken).ConfigureAwait(false);
 
             await Dispatcher.Enqueue(() =>
             {
-                Items.Clear();
+                if (resetPage)
+                {
+                    Items.Clear();
+                }
+
                 foreach (var item in result.Items)
                 {
                     Items.Add(item);
                 }
-            }).ConfigureAwait(false);
 
-            StatusService.Info($"Načteno {Items.Count} položek.");
+                _currentPage = result.TotalPages == 0 ? 0 : result.Page;
+                _totalPages = result.TotalPages;
+                _totalCount = result.TotalCount;
+
+                var shown = Items.Count;
+                var pageDisplay = _totalPages == 0 ? 0 : _currentPage;
+                StatusText = $"{shown}/{_totalCount} · {pageDisplay}/{_totalPages}";
+            }).ConfigureAwait(false);
         });
+    }
+
+    private async Task ClearFiltersAsync()
+    {
+        ExtensionFilter = null;
+        MimeFilter = null;
+        AuthorFilter = null;
+        VersionFilter = null;
+        ReadOnlyFilter = null;
+        IsIndexStaleFilter = null;
+        HasValidityFilter = null;
+        CurrentlyValidFilter = null;
+        ExpiringInDaysFilter = null;
+        SizeMinFilter = null;
+        SizeMaxFilter = null;
+        CreatedFromFilter = null;
+        CreatedToFilter = null;
+        ModifiedFromFilter = null;
+        ModifiedToFilter = null;
+
+        _currentPage = 0;
+        _totalPages = 0;
+        _totalCount = 0;
+
+        await RefreshAsync(true).ConfigureAwait(false);
+    }
+
+    private FileGridQueryDto BuildQuery(int page)
+    {
+        var extension = string.IsNullOrWhiteSpace(ExtensionFilter) ? null : ExtensionFilter.Trim();
+        var mime = string.IsNullOrWhiteSpace(MimeFilter) ? null : MimeFilter.Trim();
+        var author = string.IsNullOrWhiteSpace(AuthorFilter) ? null : AuthorFilter.Trim();
+        var version = ParseVersion(VersionFilter);
+
+        var query = new FileGridQueryDto
+        {
+            Text = SearchText,
+            Fuzzy = Fuzzy,
+            Extension = extension,
+            Mime = mime,
+            Author = author,
+            Version = version,
+            IsReadOnly = ReadOnlyFilter,
+            IsIndexStale = IsIndexStaleFilter,
+            HasValidity = HasValidityFilter,
+            IsCurrentlyValid = CurrentlyValidFilter,
+            ExpiringInDays = ExpiringInDaysFilter,
+            SizeMin = SizeMinFilter,
+            SizeMax = SizeMaxFilter,
+            CreatedFromUtc = CreatedFromFilter,
+            CreatedToUtc = CreatedToFilter,
+            ModifiedFromUtc = ModifiedFromFilter,
+            ModifiedToUtc = ModifiedToFilter,
+            Page = page,
+            PageSize = Math.Clamp(PageSize <= 0 ? DefaultPageSize : PageSize, 1, 200),
+        };
+
+        return query;
+    }
+
+    private static int? ParseVersion(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        return int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed)
+            ? parsed
+            : null;
     }
 }

--- a/Veriado.WinUI/Views/Files/FilesPage.xaml
+++ b/Veriado.WinUI/Views/Files/FilesPage.xaml
@@ -5,24 +5,188 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:controls="using:Microsoft.UI.Xaml.Controls"
+    xmlns:converters="using:Veriado.WinUI.Converters"
     xmlns:contracts="using:Veriado.Contracts.Files"
     mc:Ignorable="d">
-    <Grid Padding="24" RowSpacing="16">
+    <Page.Resources>
+        <converters:NullableIntToDoubleConverter x:Key="NullableIntToDoubleConverter" />
+        <converters:NullableLongToDoubleConverter x:Key="NullableLongToDoubleConverter" />
+    </Page.Resources>
+
+    <Grid Padding="24" RowSpacing="16" ColumnSpacing="24">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="320" />
+            <ColumnDefinition Width="*" />
+        </Grid.ColumnDefinitions>
 
-        <StackPanel Orientation="Horizontal" Spacing="8">
-            <TextBox
-                Width="320"
-                PlaceholderText="Hledat soubory"
-                Text="{Binding SearchText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-            <Button Content="Hledat" Command="{Binding RefreshCommand}" />
+        <Grid Grid.Column="0" Grid.RowSpan="2" RowSpacing="12">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+
+            <Grid x:Uid="FilesPage_SearchRow" Grid.Row="0" ColumnSpacing="12">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+
+                <AutoSuggestBox
+                    x:Uid="FilesPage_SearchBox"
+                    Grid.Column="0"
+                    PlaceholderText="Hledat soubory"
+                    Text="{x:Bind ViewModel!.SearchText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                <ToggleSwitch
+                    x:Uid="FilesPage_FuzzyToggle"
+                    Grid.Column="1"
+                    HorizontalAlignment="Right"
+                    VerticalAlignment="Center"
+                    IsOn="{x:Bind ViewModel!.Fuzzy, Mode=TwoWay}" />
+            </Grid>
+
+            <ScrollViewer
+                x:Uid="FilesPage_FilterScrollViewer"
+                Grid.Row="1"
+                HorizontalScrollMode="Disabled"
+                HorizontalScrollBarVisibility="Hidden"
+                VerticalScrollMode="Auto"
+                VerticalScrollBarVisibility="Auto">
+                <StackPanel Spacing="12">
+                    <controls:Expander x:Uid="FilesPage_AttributesExpander" Header="Atributy" IsExpanded="True">
+                        <StackPanel Spacing="8">
+                            <TextBox
+                                x:Uid="FilesPage_ExtensionTextBox"
+                                PlaceholderText="Přípona"
+                                Text="{x:Bind ViewModel!.ExtensionFilter, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                            <TextBox
+                                x:Uid="FilesPage_MimeTextBox"
+                                PlaceholderText="MIME"
+                                Text="{x:Bind ViewModel!.MimeFilter, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                            <TextBox
+                                x:Uid="FilesPage_AuthorTextBox"
+                                PlaceholderText="Autor"
+                                Text="{x:Bind ViewModel!.AuthorFilter, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                            <TextBox
+                                x:Uid="FilesPage_VersionTextBox"
+                                PlaceholderText="Verze"
+                                Text="{x:Bind ViewModel!.VersionFilter, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                        </StackPanel>
+                    </controls:Expander>
+
+                    <controls:Expander x:Uid="FilesPage_ValidityExpander" Header="Platnost" IsExpanded="True">
+                        <StackPanel Spacing="8">
+                            <CheckBox
+                                x:Uid="FilesPage_ReadOnlyCheckBox"
+                                Content="Jen pro čtení"
+                                IsThreeState="True"
+                                IsChecked="{x:Bind ViewModel!.ReadOnlyFilter, Mode=TwoWay}" />
+                            <CheckBox
+                                x:Uid="FilesPage_IndexStaleCheckBox"
+                                Content="Neaktuální index"
+                                IsThreeState="True"
+                                IsChecked="{x:Bind ViewModel!.IsIndexStaleFilter, Mode=TwoWay}" />
+                            <CheckBox
+                                x:Uid="FilesPage_HasValidityCheckBox"
+                                Content="Má platnost"
+                                IsThreeState="True"
+                                IsChecked="{x:Bind ViewModel!.HasValidityFilter, Mode=TwoWay}" />
+                            <CheckBox
+                                x:Uid="FilesPage_CurrentlyValidCheckBox"
+                                Content="Aktuálně platné"
+                                IsThreeState="True"
+                                IsChecked="{x:Bind ViewModel!.CurrentlyValidFilter, Mode=TwoWay}" />
+                            <controls:NumberBox
+                                x:Uid="FilesPage_ExpiringNumberBox"
+                                Header="Vyprší za (dní)"
+                                Minimum="0"
+                                SmallChange="1"
+                                SpinButtonPlacementMode="Compact"
+                                Value="{x:Bind ViewModel!.ExpiringInDaysFilter, Mode=TwoWay, Converter={StaticResource NullableIntToDoubleConverter}}" />
+                        </StackPanel>
+                    </controls:Expander>
+
+                    <controls:Expander x:Uid="FilesPage_DatesExpander" Header="Data" IsExpanded="False">
+                        <StackPanel Spacing="8">
+                            <CalendarDatePicker
+                                x:Uid="FilesPage_CreatedFromPicker"
+                                PlaceholderText="Vytvořeno od"
+                                Date="{x:Bind ViewModel!.CreatedFromFilter, Mode=TwoWay}" />
+                            <CalendarDatePicker
+                                x:Uid="FilesPage_CreatedToPicker"
+                                PlaceholderText="Vytvořeno do"
+                                Date="{x:Bind ViewModel!.CreatedToFilter, Mode=TwoWay}" />
+                            <CalendarDatePicker
+                                x:Uid="FilesPage_ModifiedFromPicker"
+                                PlaceholderText="Upraveno od"
+                                Date="{x:Bind ViewModel!.ModifiedFromFilter, Mode=TwoWay}" />
+                            <CalendarDatePicker
+                                x:Uid="FilesPage_ModifiedToPicker"
+                                PlaceholderText="Upraveno do"
+                                Date="{x:Bind ViewModel!.ModifiedToFilter, Mode=TwoWay}" />
+                        </StackPanel>
+                    </controls:Expander>
+
+                    <controls:Expander x:Uid="FilesPage_SizeExpander" Header="Velikost" IsExpanded="False">
+                        <StackPanel Spacing="8">
+                            <controls:NumberBox
+                                x:Uid="FilesPage_SizeMinNumberBox"
+                                Header="Minimální velikost (B)"
+                                Minimum="0"
+                                SpinButtonPlacementMode="Compact"
+                                Value="{x:Bind ViewModel!.SizeMinFilter, Mode=TwoWay, Converter={StaticResource NullableLongToDoubleConverter}}" />
+                            <controls:NumberBox
+                                x:Uid="FilesPage_SizeMaxNumberBox"
+                                Header="Maximální velikost (B)"
+                                Minimum="0"
+                                SpinButtonPlacementMode="Compact"
+                                Value="{x:Bind ViewModel!.SizeMaxFilter, Mode=TwoWay, Converter={StaticResource NullableLongToDoubleConverter}}" />
+                        </StackPanel>
+                    </controls:Expander>
+                </StackPanel>
+            </ScrollViewer>
+
+            <Grid Grid.Row="2" ColumnSpacing="12">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+                <Button
+                    x:Uid="FilesPage_ApplyButton"
+                    Grid.Column="0"
+                    Content="Použít"
+                    Command="{x:Bind ViewModel!.RefreshCommand}" />
+                <Button
+                    x:Uid="FilesPage_ClearButton"
+                    Grid.Column="1"
+                    Content="Vyčistit"
+                    Command="{x:Bind ViewModel!.ClearFiltersCommand}" />
+            </Grid>
+        </Grid>
+
+        <StackPanel Grid.Row="0" Grid.Column="1" Orientation="Vertical" Spacing="8">
+            <StackPanel Orientation="Horizontal" Spacing="12" VerticalAlignment="Center">
+                <ProgressRing Width="20" Height="20" IsActive="{x:Bind ViewModel!.IsBusy}" />
+                <TextBlock
+                    x:Uid="FilesPage_StatusText"
+                    VerticalAlignment="Center"
+                    Text="{x:Bind ViewModel!.StatusText, Mode=OneWay}" />
+            </StackPanel>
+            <controls:InfoBar
+                x:Uid="FilesPage_ErrorInfoBar"
+                IsClosable="False"
+                IsOpen="{x:Bind ViewModel!.HasError, Mode=OneWay}"
+                Severity="Error"
+                Title="Chyba načítání"
+                Message="Nepodařilo se načíst výsledky." />
         </StackPanel>
 
-        <ScrollViewer Grid.Row="1">
-            <ItemsRepeater ItemsSource="{Binding Items}">
+        <controls:ItemsRepeaterScrollHost Grid.Row="1" Grid.Column="1">
+            <ItemsRepeater ItemsSource="{x:Bind ViewModel!.Items}">
                 <ItemsRepeater.Layout>
                     <controls:UniformGridLayout
                         Orientation="Vertical"
@@ -49,6 +213,6 @@
                     </DataTemplate>
                 </ItemsRepeater.ItemTemplate>
             </ItemsRepeater>
-        </ScrollViewer>
+        </controls:ItemsRepeaterScrollHost>
     </Grid>
 </Page>


### PR DESCRIPTION
## Summary
- replace the files page layout with a two-column grid that adds a fixed-width sidebar for search, fuzzy toggle, grouped filters, and action buttons while keeping the virtualized results on the right
- extend the files page view model with the required filter properties, hot-state persistence, debounced search refresh, query construction, and status updates
- add a reusable nullable-long to double converter to support NumberBox bindings for size filters

## Testing
- dotnet build *(fails: `dotnet` is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da7531cf608326a3d0c2b979c3c991