### PR TITLE
Fix compilation issues in search services

### DIFF
--- a/Veriado.Application/UseCases/Search/SearchFilesHandler.cs
+++ b/Veriado.Application/UseCases/Search/SearchFilesHandler.cs
@@ -57,7 +57,7 @@ public sealed class SearchFilesHandler : IRequestHandler<SearchFilesQuery, IRead
             switch (token.Type)
             {
                 case LexTokenType.Operator:
-                    syntaxTokens.Add(SyntaxToken.Operator(token.Operator));
+                    syntaxTokens.Add(SyntaxToken.Operator(token.OperatorKind));
                     break;
                 case LexTokenType.Phrase:
                     if (CreatePhraseNode(token.Value) is { } phraseNode)
@@ -239,7 +239,7 @@ public sealed class SearchFilesHandler : IRequestHandler<SearchFilesQuery, IRead
             switch (token.Type)
             {
                 case SyntaxTokenType.Node:
-                    var node = token.Node!;
+                    var node = token.NodeValue!;
                     if (pendingNot % 2 != 0)
                     {
                         node = new NotNode(node);
@@ -343,7 +343,7 @@ public sealed class SearchFilesHandler : IRequestHandler<SearchFilesQuery, IRead
         Not,
     }
 
-    private readonly record struct LexToken(LexTokenType Type, string Value, SyntaxTokenType Operator)
+    private readonly record struct LexToken(LexTokenType Type, string Value, SyntaxTokenType OperatorKind)
     {
         public static LexToken Word(string value)
             => new(LexTokenType.Word, value, SyntaxTokenType.Node);
@@ -355,7 +355,7 @@ public sealed class SearchFilesHandler : IRequestHandler<SearchFilesQuery, IRead
             => new(LexTokenType.Operator, string.Empty, op);
     }
 
-    private readonly record struct SyntaxToken(SyntaxTokenType Type, QueryNode? Node)
+    private readonly record struct SyntaxToken(SyntaxTokenType Type, QueryNode? NodeValue)
     {
         public static SyntaxToken Node(QueryNode node)
             => new(SyntaxTokenType.Node, node);

--- a/Veriado.Infrastructure/Search/FacetService.cs
+++ b/Veriado.Infrastructure/Search/FacetService.cs
@@ -222,7 +222,10 @@ internal sealed class FacetService : IFacetService
         var histogram = await query
             .Select(file => new
             {
-                Bucket = EF.Functions.Strftime(format, EF.Property<string>(file, property)),
+                Bucket = SqliteDbFunctionsExtensions.Strftime(
+                    EF.Functions,
+                    format,
+                    EF.Property<string>(file, property)),
             })
             .GroupBy(x => x.Bucket)
             .Select(group => new FacetValue(group.Key ?? "n/a", group.LongCount()))

--- a/Veriado.Infrastructure/Search/SearchTelemetry.cs
+++ b/Veriado.Infrastructure/Search/SearchTelemetry.cs
@@ -5,7 +5,7 @@ using System.Diagnostics.Metrics;
 /// <summary>
 /// Provides <see cref="ISearchTelemetry"/> implementation backed by <see cref="Meter"/> instruments.
 /// </summary>
-internal sealed class SearchTelemetry : ISearchTelemetry, IDisposable
+internal sealed class SearchTelemetry : ISearchTelemetry
 {
     private static readonly Meter Meter = new("Veriado.Search", "1.0.0");
 
@@ -41,12 +41,6 @@ internal sealed class SearchTelemetry : ISearchTelemetry, IDisposable
     {
         Interlocked.Exchange(ref _documentCount, documentCount);
         Interlocked.Exchange(ref _indexSizeBytes, indexSizeBytes);
-    }
-
-    public void Dispose()
-    {
-        _documentGauge.Dispose();
-        _indexSizeGauge.Dispose();
     }
 
     private IEnumerable<Measurement<long>> ObserveDocuments()


### PR DESCRIPTION
## Summary
- rename internal token properties to avoid duplicate member names in the search handler
- adjust date histogram projection to call SqliteDbFunctionsExtensions.Strftime explicitly
- drop IDisposable implementation from SearchTelemetry because ObservableGauge does not implement Dispose

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dbf96f10e483268496148e970a1098