### PR TITLE
Refine trigram MATCH token quoting

### DIFF
--- a/Veriado.Application.Tests/Search/TrigramQueryBuilderTests.cs
+++ b/Veriado.Application.Tests/Search/TrigramQueryBuilderTests.cs
@@ -1,0 +1,75 @@
+using System.Threading.Tasks;
+using Microsoft.Data.Sqlite;
+using Veriado.Appl.Search;
+using Xunit;
+
+namespace Veriado.Application.Tests.Search;
+
+public static class TrigramQueryBuilderTests
+{
+    [Fact]
+    public static void BuildTrigramMatch_QuotesReservedKeywords()
+    {
+        var result = TrigramQueryBuilder.BuildTrigramMatch("and or not", requireAllTerms: false);
+
+        Assert.Equal("\"and\" OR \"not\" OR \"or\"", result);
+    }
+
+    [Fact]
+    public static void TryBuild_ReturnsQuotedExpressionForReservedKeyword()
+    {
+        var built = TrigramQueryBuilder.TryBuild("AND", requireAllTerms: false, out var match);
+
+        Assert.True(built);
+        Assert.Equal("\"and\"", match);
+    }
+
+    [Fact]
+    public static void BuildIndexEntry_DoesNotIncludeQuotes()
+    {
+        var entry = TrigramQueryBuilder.BuildIndexEntry("and", "or", "not");
+
+        Assert.DoesNotContain('"', entry);
+        Assert.False(string.IsNullOrWhiteSpace(entry));
+    }
+
+    [Fact]
+    public static async Task TrigramMatch_WithReservedKeyword_ReturnsResults()
+    {
+        await using var connection = new SqliteConnection("Data Source=:memory:");
+        await connection.OpenAsync();
+
+        await using (var create = connection.CreateCommand())
+        {
+            create.CommandText = "CREATE VIRTUAL TABLE trigram USING fts5(token);";
+            await create.ExecuteNonQueryAsync();
+        }
+
+        var indexEntry = TrigramQueryBuilder.BuildIndexEntry("andromeda");
+        await using (var insert = connection.CreateCommand())
+        {
+            insert.CommandText = "INSERT INTO trigram(token) VALUES ($value);";
+            insert.Parameters.AddWithValue("$value", indexEntry);
+            await insert.ExecuteNonQueryAsync();
+        }
+
+        await using (var failing = connection.CreateCommand())
+        {
+            failing.CommandText = "SELECT count(*) FROM trigram WHERE trigram MATCH $query;";
+            failing.Parameters.AddWithValue("$query", "and");
+
+            await Assert.ThrowsAsync<SqliteException>(() => failing.ExecuteScalarAsync());
+        }
+
+        var sanitizedQuery = TrigramQueryBuilder.BuildTrigramMatch("and", requireAllTerms: false);
+
+        await using (var passing = connection.CreateCommand())
+        {
+            passing.CommandText = "SELECT count(*) FROM trigram WHERE trigram MATCH $query;";
+            passing.Parameters.AddWithValue("$query", sanitizedQuery);
+
+            var count = (long)(await passing.ExecuteScalarAsync() ?? 0L);
+            Assert.Equal(1L, count);
+        }
+    }
+}

--- a/Veriado.Application.Tests/Veriado.Application.Tests.csproj
+++ b/Veriado.Application.Tests/Veriado.Application.Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.6" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Veriado.Application\Veriado.Appl.csproj" />
+  </ItemGroup>
+</Project>

--- a/Veriado.Infrastructure/Search/TrigramQueryService.cs
+++ b/Veriado.Infrastructure/Search/TrigramQueryService.cs
@@ -49,15 +49,21 @@ internal sealed class TrigramQueryService
             return Array.Empty<(Guid, double)>();
         }
 
-        var trigramQuery = !string.IsNullOrWhiteSpace(plan.TrigramExpression)
+        var trigramSource = !string.IsNullOrWhiteSpace(plan.TrigramExpression)
             ? plan.TrigramExpression
             : plan.MatchExpression;
-        if (string.IsNullOrWhiteSpace(trigramQuery))
+        if (string.IsNullOrWhiteSpace(trigramSource))
         {
             return Array.Empty<(Guid, double)>();
         }
 
-        var queryTokens = BuildTokenSet(plan.RawQueryText ?? trigramQuery);
+        var normalizedQuery = NormalizeForTrigram(trigramSource);
+        if (!TrigramQueryBuilder.TryBuild(normalizedQuery, requireAllTerms: false, out var trigramQuery))
+        {
+            return Array.Empty<(Guid, double)>();
+        }
+
+        var queryTokens = BuildTokenSet(plan.RawQueryText ?? normalizedQuery);
         if (queryTokens.Count == 0)
         {
             return Array.Empty<(Guid, double)>();

--- a/Veriado.sln
+++ b/Veriado.sln
@@ -16,6 +16,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Veriado.Mapping", "Veriado.
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Veriado.Services", "Veriado.Services\Veriado.Services.csproj", "{62B8ABC0-5DB1-4F84-912F-6E9250AB8954}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Veriado.Application.Tests", "Veriado.Application.Tests\Veriado.Application.Tests.csproj", "{1360C1C4-0CB4-429D-A65E-1FFF58B4BBDB}"
+EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Source", "Source", "{02EA681E-C7D8-13C7-8484-4AC65E1B71E8}"
 EndProject
 Global
@@ -112,10 +114,22 @@ Global
 		{62B8ABC0-5DB1-4F84-912F-6E9250AB8954}.Debug|x86.Build.0 = Debug|Any CPU
 		{62B8ABC0-5DB1-4F84-912F-6E9250AB8954}.Release|ARM64.ActiveCfg = Release|Any CPU
 		{62B8ABC0-5DB1-4F84-912F-6E9250AB8954}.Release|ARM64.Build.0 = Release|Any CPU
-		{62B8ABC0-5DB1-4F84-912F-6E9250AB8954}.Release|x64.ActiveCfg = Release|Any CPU
+                {62B8ABC0-5DB1-4F84-912F-6E9250AB8954}.Release|x64.ActiveCfg = Release|Any CPU
                 {62B8ABC0-5DB1-4F84-912F-6E9250AB8954}.Release|x64.Build.0 = Release|Any CPU
                 {62B8ABC0-5DB1-4F84-912F-6E9250AB8954}.Release|x86.ActiveCfg = Release|Any CPU
                 {62B8ABC0-5DB1-4F84-912F-6E9250AB8954}.Release|x86.Build.0 = Release|Any CPU
+                {1360C1C4-0CB4-429D-A65E-1FFF58B4BBDB}.Debug|ARM64.ActiveCfg = Debug|Any CPU
+                {1360C1C4-0CB4-429D-A65E-1FFF58B4BBDB}.Debug|ARM64.Build.0 = Debug|Any CPU
+                {1360C1C4-0CB4-429D-A65E-1FFF58B4BBDB}.Debug|x64.ActiveCfg = Debug|Any CPU
+                {1360C1C4-0CB4-429D-A65E-1FFF58B4BBDB}.Debug|x64.Build.0 = Debug|Any CPU
+                {1360C1C4-0CB4-429D-A65E-1FFF58B4BBDB}.Debug|x86.ActiveCfg = Debug|Any CPU
+                {1360C1C4-0CB4-429D-A65E-1FFF58B4BBDB}.Debug|x86.Build.0 = Debug|Any CPU
+                {1360C1C4-0CB4-429D-A65E-1FFF58B4BBDB}.Release|ARM64.ActiveCfg = Release|Any CPU
+                {1360C1C4-0CB4-429D-A65E-1FFF58B4BBDB}.Release|ARM64.Build.0 = Release|Any CPU
+                {1360C1C4-0CB4-429D-A65E-1FFF58B4BBDB}.Release|x64.ActiveCfg = Release|Any CPU
+                {1360C1C4-0CB4-429D-A65E-1FFF58B4BBDB}.Release|x64.Build.0 = Release|Any CPU
+                {1360C1C4-0CB4-429D-A65E-1FFF58B4BBDB}.Release|x86.ActiveCfg = Release|Any CPU
+                {1360C1C4-0CB4-429D-A65E-1FFF58B4BBDB}.Release|x86.Build.0 = Release|Any CPU
         EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -125,8 +139,9 @@ Global
 		{86B8F682-4E4A-4E11-804A-3513C85B8ADB} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 		{6FA76EE3-8C55-4176-AF31-CA4AD7DA6777} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 		{A238B7DB-438E-4502-A0E1-068306307A3A} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
-		{E3CF91DC-9121-404E-81CA-1BFED5C38420} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+                {E3CF91DC-9121-404E-81CA-1BFED5C38420} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
                 {62B8ABC0-5DB1-4F84-912F-6E9250AB8954} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+                {1360C1C4-0CB4-429D-A65E-1FFF58B4BBDB} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
         EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {015A55A8-BE3A-4015-BDD2-CBAE0F721F7E}


### PR DESCRIPTION
## Summary
- add helper logic to keep trigram MATCH tokens escaped while only quoting reserved keywords

## Testing
- not run (dotnet CLI unavailable in execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68dbbba190288326b9bfb59539614e7d