### PR TITLE
Replace ScrollViewer with ScrollView for Files ItemsRepeater

### DIFF
--- a/Veriado.WinUI/Views/Files/FilesPage.xaml
+++ b/Veriado.WinUI/Views/Files/FilesPage.xaml
@@ -185,7 +185,7 @@
                 Message="Nepodařilo se načíst výsledky." />
         </StackPanel>
 
-        <ScrollViewer Grid.Row="1" Grid.Column="1" HorizontalScrollMode="Disabled" HorizontalScrollBarVisibility="Hidden" VerticalScrollMode="Auto" VerticalScrollBarVisibility="Auto">
+        <controls:ScrollView Grid.Row="1" Grid.Column="1" HorizontalScrollMode="Disabled" HorizontalScrollBarVisibility="Hidden" VerticalScrollMode="Auto" VerticalScrollBarVisibility="Auto">
             <controls:ItemsRepeaterScrollHost>
                 <controls:ItemsRepeater ItemsSource="{x:Bind ViewModel.Items}">
                     <controls:ItemsRepeater.Layout>
@@ -215,6 +215,6 @@
                     </controls:ItemsRepeater.ItemTemplate>
                 </controls:ItemsRepeater>
             </controls:ItemsRepeaterScrollHost>
-        </ScrollViewer>
+        </controls:ScrollView>
     </Grid>
 </Page>


### PR DESCRIPTION
## Summary
- replace the Files page ScrollViewer with ScrollView to use a supported host for ItemsRepeater

## Testing
- dotnet build Veriado.sln *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68da80cb20c88326aede6f3f28eb4134