### PR TITLE
Fix FilesPage ItemsRepeater ScrollViewer wiring

### DIFF
--- a/Veriado.WinUI/Views/Files/FilesPage.xaml
+++ b/Veriado.WinUI/Views/Files/FilesPage.xaml
@@ -185,36 +185,41 @@
                 Message="Nepodařilo se načíst výsledky." />
         </StackPanel>
 
-        <controls:ScrollView Grid.Row="1" Grid.Column="1" HorizontalScrollMode="Disabled" HorizontalScrollBarVisibility="Hidden" VerticalScrollMode="Auto" VerticalScrollBarVisibility="Auto">
-            <controls:ItemsRepeaterScrollHost>
-                <controls:ItemsRepeater ItemsSource="{x:Bind ViewModel.Items}">
-                    <controls:ItemsRepeater.Layout>
-                        <controls:UniformGridLayout
-                            Orientation="Vertical"
-                            MinItemWidth="220"
-                            MinItemHeight="120"
-                            ItemsJustification="Start" />
-                    </controls:ItemsRepeater.Layout>
-                    <controls:ItemsRepeater.ItemTemplate>
-                        <DataTemplate x:DataType="contracts:FileSummaryDto">
-                            <Border
-                                Margin="8"
-                                Padding="12"
-                                CornerRadius="6"
-                                BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}"
-                                BorderThickness="1">
-                                <StackPanel Spacing="4">
-                                    <TextBlock Text="{x:Bind Name}" FontWeight="SemiBold" TextTrimming="CharacterEllipsis" />
-                                    <TextBlock Text="{x:Bind Mime}" FontSize="12" Opacity="0.7" TextTrimming="CharacterEllipsis" />
-                                    <TextBlock
-                                        Text="{x:Bind Size, Converter={StaticResource SizeToHumanConverter}}"
-                                        FontSize="12" />
-                                </StackPanel>
-                            </Border>
-                        </DataTemplate>
-                    </controls:ItemsRepeater.ItemTemplate>
-                </controls:ItemsRepeater>
-            </controls:ItemsRepeaterScrollHost>
-        </controls:ScrollView>
+        <controls:ItemsRepeaterScrollHost Grid.Row="1" Grid.Column="1">
+            <controls:ItemsRepeaterScrollHost.ScrollViewer>
+                <controls:ScrollView
+                    HorizontalScrollMode="Disabled"
+                    HorizontalScrollBarVisibility="Hidden"
+                    VerticalScrollMode="Auto"
+                    VerticalScrollBarVisibility="Auto" />
+            </controls:ItemsRepeaterScrollHost.ScrollViewer>
+            <controls:ItemsRepeater ItemsSource="{x:Bind ViewModel.Items}">
+                <controls:ItemsRepeater.Layout>
+                    <controls:UniformGridLayout
+                        Orientation="Vertical"
+                        MinItemWidth="220"
+                        MinItemHeight="120"
+                        ItemsJustification="Start" />
+                </controls:ItemsRepeater.Layout>
+                <controls:ItemsRepeater.ItemTemplate>
+                    <DataTemplate x:DataType="contracts:FileSummaryDto">
+                        <Border
+                            Margin="8"
+                            Padding="12"
+                            CornerRadius="6"
+                            BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}"
+                            BorderThickness="1">
+                            <StackPanel Spacing="4">
+                                <TextBlock Text="{x:Bind Name}" FontWeight="SemiBold" TextTrimming="CharacterEllipsis" />
+                                <TextBlock Text="{x:Bind Mime}" FontSize="12" Opacity="0.7" TextTrimming="CharacterEllipsis" />
+                                <TextBlock
+                                    Text="{x:Bind Size, Converter={StaticResource SizeToHumanConverter}}"
+                                    FontSize="12" />
+                            </StackPanel>
+                        </Border>
+                    </DataTemplate>
+                </controls:ItemsRepeater.ItemTemplate>
+            </controls:ItemsRepeater>
+        </controls:ItemsRepeaterScrollHost>
     </Grid>
 </Page>


### PR DESCRIPTION
## Summary
- configure the Files page ItemsRepeaterScrollHost to provide its ScrollView via the dedicated property
- keep the existing grid layout while ensuring the repeater uses the correct scroll host structure

## Testing
- not run (UI markup change only)


------
https://chatgpt.com/codex/tasks/task_e_68da824309fc8326a98c56a5609a01e4