### PR TITLE
Implement analyzer-driven normalization across search services

### DIFF
--- a/Veriado.Application/Search/AnalyzerOptions.cs
+++ b/Veriado.Application/Search/AnalyzerOptions.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+
+namespace Veriado.Appl.Search;
+
+/// <summary>
+/// Represents the configuration store for analyzer profiles.
+/// </summary>
+public sealed class AnalyzerOptions
+{
+    /// <summary>
+    /// Gets or sets the default profile identifier.
+    /// </summary>
+    public string DefaultProfile { get; set; } = "cs";
+
+    /// <summary>
+    /// Gets or sets the configured analyzer profiles keyed by their identifiers.
+    /// </summary>
+    public Dictionary<string, AnalyzerProfile> Profiles { get; set; }
+        = new(StringComparer.OrdinalIgnoreCase);
+}

--- a/Veriado.Application/Search/AnalyzerProfile.cs
+++ b/Veriado.Application/Search/AnalyzerProfile.cs
@@ -1,0 +1,50 @@
+using System;
+
+namespace Veriado.Appl.Search;
+
+/// <summary>
+/// Represents the configuration applied to a text analyzer profile.
+/// </summary>
+public sealed class AnalyzerProfile
+{
+    /// <summary>
+    /// Gets or sets the unique profile name.
+    /// </summary>
+    public string Name { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether stemming is enabled when a stemmer is available.
+    /// </summary>
+    public bool EnableStemming { get; init; }
+        = false;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether numeric tokens should be preserved.
+    /// </summary>
+    public bool KeepNumbers { get; init; }
+        = true;
+
+    /// <summary>
+    /// Gets or sets the stopword list applied after tokenisation.
+    /// </summary>
+    public string[] Stopwords { get; init; }
+        = Array.Empty<string>();
+
+    /// <summary>
+    /// Gets or sets a value indicating whether filenames should be split on common delimiters prior to tokenisation.
+    /// </summary>
+    public bool SplitFilenames { get; init; }
+        = true;
+
+    /// <summary>
+    /// Gets or sets the optional custom tokenizer identifier.
+    /// </summary>
+    public string? CustomTokenizer { get; init; }
+        = null;
+
+    /// <summary>
+    /// Gets or sets additional custom filter identifiers.
+    /// </summary>
+    public string[] CustomFilters { get; init; }
+        = Array.Empty<string>();
+}

--- a/Veriado.Application/Search/IAnalyzerFactory.cs
+++ b/Veriado.Application/Search/IAnalyzerFactory.cs
@@ -1,0 +1,22 @@
+namespace Veriado.Appl.Search;
+
+/// <summary>
+/// Creates configured analyzers for specific language profiles.
+/// </summary>
+public interface IAnalyzerFactory
+{
+    /// <summary>
+    /// Creates an analyzer for the requested profile or the default profile when <paramref name="profileOrLang"/> is null.
+    /// </summary>
+    /// <param name="profileOrLang">The optional profile or language identifier.</param>
+    /// <returns>The configured analyzer.</returns>
+    ITextAnalyzer Create(string? profileOrLang = null);
+
+    /// <summary>
+    /// Attempts to locate the configuration profile for the specified identifier.
+    /// </summary>
+    /// <param name="profileOrLang">The profile or language identifier.</param>
+    /// <param name="profile">The resolved profile.</param>
+    /// <returns><see langword="true"/> when a profile was found; otherwise <see langword="false"/>.</returns>
+    bool TryGetProfile(string profileOrLang, out AnalyzerProfile profile);
+}

--- a/Veriado.Application/Search/ITextAnalyzer.cs
+++ b/Veriado.Application/Search/ITextAnalyzer.cs
@@ -1,0 +1,23 @@
+namespace Veriado.Appl.Search;
+
+/// <summary>
+/// Provides normalization and tokenization services for search text.
+/// </summary>
+public interface ITextAnalyzer
+{
+    /// <summary>
+    /// Normalises the supplied text using the configured pipeline.
+    /// </summary>
+    /// <param name="text">The input text.</param>
+    /// <param name="profileOrLang">The optional profile or language identifier.</param>
+    /// <returns>The normalised text.</returns>
+    string Normalize(string text, string? profileOrLang = null);
+
+    /// <summary>
+    /// Tokenises the supplied text using the configured pipeline.
+    /// </summary>
+    /// <param name="text">The input text.</param>
+    /// <param name="profileOrLang">The optional profile or language identifier.</param>
+    /// <returns>The produced tokens.</returns>
+    IEnumerable<string> Tokenize(string text, string? profileOrLang = null);
+}

--- a/Veriado.Application/Search/TextNormalization.cs
+++ b/Veriado.Application/Search/TextNormalization.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Linq;
+using System.Text;
+
+namespace Veriado.Appl.Search;
+
+/// <summary>
+/// Provides helper methods for working with analyzer driven text normalisation.
+/// </summary>
+public static class TextNormalization
+{
+    /// <summary>
+    /// Normalises the supplied text using the analyzer created by the provided factory.
+    /// </summary>
+    public static string NormalizeText(string s, IAnalyzerFactory factory, string? profile = null)
+    {
+        ArgumentNullException.ThrowIfNull(factory);
+        var text = s ?? string.Empty;
+        var analyzer = factory.Create(profile);
+        return analyzer.Normalize(text, profile);
+    }
+
+    /// <summary>
+    /// Tokenises the supplied text using the analyzer created by the provided factory.
+    /// </summary>
+    public static IEnumerable<string> Tokenize(string s, IAnalyzerFactory factory, string? profile = null)
+    {
+        ArgumentNullException.ThrowIfNull(factory);
+        var text = s ?? string.Empty;
+        var analyzer = factory.Create(profile);
+        return analyzer.Tokenize(text, profile);
+    }
+
+    /// <summary>
+    /// Builds a quoted MATCH phrase from the supplied text.
+    /// </summary>
+    public static string BuildMatchPhrase(string s, IAnalyzerFactory factory, string? profile = null)
+    {
+        var tokens = Tokenize(s, factory, profile).Where(static token => !string.IsNullOrWhiteSpace(token)).ToArray();
+        if (tokens.Length == 0)
+        {
+            return string.Empty;
+        }
+
+        var phrase = string.Join(' ', tokens);
+        var escaped = EscapeMatchToken(phrase);
+        if (string.IsNullOrEmpty(escaped))
+        {
+            return string.Empty;
+        }
+
+        return $"\"{escaped}\"";
+    }
+
+    /// <summary>
+    /// Builds a prefix token suitable for SQLite FTS5 queries.
+    /// </summary>
+    public static string BuildMatchPrefix(string token)
+    {
+        var escaped = EscapeMatchToken(token);
+        return string.IsNullOrEmpty(escaped) ? string.Empty : escaped + '*';
+    }
+
+    /// <summary>
+    /// Escapes characters that would otherwise break an FTS5 MATCH token.
+    /// </summary>
+    public static string EscapeMatchToken(string token)
+    {
+        if (string.IsNullOrWhiteSpace(token))
+        {
+            return string.Empty;
+        }
+
+        var builder = new StringBuilder(token.Length);
+        foreach (var ch in token)
+        {
+            if (ch == '\"')
+            {
+                builder.Append("\"\"");
+            }
+            else if (ch == '\'')
+            {
+                builder.Append("''");
+            }
+            else
+            {
+                builder.Append(ch);
+            }
+        }
+
+        return builder.ToString();
+    }
+}

--- a/Veriado.Application/UseCases/Search/SearchFilesHandler.cs
+++ b/Veriado.Application/UseCases/Search/SearchFilesHandler.cs
@@ -1,3 +1,4 @@
+using System;
 using AutoMapper;
 using Veriado.Appl.Search;
 using Veriado.Appl.Search.Abstractions;
@@ -11,21 +12,29 @@ public sealed class SearchFilesHandler : IRequestHandler<SearchFilesQuery, IRead
 {
     private readonly ISearchQueryService _searchQueryService;
     private readonly IMapper _mapper;
+    private readonly IAnalyzerFactory _analyzerFactory;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="SearchFilesHandler"/> class.
     /// </summary>
-    public SearchFilesHandler(ISearchQueryService searchQueryService, IMapper mapper)
+    public SearchFilesHandler(ISearchQueryService searchQueryService, IMapper mapper, IAnalyzerFactory analyzerFactory)
     {
         _searchQueryService = searchQueryService;
         _mapper = mapper;
+        _analyzerFactory = analyzerFactory ?? throw new ArgumentNullException(nameof(analyzerFactory));
     }
 
     /// <inheritdoc />
     public async Task<IReadOnlyList<SearchHitDto>> Handle(SearchFilesQuery request, CancellationToken cancellationToken)
     {
         Guard.AgainstNullOrWhiteSpace(request.Text, nameof(request.Text));
-        var plan = SearchQueryPlanFactory.FromMatch(request.Text, request.Text);
+        var match = FtsQueryBuilder.BuildMatch(request.Text, prefix: false, allTerms: false, _analyzerFactory);
+        if (string.IsNullOrWhiteSpace(match))
+        {
+            return Array.Empty<SearchHitDto>();
+        }
+
+        var plan = SearchQueryPlanFactory.FromMatch(match, request.Text);
         var hits = await _searchQueryService.SearchAsync(plan, request.Limit, cancellationToken);
         return _mapper.Map<IReadOnlyList<SearchHitDto>>(hits);
     }

--- a/Veriado.Infrastructure/Search/AnalyzerFactory.cs
+++ b/Veriado.Infrastructure/Search/AnalyzerFactory.cs
@@ -1,0 +1,127 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.Options;
+using Veriado.Appl.Search;
+
+namespace Veriado.Infrastructure.Search;
+
+/// <summary>
+/// Provides access to configured analyzers and their profiles.
+/// </summary>
+public sealed class AnalyzerFactory : IAnalyzerFactory
+{
+    private readonly AnalyzerOptions _options;
+    private readonly ConcurrentDictionary<string, ITextAnalyzer> _analyzers;
+    private readonly Dictionary<string, AnalyzerProfile> _profiles;
+
+    /// <summary>
+    /// Initialises a new instance of the <see cref="AnalyzerFactory"/> class.
+    /// </summary>
+    public AnalyzerFactory(IOptions<AnalyzerOptions> options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        _options = options.Value ?? throw new ArgumentNullException(nameof(options));
+        _profiles = BuildProfileMap(_options);
+        _analyzers = new ConcurrentDictionary<string, ITextAnalyzer>(StringComparer.OrdinalIgnoreCase);
+    }
+
+    /// <inheritdoc />
+    public ITextAnalyzer Create(string? profileOrLang = null)
+    {
+        var profile = ResolveProfile(profileOrLang);
+        return _analyzers.GetOrAdd(profile.Name, _ => new GeneralTextAnalyzer(CloneProfile(profile)));
+    }
+
+    /// <inheritdoc />
+    public bool TryGetProfile(string profileOrLang, out AnalyzerProfile profile)
+    {
+        if (string.IsNullOrWhiteSpace(profileOrLang))
+        {
+            profile = CloneProfile(ResolveProfile(null));
+            return true;
+        }
+
+        if (_profiles.TryGetValue(profileOrLang, out var existing))
+        {
+            profile = CloneProfile(existing);
+            return true;
+        }
+
+        profile = null!;
+        return false;
+    }
+
+    private AnalyzerProfile ResolveProfile(string? profileOrLang)
+    {
+        var key = string.IsNullOrWhiteSpace(profileOrLang) ? _options.DefaultProfile : profileOrLang!;
+        if (_profiles.TryGetValue(key, out var profile))
+        {
+            return profile;
+        }
+
+        if (_profiles.TryGetValue(_options.DefaultProfile, out var fallback))
+        {
+            return fallback;
+        }
+
+        return _profiles.Values.First();
+    }
+
+    private static Dictionary<string, AnalyzerProfile> BuildProfileMap(AnalyzerOptions options)
+    {
+        var map = new Dictionary<string, AnalyzerProfile>(StringComparer.OrdinalIgnoreCase);
+        foreach (var pair in options.Profiles)
+        {
+            if (pair.Value is null)
+            {
+                continue;
+            }
+
+            var profile = CloneProfile(pair.Key, pair.Value);
+            map[profile.Name] = profile;
+        }
+
+        if (map.Count == 0)
+        {
+            var profile = new AnalyzerProfile { Name = options.DefaultProfile };
+            map[profile.Name] = profile;
+        }
+        else if (!map.ContainsKey(options.DefaultProfile))
+        {
+            map[options.DefaultProfile] = new AnalyzerProfile { Name = options.DefaultProfile };
+        }
+
+        return map;
+    }
+
+    private static AnalyzerProfile CloneProfile(AnalyzerProfile profile)
+    {
+        return new AnalyzerProfile
+        {
+            Name = profile.Name,
+            EnableStemming = profile.EnableStemming,
+            KeepNumbers = profile.KeepNumbers,
+            Stopwords = profile.Stopwords?.ToArray() ?? Array.Empty<string>(),
+            SplitFilenames = profile.SplitFilenames,
+            CustomTokenizer = profile.CustomTokenizer,
+            CustomFilters = profile.CustomFilters?.ToArray() ?? Array.Empty<string>(),
+        };
+    }
+
+    private static AnalyzerProfile CloneProfile(string key, AnalyzerProfile profile)
+    {
+        var name = string.IsNullOrWhiteSpace(profile.Name) ? key : profile.Name;
+        return new AnalyzerProfile
+        {
+            Name = name,
+            EnableStemming = profile.EnableStemming,
+            KeepNumbers = profile.KeepNumbers,
+            Stopwords = profile.Stopwords?.ToArray() ?? Array.Empty<string>(),
+            SplitFilenames = profile.SplitFilenames,
+            CustomTokenizer = profile.CustomTokenizer,
+            CustomFilters = profile.CustomFilters?.ToArray() ?? Array.Empty<string>(),
+        };
+    }
+}

--- a/Veriado.Infrastructure/Search/GeneralTextAnalyzer.cs
+++ b/Veriado.Infrastructure/Search/GeneralTextAnalyzer.cs
@@ -1,0 +1,304 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using Veriado.Appl.Search;
+
+namespace Veriado.Infrastructure.Search;
+
+/// <summary>
+/// Provides a configurable analyzer implementation backed by <see cref="AnalyzerProfile"/> settings.
+/// </summary>
+public sealed class GeneralTextAnalyzer : ITextAnalyzer
+{
+    private static readonly Regex FilenameSplitRegex = new("[-_. ]", RegexOptions.Compiled);
+    private static readonly Dictionary<char, string> SpecialFoldMap = new()
+    {
+        ['ß'] = "ss",
+        ['ẞ'] = "ss",
+        ['ø'] = "o",
+        ['Ø'] = "o",
+        ['đ'] = "d",
+        ['Đ'] = "d",
+        ['ð'] = "d",
+        ['Ð'] = "d",
+        ['þ'] = "th",
+        ['Þ'] = "th",
+    };
+
+    private readonly AnalyzerProfile _profile;
+    private readonly HashSet<string> _stopwords;
+    private readonly IStemmer? _stemmer;
+
+    /// <summary>
+    /// Initialises a new instance of the <see cref="GeneralTextAnalyzer"/> class.
+    /// </summary>
+    public GeneralTextAnalyzer(AnalyzerProfile profile)
+    {
+        _profile = profile ?? throw new ArgumentNullException(nameof(profile));
+        _stopwords = new HashSet<string>(profile.Stopwords?.Select(NormalizeToken) ?? Array.Empty<string>(), StringComparer.Ordinal);
+        _stemmer = StemmerRegistry.Resolve(profile.Name, profile.EnableStemming);
+    }
+
+    /// <inheritdoc />
+    public string Normalize(string text, string? profileOrLang = null)
+    {
+        if (!string.IsNullOrWhiteSpace(profileOrLang) && !string.Equals(profileOrLang, _profile.Name, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException($"Analyzer was created for profile '{_profile.Name}' and cannot process '{profileOrLang}'.");
+        }
+
+        return NormalizeInternal(text);
+    }
+
+    /// <inheritdoc />
+    public IEnumerable<string> Tokenize(string text, string? profileOrLang = null)
+    {
+        if (!string.IsNullOrWhiteSpace(profileOrLang) && !string.Equals(profileOrLang, _profile.Name, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException($"Analyzer was created for profile '{_profile.Name}' and cannot process '{profileOrLang}'.");
+        }
+
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            yield break;
+        }
+
+        var normalized = NormalizeInternal(text);
+        var segments = _profile.SplitFilenames ? SplitFilenameSegments(normalized) : new[] { normalized };
+
+        foreach (var segment in segments)
+        {
+            if (segment.Length == 0)
+            {
+                continue;
+            }
+
+            foreach (var token in EnumerateTokens(segment))
+            {
+                if (token.Length == 0)
+                {
+                    continue;
+                }
+
+                if (_stopwords.Contains(token))
+                {
+                    continue;
+                }
+
+                var candidate = _stemmer is null ? token : _stemmer.Stem(token);
+                if (!string.IsNullOrEmpty(candidate))
+                {
+                    yield return candidate;
+                }
+            }
+        }
+    }
+
+    private string NormalizeInternal(string? text)
+    {
+        if (string.IsNullOrEmpty(text))
+        {
+            return string.Empty;
+        }
+
+        var lower = text.ToLowerInvariant();
+        return FoldDiacritics(lower);
+    }
+
+    private static IEnumerable<string> SplitFilenameSegments(string text)
+    {
+        if (string.IsNullOrEmpty(text))
+        {
+            yield break;
+        }
+
+        var lastIndex = 0;
+        foreach (Match match in FilenameSplitRegex.Matches(text))
+        {
+            var segmentLength = match.Index - lastIndex;
+            if (segmentLength > 0)
+            {
+                yield return text.Substring(lastIndex, segmentLength);
+            }
+
+            lastIndex = match.Index + match.Length;
+        }
+
+        if (lastIndex < text.Length)
+        {
+            yield return text[lastIndex..];
+        }
+    }
+
+    private IEnumerable<string> EnumerateTokens(string text)
+    {
+        if (string.IsNullOrEmpty(text))
+        {
+            yield break;
+        }
+
+        var builder = new StringBuilder(text.Length);
+        foreach (var rune in text.EnumerateRunes())
+        {
+            if (Rune.IsLetter(rune))
+            {
+                builder.Append(rune);
+                continue;
+            }
+
+            if (Rune.IsDigit(rune))
+            {
+                if (_profile.KeepNumbers)
+                {
+                    builder.Append(rune);
+                }
+                else if (builder.Length > 0)
+                {
+                    yield return builder.ToString();
+                    builder.Clear();
+                }
+
+                continue;
+            }
+
+            if (builder.Length > 0)
+            {
+                yield return builder.ToString();
+                builder.Clear();
+            }
+        }
+
+        if (builder.Length > 0)
+        {
+            yield return builder.ToString();
+        }
+    }
+
+    private static string FoldDiacritics(string text)
+    {
+        var decomposed = text.Normalize(NormalizationForm.FormD);
+        var builder = new StringBuilder(decomposed.Length);
+        foreach (var ch in decomposed)
+        {
+            var category = CharUnicodeInfo.GetUnicodeCategory(ch);
+            if (category is UnicodeCategory.NonSpacingMark or UnicodeCategory.SpacingCombiningMark or UnicodeCategory.EnclosingMark)
+            {
+                continue;
+            }
+
+            if (SpecialFoldMap.TryGetValue(ch, out var replacement))
+            {
+                builder.Append(replacement);
+            }
+            else
+            {
+                builder.Append(ch);
+            }
+        }
+
+        return builder.ToString().Normalize(NormalizationForm.FormC);
+    }
+
+    private static string NormalizeToken(string token)
+    {
+        if (string.IsNullOrWhiteSpace(token))
+        {
+            return string.Empty;
+        }
+
+        var lower = token.ToLowerInvariant();
+        return FoldDiacritics(lower);
+    }
+
+    private interface IStemmer
+    {
+        string Stem(string token);
+    }
+
+    private static class StemmerRegistry
+    {
+        public static IStemmer? Resolve(string profileName, bool enabled)
+        {
+            if (!enabled)
+            {
+                return null;
+            }
+
+            if (string.Equals(profileName, "en", StringComparison.OrdinalIgnoreCase))
+            {
+                return new EnglishPorterStemmer();
+            }
+
+            return null;
+        }
+    }
+
+    private sealed class EnglishPorterStemmer : IStemmer
+    {
+        public string Stem(string token)
+        {
+            if (string.IsNullOrWhiteSpace(token) || token.Length <= 2)
+            {
+                return token;
+            }
+
+            var word = token;
+            if (word.EndsWith("sses", StringComparison.Ordinal))
+            {
+                word = word[..^2];
+            }
+            else if (word.EndsWith("ies", StringComparison.Ordinal))
+            {
+                word = word[..^3] + "y";
+            }
+            else if (word.EndsWith('s') && !word.EndsWith("ss", StringComparison.Ordinal))
+            {
+                word = word[..^1];
+            }
+
+            if (word.EndsWith("ing", StringComparison.Ordinal) && word.Length > 4)
+            {
+                var stem = word[..^3];
+                if (ContainsVowel(stem))
+                {
+                    word = stem;
+                }
+            }
+            else if (word.EndsWith("ed", StringComparison.Ordinal) && word.Length > 3)
+            {
+                var stem = word[..^2];
+                if (ContainsVowel(stem))
+                {
+                    word = stem;
+                }
+            }
+
+            if (word.EndsWith("ly", StringComparison.Ordinal) && word.Length > 4)
+            {
+                word = word[..^2];
+            }
+            else if (word.EndsWith("er", StringComparison.Ordinal) && word.Length > 4)
+            {
+                word = word[..^2];
+            }
+
+            return word;
+        }
+
+        private static bool ContainsVowel(string text)
+        {
+            foreach (var ch in text)
+            {
+                if (ch is 'a' or 'e' or 'i' or 'o' or 'u' or 'y')
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/Veriado.Infrastructure/Search/SqliteFts5Indexer.cs
+++ b/Veriado.Infrastructure/Search/SqliteFts5Indexer.cs
@@ -1,3 +1,6 @@
+using System;
+using Veriado.Appl.Search;
+
 namespace Veriado.Infrastructure.Search;
 
 /// <summary>
@@ -7,10 +10,15 @@ internal sealed class SqliteFts5Indexer : ISearchIndexer
 {
     private readonly InfrastructureOptions _options;
     private readonly SuggestionMaintenanceService? _suggestionMaintenance;
+    private readonly IAnalyzerFactory _analyzerFactory;
 
-    public SqliteFts5Indexer(InfrastructureOptions options, SuggestionMaintenanceService? suggestionMaintenance = null)
+    public SqliteFts5Indexer(
+        InfrastructureOptions options,
+        IAnalyzerFactory analyzerFactory,
+        SuggestionMaintenanceService? suggestionMaintenance = null)
     {
         _options = options;
+        _analyzerFactory = analyzerFactory ?? throw new ArgumentNullException(nameof(analyzerFactory));
         _suggestionMaintenance = suggestionMaintenance;
     }
 
@@ -48,7 +56,7 @@ internal sealed class SqliteFts5Indexer : ISearchIndexer
         await SqlitePragmaHelper.ApplyAsync(connection, cancellationToken).ConfigureAwait(false);
         await using var dbTransaction = await connection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
         var transaction = (SqliteTransaction)dbTransaction;
-        var helper = new SqliteFts5Transactional();
+        var helper = new SqliteFts5Transactional(_analyzerFactory);
 
         try
         {
@@ -82,7 +90,7 @@ internal sealed class SqliteFts5Indexer : ISearchIndexer
         await SqlitePragmaHelper.ApplyAsync(connection, cancellationToken).ConfigureAwait(false);
         await using var dbTransaction = await connection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
         var transaction = (SqliteTransaction)dbTransaction;
-        var helper = new SqliteFts5Transactional();
+        var helper = new SqliteFts5Transactional(_analyzerFactory);
 
         try
         {

--- a/Veriado.Infrastructure/Search/SqliteSearchIndexCoordinator.cs
+++ b/Veriado.Infrastructure/Search/SqliteSearchIndexCoordinator.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Data.Common;
+using Veriado.Appl.Search;
 
 namespace Veriado.Infrastructure.Search;
 
@@ -11,17 +13,20 @@ internal sealed class SqliteSearchIndexCoordinator : ISearchIndexCoordinator
     private readonly InfrastructureOptions _options;
     private readonly ILogger<SqliteSearchIndexCoordinator> _logger;
     private readonly OutboxDrainService _outboxDrainService;
+    private readonly IAnalyzerFactory _analyzerFactory;
 
     public SqliteSearchIndexCoordinator(
         ISearchIndexer searchIndexer,
         InfrastructureOptions options,
         ILogger<SqliteSearchIndexCoordinator> logger,
-        OutboxDrainService outboxDrainService)
+        OutboxDrainService outboxDrainService,
+        IAnalyzerFactory analyzerFactory)
     {
         _searchIndexer = searchIndexer;
         _options = options;
         _logger = logger;
         _outboxDrainService = outboxDrainService;
+        _analyzerFactory = analyzerFactory ?? throw new ArgumentNullException(nameof(analyzerFactory));
     }
 
     public async Task<bool> IndexAsync(FileEntity file, FilePersistenceOptions options, DbTransaction? transaction, CancellationToken cancellationToken)
@@ -51,7 +56,7 @@ internal sealed class SqliteSearchIndexCoordinator : ISearchIndexCoordinator
         if (sqliteTransaction is not null)
         {
             var sqliteConnection = (SqliteConnection)sqliteTransaction.Connection!;
-            var helper = new SqliteFts5Transactional();
+            var helper = new SqliteFts5Transactional(_analyzerFactory);
             await helper.IndexAsync(document, sqliteConnection, sqliteTransaction, beforeCommit: null, cancellationToken)
                 .ConfigureAwait(false);
             return true;

--- a/Veriado.WinUI/AppHost.cs
+++ b/Veriado.WinUI/AppHost.cs
@@ -31,7 +31,7 @@ internal sealed class AppHost : IAsyncDisposable
     {
         var host = Host
             .CreateDefaultBuilder()
-            .ConfigureServices((_, services) =>
+            .ConfigureServices((context, services) =>
             {
                 var messenger = WeakReferenceMessenger.Default;
                 services.AddSingleton(messenger);
@@ -64,7 +64,7 @@ internal sealed class AppHost : IAsyncDisposable
                 services.AddWinUiShell();
 
                 services.AddVeriadoMapping();
-                services.AddInfrastructure(options =>
+                services.AddInfrastructure(context.Configuration, options =>
                 {
                     var databasePath = infrastructureConfig.GetDatabasePath();
                     infrastructureConfig.EnsureStorageExists(databasePath);


### PR DESCRIPTION
## Summary
- add analyzer abstractions, options, and a general analyzer implementation backed by configurable profiles
- normalize full-text and trigram indexing using the shared analyzer pipeline and integrate analyzer-aware factories into DI
- update query services, spell suggestions, and application handlers to build match expressions via analyzer-driven helpers

## Testing
- dotnet build *(fails: command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dbac3780f88326aeb8edb27bfd1a85