### PR TITLE
Implement rich search query builder and scoring support

### DIFF
--- a/Veriado.Application/Search/Abstractions/SearchServices.cs
+++ b/Veriado.Application/Search/Abstractions/SearchServices.cs
@@ -1,3 +1,4 @@
+using Veriado.Appl.Search;
 using Veriado.Domain.Search;
 
 namespace Veriado.Appl.Search.Abstractions;
@@ -8,15 +9,15 @@ namespace Veriado.Appl.Search.Abstractions;
 public interface ISearchQueryService
 {
     /// <summary>
-    /// Executes an FTS5 match query and returns the matching file identifiers with scores.
+    /// Executes an FTS5 search query and returns the matching file identifiers with scores.
     /// </summary>
-    /// <param name="matchQuery">The FTS5 match query.</param>
+    /// <param name="plan">The structured query plan.</param>
     /// <param name="skip">The number of results to skip.</param>
     /// <param name="take">The maximum number of results to return.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The matching identifiers ordered by relevance.</returns>
     Task<IReadOnlyList<(Guid Id, double Score)>> SearchWithScoresAsync(
-        string matchQuery,
+        SearchQueryPlan plan,
         int skip,
         int take,
         CancellationToken cancellationToken);
@@ -24,33 +25,33 @@ public interface ISearchQueryService
     /// <summary>
     /// Executes a trigram-based fuzzy match query and returns matching identifiers with scores.
     /// </summary>
-    /// <param name="matchQuery">The trigram FTS5 match query.</param>
+    /// <param name="plan">The structured query plan.</param>
     /// <param name="skip">The number of results to skip.</param>
     /// <param name="take">The maximum number of results to return.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The matching identifiers ordered by relevance.</returns>
     Task<IReadOnlyList<(Guid Id, double Score)>> SearchFuzzyWithScoresAsync(
-        string matchQuery,
+        SearchQueryPlan plan,
         int skip,
         int take,
         CancellationToken cancellationToken);
 
     /// <summary>
-    /// Counts the number of hits returned by the specified match query.
+    /// Counts the number of hits returned by the specified search query.
     /// </summary>
-    /// <param name="matchQuery">The FTS5 match query.</param>
+    /// <param name="plan">The structured query plan.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The number of matching rows.</returns>
-    Task<int> CountAsync(string matchQuery, CancellationToken cancellationToken);
+    Task<int> CountAsync(SearchQueryPlan plan, CancellationToken cancellationToken);
 
     /// <summary>
     /// Executes a search query returning hydrated search hits including snippets.
     /// </summary>
-    /// <param name="query">The search query text.</param>
+    /// <param name="plan">The structured query plan.</param>
     /// <param name="limit">The optional maximum number of results.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The matched search hits.</returns>
-    Task<IReadOnlyList<SearchHit>> SearchAsync(string query, int? limit, CancellationToken cancellationToken);
+    Task<IReadOnlyList<SearchHit>> SearchAsync(SearchQueryPlan plan, int? limit, CancellationToken cancellationToken);
 }
 
 /// <summary>

--- a/Veriado.Application/Search/ISearchQueryBuilder.cs
+++ b/Veriado.Application/Search/ISearchQueryBuilder.cs
@@ -1,0 +1,124 @@
+namespace Veriado.Appl.Search;
+
+using System;
+
+/// <summary>
+/// Provides a fluent API for constructing rich SQLite FTS5 search queries including range filters
+/// and scoring metadata.
+/// </summary>
+public interface ISearchQueryBuilder
+{
+    /// <summary>
+    /// Creates a term node matching the supplied token.
+    /// </summary>
+    /// <param name="field">An optional field restriction.</param>
+    /// <param name="term">The term to match.</param>
+    /// <returns>The created query node or <see langword="null"/> when no valid token could be produced.</returns>
+    QueryNode? Term(string? field, string term);
+
+    /// <summary>
+    /// Creates a phrase node that requires an exact match.
+    /// </summary>
+    /// <param name="field">The column restriction.</param>
+    /// <param name="phrase">The phrase to match.</param>
+    /// <returns>The created query node or <see langword="null"/> when no valid token could be produced.</returns>
+    QueryNode? Phrase(string? field, string phrase);
+
+    /// <summary>
+    /// Creates a proximity node ensuring the two supplied tokens appear within the specified distance.
+    /// </summary>
+    /// <param name="field">The column restriction.</param>
+    /// <param name="first">The first token.</param>
+    /// <param name="second">The second token.</param>
+    /// <param name="distance">The maximum distance between the tokens.</param>
+    /// <returns>The created query node or <see langword="null"/> when no valid token could be produced.</returns>
+    QueryNode? Proximity(string? field, string first, string second, int distance);
+
+    /// <summary>
+    /// Creates a prefix match node.
+    /// </summary>
+    /// <param name="field">The column restriction.</param>
+    /// <param name="prefix">The prefix including the trailing wildcard.</param>
+    /// <returns>The created query node or <see langword="null"/> when no valid token could be produced.</returns>
+    QueryNode? Prefix(string? field, string prefix);
+
+    /// <summary>
+    /// Signals that the provided token should be resolved using trigram similarity instead of FTS5.
+    /// </summary>
+    /// <param name="field">The optional column restriction used for diagnostics.</param>
+    /// <param name="term">The fuzzy term.</param>
+    /// <param name="requireAllTerms">Indicates whether all trigram terms should match.</param>
+    /// <returns>An optional FTS node to combine with other clauses.</returns>
+    QueryNode? Fuzzy(string? field, string term, bool requireAllTerms = false);
+
+    /// <summary>
+    /// Combines the supplied nodes using the logical AND operator.
+    /// </summary>
+    /// <param name="nodes">The child nodes.</param>
+    /// <returns>The combined node or <see langword="null"/> when no children were provided.</returns>
+    QueryNode? And(params QueryNode?[] nodes);
+
+    /// <summary>
+    /// Combines the supplied nodes using the logical OR operator.
+    /// </summary>
+    /// <param name="nodes">The child nodes.</param>
+    /// <returns>The combined node or <see langword="null"/> when no children were provided.</returns>
+    QueryNode? Or(params QueryNode?[] nodes);
+
+    /// <summary>
+    /// Negates the supplied node.
+    /// </summary>
+    /// <param name="node">The node to negate.</param>
+    /// <returns>The negated node or <see langword="null"/> when the argument was <see langword="null"/>.</returns>
+    QueryNode? Not(QueryNode? node);
+
+    /// <summary>
+    /// Adds a range filter that will be applied in the SQL WHERE clause.
+    /// </summary>
+    /// <param name="field">The field identifier.</param>
+    /// <param name="from">The lower bound.</param>
+    /// <param name="to">The upper bound.</param>
+    /// <param name="includeLower">Indicates whether the lower bound is inclusive.</param>
+    /// <param name="includeUpper">Indicates whether the upper bound is inclusive.</param>
+    void Range(string field, object? from, object? to, bool includeLower = true, bool includeUpper = true);
+
+    /// <summary>
+    /// Applies a boost factor to the specified column by adjusting the BM25 weight.
+    /// </summary>
+    /// <param name="field">The column identifier.</param>
+    /// <param name="factor">The multiplier applied to the default weight.</param>
+    void Boost(string field, double factor);
+
+    /// <summary>
+    /// Enables a TF-IDF like score expression expressed as <c>1 / (d + bm25)</c>.
+    /// </summary>
+    /// <param name="dampingFactor">The damping factor.</param>
+    void UseTfIdfRanking(double dampingFactor = 0.5d);
+
+    /// <summary>
+    /// Overrides the SQL rank expression used for ordering.
+    /// </summary>
+    /// <param name="sqlExpression">The SQL fragment.</param>
+    /// <param name="higherIsBetter">Indicates whether larger values represent better matches.</param>
+    void UseRankExpression(string sqlExpression, bool higherIsBetter = false);
+
+    /// <summary>
+    /// Supplies a SQL expression that yields an additional similarity value.
+    /// </summary>
+    /// <param name="sqlExpression">The SQL fragment.</param>
+    void UseCustomSimilaritySql(string sqlExpression);
+
+    /// <summary>
+    /// Registers a managed delegate that computes a final similarity score.
+    /// </summary>
+    /// <param name="similarity">The delegate.</param>
+    void UseCustomSimilarity(Func<double, double?, DateTimeOffset?, double> similarity);
+
+    /// <summary>
+    /// Constructs the search query plan from the provided root node.
+    /// </summary>
+    /// <param name="root">The root node.</param>
+    /// <param name="rawQuery">The optional raw query text.</param>
+    /// <returns>The built search query plan.</returns>
+    SearchQueryPlan Build(QueryNode? root, string? rawQuery = null);
+}

--- a/Veriado.Application/Search/QueryNode.cs
+++ b/Veriado.Application/Search/QueryNode.cs
@@ -1,0 +1,71 @@
+namespace Veriado.Appl.Search;
+
+using System.Collections.Generic;
+
+/// <summary>
+/// Represents a node in the FTS query expression tree.
+/// </summary>
+public abstract record QueryNode;
+
+/// <summary>
+/// A node that wraps a literal term, phrase or proximity expression.
+/// </summary>
+/// <param name="Field">The optional field restriction.</param>
+/// <param name="Value">The processed token value.</param>
+/// <param name="TokenType">The token type.</param>
+public sealed record TokenNode(string? Field, string Value, QueryTokenType TokenType) : QueryNode;
+
+/// <summary>
+/// Represents a boolean combination of nodes.
+/// </summary>
+/// <param name="Operator">The boolean operator.</param>
+/// <param name="Children">The child nodes.</param>
+public sealed record BooleanNode(BooleanOperator Operator, IReadOnlyList<QueryNode> Children) : QueryNode;
+
+/// <summary>
+/// Represents a negated node.
+/// </summary>
+/// <param name="Operand">The operand.</param>
+public sealed record NotNode(QueryNode Operand) : QueryNode;
+
+/// <summary>
+/// Enumerates the supported token types.
+/// </summary>
+public enum QueryTokenType
+{
+    /// <summary>
+    /// A single token term.
+    /// </summary>
+    Term,
+
+    /// <summary>
+    /// An exact phrase.
+    /// </summary>
+    Phrase,
+
+    /// <summary>
+    /// A proximity expression constructed using NEAR.
+    /// </summary>
+    Proximity,
+
+    /// <summary>
+    /// A prefix match (trailing wildcard).
+    /// </summary>
+    Prefix,
+}
+
+/// <summary>
+/// Enumerates the supported boolean operators.
+/// </summary>
+public enum BooleanOperator
+{
+    /// <summary>
+    /// Logical AND.
+    /// </summary>
+    And,
+
+    /// <summary>
+    /// Logical OR.
+    /// </summary>
+    Or,
+}

--- a/Veriado.Application/Search/SearchQueryBuilder.cs
+++ b/Veriado.Application/Search/SearchQueryBuilder.cs
@@ -1,0 +1,502 @@
+namespace Veriado.Appl.Search;
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using Microsoft.Data.Sqlite;
+
+/// <summary>
+/// Default implementation of <see cref="ISearchQueryBuilder"/> that targets SQLite FTS5.
+/// <para>
+/// Example usage:
+/// <code>
+/// var builder = new SearchQueryBuilder();
+/// var expression = builder.Or(
+///     builder.And(
+///         builder.Term("title", "report"),
+///         builder.Phrase("author", "Alice Smith")),
+///     builder.Phrase(null, "quarterly earnings"));
+/// builder.Range("modified", new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero), null);
+/// var plan = builder.Build(expression);
+/// // plan.MatchExpression => "(title:report AND author:\"alice smith\") OR \"quarterly earnings\""
+/// // plan.WhereClauses => ["f.modified_utc >= $p0"]
+/// </code>
+/// </para>
+/// </summary>
+public sealed class SearchQueryBuilder : ISearchQueryBuilder
+{
+    private const char Wildcard = '*';
+
+    private static readonly IReadOnlyDictionary<string, string?> FieldMap = new Dictionary<string, string?>(
+        StringComparer.OrdinalIgnoreCase)
+    {
+        ["title"] = "title",
+        ["author"] = "author",
+        ["mime"] = "mime",
+        ["metadata_text"] = "metadata_text",
+        ["metadata"] = "metadata",
+        ["content"] = null,
+        ["any"] = null,
+    };
+
+    private static readonly IReadOnlyDictionary<string, RangeTarget> RangeMap = new Dictionary<string, RangeTarget>(
+        StringComparer.OrdinalIgnoreCase)
+    {
+        ["modified"] = new("f.modified_utc", SqliteType.Text, ConvertDateTime),
+        ["modified_utc"] = new("f.modified_utc", SqliteType.Text, ConvertDateTime),
+        ["created"] = new("f.created_utc", SqliteType.Text, ConvertDateTime),
+        ["created_utc"] = new("f.created_utc", SqliteType.Text, ConvertDateTime),
+        ["size"] = new("f.size_bytes", SqliteType.Integer, static value => value),
+        ["size_bytes"] = new("f.size_bytes", SqliteType.Integer, static value => value),
+    };
+
+    private readonly List<string> _whereClauses = new();
+    private readonly List<SqliteParameterDefinition> _parameters = new();
+    private readonly SearchScorePlan _scorePlan = new();
+    private readonly List<(string Expression, bool RequireAll)> _trigramExpressions = new();
+
+    private bool _requiresTrigramFallback;
+    private int _parameterIndex;
+
+    /// <inheritdoc />
+    public QueryNode? Term(string? field, string term)
+    {
+        var token = ExtractSingleToken(term);
+        if (string.IsNullOrWhiteSpace(token))
+        {
+            return null;
+        }
+
+        return new TokenNode(NormalizeField(field), token, QueryTokenType.Term);
+    }
+
+    /// <inheritdoc />
+    public QueryNode? Phrase(string? field, string phrase)
+    {
+        var normalized = NormalizeText(phrase);
+        if (string.IsNullOrWhiteSpace(normalized))
+        {
+            return null;
+        }
+
+        return new TokenNode(NormalizeField(field), normalized, QueryTokenType.Phrase);
+    }
+
+    /// <inheritdoc />
+    public QueryNode? Proximity(string? field, string first, string second, int distance)
+    {
+        if (distance <= 0)
+        {
+            distance = 1;
+        }
+
+        var firstToken = ExtractSingleToken(first);
+        var secondToken = ExtractSingleToken(second);
+        if (string.IsNullOrWhiteSpace(firstToken) || string.IsNullOrWhiteSpace(secondToken))
+        {
+            return null;
+        }
+
+        var builder = new StringBuilder(firstToken!.Length + secondToken!.Length + 16);
+        builder.Append('"').Append(firstToken).Append('"');
+        builder.Append(' ').Append("NEAR/").Append(distance).Append(' ');
+        builder.Append('"').Append(secondToken).Append('"');
+
+        return new TokenNode(NormalizeField(field), builder.ToString(), QueryTokenType.Proximity);
+    }
+
+    /// <inheritdoc />
+    public QueryNode? Prefix(string? field, string prefix)
+    {
+        if (string.IsNullOrWhiteSpace(prefix))
+        {
+            return null;
+        }
+
+        var trimmed = prefix.Trim();
+        var hasWildcard = trimmed.EndsWith(Wildcard);
+        var core = hasWildcard ? trimmed.TrimEnd(Wildcard) : trimmed;
+        var token = ExtractSingleToken(core);
+        if (string.IsNullOrWhiteSpace(token))
+        {
+            return null;
+        }
+
+        var value = hasWildcard ? token + Wildcard : token + Wildcard;
+        return new TokenNode(NormalizeField(field), value, QueryTokenType.Prefix);
+    }
+
+    /// <inheritdoc />
+    public QueryNode? Fuzzy(string? field, string term, bool requireAllTerms = false)
+    {
+        var expression = TrigramQueryBuilder.BuildTrigramMatch(term ?? string.Empty, requireAllTerms);
+        if (!string.IsNullOrWhiteSpace(expression))
+        {
+            _requiresTrigramFallback = true;
+            _trigramExpressions.Add((expression, requireAllTerms));
+        }
+
+        return Term(field, term);
+    }
+
+    /// <inheritdoc />
+    public QueryNode? And(params QueryNode?[] nodes)
+        => Combine(BooleanOperator.And, nodes);
+
+    /// <inheritdoc />
+    public QueryNode? Or(params QueryNode?[] nodes)
+        => Combine(BooleanOperator.Or, nodes);
+
+    /// <inheritdoc />
+    public QueryNode? Not(QueryNode? node)
+    {
+        if (node is null)
+        {
+            return null;
+        }
+
+        return new NotNode(node);
+    }
+
+    /// <inheritdoc />
+    public void Range(string field, object? from, object? to, bool includeLower = true, bool includeUpper = true)
+    {
+        if (!RangeMap.TryGetValue(field, out var target))
+        {
+            return;
+        }
+
+        if (from is not null)
+        {
+            var parameter = CreateParameter(from, target, includeLower ? ">=" : ">");
+            if (parameter is not null)
+            {
+                _whereClauses.Add(parameter.Value.Clause);
+                _parameters.Add(parameter.Value.Parameter);
+            }
+        }
+
+        if (to is not null)
+        {
+            var parameter = CreateParameter(to, target, includeUpper ? "<=" : "<");
+            if (parameter is not null)
+            {
+                _whereClauses.Add(parameter.Value.Clause);
+                _parameters.Add(parameter.Value.Parameter);
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public void Boost(string field, double factor)
+    {
+        if (factor <= 0d)
+        {
+            return;
+        }
+
+        switch (NormalizeField(field))
+        {
+            case "title":
+                _scorePlan.TitleWeight *= factor;
+                break;
+            case "author":
+                _scorePlan.AuthorWeight *= factor;
+                break;
+            case "mime":
+                _scorePlan.MimeWeight *= factor;
+                break;
+            case "metadata_text":
+                _scorePlan.MetadataTextWeight *= factor;
+                break;
+            case "metadata":
+                _scorePlan.MetadataWeight *= factor;
+                break;
+            default:
+                break;
+        }
+    }
+
+    /// <inheritdoc />
+    public void UseTfIdfRanking(double dampingFactor = 0.5d)
+    {
+        if (double.IsNaN(dampingFactor) || double.IsInfinity(dampingFactor) || dampingFactor < 0d)
+        {
+            dampingFactor = 0.5d;
+        }
+
+        _scorePlan.UseTfIdfAlternative = true;
+        _scorePlan.TfIdfDampingFactor = dampingFactor;
+        _scorePlan.HigherScoreIsBetter = true;
+    }
+
+    /// <inheritdoc />
+    public void UseRankExpression(string sqlExpression, bool higherIsBetter = false)
+    {
+        if (!string.IsNullOrWhiteSpace(sqlExpression))
+        {
+            _scorePlan.CustomRankExpression = sqlExpression;
+            _scorePlan.HigherScoreIsBetter = higherIsBetter;
+        }
+    }
+
+    /// <inheritdoc />
+    public void UseCustomSimilaritySql(string sqlExpression)
+    {
+        if (!string.IsNullOrWhiteSpace(sqlExpression))
+        {
+            _scorePlan.CustomSimilaritySql = sqlExpression;
+        }
+    }
+
+    /// <inheritdoc />
+    public void UseCustomSimilarity(Func<double, double?, DateTimeOffset?, double> similarity)
+    {
+        ArgumentNullException.ThrowIfNull(similarity);
+        _scorePlan.CustomSimilarityDelegate = similarity;
+    }
+
+    /// <inheritdoc />
+    public SearchQueryPlan Build(QueryNode? root, string? rawQuery = null)
+    {
+        var match = BuildMatch(root);
+        if (string.IsNullOrWhiteSpace(match))
+        {
+            throw new InvalidOperationException("Search query must produce a non-empty MATCH expression.");
+        }
+
+        var trigramExpression = BuildTrigramExpression();
+        return new SearchQueryPlan(
+            match,
+            _whereClauses.AsReadOnly(),
+            _parameters.AsReadOnly(),
+            _scorePlan,
+            _requiresTrigramFallback,
+            trigramExpression,
+            rawQuery);
+    }
+
+    private QueryNode? Combine(BooleanOperator op, params QueryNode?[] nodes)
+    {
+        if (nodes is null || nodes.Length == 0)
+        {
+            return null;
+        }
+
+        var materialised = new List<QueryNode>();
+        foreach (var node in nodes)
+        {
+            if (node is null)
+            {
+                continue;
+            }
+
+            if (node is BooleanNode booleanNode && booleanNode.Operator == op)
+            {
+                materialised.AddRange(booleanNode.Children);
+            }
+            else
+            {
+                materialised.Add(node);
+            }
+        }
+
+        if (materialised.Count == 0)
+        {
+            return null;
+        }
+
+        if (materialised.Count == 1)
+        {
+            return materialised[0];
+        }
+
+        return new BooleanNode(op, materialised);
+    }
+
+    private string BuildMatch(QueryNode? node)
+    {
+        if (node is null)
+        {
+            return string.Empty;
+        }
+
+        return node switch
+        {
+            TokenNode token => FormatToken(token),
+            BooleanNode boolean => FormatBoolean(boolean),
+            NotNode notNode => $"NOT ({BuildMatch(notNode.Operand)})",
+            _ => string.Empty,
+        };
+    }
+
+    private string FormatToken(TokenNode token)
+    {
+        var fieldPrefix = string.IsNullOrWhiteSpace(token.Field) ? string.Empty : token.Field + ':';
+        return token.TokenType switch
+        {
+            QueryTokenType.Term => fieldPrefix + token.Value,
+            QueryTokenType.Phrase => fieldPrefix + '"' + EscapeQuotes(token.Value) + '"',
+            QueryTokenType.Proximity => fieldPrefix + token.Value,
+            QueryTokenType.Prefix => fieldPrefix + token.Value,
+            _ => token.Value,
+        };
+    }
+
+    private string FormatBoolean(BooleanNode node)
+    {
+        if (node.Children.Count == 0)
+        {
+            return string.Empty;
+        }
+
+        var op = node.Operator == BooleanOperator.And ? " AND " : " OR ";
+        var parts = node.Children
+            .Select(BuildMatch)
+            .Where(static part => !string.IsNullOrWhiteSpace(part))
+            .ToArray();
+
+        if (parts.Length == 0)
+        {
+            return string.Empty;
+        }
+
+        if (parts.Length == 1)
+        {
+            return parts[0];
+        }
+
+        return "(" + string.Join(op, parts) + ")";
+    }
+
+    private static string? NormalizeField(string? field)
+    {
+        if (string.IsNullOrWhiteSpace(field))
+        {
+            return null;
+        }
+
+        return FieldMap.TryGetValue(field.Trim(), out var value) ? value : field.Trim().ToLowerInvariant();
+    }
+
+    private static string? ExtractSingleToken(string text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return null;
+        }
+
+        var normalized = NormalizeText(text);
+        if (string.IsNullOrWhiteSpace(normalized))
+        {
+            return null;
+        }
+
+        var tokens = normalized.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        return tokens.Length == 0 ? null : tokens[0];
+    }
+
+    private static string NormalizeText(string text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return string.Empty;
+        }
+
+        var builder = new StringBuilder(text.Length);
+        var previousWhitespace = false;
+        foreach (var ch in text)
+        {
+            if (char.IsLetterOrDigit(ch) || ch is '_' or '-' or '.')
+            {
+                builder.Append(char.ToLowerInvariant(ch));
+                previousWhitespace = false;
+            }
+            else if (char.IsWhiteSpace(ch))
+            {
+                if (!previousWhitespace)
+                {
+                    builder.Append(' ');
+                    previousWhitespace = true;
+                }
+            }
+            else
+            {
+                if (!previousWhitespace)
+                {
+                    builder.Append(' ');
+                    previousWhitespace = true;
+                }
+            }
+        }
+
+        return builder.ToString().Trim();
+    }
+
+    private static string EscapeQuotes(string value)
+        => value.Replace("\"", "\"\"");
+
+    private string BuildTrigramExpression()
+    {
+        if (_trigramExpressions.Count == 0)
+        {
+            return string.Empty;
+        }
+
+        if (_trigramExpressions.Count == 1)
+        {
+            return _trigramExpressions[0].Expression;
+        }
+
+        var builder = new StringBuilder();
+        for (var index = 0; index < _trigramExpressions.Count; index++)
+        {
+            var current = _trigramExpressions[index];
+            if (index > 0)
+            {
+                var op = current.RequireAll ? " AND " : " OR ";
+                builder.Append(op);
+            }
+
+            builder.Append('(').Append(current.Expression).Append(')');
+        }
+
+        return builder.ToString();
+    }
+
+    private (string Clause, SqliteParameterDefinition Parameter)? CreateParameter(
+        object value,
+        RangeTarget target,
+        string op)
+    {
+        var converted = target.Converter(value);
+        if (converted is null)
+        {
+            return null;
+        }
+
+        var parameterName = NextParameterName();
+        var parameter = new SqliteParameterDefinition(parameterName, converted, target.Type);
+        var clause = $"{target.Column} {op} {parameterName}";
+        return (clause, parameter);
+    }
+
+    private string NextParameterName()
+        => "$p" + _parameterIndex++;
+
+    private static object? ConvertDateTime(object value)
+    {
+        return value switch
+        {
+            DateTimeOffset dto => dto.ToString("O", CultureInfo.InvariantCulture),
+            DateTime dt => DateTime.SpecifyKind(dt, DateTimeKind.Utc).ToString("O", CultureInfo.InvariantCulture),
+            string s when DateTimeOffset.TryParse(s, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var dto)
+                => dto.ToString("O", CultureInfo.InvariantCulture),
+            _ => value,
+        };
+    }
+
+    private readonly record struct RangeTarget(string Column, SqliteType Type, Func<object, object?> Converter);
+}

--- a/Veriado.Application/Search/SearchQueryPlan.cs
+++ b/Veriado.Application/Search/SearchQueryPlan.cs
@@ -1,0 +1,155 @@
+namespace Veriado.Appl.Search;
+
+using System;
+using Microsoft.Data.Sqlite;
+
+/// <summary>
+/// Represents a structured search query composed of FTS match clauses, range filters and scoring hints.
+/// </summary>
+/// <param name="MatchExpression">The SQLite FTS5 MATCH expression.</param>
+/// <param name="WhereClauses">Additional SQL <c>WHERE</c> fragments joined using <c>AND</c>.</param>
+/// <param name="Parameters">The parameters required by <see cref="WhereClauses"/>.</param>
+/// <param name="ScorePlan">The scoring configuration.</param>
+/// <param name="RequiresTrigramFallback">Indicates whether the query needs trigram evaluation.</param>
+/// <param name="TrigramExpression">The optional trigram query expression.</param>
+/// <param name="RawQueryText">The user supplied raw text for diagnostics.</param>
+public sealed record SearchQueryPlan(
+    string MatchExpression,
+    IReadOnlyList<string> WhereClauses,
+    IReadOnlyList<SqliteParameterDefinition> Parameters,
+    SearchScorePlan ScorePlan,
+    bool RequiresTrigramFallback,
+    string? TrigramExpression,
+    string? RawQueryText = null);
+
+/// <summary>
+/// Provides factory helpers for creating simple search plans.
+/// </summary>
+public static class SearchQueryPlanFactory
+{
+    /// <summary>
+    /// Creates a plan representing a plain FTS5 match query without additional filters.
+    /// </summary>
+    public static SearchQueryPlan FromMatch(string matchExpression, string? rawQueryText = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(matchExpression);
+        return new SearchQueryPlan(
+            matchExpression,
+            Array.Empty<string>(),
+            Array.Empty<SqliteParameterDefinition>(),
+            new SearchScorePlan(),
+            false,
+            null,
+            rawQueryText ?? matchExpression);
+    }
+
+    /// <summary>
+    /// Creates a plan that executes only a trigram query.
+    /// </summary>
+    public static SearchQueryPlan FromTrigram(string trigramExpression, string? rawQueryText = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(trigramExpression);
+        return new SearchQueryPlan(
+            string.Empty,
+            Array.Empty<string>(),
+            Array.Empty<SqliteParameterDefinition>(),
+            new SearchScorePlan(),
+            true,
+            trigramExpression,
+            rawQueryText ?? trigramExpression);
+    }
+}
+
+/// <summary>
+/// Describes a scoring configuration for an FTS5 query.
+/// </summary>
+public sealed record SearchScorePlan
+{
+    /// <summary>
+    /// Initialises a new instance of the <see cref="SearchScorePlan"/> class.
+    /// </summary>
+    public SearchScorePlan()
+    {
+    }
+
+    /// <summary>
+    /// Gets or sets the BM25 weight applied to the title column.
+    /// </summary>
+    public double TitleWeight { get; set; } = 4.0d;
+
+    /// <summary>
+    /// Gets or sets the BM25 weight applied to the MIME column.
+    /// </summary>
+    public double MimeWeight { get; set; } = 0.1d;
+
+    /// <summary>
+    /// Gets or sets the BM25 weight applied to the author column.
+    /// </summary>
+    public double AuthorWeight { get; set; } = 2.0d;
+
+    /// <summary>
+    /// Gets or sets the BM25 weight applied to the metadata text column.
+    /// </summary>
+    public double MetadataTextWeight { get; set; } = 0.8d;
+
+    /// <summary>
+    /// Gets or sets the BM25 weight applied to the structured metadata JSON column.
+    /// </summary>
+    public double MetadataWeight { get; set; } = 0.2d;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the query should emit a TF-IDF like ranking value
+    /// expressed as <c>1 / (damping + bm25)</c>.
+    /// </summary>
+    public bool UseTfIdfAlternative { get; set; }
+        = false;
+
+    /// <summary>
+    /// Gets or sets the damping factor used when <see cref="UseTfIdfAlternative"/> is enabled.
+    /// </summary>
+    public double TfIdfDampingFactor { get; set; } = 0.5d;
+
+    /// <summary>
+    /// Gets or sets an optional score multiplier applied to the BM25 result.
+    /// </summary>
+    public double ScoreMultiplier { get; set; } = 1.0d;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether larger rank values represent better matches.
+    /// When <see langword="false"/>, lower scores are considered better (the default for BM25).
+    /// </summary>
+    public bool HigherScoreIsBetter { get; set; }
+        = false;
+
+    /// <summary>
+    /// Gets or sets an optional SQL fragment that computes a custom rank.
+    /// When specified the fragment must evaluate to a numeric value and can reference
+    /// <c>bm25_score</c> (the computed bm25 value) as well as any table aliases present in the
+    /// search query.
+    /// </summary>
+    public string? CustomRankExpression { get; set; }
+        = null;
+
+    /// <summary>
+    /// Gets or sets an optional SQL fragment that computes a custom similarity contribution.
+    /// The fragment is selected into the query as <c>custom_similarity</c>.
+    /// </summary>
+    public string? CustomSimilaritySql { get; set; }
+        = null;
+
+    /// <summary>
+    /// Gets or sets an optional managed delegate invoked for each hit to compute a final similarity
+    /// score. The delegate receives the raw BM25 score, the custom similarity value (when supplied)
+    /// and the last modified timestamp.
+    /// </summary>
+    public Func<double, double?, DateTimeOffset?, double>? CustomSimilarityDelegate { get; set; }
+        = null;
+}
+
+/// <summary>
+/// Represents a SQLite parameter definition produced by the query builder.
+/// </summary>
+/// <param name="Name">The unique parameter name including the <c>$</c> prefix.</param>
+/// <param name="Value">The parameter value.</param>
+/// <param name="Type">The optional SQLite type hint.</param>
+public sealed record SqliteParameterDefinition(string Name, object? Value, SqliteType? Type);

--- a/Veriado.Application/UseCases/Queries/FileGrid/FileGridQueryHandler.cs
+++ b/Veriado.Application/UseCases/Queries/FileGrid/FileGridQueryHandler.cs
@@ -103,8 +103,9 @@ public sealed class FileGridQueryHandler : IRequestHandler<FileGridQuery, PageRe
         if (fuzzyMode)
         {
             var match = fuzzyMatchQuery!;
+            var plan = SearchQueryPlanFactory.FromTrigram(match, queryText);
             var candidates = await _searchQueryService
-                .SearchFuzzyWithScoresAsync(match, 0, _options.MaxCandidateResults, cancellationToken)
+                .SearchFuzzyWithScoresAsync(plan, 0, _options.MaxCandidateResults, cancellationToken)
                 .ConfigureAwait(false);
 
             if (candidates.Count == 0)
@@ -210,8 +211,9 @@ public sealed class FileGridQueryHandler : IRequestHandler<FileGridQuery, PageRe
         if (!string.IsNullOrWhiteSpace(matchQuery))
         {
             var match = matchQuery!;
+            var plan = SearchQueryPlanFactory.FromMatch(match, queryText);
             var candidates = await _searchQueryService
-                .SearchWithScoresAsync(match, 0, _options.MaxCandidateResults, cancellationToken)
+                .SearchWithScoresAsync(plan, 0, _options.MaxCandidateResults, cancellationToken)
                 .ConfigureAwait(false);
 
             if (candidates.Count == 0)

--- a/Veriado.Application/UseCases/Search/SearchFilesHandler.cs
+++ b/Veriado.Application/UseCases/Search/SearchFilesHandler.cs
@@ -1,4 +1,5 @@
 using AutoMapper;
+using Veriado.Appl.Search;
 using Veriado.Appl.Search.Abstractions;
 
 namespace Veriado.Appl.UseCases.Search;
@@ -24,7 +25,8 @@ public sealed class SearchFilesHandler : IRequestHandler<SearchFilesQuery, IRead
     public async Task<IReadOnlyList<SearchHitDto>> Handle(SearchFilesQuery request, CancellationToken cancellationToken)
     {
         Guard.AgainstNullOrWhiteSpace(request.Text, nameof(request.Text));
-        var hits = await _searchQueryService.SearchAsync(request.Text, request.Limit, cancellationToken);
+        var plan = SearchQueryPlanFactory.FromMatch(request.Text, request.Text);
+        var hits = await _searchQueryService.SearchAsync(plan, request.Limit, cancellationToken);
         return _mapper.Map<IReadOnlyList<SearchHitDto>>(hits);
     }
 }


### PR DESCRIPTION
## Summary
- add a structured search query representation and fluent builder with boolean logic, phrases, proximity, prefix, range filters and boosting controls
- update the SQLite FTS5 and trigram query services plus the hybrid coordinator to execute the new plans, parameterise bm25 weighting and support custom similarity hooks
- switch application consumers to build and pass query plans, including helper factories for simple FTS and trigram favourites

## Testing
- Not run (dotnet CLI unavailable in execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68db8e2b8e508326a4994179c05b961b