### PR TITLE
Extend search metadata and highlight handling

### DIFF
--- a/Veriado.Domain/Files/FileEntity.cs
+++ b/Veriado.Domain/Files/FileEntity.cs
@@ -366,6 +366,22 @@ public sealed class FileEntity : AggregateRoot
     {
         var title = string.IsNullOrWhiteSpace(Title) ? Name.Value : Title!;
         var authorText = string.IsNullOrWhiteSpace(Author) ? null : Author;
+        var metadata = new SearchDocumentMetadata(
+            Name.Value,
+            Extension.Value,
+            Mime.Value,
+            string.IsNullOrWhiteSpace(Title) ? null : Title,
+            authorText,
+            Size.Value,
+            new SearchDocumentSystemMetadata(
+                SystemMetadata.Attributes,
+                SystemMetadata.OwnerSid,
+                SystemMetadata.HardLinkCount,
+                SystemMetadata.AlternateDataStreamCount,
+                SystemMetadata.CreatedUtc.Value,
+                SystemMetadata.LastWriteUtc.Value,
+                SystemMetadata.LastAccessUtc.Value));
+        var metadataJson = SearchDocument.SerializeMetadata(metadata);
         return new SearchDocument(
             Id,
             title,
@@ -373,7 +389,8 @@ public sealed class FileEntity : AggregateRoot
             authorText,
             Name.Value,
             CreatedUtc.Value,
-            LastModifiedUtc.Value);
+            LastModifiedUtc.Value,
+            metadataJson);
     }
 
     /// <summary>

--- a/Veriado.Domain/Search/SearchDocument.cs
+++ b/Veriado.Domain/Search/SearchDocument.cs
@@ -1,3 +1,8 @@
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Veriado.Domain.Metadata;
+
 namespace Veriado.Domain.Search;
 
 /// <summary>
@@ -10,4 +15,66 @@ public sealed record SearchDocument(
     string? Author,
     string FileName,
     DateTimeOffset CreatedUtc,
-    DateTimeOffset ModifiedUtc);
+    DateTimeOffset ModifiedUtc,
+    string? MetadataJson)
+{
+    /// <summary>
+    /// Gets serializer options used when emitting the metadata JSON payload.
+    /// </summary>
+    public static JsonSerializerOptions MetadataSerializerOptions { get; } = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        WriteIndented = false,
+        Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) },
+    };
+
+    /// <summary>
+    /// Serialises the supplied metadata using the canonical options.
+    /// </summary>
+    /// <param name="metadata">The metadata model.</param>
+    /// <returns>The JSON payload.</returns>
+    public static string SerializeMetadata(SearchDocumentMetadata metadata)
+    {
+        ArgumentNullException.ThrowIfNull(metadata);
+        return JsonSerializer.Serialize(metadata, MetadataSerializerOptions);
+    }
+}
+
+/// <summary>
+/// Represents structured metadata associated with a search document.
+/// </summary>
+/// <param name="FileName">The logical file name.</param>
+/// <param name="Extension">The file extension without a dot.</param>
+/// <param name="Mime">The MIME type.</param>
+/// <param name="Title">The user-facing title, if available.</param>
+/// <param name="Author">The document author, if available.</param>
+/// <param name="SizeBytes">The file size in bytes.</param>
+/// <param name="System">The system metadata snapshot.</param>
+public sealed record SearchDocumentMetadata(
+    string FileName,
+    string Extension,
+    string Mime,
+    string? Title,
+    string? Author,
+    long SizeBytes,
+    SearchDocumentSystemMetadata System);
+
+/// <summary>
+/// Represents file-system specific metadata included in the search document.
+/// </summary>
+/// <param name="Attributes">The file attribute flags.</param>
+/// <param name="Owner">The owning security identifier, if known.</param>
+/// <param name="HardLinkCount">The number of hard links, if known.</param>
+/// <param name="AlternateDataStreamCount">The number of alternate data streams, if known.</param>
+/// <param name="CreatedUtc">The creation timestamp in UTC.</param>
+/// <param name="LastWriteUtc">The last write timestamp in UTC.</param>
+/// <param name="LastAccessUtc">The last access timestamp in UTC.</param>
+public sealed record SearchDocumentSystemMetadata(
+    FileAttributesFlags Attributes,
+    string? Owner,
+    uint? HardLinkCount,
+    uint? AlternateDataStreamCount,
+    DateTimeOffset CreatedUtc,
+    DateTimeOffset LastWriteUtc,
+    DateTimeOffset LastAccessUtc);

--- a/Veriado.Infrastructure/Integrity/StartupIntegrityCheck.cs
+++ b/Veriado.Infrastructure/Integrity/StartupIntegrityCheck.cs
@@ -32,6 +32,16 @@ internal static class StartupIntegrityCheck
         }
 
         logger.LogWarning("Full-text index inconsistencies detected: {Missing} missing, {Orphans} orphans", report.MissingCount, report.OrphanCount);
+        if (report.MissingFileIds.Count > 0)
+        {
+            logger.LogWarning("Missing search index entries for files: {MissingIds}", string.Join(", ", report.MissingFileIds));
+        }
+
+        if (report.OrphanIndexIds.Count > 0)
+        {
+            logger.LogWarning("Orphaned search rows without matching files: {OrphanIds}", string.Join(", ", report.OrphanIndexIds));
+        }
+
         if (options.RepairIntegrityAutomatically)
         {
             var repaired = await integrity.RepairAsync(reindexAll: false, cancellationToken)

--- a/Veriado.Infrastructure/Persistence/Schema/Fts5.sql
+++ b/Veriado.Infrastructure/Persistence/Schema/Fts5.sql
@@ -2,6 +2,7 @@ CREATE VIRTUAL TABLE IF NOT EXISTS file_search USING fts5(
     title,
     mime,
     author,
+    metadata,
     tokenize = 'unicode61 remove_diacritics 2',
     content='',
     columnsize=0

--- a/Veriado.Infrastructure/Search/HybridSearchQueryService.cs
+++ b/Veriado.Infrastructure/Search/HybridSearchQueryService.cs
@@ -179,14 +179,14 @@ internal sealed class HybridSearchQueryService : ISearchQueryService
 
         foreach (var hit in ftsHits)
         {
-            var hasHighlight = ContainsHighlight(hit.Title);
+            var hasHighlight = ContainsHighlight(hit.Title, hit.Snippet);
             combined[hit.FileId] = (hit, hit.Score, hasHighlight);
         }
 
         foreach (var hit in luceneHits)
         {
             var weightedScore = hit.Score * LuceneWeight;
-            var hasHighlight = ContainsHighlight(hit.Title);
+            var hasHighlight = ContainsHighlight(hit.Title, hit.Snippet);
             if (combined.TryGetValue(hit.FileId, out var existing))
             {
                 var bestScore = Math.Max(existing.Score, weightedScore);
@@ -325,8 +325,15 @@ internal sealed class HybridSearchQueryService : ISearchQueryService
         return Math.Max(target, oversample);
     }
 
-    private static bool ContainsHighlight(string title)
-        => !string.IsNullOrEmpty(title) && title.IndexOf('[', StringComparison.Ordinal) >= 0;
+    private static bool ContainsHighlight(string title, string? snippet)
+    {
+        if (!string.IsNullOrEmpty(title) && title.IndexOf('[', StringComparison.Ordinal) >= 0)
+        {
+            return true;
+        }
+
+        return !string.IsNullOrEmpty(snippet) && snippet.IndexOf('[', StringComparison.Ordinal) >= 0;
+    }
 
     private static int SafeAdd(int left, int right)
     {

--- a/Veriado.Infrastructure/Search/LuceneSearchFields.cs
+++ b/Veriado.Infrastructure/Search/LuceneSearchFields.cs
@@ -9,6 +9,7 @@ internal static class LuceneSearchFields
     public const string Title = "title";
     public const string Mime = "mime";
     public const string Author = "author";
+    public const string Metadata = "metadata";
     public const string Created = "created";
     public const string Modified = "modified";
 }

--- a/Veriado.Infrastructure/Search/SqliteFts5Transactional.cs
+++ b/Veriado.Infrastructure/Search/SqliteFts5Transactional.cs
@@ -30,11 +30,12 @@ internal sealed class SqliteFts5Transactional
             await using (var insert = connection.CreateCommand())
             {
                 insert.Transaction = transaction;
-                insert.CommandText = "INSERT INTO file_search(rowid, title, mime, author) VALUES ($rowid, $title, $mime, $author);";
+                insert.CommandText = "INSERT INTO file_search(rowid, title, mime, author, metadata) VALUES ($rowid, $title, $mime, $author, $metadata);";
                 insert.Parameters.Add("$rowid", SqliteType.Integer).Value = searchRowId;
                 insert.Parameters.AddWithValue("$title", (object?)document.Title ?? DBNull.Value);
                 insert.Parameters.AddWithValue("$mime", document.Mime);
                 insert.Parameters.AddWithValue("$author", (object?)document.Author ?? DBNull.Value);
+                insert.Parameters.AddWithValue("$metadata", (object?)document.MetadataJson ?? DBNull.Value);
                 await insert.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
             }
 
@@ -42,7 +43,8 @@ internal sealed class SqliteFts5Transactional
                 document.Title,
                 document.Author,
                 document.FileName,
-                document.Mime);
+                document.Mime,
+                document.MetadataJson);
 
             await using (var deleteTrgm = connection.CreateCommand())
             {


### PR DESCRIPTION
## Summary
- serialize system metadata into search documents and propagate the JSON payload into SQLite FTS, trigram, and Lucene indexes
- widen SQLite highlight/snippet coverage, adjust bm25 weights, and surface metadata-driven context in both FTS and hybrid results
- add Lucene metadata field, generate highlighted snippets with the highlighter, and batch index writer commits for better throughput
- log detailed integrity discrepancies during startup checks

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68db5b230ec88326bca36bf91b9a372f