### PR TITLE
Add configurable outbox batch size

### DIFF
--- a/Veriado.Infrastructure/Persistence/Options/InfrastructureOptions.cs
+++ b/Veriado.Infrastructure/Persistence/Options/InfrastructureOptions.cs
@@ -7,6 +7,7 @@ public sealed class InfrastructureOptions
 {
     private const int DefaultBatchSize = 300;
     private const int DefaultBatchWindowMs = 250;
+    private const int DefaultOutboxBatchSize = 50;
 
     /// <summary>
     /// Gets or sets the absolute path to the SQLite database file.
@@ -74,8 +75,18 @@ public sealed class InfrastructureOptions
     /// </summary>
     public TimeSpan IdempotencyCleanupInterval { get; set; } = TimeSpan.FromHours(1);
 
+    /// <summary>
+    /// Gets or sets the maximum number of outbox events fetched in a single drain operation.
+    /// </summary>
+    public int OutboxBatchSize
+    {
+        get => _outboxBatchSize;
+        set => _outboxBatchSize = value > 0 ? value : throw new ArgumentOutOfRangeException(nameof(value));
+    }
+
     private int _batchSize = DefaultBatchSize;
     private int _batchWindowMs = DefaultBatchWindowMs;
+    private int _outboxBatchSize = DefaultOutboxBatchSize;
 
     internal string? ConnectionString { get; set; }
         = null;

--- a/Veriado.Infrastructure/Search/Outbox/OutboxDrainService.cs
+++ b/Veriado.Infrastructure/Search/Outbox/OutboxDrainService.cs
@@ -115,7 +115,7 @@ internal sealed class OutboxDrainService
             .AsNoTracking()
             .Where(evt => evt.ProcessedUtc == null)
             .OrderBy(evt => evt.CreatedUtc)
-            .Take(50)
+            .Take(_options.OutboxBatchSize)
             .Select(evt => evt.Id)
             .ToListAsync(cancellationToken)
             .ConfigureAwait(false);


### PR DESCRIPTION
## Summary
- add an OutboxBatchSize setting to InfrastructureOptions with a default of 50
- use the configured outbox batch size when loading pending search index events

## Testing
- dotnet test *(fails: command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dbf715c76c8326ae3a2a0d1aeda929