### PR TITLE
Adjust hybrid search scaling for empty score sets

### DIFF
--- a/Veriado.Infrastructure/Search/HybridSearchQueryService.cs
+++ b/Veriado.Infrastructure/Search/HybridSearchQueryService.cs
@@ -197,7 +197,7 @@ internal sealed class HybridSearchQueryService : ISearchQueryService
     {
         if (scores.Count == 0)
         {
-            return 0.6d;
+            return 1.0d;
         }
 
         var ordered = scores.OrderBy(static value => value).ToArray();


### PR DESCRIPTION
## Summary
- ensure the hybrid search scale defaults to 1.0 when no scores are provided
- maintain ranking parity so trigram-only results can surface appropriately

## Testing
- dotnet test *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dbf70aa9bc8326a6401a91cf81cc87