### PR TITLE
Monitor indexing health on files page

### DIFF
--- a/Veriado.WinUI/Views/Files/FilesPage.xaml
+++ b/Veriado.WinUI/Views/Files/FilesPage.xaml
@@ -177,6 +177,13 @@
                     Text="{x:Bind ViewModel.StatusText, Mode=OneWay}" />
             </StackPanel>
             <controls:InfoBar
+                x:Uid="FilesPage_IndexingInfoBar"
+                IsClosable="False"
+                IsOpen="{x:Bind ViewModel.IsIndexingPending, Mode=OneWay}"
+                Severity="Warning"
+                Title="Probíhá indexace"
+                Message="{x:Bind ViewModel.IndexingWarningMessage, Mode=OneWay}" />
+            <controls:InfoBar
                 x:Uid="FilesPage_ErrorInfoBar"
                 IsClosable="False"
                 IsOpen="{x:Bind ViewModel.HasError, Mode=OneWay}"

--- a/Veriado.WinUI/Views/Files/FilesPage.xaml.cs
+++ b/Veriado.WinUI/Views/Files/FilesPage.xaml.cs
@@ -12,6 +12,7 @@ public sealed partial class FilesPage : Page
         DataContext = ViewModel;
         InitializeComponent();
         Loaded += OnLoaded;
+        Unloaded += OnUnloaded;
     }
 
     public FilesPageViewModel ViewModel { get; }
@@ -19,7 +20,13 @@ public sealed partial class FilesPage : Page
     private async void OnLoaded(object sender, RoutedEventArgs e)
     {
         Loaded -= OnLoaded;
+        ViewModel.StartHealthMonitoring();
         await ExecuteInitialRefreshAsync().ConfigureAwait(true);
+    }
+
+    private void OnUnloaded(object sender, RoutedEventArgs e)
+    {
+        ViewModel.StopHealthMonitoring();
     }
 
     private Task ExecuteInitialRefreshAsync()


### PR DESCRIPTION
## Summary
- inject IHealthService into the files page view model and poll search indexing health in the background
- expose indexing warning state that is surfaced through a new InfoBar on the files page
- start and stop health monitoring with the page lifecycle to avoid leaking background work

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68da9864c1588326927a5682ef9fc5d6