### PR TITLE
Add configurable search options and update DTOs

### DIFF
--- a/Veriado.Application/Search/SearchOptions.cs
+++ b/Veriado.Application/Search/SearchOptions.cs
@@ -1,0 +1,138 @@
+using System;
+namespace Veriado.Appl.Search;
+
+/// <summary>
+/// Represents the root configuration object for the search subsystem.
+/// </summary>
+public sealed class SearchOptions
+{
+    /// <summary>
+    /// Gets or sets the scoring configuration applied to FTS and hybrid queries.
+    /// </summary>
+    public SearchScoreOptions Score { get; set; } = new();
+
+    /// <summary>
+    /// Gets or sets the analyser options shared between indexing and querying.
+    /// </summary>
+    public AnalyzerOptions Analyzer { get; set; } = new();
+
+    /// <summary>
+    /// Gets or sets trigram index related settings.
+    /// </summary>
+    public TrigramIndexOptions Trigram { get; set; } = new();
+
+    /// <summary>
+    /// Gets or sets facet aggregation options.
+    /// </summary>
+    public FacetOptions Facets { get; set; } = new();
+
+    /// <summary>
+    /// Gets or sets synonym expansion options.
+    /// </summary>
+    public SynonymOptions Synonyms { get; set; } = new();
+
+    /// <summary>
+    /// Gets or sets suggestion service options.
+    /// </summary>
+    public SuggesterOptions Suggestions { get; set; } = new();
+
+    /// <summary>
+    /// Gets or sets spell suggestion options.
+    /// </summary>
+    public SpellOptions Spell { get; set; } = new();
+}
+
+/// <summary>
+/// Provides tuning parameters for BM25 scoring and hybrid result merging.
+/// </summary>
+public sealed class SearchScoreOptions
+{
+    public double TitleWeight { get; set; } = 4.0d;
+    public double MimeWeight { get; set; } = 0.1d;
+    public double AuthorWeight { get; set; } = 2.0d;
+    public double MetadataTextWeight { get; set; } = 0.8d;
+    public double MetadataWeight { get; set; } = 0.2d;
+    public double ScoreMultiplier { get; set; } = 1.0d;
+    public bool HigherScoreIsBetter { get; set; }
+        = false;
+    public bool UseTfIdfAlternative { get; set; }
+        = false;
+    public double TfIdfDampingFactor { get; set; } = 0.5d;
+    public int OversampleMultiplier { get; set; } = 3;
+    public double DefaultTrigramScale { get; set; } = 0.45d;
+    public double TrigramFloor { get; set; } = 0.30d;
+    public string MergeMode { get; set; } = "max";
+    public double WeightedFts { get; set; } = 0.7d;
+}
+
+/// <summary>
+/// Configures trigram index generation.
+/// </summary>
+public sealed class TrigramIndexOptions
+{
+    public int MaxTokens { get; set; } = 2048;
+
+    public string[] Fields { get; set; } =
+    {
+        "title",
+        "author",
+        "filename",
+        "metadata_text",
+    };
+}
+
+/// <summary>
+/// Specifies defaults for facet aggregations.
+/// </summary>
+public sealed class FacetOptions
+{
+    public int TermLimit { get; set; } = 12;
+    public int MaxBuckets { get; set; } = 24;
+
+    public string[] SupportedDateIntervals { get; set; } =
+    {
+        "month",
+        "quarter",
+        "year",
+    };
+}
+
+/// <summary>
+/// Options controlling synonym expansion.
+/// </summary>
+public sealed class SynonymOptions
+{
+    public int MaxVariantsPerTerm { get; set; } = 5;
+    public bool EnableCaching { get; set; } = true;
+    public TimeSpan CacheTtl { get; set; } = TimeSpan.FromMinutes(10);
+}
+
+/// <summary>
+/// Options for the autocomplete suggestion subsystem.
+/// </summary>
+public sealed class SuggesterOptions
+{
+    public int MaxSuggestions { get; set; } = 8;
+    public int MinTermLength { get; set; } = 3;
+
+    public string[] Sources { get; set; } =
+    {
+        "title",
+        "author",
+        "filename",
+        "metadata_text",
+    };
+
+    public TimeSpan RefreshInterval { get; set; } = TimeSpan.FromMinutes(5);
+}
+
+/// <summary>
+/// Provides parameters for the trigram based spell-check feature.
+/// </summary>
+public sealed class SpellOptions
+{
+    public int MaxSuggestions { get; set; } = 5;
+    public double SimilarityThreshold { get; set; } = 0.5d;
+    public bool EnableWhenResultsFound { get; set; }
+        = false;
+}

--- a/Veriado.Application/UseCases/Search/SearchFilesHandler.cs
+++ b/Veriado.Application/UseCases/Search/SearchFilesHandler.cs
@@ -16,22 +16,28 @@ public sealed class SearchFilesHandler : IRequestHandler<SearchFilesQuery, IRead
     private readonly ISearchQueryService _searchQueryService;
     private readonly IMapper _mapper;
     private readonly IAnalyzerFactory _analyzerFactory;
+    private readonly SearchOptions _searchOptions;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="SearchFilesHandler"/> class.
     /// </summary>
-    public SearchFilesHandler(ISearchQueryService searchQueryService, IMapper mapper, IAnalyzerFactory analyzerFactory)
+    public SearchFilesHandler(
+        ISearchQueryService searchQueryService,
+        IMapper mapper,
+        IAnalyzerFactory analyzerFactory,
+        SearchOptions searchOptions)
     {
         _searchQueryService = searchQueryService;
         _mapper = mapper;
         _analyzerFactory = analyzerFactory ?? throw new ArgumentNullException(nameof(analyzerFactory));
+        _searchOptions = searchOptions ?? throw new ArgumentNullException(nameof(searchOptions));
     }
 
     /// <inheritdoc />
     public async Task<IReadOnlyList<SearchHitDto>> Handle(SearchFilesQuery request, CancellationToken cancellationToken)
     {
         Guard.AgainstNullOrWhiteSpace(request.Text, nameof(request.Text));
-        var builder = new SearchQueryBuilder();
+        var builder = new SearchQueryBuilder(_searchOptions.Score, null, _searchOptions.Analyzer.DefaultProfile);
         var expression = BuildQueryExpression(request.Text, builder);
         if (expression is null)
         {

--- a/Veriado.Contracts/Search/SearchHitDto.cs
+++ b/Veriado.Contracts/Search/SearchHitDto.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace Veriado.Contracts.Search;
 
 /// <summary>
@@ -26,6 +28,6 @@ public sealed record SearchHitDto(
     string Source,
     string? PrimaryField,
     string SnippetText,
-    IReadOnlyList<HighlightSpanDto> Highlights,
-    IReadOnlyDictionary<string, string?> Fields,
+    List<HighlightSpanDto> Highlights,
+    Dictionary<string, string?> Fields,
     object? SortValues);

--- a/Veriado.Domain/Search/SearchHit.cs
+++ b/Veriado.Domain/Search/SearchHit.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace Veriado.Domain.Search;
 
 /// <summary>
@@ -26,8 +28,8 @@ public sealed record SearchHit(
     string Source,
     string? PrimaryField,
     string SnippetText,
-    IReadOnlyList<HighlightSpan> Highlights,
-    IReadOnlyDictionary<string, string?> Fields,
+    List<HighlightSpan> Highlights,
+    Dictionary<string, string?> Fields,
     object? SortValues);
 
 /// <summary>

--- a/Veriado.Infrastructure/Concurrency/WriteWorker.cs
+++ b/Veriado.Infrastructure/Concurrency/WriteWorker.cs
@@ -25,6 +25,7 @@ internal sealed class WriteWorker : BackgroundService
     private readonly IEventPublisher _eventPublisher;
     private readonly IClock _clock;
     private readonly IAnalyzerFactory _analyzerFactory;
+    private readonly TrigramIndexOptions _trigramOptions;
 
     public WriteWorker(
         IWriteQueue writeQueue,
@@ -36,7 +37,8 @@ internal sealed class WriteWorker : BackgroundService
         IFulltextIntegrityService integrityService,
         IEventPublisher eventPublisher,
         IClock clock,
-        IAnalyzerFactory analyzerFactory)
+        IAnalyzerFactory analyzerFactory,
+        TrigramIndexOptions trigramOptions)
     {
         _writeQueue = writeQueue;
         _dbContextFactory = dbContextFactory;
@@ -48,6 +50,7 @@ internal sealed class WriteWorker : BackgroundService
         _eventPublisher = eventPublisher;
         _clock = clock;
         _analyzerFactory = analyzerFactory ?? throw new ArgumentNullException(nameof(analyzerFactory));
+        _trigramOptions = trigramOptions ?? throw new ArgumentNullException(nameof(trigramOptions));
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -383,7 +386,7 @@ internal sealed class WriteWorker : BackgroundService
             }
 
             var sqliteConnection = (SqliteConnection)sqliteTransaction.Connection!;
-            var helper = new SqliteFts5Transactional(_analyzerFactory);
+            var helper = new SqliteFts5Transactional(_analyzerFactory, _trigramOptions);
 
             foreach (var id in filesToDelete)
             {

--- a/Veriado.Infrastructure/Search/SqliteFts5Indexer.cs
+++ b/Veriado.Infrastructure/Search/SqliteFts5Indexer.cs
@@ -12,16 +12,19 @@ internal sealed class SqliteFts5Indexer : ISearchIndexer
     private readonly SuggestionMaintenanceService? _suggestionMaintenance;
     private readonly IAnalyzerFactory _analyzerFactory;
     private readonly ISqliteConnectionFactory _connectionFactory;
+    private readonly TrigramIndexOptions _trigramOptions;
 
     public SqliteFts5Indexer(
         InfrastructureOptions options,
         IAnalyzerFactory analyzerFactory,
         ISqliteConnectionFactory connectionFactory,
+        TrigramIndexOptions trigramOptions,
         SuggestionMaintenanceService? suggestionMaintenance = null)
     {
         _options = options;
         _analyzerFactory = analyzerFactory ?? throw new ArgumentNullException(nameof(analyzerFactory));
         _connectionFactory = connectionFactory ?? throw new ArgumentNullException(nameof(connectionFactory));
+        _trigramOptions = trigramOptions ?? throw new ArgumentNullException(nameof(trigramOptions));
         _suggestionMaintenance = suggestionMaintenance;
     }
 
@@ -60,7 +63,7 @@ internal sealed class SqliteFts5Indexer : ISearchIndexer
         await SqlitePragmaHelper.ApplyAsync(connection, cancellationToken).ConfigureAwait(false);
         await using var dbTransaction = await connection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
         var transaction = (SqliteTransaction)dbTransaction;
-        var helper = new SqliteFts5Transactional(_analyzerFactory);
+        var helper = new SqliteFts5Transactional(_analyzerFactory, _trigramOptions);
 
         try
         {
@@ -95,7 +98,7 @@ internal sealed class SqliteFts5Indexer : ISearchIndexer
         await SqlitePragmaHelper.ApplyAsync(connection, cancellationToken).ConfigureAwait(false);
         await using var dbTransaction = await connection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
         var transaction = (SqliteTransaction)dbTransaction;
-        var helper = new SqliteFts5Transactional(_analyzerFactory);
+        var helper = new SqliteFts5Transactional(_analyzerFactory, _trigramOptions);
 
         try
         {

--- a/Veriado.Infrastructure/Search/SqliteFts5QueryService.cs
+++ b/Veriado.Infrastructure/Search/SqliteFts5QueryService.cs
@@ -463,7 +463,7 @@ internal sealed class SqliteFts5QueryService
         return normalized;
     }
 
-    private static IReadOnlyList<HighlightSpan> BuildHighlights(
+    private static List<HighlightSpan> BuildHighlights(
         int columnIndex,
         string snippet,
         IReadOnlyDictionary<int, string> columnValues,
@@ -471,12 +471,12 @@ internal sealed class SqliteFts5QueryService
     {
         if (!offsetsByColumn.TryGetValue(columnIndex, out var offsets) || offsets.Count == 0)
         {
-            return Array.Empty<HighlightSpan>();
+            return new List<HighlightSpan>();
         }
 
         if (!columnValues.TryGetValue(columnIndex, out var columnText) || string.IsNullOrEmpty(columnText))
         {
-            return Array.Empty<HighlightSpan>();
+            return new List<HighlightSpan>();
         }
 
         if (!ColumnNameMap.TryGetValue(columnIndex, out var field))
@@ -492,7 +492,7 @@ internal sealed class SqliteFts5QueryService
         var map = BuildSnippetIndexMap(columnText, snippet);
         if (map.Count == 0)
         {
-            return Array.Empty<HighlightSpan>();
+            return new List<HighlightSpan>();
         }
 
         var columnBytes = Utf8.GetBytes(columnText);

--- a/Veriado.Infrastructure/Search/TrigramQueryService.cs
+++ b/Veriado.Infrastructure/Search/TrigramQueryService.cs
@@ -380,17 +380,17 @@ internal sealed class TrigramQueryService
         return snippet;
     }
 
-    private static IReadOnlyList<HighlightSpan> BuildHighlights(string field, string snippet, IReadOnlyCollection<string> tokens)
+    private static List<HighlightSpan> BuildHighlights(string field, string snippet, IReadOnlyCollection<string> tokens)
     {
         if (string.IsNullOrEmpty(snippet) || tokens.Count == 0)
         {
-            return Array.Empty<HighlightSpan>();
+            return new List<HighlightSpan>();
         }
 
         var normalized = NormalizeForComparison(snippet, out var map);
         if (normalized.Length == 0 || map.Count == 0)
         {
-            return Array.Empty<HighlightSpan>();
+            return new List<HighlightSpan>();
         }
 
         var spans = new List<HighlightSpan>();

--- a/docs/fulltext-analysis.md
+++ b/docs/fulltext-analysis.md
@@ -45,3 +45,95 @@ INSERT INTO synonyms(lang, term, variant) VALUES ('en', 'analysis', 'analytics')
 ```
 
 Tabulka `suggestions` je napájena službou `SuggestionMaintenanceService`, která při indexaci sklízí tokeny z názvů, autora a metadat a zapisuje je s váhami. Stejná data slouží jako slovník pro trigramovou kontrolu pravopisu.
+
+## Konfigurace a DI registrace
+
+- `ServiceCollectionExtensions` registruje všechny dílčí možnosti (`SearchOptions.Score`, `Trigram`, `Facets`, `Synonyms`, `Suggestions`, `Spell`) a zároveň publikuje `IOptions<T>` pro analyzér i trigramový index. Díky tomu lze nastavení přirozeně injektovat do `HybridSearchQueryService`, `SqliteFts5Transactional` a dalších služeb.【F:Veriado.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs†L93-L123】
+- `SearchOptions` agregují výchozí hodnoty – například prefixová váha titulu 4.0, limit trigramů 2 048 tokenů a seznam indexovaných polí (`title`, `author`, `filename`, `metadata_text`).【F:Veriado.Application/Search/SearchOptions.cs†L7-L106】
+- `SqliteFts5Transactional` respektuje nakonfigurovaný seznam polí i limit tokenů při generování trigramového obsahu; přebytek ořeže ještě před vložením do tabulky `file_trgm`.【F:Veriado.Infrastructure/Search/SqliteFts5Transactional.cs†L18-L127】
+
+Příklad úseku `appsettings.json` v produkci:
+
+```json
+{
+  "Search": {
+    "Analyzer": {
+      "DefaultProfile": "cs"
+    },
+    "Score": {
+      "OversampleMultiplier": 3,
+      "DefaultTrigramScale": 0.45,
+      "TrigramFloor": 0.3,
+      "MergeMode": "weighted",
+      "WeightedFts": 0.7
+    },
+    "Trigram": {
+      "MaxTokens": 2048,
+      "Fields": ["title", "author", "filename", "metadata_text"]
+    }
+  }
+}
+```
+
+## Příklady integrace
+
+1. **Kombinovaný boolovský + frázový + rozsahový dotaz přes EF Core**
+
+    ```csharp
+    var builder = new SearchQueryBuilder(options.Score, synonymProvider, options.Analyzer.DefaultProfile);
+    var query = builder.And(
+        builder.Term("metadata_text", "faktura"),
+        builder.Phrase("title", "daňový doklad"),
+        builder.Range("modified_utc", new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero), new DateTimeOffset(2024, 12, 31, 23, 59, 59, TimeSpan.Zero)));
+    var plan = builder.Build(query, rawQuery: "faktura title:\"daňový doklad\" modified:[2024-01-01 TO 2024-12-31]");
+    var hits = await searchQueryService.SearchAsync(plan, limit: 50, cancellationToken);
+    ```
+
+2. **Prefixový dotaz s fallbackem na trigramy (`ucte*`)**
+
+    ```csharp
+    var builder = new SearchQueryBuilder(options.Score, synonymProvider, options.Analyzer.DefaultProfile);
+    var prefix = builder.Prefix("metadata_text", "ucte");
+    var plan = builder.Build(prefix, rawQuery: "ucte*");
+    var results = await searchQueryService.SearchAsync(plan, limit: 20, cancellationToken);
+    // plan.RequiresTrigramFallback == true → HybridSearchQueryService automaticky kombinuje FTS5 i trigramové skóre.
+    ```
+
+3. **Fuzzy překlep `uctenk` → trigramový Jaccard + normalizované FTS skóre**
+
+    ```csharp
+    var fuzzy = builder.Term(null, "uctenk");
+    var fuzzyPlan = builder.Build(fuzzy, rawQuery: "uctenk");
+    var fuzzyHits = await searchQueryService.SearchAsync(fuzzyPlan, limit: 10, cancellationToken);
+    // HybridSearchQueryService využije _scoreOptions.DefaultTrigramScale a TrigramFloor, aby výsledky z trigramů držely konzistentní pořadí.【F:Veriado.Infrastructure/Search/HybridSearchQueryService.cs†L26-L155】
+    ```
+
+4. **Vykreslení zvýraznění ve WinUI**
+
+    ```csharp
+    foreach (var hit in hits)
+    {
+        var spans = hit.Highlights.Where(span => span.Field == hit.PrimaryField);
+        var textBlock = new TextBlock { Text = hit.SnippetText };
+        foreach (var span in spans)
+        {
+            textBlock.TextHighlighters.Add(new TextHighlighter
+            {
+                Ranges = { new TextRange(span.Start, span.Length) },
+                Background = highlightBrush
+            });
+        }
+        resultsPanel.Children.Add(textBlock);
+    }
+    ```
+
+5. **Volání facetování nad MIME a měsíční histogram**
+
+    ```csharp
+    var request = new FacetRequest(new[]
+    {
+        new FacetField("mime", FacetKind.Term),
+        new FacetField("modified_utc", FacetKind.DateHistogram, interval: "month"),
+    });
+    var facetResult = await facetService.GetFacetsAsync(request, cancellationToken);
+    ```


### PR DESCRIPTION
## Summary
- switch search hit DTOs to mutable List/Dictionary collections for WinUI highlighting
- introduce strongly typed SearchOptions (score, trigram, facet, synonym, suggester, spell) and wire them into DI and query builder
- scale hybrid search using configurable oversampling/merge parameters and enforce trigram field limits during indexing
- document configuration/usage patterns and add end-to-end code samples

## Testing
- dotnet build *(fails: command not found in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc05b723d0832688baf3443194eb30