### PR TITLE
Implement unified search hit contract and hybrid search pipeline

### DIFF
--- a/Veriado.Application/UseCases/Search/SearchFilesHandler.cs
+++ b/Veriado.Application/UseCases/Search/SearchFilesHandler.cs
@@ -1,3 +1,4 @@
+using AutoMapper;
 using Veriado.Appl.Search.Abstractions;
 
 namespace Veriado.Appl.UseCases.Search;

--- a/Veriado.Contracts/Search/SearchHitDto.cs
+++ b/Veriado.Contracts/Search/SearchHitDto.cs
@@ -1,18 +1,31 @@
 namespace Veriado.Contracts.Search;
 
 /// <summary>
+/// Represents an individual highlight span inside a snippet.
+/// </summary>
+/// <param name="Field">The field associated with the highlight.</param>
+/// <param name="Start">The zero-based start offset inside the snippet.</param>
+/// <param name="Length">The number of characters covered by the highlight.</param>
+/// <param name="Term">The optional matching term.</param>
+public sealed record HighlightSpanDto(string Field, int Start, int Length, string? Term);
+
+/// <summary>
 /// Represents a single hit returned by the search subsystem.
 /// </summary>
-/// <param name="FileId">The identifier of the matching file.</param>
-/// <param name="Title">The display title of the hit.</param>
-/// <param name="Mime">The MIME type of the file.</param>
-/// <param name="Snippet">The optional snippet that matched the query.</param>
+/// <param name="Id">The identifier of the matching file.</param>
 /// <param name="Score">The relevance score.</param>
-/// <param name="LastModifiedUtc">The last modification timestamp.</param>
+/// <param name="Source">The origin of the hit (FTS or TRIGRAM).</param>
+/// <param name="PrimaryField">The field from which the snippet was generated.</param>
+/// <param name="SnippetText">The plain-text snippet.</param>
+/// <param name="Highlights">The highlight spans located within the snippet.</param>
+/// <param name="Fields">Additional key/value fields related to the hit.</param>
+/// <param name="SortValues">Optional sort metadata.</param>
 public sealed record SearchHitDto(
-    Guid FileId,
-    string Title,
-    string Mime,
-    string? Snippet,
+    Guid Id,
     double Score,
-    DateTimeOffset LastModifiedUtc);
+    string Source,
+    string? PrimaryField,
+    string SnippetText,
+    IReadOnlyList<HighlightSpanDto> Highlights,
+    IReadOnlyDictionary<string, string?> Fields,
+    object? SortValues);

--- a/Veriado.Domain/Search/SearchHit.cs
+++ b/Veriado.Domain/Search/SearchHit.cs
@@ -1,12 +1,44 @@
 namespace Veriado.Domain.Search;
 
 /// <summary>
-/// Represents a search hit returned from the full-text search index.
+/// Represents a highlighted segment within a search hit snippet.
 /// </summary>
+/// <param name="Field">The field containing the highlighted text.</param>
+/// <param name="Start">The zero-based character offset within the snippet.</param>
+/// <param name="Length">The length of the highlighted segment in characters.</param>
+/// <param name="Term">The original matching term, when available.</param>
+public sealed record HighlightSpan(string Field, int Start, int Length, string? Term);
+
+/// <summary>
+/// Represents a unified search hit returned by the search subsystem.
+/// </summary>
+/// <param name="Id">The unique identifier of the matching document.</param>
+/// <param name="Score">The relevance score for the hit.</param>
+/// <param name="Source">The origin of the hit (e.g. FTS or TRIGRAM).</param>
+/// <param name="PrimaryField">The primary field used to generate the snippet.</param>
+/// <param name="SnippetText">The snippet presented to the caller.</param>
+/// <param name="Highlights">The highlight spans contained within the snippet.</param>
+/// <param name="Fields">Additional indexed fields associated with the hit.</param>
+/// <param name="SortValues">Optional sort metadata emitted by the query pipeline.</param>
 public sealed record SearchHit(
-    Guid FileId,
-    string Title,
-    string Mime,
-    string? Snippet,
+    Guid Id,
     double Score,
-    DateTimeOffset LastModifiedUtc);
+    string Source,
+    string? PrimaryField,
+    string SnippetText,
+    IReadOnlyList<HighlightSpan> Highlights,
+    IReadOnlyDictionary<string, string?> Fields,
+    object? SortValues);
+
+/// <summary>
+/// Provides optional sort metadata emitted with a search hit.
+/// </summary>
+/// <param name="LastModifiedUtc">The last modification timestamp of the document.</param>
+/// <param name="NormalizedScore">A score normalised to the range &lt;0,1&gt; for ordering.</param>
+/// <param name="RawScore">The raw score produced by the underlying search provider.</param>
+/// <param name="SecondaryScore">An optional secondary score when combining providers.</param>
+public sealed record SearchHitSortValues(
+    DateTimeOffset LastModifiedUtc,
+    double NormalizedScore,
+    double RawScore,
+    double? SecondaryScore = null);

--- a/Veriado.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/Veriado.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
@@ -82,7 +82,9 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<ISearchIndexCoordinator, SqliteSearchIndexCoordinator>();
         services.AddSingleton<IDatabaseMaintenanceService, SqliteDatabaseMaintenanceService>();
         services.AddSingleton<SqliteFts5QueryService>();
-        services.AddSingleton<ISearchQueryService>(sp => sp.GetRequiredService<SqliteFts5QueryService>());
+        services.AddSingleton<TrigramQueryService>();
+        services.AddSingleton<HybridSearchQueryService>();
+        services.AddSingleton<ISearchQueryService>(sp => sp.GetRequiredService<HybridSearchQueryService>());
         services.AddSingleton<ISearchHistoryService, SearchHistoryService>();
         services.AddSingleton<ISearchFavoritesService, SearchFavoritesService>();
         services.AddSingleton<IFulltextIntegrityService, FulltextIntegrityService>();

--- a/Veriado.Infrastructure/Search/HybridSearchQueryService.cs
+++ b/Veriado.Infrastructure/Search/HybridSearchQueryService.cs
@@ -1,0 +1,255 @@
+using Veriado.Domain.Search;
+
+namespace Veriado.Infrastructure.Search;
+
+/// <summary>
+/// Aggregates FTS5 and trigram search providers into a unified result set.
+/// </summary>
+internal sealed class HybridSearchQueryService : ISearchQueryService
+{
+    private readonly SqliteFts5QueryService _ftsService;
+    private readonly TrigramQueryService _trigramService;
+
+    public HybridSearchQueryService(SqliteFts5QueryService ftsService, TrigramQueryService trigramService)
+    {
+        _ftsService = ftsService ?? throw new ArgumentNullException(nameof(ftsService));
+        _trigramService = trigramService ?? throw new ArgumentNullException(nameof(trigramService));
+    }
+
+    public Task<IReadOnlyList<(Guid Id, double Score)>> SearchWithScoresAsync(
+        string matchQuery,
+        int skip,
+        int take,
+        CancellationToken cancellationToken)
+    {
+        return _ftsService.SearchWithScoresAsync(matchQuery, skip, take, cancellationToken);
+    }
+
+    public Task<IReadOnlyList<(Guid Id, double Score)>> SearchFuzzyWithScoresAsync(
+        string matchQuery,
+        int skip,
+        int take,
+        CancellationToken cancellationToken)
+    {
+        return _trigramService.SearchWithScoresAsync(matchQuery, skip, take, cancellationToken);
+    }
+
+    public Task<int> CountAsync(string matchQuery, CancellationToken cancellationToken)
+    {
+        return _ftsService.CountAsync(matchQuery, cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<SearchHit>> SearchAsync(string query, int? limit, CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(query);
+        var take = limit.GetValueOrDefault(10);
+        if (take <= 0)
+        {
+            return Array.Empty<SearchHit>();
+        }
+
+        var oversample = Math.Max(take * 3, take);
+        var ftsHits = await _ftsService.SearchAsync(query, oversample, cancellationToken).ConfigureAwait(false);
+        var trigramHits = await _trigramService.SearchAsync(query, oversample, cancellationToken).ConfigureAwait(false);
+
+        if (ftsHits.Count == 0 && trigramHits.Count == 0)
+        {
+            return Array.Empty<SearchHit>();
+        }
+
+        var combined = new Dictionary<Guid, CombinedHit>();
+        var normalizedScores = new List<double>(ftsHits.Count);
+
+        foreach (var hit in ftsHits)
+        {
+            var normalized = ExtractNormalizedScore(hit.SortValues) ?? NormalizeScore(hit.Score);
+            normalizedScores.Add(normalized);
+            var lastModified = ExtractLastModified(hit.SortValues);
+            combined[hit.Id] = new CombinedHit(hit, normalized, lastModified, HasExactTitle(hit, query));
+        }
+
+        var scale = ComputeScale(normalizedScores);
+        foreach (var hit in trigramHits)
+        {
+            var normalized = ExtractNormalizedScore(hit.SortValues) ?? Math.Clamp(hit.Score, 0d, 1d);
+            var scaled = Math.Clamp(normalized * scale, 0d, 1d);
+            var lastModified = ExtractLastModified(hit.SortValues);
+
+            if (combined.TryGetValue(hit.Id, out var existing))
+            {
+                var merged = MergeHits(existing.Hit, hit);
+                var rankingScore = Math.Max(existing.RankingScore, scaled);
+                var mergedSort = MergeSortValues(existing.Hit.SortValues, hit.SortValues, rankingScore, existing.Hit.Score, hit.Score, lastModified, existing.LastModified);
+                combined[hit.Id] = existing with
+                {
+                    Hit = merged with { SortValues = mergedSort },
+                    RankingScore = rankingScore,
+                    LastModified = mergedSort?.LastModifiedUtc ?? existing.LastModified,
+                    HasExactTitle = existing.HasExactTitle || HasExactTitle(hit, query),
+                };
+            }
+            else
+            {
+                var sort = MergeSortValues(null, hit.SortValues, scaled, 0d, hit.Score, lastModified, null);
+                combined[hit.Id] = new CombinedHit(hit with { SortValues = sort }, scaled, sort?.LastModifiedUtc ?? lastModified, HasExactTitle(hit, query));
+            }
+        }
+
+        var ordered = combined.Values
+            .OrderByDescending(static item => item.RankingScore)
+            .ThenByDescending(static item => item.LastModified ?? DateTimeOffset.MinValue)
+            .ThenBy(static item => item.HasExactTitle ? 0 : 1)
+            .ThenBy(static item => item.Hit.Id)
+            .Select(static item => item.Hit)
+            .Take(take)
+            .ToList();
+
+        return ordered;
+    }
+
+    private static SearchHit MergeHits(SearchHit primary, SearchHit secondary)
+    {
+        var primaryField = string.IsNullOrWhiteSpace(primary.PrimaryField) ? secondary.PrimaryField : primary.PrimaryField;
+        var snippet = string.IsNullOrWhiteSpace(primary.SnippetText) ? secondary.SnippetText : primary.SnippetText;
+        var highlights = MergeHighlights(primary.Highlights, secondary.Highlights);
+        var fields = MergeFields(primary.Fields, secondary.Fields);
+        return primary with
+        {
+            PrimaryField = primaryField,
+            SnippetText = snippet,
+            Highlights = highlights,
+            Fields = fields,
+        };
+    }
+
+    private static IReadOnlyList<HighlightSpan> MergeHighlights(
+        IReadOnlyList<HighlightSpan> primary,
+        IReadOnlyList<HighlightSpan> secondary)
+    {
+        if (primary.Count == 0)
+        {
+            return secondary;
+        }
+
+        if (secondary.Count == 0)
+        {
+            return primary;
+        }
+
+        var set = new HashSet<HighlightSpan>(primary);
+        var merged = new List<HighlightSpan>(primary);
+        foreach (var span in secondary)
+        {
+            if (set.Add(span))
+            {
+                merged.Add(span);
+            }
+        }
+
+        return merged;
+    }
+
+    private static IReadOnlyDictionary<string, string?> MergeFields(
+        IReadOnlyDictionary<string, string?> primary,
+        IReadOnlyDictionary<string, string?> secondary)
+    {
+        var merged = new Dictionary<string, string?>(primary, StringComparer.OrdinalIgnoreCase);
+        foreach (var (key, value) in secondary)
+        {
+            if (!merged.ContainsKey(key) || string.IsNullOrWhiteSpace(merged[key]))
+            {
+                merged[key] = value;
+            }
+        }
+
+        return merged;
+    }
+
+    private static double ComputeScale(IReadOnlyList<double> scores)
+    {
+        if (scores.Count == 0)
+        {
+            return 0.6d;
+        }
+
+        var ordered = scores.OrderBy(static value => value).ToArray();
+        var midpoint = ordered.Length / 2;
+        if (ordered.Length % 2 == 0)
+        {
+            return (ordered[midpoint - 1] + ordered[midpoint]) / 2d;
+        }
+
+        return ordered[midpoint];
+    }
+
+    private static SearchHitSortValues? MergeSortValues(
+        object? primary,
+        object? secondary,
+        double rankingScore,
+        double primaryRaw,
+        double secondaryRaw,
+        DateTimeOffset? secondaryLastModified,
+        DateTimeOffset? primaryLastModified)
+    {
+        var primarySort = primary as SearchHitSortValues;
+        var secondarySort = secondary as SearchHitSortValues;
+
+        var lastModified = primaryLastModified ?? primarySort?.LastModifiedUtc ?? secondaryLastModified ?? secondarySort?.LastModifiedUtc;
+        if (primarySort is not null && secondarySort is not null)
+        {
+            lastModified = primarySort.LastModifiedUtc >= secondarySort.LastModifiedUtc
+                ? primarySort.LastModifiedUtc
+                : secondarySort.LastModifiedUtc;
+        }
+
+        double raw;
+        if (primarySort is not null)
+        {
+            raw = primarySort.RawScore;
+        }
+        else if (secondarySort is not null)
+        {
+            raw = secondarySort.RawScore;
+        }
+        else
+        {
+            raw = primaryRaw != 0d ? primaryRaw : secondaryRaw;
+        }
+
+        var secondaryScore = secondarySort?.NormalizedScore ?? secondaryRaw;
+        return new SearchHitSortValues(lastModified ?? DateTimeOffset.MinValue, rankingScore, raw, secondaryScore);
+    }
+
+    private static double NormalizeScore(double rawScore)
+    {
+        if (double.IsNaN(rawScore) || double.IsInfinity(rawScore))
+        {
+            return 0d;
+        }
+
+        var clamped = Math.Max(0d, rawScore);
+        return 1d / (1d + clamped);
+    }
+
+    private static double? ExtractNormalizedScore(object? sortValues)
+    {
+        return sortValues is SearchHitSortValues values ? values.NormalizedScore : null;
+    }
+
+    private static DateTimeOffset? ExtractLastModified(object? sortValues)
+    {
+        return sortValues is SearchHitSortValues values ? values.LastModifiedUtc : null;
+    }
+
+    private static bool HasExactTitle(SearchHit hit, string query)
+    {
+        if (!hit.Fields.TryGetValue("title", out var title) || string.IsNullOrWhiteSpace(title))
+        {
+            return false;
+        }
+
+        return string.Equals(title, query, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private sealed record CombinedHit(SearchHit Hit, double RankingScore, DateTimeOffset? LastModified, bool HasExactTitle);
+}

--- a/Veriado.Infrastructure/Search/TrigramQueryService.cs
+++ b/Veriado.Infrastructure/Search/TrigramQueryService.cs
@@ -1,0 +1,423 @@
+using System.Globalization;
+using System.Text;
+using Microsoft.Data.Sqlite;
+using Veriado.Appl.Search;
+
+namespace Veriado.Infrastructure.Search;
+
+/// <summary>
+/// Executes trigram-based fuzzy queries using the existing SQLite FTS5 index.
+/// </summary>
+internal sealed class TrigramQueryService
+{
+    private const char Ellipsis = '…';
+
+    private readonly InfrastructureOptions _options;
+
+    public TrigramQueryService(InfrastructureOptions options)
+    {
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+    }
+
+    public async Task<IReadOnlyList<(Guid Id, double Score)>> SearchWithScoresAsync(
+        string matchQuery,
+        int skip,
+        int take,
+        CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(matchQuery);
+        if (take <= 0)
+        {
+            return Array.Empty<(Guid, double)>();
+        }
+
+        if (skip < 0)
+        {
+            skip = 0;
+        }
+
+        if (!_options.IsFulltextAvailable)
+        {
+            return Array.Empty<(Guid, double)>();
+        }
+
+        var queryTokens = ExtractTokens(matchQuery);
+        if (queryTokens.Count == 0)
+        {
+            return Array.Empty<(Guid, double)>();
+        }
+
+        var fetch = skip + take;
+        await using var connection = CreateConnection();
+        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+        await SqlitePragmaHelper.ApplyAsync(connection, cancellationToken).ConfigureAwait(false);
+        await using var command = connection.CreateCommand();
+        command.CommandText =
+            "SELECT m.file_id, t.trgm " +
+            "FROM file_trgm t " +
+            "JOIN file_trgm_map m ON t.rowid = m.rowid " +
+            "WHERE file_trgm MATCH $query " +
+            "ORDER BY bm25(t) ASC, m.rowid ASC " +
+            "LIMIT $limit;";
+        command.Parameters.Add("$query", SqliteType.Text).Value = matchQuery;
+        command.Parameters.Add("$limit", SqliteType.Integer).Value = fetch;
+
+        var results = new List<(Guid Id, double Score)>();
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            var idBytes = (byte[])reader[0];
+            var id = new Guid(idBytes);
+            var trigrams = reader.IsDBNull(1) ? string.Empty : reader.GetString(1);
+            var candidateTokens = ExtractTokens(trigrams);
+            if (candidateTokens.Count == 0)
+            {
+                continue;
+            }
+
+            var score = ComputeJaccard(queryTokens, candidateTokens);
+            if (score <= 0d)
+            {
+                continue;
+            }
+
+            results.Add((id, score));
+        }
+
+        if (results.Count == 0)
+        {
+            return results;
+        }
+
+        var ordered = results
+            .OrderByDescending(static item => item.Score)
+            .ThenBy(static item => item.Id)
+            .Skip(skip)
+            .Take(take)
+            .ToList();
+
+        return ordered;
+    }
+
+    public async Task<IReadOnlyList<SearchHit>> SearchAsync(string query, int take, CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(query);
+        if (take <= 0)
+        {
+            return Array.Empty<SearchHit>();
+        }
+
+        if (!_options.IsFulltextAvailable)
+        {
+            return Array.Empty<SearchHit>();
+        }
+
+        if (!TrigramQueryBuilder.TryBuild(query, requireAllTerms: false, out var matchQuery))
+        {
+            return Array.Empty<SearchHit>();
+        }
+
+        var queryTokens = TrigramQueryBuilder.BuildTrigrams(query)
+            .Select(static token => token.ToLowerInvariant())
+            .ToHashSet(StringComparer.Ordinal);
+        if (queryTokens.Count == 0)
+        {
+            return Array.Empty<SearchHit>();
+        }
+
+        await using var connection = CreateConnection();
+        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+        await SqlitePragmaHelper.ApplyAsync(connection, cancellationToken).ConfigureAwait(false);
+        await using var command = connection.CreateCommand();
+        command.CommandText =
+            "SELECT tm.file_id, " +
+            "       sm.rowid, " +
+            "       COALESCE(s.title, '') AS title, " +
+            "       COALESCE(s.mime, '') AS mime, " +
+            "       COALESCE(s.author, '') AS author, " +
+            "       COALESCE(s.metadata_text, '') AS metadata_text, " +
+            "       COALESCE(s.metadata, '') AS metadata_json, " +
+            "       t.trgm, " +
+            "       f.modified_utc " +
+            "FROM file_trgm t " +
+            "JOIN file_trgm_map tm ON t.rowid = tm.rowid " +
+            "JOIN file_search_map sm ON sm.file_id = tm.file_id " +
+            "JOIN file_search s ON s.rowid = sm.rowid " +
+            "JOIN files f ON f.id = tm.file_id " +
+            "WHERE file_trgm MATCH $query " +
+            "ORDER BY bm25(t) ASC, tm.rowid ASC " +
+            "LIMIT $limit;";
+        command.Parameters.Add("$query", SqliteType.Text).Value = matchQuery;
+        command.Parameters.Add("$limit", SqliteType.Integer).Value = take;
+
+        var hits = new List<SearchHit>(take);
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            var idBytes = (byte[])reader[0];
+            var fileId = new Guid(idBytes);
+            var title = reader.GetString(2);
+            var mime = reader.GetString(3);
+            var author = reader.GetString(4);
+            var metadataText = reader.GetString(5);
+            var metadataJson = reader.GetString(6);
+            var candidate = reader.IsDBNull(7) ? string.Empty : reader.GetString(7);
+            var modifiedUtcRaw = reader.GetString(8);
+            var modifiedUtc = DateTimeOffset.Parse(modifiedUtcRaw, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind);
+
+            var candidateTokens = ExtractTokens(candidate);
+            if (candidateTokens.Count == 0)
+            {
+                continue;
+            }
+
+            var score = ComputeJaccard(queryTokens, candidateTokens);
+            if (score <= 0d)
+            {
+                continue;
+            }
+
+            var snippetSource = !string.IsNullOrWhiteSpace(metadataText) ? "metadata_text" : "title";
+            var sourceText = snippetSource == "metadata_text" ? metadataText : title;
+            var snippet = BuildSnippet(sourceText, queryTokens);
+            var highlights = BuildHighlights(snippetSource, snippet, queryTokens);
+            var fields = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["title"] = string.IsNullOrWhiteSpace(title) ? null : title,
+                ["mime"] = string.IsNullOrWhiteSpace(mime) ? null : mime,
+                ["author"] = string.IsNullOrWhiteSpace(author) ? null : author,
+                ["metadata_text"] = string.IsNullOrWhiteSpace(metadataText) ? null : metadataText,
+                ["metadata"] = string.IsNullOrWhiteSpace(metadataJson) ? null : metadataJson,
+            };
+            fields["last_modified_utc"] = modifiedUtc.ToString("O", CultureInfo.InvariantCulture);
+
+            var sortValues = new SearchHitSortValues(modifiedUtc, score, score, score);
+            hits.Add(new SearchHit(fileId, score, "TRIGRAM", snippetSource, snippet, highlights, fields, sortValues));
+        }
+
+        if (hits.Count == 0)
+        {
+            return hits;
+        }
+
+        return hits
+            .OrderByDescending(static hit => hit.Score)
+            .ThenBy(static hit => hit.Id)
+            .ToList();
+    }
+
+    private static double ComputeJaccard(IReadOnlyCollection<string> query, IReadOnlyCollection<string> candidate)
+    {
+        if (query.Count == 0 || candidate.Count == 0)
+        {
+            return 0d;
+        }
+
+        var intersection = query.Intersect(candidate, StringComparer.Ordinal).Count();
+        if (intersection == 0)
+        {
+            return 0d;
+        }
+
+        var union = query.Count + candidate.Count - intersection;
+        if (union <= 0)
+        {
+            return 0d;
+        }
+
+        return Math.Clamp((double)intersection / union, 0d, 1d);
+    }
+
+    private static HashSet<string> ExtractTokens(string text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return new HashSet<string>(StringComparer.Ordinal);
+        }
+
+        var tokens = text
+            .Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Where(static token => !string.Equals(token, "AND", StringComparison.OrdinalIgnoreCase)
+                && !string.Equals(token, "OR", StringComparison.OrdinalIgnoreCase))
+            .Select(static token => token.ToLowerInvariant());
+
+        return tokens.ToHashSet(StringComparer.Ordinal);
+    }
+
+    private static string BuildSnippet(string text, IReadOnlyCollection<string> tokens)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return string.Empty;
+        }
+
+        var trimmed = text.Trim();
+        var normalized = NormalizeForComparison(trimmed, out var map);
+        if (tokens.Count == 0 || normalized.Length == 0)
+        {
+            return trimmed.Length <= 240 ? trimmed : trimmed[..240] + Ellipsis;
+        }
+
+        var bestIndex = int.MaxValue;
+        foreach (var token in tokens)
+        {
+            if (token.Length == 0)
+            {
+                continue;
+            }
+
+            var index = normalized.IndexOf(token, StringComparison.Ordinal);
+            if (index >= 0 && index < bestIndex)
+            {
+                bestIndex = index;
+            }
+        }
+
+        if (bestIndex == int.MaxValue || bestIndex >= map.Count)
+        {
+            return trimmed.Length <= 240 ? trimmed : trimmed[..240] + Ellipsis;
+        }
+
+        var matchStart = map[bestIndex];
+        var start = Math.Max(0, matchStart - 60);
+        var end = Math.Min(trimmed.Length, start + 240);
+
+        var snippet = trimmed.Substring(start, end - start);
+        if (start > 0)
+        {
+            snippet = Ellipsis + snippet;
+        }
+
+        if (end < trimmed.Length)
+        {
+            snippet += Ellipsis;
+        }
+
+        return snippet;
+    }
+
+    private static IReadOnlyList<HighlightSpan> BuildHighlights(string field, string snippet, IReadOnlyCollection<string> tokens)
+    {
+        if (string.IsNullOrEmpty(snippet) || tokens.Count == 0)
+        {
+            return Array.Empty<HighlightSpan>();
+        }
+
+        var normalized = NormalizeForComparison(snippet, out var map);
+        if (normalized.Length == 0 || map.Count == 0)
+        {
+            return Array.Empty<HighlightSpan>();
+        }
+
+        var spans = new List<HighlightSpan>();
+        var seen = new HashSet<(int Start, int Length)>();
+
+        foreach (var token in tokens)
+        {
+            if (token.Length == 0)
+            {
+                continue;
+            }
+
+            var searchIndex = 0;
+            while (searchIndex < normalized.Length)
+            {
+                var index = normalized.IndexOf(token, searchIndex, StringComparison.Ordinal);
+                if (index < 0)
+                {
+                    break;
+                }
+
+                var lastIndex = Math.Min(index + token.Length - 1, map.Count - 1);
+                var start = map[index];
+                var end = map[lastIndex];
+                var length = end - start + 1;
+                if (length > 0)
+                {
+                    var key = (start, length);
+                    if (seen.Add(key))
+                    {
+                        var term = SafeSubstring(snippet, start, length);
+                        spans.Add(new HighlightSpan(field, start, length, term));
+                    }
+                }
+
+                searchIndex = index + token.Length;
+            }
+        }
+
+        return spans;
+    }
+
+    private static string SafeSubstring(string text, int start, int length)
+    {
+        if (start < 0)
+        {
+            start = 0;
+        }
+
+        if (start >= text.Length)
+        {
+            return string.Empty;
+        }
+
+        if (length <= 0)
+        {
+            return string.Empty;
+        }
+
+        if (start + length > text.Length)
+        {
+            length = text.Length - start;
+        }
+
+        return text.Substring(start, length);
+    }
+
+    private static string NormalizeForComparison(string text, out List<int> indexMap)
+    {
+        var builder = new StringBuilder(text.Length);
+        indexMap = new List<int>(text.Length);
+        var position = 0;
+
+        foreach (var rune in text.EnumerateRunes())
+        {
+            var runeLength = rune.Utf16SequenceLength;
+            var decomposed = rune.ToString().Normalize(NormalizationForm.FormD);
+            foreach (var ch in decomposed)
+            {
+                var category = CharUnicodeInfo.GetUnicodeCategory(ch);
+                if (category is UnicodeCategory.NonSpacingMark or UnicodeCategory.SpacingCombiningMark or UnicodeCategory.EnclosingMark)
+                {
+                    continue;
+                }
+
+                if (char.IsLetterOrDigit(ch))
+                {
+                    builder.Append(char.ToLowerInvariant(ch));
+                    indexMap.Add(position);
+                }
+                else
+                {
+                    builder.Append(' ');
+                    indexMap.Add(position);
+                }
+            }
+
+            position += runeLength;
+        }
+
+        return builder.ToString();
+    }
+
+    private SqliteConnection CreateConnection()
+    {
+        if (string.IsNullOrWhiteSpace(_options.ConnectionString))
+        {
+            throw new InvalidOperationException("Infrastructure has not been initialised with a connection string.");
+        }
+
+        return new SqliteConnection(_options.ConnectionString);
+    }
+
+}

--- a/Veriado.Mapping/Profiles/SearchProfiles.cs
+++ b/Veriado.Mapping/Profiles/SearchProfiles.cs
@@ -1,4 +1,5 @@
 using Veriado.Contracts.Search;
+using Veriado.Domain.Search;
 
 namespace Veriado.Mapping.Profiles;
 
@@ -12,7 +13,17 @@ public sealed class SearchProfiles : Profile
     /// </summary>
     public SearchProfiles()
     {
-        CreateMap<SearchHit, SearchHitDto>();
+        CreateMap<HighlightSpan, HighlightSpanDto>();
+
+        CreateMap<SearchHit, SearchHitDto>()
+            .ForCtorParam(nameof(SearchHitDto.Id), opt => opt.MapFrom(static src => src.Id))
+            .ForCtorParam(nameof(SearchHitDto.Score), opt => opt.MapFrom(static src => src.Score))
+            .ForCtorParam(nameof(SearchHitDto.Source), opt => opt.MapFrom(static src => src.Source))
+            .ForCtorParam(nameof(SearchHitDto.PrimaryField), opt => opt.MapFrom(static src => src.PrimaryField))
+            .ForCtorParam(nameof(SearchHitDto.SnippetText), opt => opt.MapFrom(static src => src.SnippetText))
+            .ForCtorParam(nameof(SearchHitDto.Highlights), opt => opt.MapFrom(static src => src.Highlights))
+            .ForCtorParam(nameof(SearchHitDto.Fields), opt => opt.MapFrom(static src => src.Fields))
+            .ForCtorParam(nameof(SearchHitDto.SortValues), opt => opt.MapFrom(static src => src.SortValues));
 
         CreateMap<SearchHistoryEntryEntity, SearchHistoryEntry>()
             .ForCtorParam(nameof(SearchHistoryEntry.Id), opt => opt.MapFrom(static src => src.Id))

--- a/Veriado.Services/Search/SearchFacade.cs
+++ b/Veriado.Services/Search/SearchFacade.cs
@@ -1,3 +1,4 @@
+using AutoMapper;
 using Veriado.Appl.Search;
 using Veriado.Appl.Search.Abstractions;
 using Veriado.Contracts.Search.Abstractions;
@@ -9,15 +10,18 @@ public sealed class SearchFacade : ISearchFacade
     private readonly ISearchQueryService _searchQueryService;
     private readonly ISearchHistoryService _historyService;
     private readonly ISearchFavoritesService _favoritesService;
+    private readonly IMapper _mapper;
 
     public SearchFacade(
         ISearchQueryService searchQueryService,
         ISearchHistoryService historyService,
-        ISearchFavoritesService favoritesService)
+        ISearchFavoritesService favoritesService,
+        IMapper mapper)
     {
         _searchQueryService = searchQueryService ?? throw new ArgumentNullException(nameof(searchQueryService));
         _historyService = historyService ?? throw new ArgumentNullException(nameof(historyService));
         _favoritesService = favoritesService ?? throw new ArgumentNullException(nameof(favoritesService));
+        _mapper = mapper ?? throw new ArgumentNullException(nameof(mapper));
     }
 
     public async Task<IReadOnlyList<SearchHitDto>> SearchAsync(string query, int take, CancellationToken ct)
@@ -34,13 +38,7 @@ public sealed class SearchFacade : ISearchFacade
             return Array.Empty<SearchHitDto>();
         }
 
-        var results = new List<SearchHitDto>(hits.Count);
-        foreach (var hit in hits)
-        {
-            results.Add(new SearchHitDto(hit.FileId, hit.Title, hit.Mime, hit.Snippet, hit.Score, hit.LastModifiedUtc));
-        }
-
-        return results;
+        return _mapper.Map<IReadOnlyList<SearchHitDto>>(hits);
     }
 
     public async Task<IReadOnlyList<SearchHistoryEntry>> GetHistoryAsync(int take, CancellationToken ct)


### PR DESCRIPTION
## Summary
- replace the legacy search hit contract with a highlight-aware DTO shared between domain and service layers
- rework the SQLite FTS query service to build plain-text snippets, parse offsets, and emit highlight spans and metadata
- add trigram fuzzy search plus a hybrid aggregator that merges FTS and trigram hits before the facade maps them to DTOs

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68db816e0c2883268db03693b1ad5dc8