### PR TITLE
Fix Files page indexing bindings

### DIFF
--- a/Veriado.WinUI/ViewModels/Files/FilesPageViewModel.cs
+++ b/Veriado.WinUI/ViewModels/Files/FilesPageViewModel.cs
@@ -118,11 +118,21 @@ public partial class FilesPageViewModel : ViewModelBase
     [ObservableProperty]
     private string statusText = string.Empty;
 
-    [ObservableProperty]
     private bool isIndexingPending;
 
-    [ObservableProperty]
+    public bool IsIndexingPending
+    {
+        get => isIndexingPending;
+        set => SetProperty(ref isIndexingPending, value);
+    }
+
     private string? indexingWarningMessage;
+
+    public string? IndexingWarningMessage
+    {
+        get => indexingWarningMessage;
+        set => SetProperty(ref indexingWarningMessage, value);
+    }
 
     public void StartHealthMonitoring()
     {


### PR DESCRIPTION
## Summary
- replace observable field generators for the indexing status properties with explicit properties
- ensure the Files page bindings compile by exposing the properties directly

## Testing
- dotnet build Veriado.sln *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68da9c0697bc83269e93ea298c81dbb4