### PR TITLE
Fix ItemsRepeater namespace for FilesPage

### DIFF
--- a/Veriado.WinUI/Views/Files/FilesPage.xaml
+++ b/Veriado.WinUI/Views/Files/FilesPage.xaml
@@ -187,33 +187,33 @@
 
         <ScrollViewer Grid.Row="1" Grid.Column="1" HorizontalScrollMode="Disabled" HorizontalScrollBarVisibility="Hidden" VerticalScrollMode="Auto" VerticalScrollBarVisibility="Auto">
             <controls:ItemsRepeaterScrollHost>
-                <ItemsRepeater ItemsSource="{x:Bind ViewModel.Items}">
-                <ItemsRepeater.Layout>
-                    <controls:UniformGridLayout
-                        Orientation="Vertical"
-                        MinItemWidth="220"
-                        MinItemHeight="120"
-                        ItemsJustification="Start" />
-                </ItemsRepeater.Layout>
-                <ItemsRepeater.ItemTemplate>
-                    <DataTemplate x:DataType="contracts:FileSummaryDto">
-                        <Border
-                            Margin="8"
-                            Padding="12"
-                            CornerRadius="6"
-                            BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}"
-                            BorderThickness="1">
-                            <StackPanel Spacing="4">
-                                <TextBlock Text="{x:Bind Name}" FontWeight="SemiBold" TextTrimming="CharacterEllipsis" />
-                                <TextBlock Text="{x:Bind Mime}" FontSize="12" Opacity="0.7" TextTrimming="CharacterEllipsis" />
-                                <TextBlock
-                                    Text="{x:Bind Size, Converter={StaticResource SizeToHumanConverter}}"
-                                    FontSize="12" />
-                            </StackPanel>
-                        </Border>
-                    </DataTemplate>
-                </ItemsRepeater.ItemTemplate>
-                </ItemsRepeater>
+                <controls:ItemsRepeater ItemsSource="{x:Bind ViewModel.Items}">
+                    <controls:ItemsRepeater.Layout>
+                        <controls:UniformGridLayout
+                            Orientation="Vertical"
+                            MinItemWidth="220"
+                            MinItemHeight="120"
+                            ItemsJustification="Start" />
+                    </controls:ItemsRepeater.Layout>
+                    <controls:ItemsRepeater.ItemTemplate>
+                        <DataTemplate x:DataType="contracts:FileSummaryDto">
+                            <Border
+                                Margin="8"
+                                Padding="12"
+                                CornerRadius="6"
+                                BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}"
+                                BorderThickness="1">
+                                <StackPanel Spacing="4">
+                                    <TextBlock Text="{x:Bind Name}" FontWeight="SemiBold" TextTrimming="CharacterEllipsis" />
+                                    <TextBlock Text="{x:Bind Mime}" FontSize="12" Opacity="0.7" TextTrimming="CharacterEllipsis" />
+                                    <TextBlock
+                                        Text="{x:Bind Size, Converter={StaticResource SizeToHumanConverter}}"
+                                        FontSize="12" />
+                                </StackPanel>
+                            </Border>
+                        </DataTemplate>
+                    </controls:ItemsRepeater.ItemTemplate>
+                </controls:ItemsRepeater>
             </controls:ItemsRepeaterScrollHost>
         </ScrollViewer>
     </Grid>


### PR DESCRIPTION
## Summary
- prefix the Files page ItemsRepeater with the WinUI controls namespace so XAML parses correctly
- adjust the related layout and template property elements to use the same namespace-qualified element names

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68da7f19f8d88326861ba046a52db751