### PR TITLE
Restore SQLite strftime helper for facet queries

### DIFF
--- a/Veriado.Infrastructure/Search/FacetService.cs
+++ b/Veriado.Infrastructure/Search/FacetService.cs
@@ -222,8 +222,7 @@ internal sealed class FacetService : IFacetService
         var histogram = await query
             .Select(file => new
             {
-                Bucket = SqliteDbFunctionsExtensions.Strftime(
-                    EF.Functions,
+                Bucket = EF.Functions.Strftime(
                     format,
                     EF.Property<string>(file, property)),
             })

--- a/Veriado.Infrastructure/Search/SqliteDbFunctionsExtensionsCompat.cs
+++ b/Veriado.Infrastructure/Search/SqliteDbFunctionsExtensionsCompat.cs
@@ -1,0 +1,24 @@
+namespace Veriado.Infrastructure.Search;
+
+using System;
+using Microsoft.EntityFrameworkCore;
+
+/// <summary>
+/// Provides compatibility shims for SQLite database functions removed from EF Core 9.
+/// </summary>
+internal static class SqliteDbFunctionsExtensionsCompat
+{
+    /// <summary>
+    /// Maps to the SQLite <c>strftime</c> function to support formatting timestamps in LINQ queries.
+    /// </summary>
+    /// <remarks>
+    /// The method is intended for use inside LINQ-to-Entities expressions only.
+    /// </remarks>
+    /// <param name="_">The EF Core database functions entry point.</param>
+    /// <param name="format">The <c>strftime</c> format string.</param>
+    /// <param name="timestring">The ISO 8601 timestamp value.</param>
+    /// <returns>The formatted timestamp value.</returns>
+    [DbFunction("strftime", IsBuiltIn = true)]
+    public static string? Strftime(this DbFunctions _, string format, string timestring)
+        => throw new InvalidOperationException("This method is only intended for use in database queries.");
+}


### PR DESCRIPTION
## Summary
- add a local compatibility extension for SQLite's `strftime` function to align with EF Core 9
- update the facet histogram projection to use the new extension helper

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dbfc65ca30832699c54d3feac76779