### PR TITLE
Extend search parser to support fuzzy and wildcard tokens

### DIFF
--- a/Veriado.Application/Search/QueryNode.cs
+++ b/Veriado.Application/Search/QueryNode.cs
@@ -20,7 +20,9 @@ public sealed record TokenNode(
     string Value,
     QueryTokenType TokenType,
     string? TrigramExpression = null,
-    bool RequiresAllTrigramTerms = false) : QueryNode;
+    bool RequiresAllTrigramTerms = false,
+    int? MaxEditDistance = null,
+    bool IsHeuristicFuzzy = false) : QueryNode;
 
 /// <summary>
 /// Represents a boolean combination of nodes.
@@ -59,6 +61,16 @@ public enum QueryTokenType
     /// A prefix match (trailing wildcard).
     /// </summary>
     Prefix,
+
+    /// <summary>
+    /// A token containing wildcard characters.
+    /// </summary>
+    Wildcard,
+
+    /// <summary>
+    /// A fuzzy token matched using trigram similarity.
+    /// </summary>
+    Fuzzy,
 }
 
 /// <summary>

--- a/Veriado.Application/Search/SearchOptions.cs
+++ b/Veriado.Application/Search/SearchOptions.cs
@@ -22,6 +22,11 @@ public sealed class SearchOptions
     public TrigramIndexOptions Trigram { get; set; } = new();
 
     /// <summary>
+    /// Gets or sets parser configuration options.
+    /// </summary>
+    public SearchParseOptions Parse { get; set; } = new();
+
+    /// <summary>
     /// Gets or sets facet aggregation options.
     /// </summary>
     public FacetOptions Facets { get; set; } = new();

--- a/Veriado.Application/Search/SearchParseOptions.cs
+++ b/Veriado.Application/Search/SearchParseOptions.cs
@@ -1,0 +1,12 @@
+namespace Veriado.Appl.Search;
+
+/// <summary>
+/// Provides configuration for the search query parser.
+/// </summary>
+public sealed class SearchParseOptions
+{
+    /// <summary>
+    /// Gets or sets a value indicating whether heuristic fuzzy detection is enabled.
+    /// </summary>
+    public bool EnableHeuristicFuzzy { get; set; } = true;
+}

--- a/Veriado.Application/UseCases/Search/SearchFilesHandler.cs
+++ b/Veriado.Application/UseCases/Search/SearchFilesHandler.cs
@@ -17,6 +17,7 @@ public sealed class SearchFilesHandler : IRequestHandler<SearchFilesQuery, IRead
     private readonly IMapper _mapper;
     private readonly IAnalyzerFactory _analyzerFactory;
     private readonly SearchOptions _searchOptions;
+    private readonly SearchParseOptions _parseOptions;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="SearchFilesHandler"/> class.
@@ -31,6 +32,7 @@ public sealed class SearchFilesHandler : IRequestHandler<SearchFilesQuery, IRead
         _mapper = mapper;
         _analyzerFactory = analyzerFactory ?? throw new ArgumentNullException(nameof(analyzerFactory));
         _searchOptions = searchOptions ?? throw new ArgumentNullException(nameof(searchOptions));
+        _parseOptions = _searchOptions.Parse ?? new SearchParseOptions();
     }
 
     /// <inheritdoc />
@@ -57,37 +59,64 @@ public sealed class SearchFilesHandler : IRequestHandler<SearchFilesQuery, IRead
             return null;
         }
 
-        var syntaxTokens = new List<SyntaxToken>(lexTokens.Count);
+        var parseTokens = new List<ParseToken>(lexTokens.Count);
+        string? pendingField = null;
+        ParseToken? previousToken = null;
+
         foreach (var token in lexTokens)
         {
             switch (token.Type)
             {
+                case LexTokenType.Field:
+                    pendingField = token.Value;
+                    break;
                 case LexTokenType.Operator:
-                    syntaxTokens.Add(SyntaxToken.Operator(token.OperatorKind));
+                    pendingField = null;
+                    AddToken(ParseToken.Operator(token.OperatorKind));
                     break;
                 case LexTokenType.Phrase:
-                    if (CreatePhraseNode(token.Value) is { } phraseNode)
+                    if (CreatePhraseNode(token.Value, pendingField) is { } phraseNode)
                     {
-                        syntaxTokens.Add(SyntaxToken.Node(phraseNode));
+                        AddToken(ParseToken.Node(phraseNode));
+                    }
+
+                    pendingField = null;
+                    break;
+                case LexTokenType.Word:
+                    var nodes = CreateTermNodes(token.Value, pendingField);
+                    pendingField = null;
+                    foreach (var node in nodes)
+                    {
+                        AddToken(ParseToken.Node(node));
                     }
 
                     break;
-                case LexTokenType.Word:
-                    foreach (var node in CreateTermNodes(token.Value))
-                    {
-                        syntaxTokens.Add(SyntaxToken.Node(node));
-                    }
-
+                case LexTokenType.OpenParen:
+                    AddToken(ParseToken.OpenParen());
+                    break;
+                case LexTokenType.CloseParen:
+                    AddToken(ParseToken.CloseParen());
                     break;
             }
         }
 
-        if (syntaxTokens.Count == 0)
-        {
-            return null;
-        }
+        return BuildBooleanTree(builder, parseTokens);
 
-        return BuildBooleanTree(builder, syntaxTokens);
+        void AddToken(ParseToken token)
+        {
+            if (pendingField is not null && token.Type != ParseTokenType.Node)
+            {
+                pendingField = null;
+            }
+
+            if (previousToken is { } previous && RequiresImplicitAnd(previous, token))
+            {
+                parseTokens.Add(ParseToken.Operator(ParseTokenType.And));
+            }
+
+            parseTokens.Add(token);
+            previousToken = token;
+        }
     }
 
     private IReadOnlyList<LexToken> Lex(string text)
@@ -107,6 +136,20 @@ public sealed class SearchFilesHandler : IRequestHandler<SearchFilesQuery, IRead
             var current = span[index];
             if (char.IsWhiteSpace(current))
             {
+                index++;
+                continue;
+            }
+
+            if (current == '(')
+            {
+                tokens.Add(LexToken.OpenParen());
+                index++;
+                continue;
+            }
+
+            if (current == ')')
+            {
+                tokens.Add(LexToken.CloseParen());
                 index++;
                 continue;
             }
@@ -152,7 +195,11 @@ public sealed class SearchFilesHandler : IRequestHandler<SearchFilesQuery, IRead
             }
 
             var start = index;
-            while (index < span.Length && !char.IsWhiteSpace(span[index]) && span[index] != '\"')
+            while (index < span.Length
+                && !char.IsWhiteSpace(span[index])
+                && span[index] != '\"'
+                && span[index] != '('
+                && span[index] != ')')
             {
                 index++;
             }
@@ -164,37 +211,88 @@ public sealed class SearchFilesHandler : IRequestHandler<SearchFilesQuery, IRead
             }
 
             var raw = span.Slice(start, index - start).ToString();
-            if (raw.Length == 0)
+            if (string.IsNullOrWhiteSpace(raw))
             {
                 continue;
             }
 
-            if (raw.Equals("AND", StringComparison.OrdinalIgnoreCase))
-            {
-                tokens.Add(LexToken.Operator(SyntaxTokenType.And));
-            }
-            else if (raw.Equals("OR", StringComparison.OrdinalIgnoreCase))
-            {
-                tokens.Add(LexToken.Operator(SyntaxTokenType.Or));
-            }
-            else if (raw.Equals("NOT", StringComparison.OrdinalIgnoreCase))
-            {
-                tokens.Add(LexToken.Operator(SyntaxTokenType.Not));
-            }
-            else
-            {
-                tokens.Add(LexToken.Word(raw));
-            }
+            ProcessRawToken(raw);
         }
 
         return tokens;
+
+        void ProcessRawToken(string rawToken)
+        {
+            if (string.IsNullOrWhiteSpace(rawToken))
+            {
+                return;
+            }
+
+            if (rawToken.Equals("AND", StringComparison.OrdinalIgnoreCase))
+            {
+                tokens.Add(LexToken.Operator(ParseTokenType.And));
+                return;
+            }
+
+            if (rawToken.Equals("OR", StringComparison.OrdinalIgnoreCase))
+            {
+                tokens.Add(LexToken.Operator(ParseTokenType.Or));
+                return;
+            }
+
+            if (rawToken.Equals("NOT", StringComparison.OrdinalIgnoreCase))
+            {
+                tokens.Add(LexToken.Operator(ParseTokenType.Not));
+                return;
+            }
+
+            if (TryExtractField(rawToken, out var fieldName, out var remainder))
+            {
+                tokens.Add(LexToken.Field(fieldName));
+                if (!string.IsNullOrEmpty(remainder))
+                {
+                    foreach (var nested in Lex(remainder))
+                    {
+                        tokens.Add(nested);
+                    }
+                }
+
+                return;
+            }
+
+            tokens.Add(LexToken.Word(rawToken));
+        }
     }
 
-    private IEnumerable<QueryNode> CreateTermNodes(string text)
+    private IEnumerable<QueryNode> CreateTermNodes(string text, string? field)
     {
-        var tokens = TextNormalization.Tokenize(text, _analyzerFactory)
+        var descriptor = AnalyzeToken(text);
+        switch (descriptor.Classification)
+        {
+            case QueryTokenType.Prefix:
+                if (CreatePrefixNode(descriptor, field) is { } prefixNode)
+                {
+                    yield return prefixNode;
+                }
+
+                yield break;
+            case QueryTokenType.Wildcard:
+                if (CreateWildcardNode(descriptor, field) is { } wildcardNode)
+                {
+                    yield return wildcardNode;
+                }
+
+                yield break;
+        }
+
+        var tokens = TextNormalization.Tokenize(descriptor.Sanitized, _analyzerFactory)
             .Where(static token => !string.IsNullOrWhiteSpace(token))
             .ToArray();
+
+        if (tokens.Length == 0)
+        {
+            yield break;
+        }
 
         foreach (var token in tokens)
         {
@@ -204,13 +302,31 @@ public sealed class SearchFilesHandler : IRequestHandler<SearchFilesQuery, IRead
                 continue;
             }
 
-            yield return IsReservedWord(token)
-                ? new TokenNode(null, escaped, QueryTokenType.Phrase)
-                : new TokenNode(null, escaped, QueryTokenType.Term);
+            var tokenType = descriptor.Classification == QueryTokenType.Fuzzy
+                ? QueryTokenType.Fuzzy
+                : QueryTokenType.Term;
+
+            var maxEdits = descriptor.ExplicitFuzzy ? descriptor.FuzzyMaxEdits ?? 1 : (int?)null;
+            var isHeuristic = false;
+
+            if (tokenType == QueryTokenType.Term && IsReservedWord(token))
+            {
+                yield return new TokenNode(field, escaped, QueryTokenType.Phrase);
+                continue;
+            }
+
+            if (tokenType == QueryTokenType.Term && _parseOptions.EnableHeuristicFuzzy && ShouldApplyHeuristicFuzzy(token))
+            {
+                tokenType = QueryTokenType.Fuzzy;
+                maxEdits = 1;
+                isHeuristic = true;
+            }
+
+            yield return new TokenNode(field, escaped, tokenType, null, false, maxEdits, isHeuristic);
         }
     }
 
-    private QueryNode? CreatePhraseNode(string text)
+    private QueryNode? CreatePhraseNode(string text, string? field)
     {
         var tokens = TextNormalization.Tokenize(text, _analyzerFactory)
             .Where(static token => !string.IsNullOrWhiteSpace(token))
@@ -224,103 +340,434 @@ public sealed class SearchFilesHandler : IRequestHandler<SearchFilesQuery, IRead
         }
 
         var value = string.Join(' ', tokens);
-        return new TokenNode(null, value, QueryTokenType.Phrase);
+        return new TokenNode(field, value, QueryTokenType.Phrase);
     }
 
-    private QueryNode? BuildBooleanTree(SearchQueryBuilder builder, IReadOnlyList<SyntaxToken> tokens)
+    private QueryNode? BuildBooleanTree(SearchQueryBuilder builder, IReadOnlyList<ParseToken> tokens)
     {
         if (tokens.Count == 0)
         {
             return null;
         }
 
-        var orClauses = new List<QueryNode>();
-        var currentAnd = new List<QueryNode>();
-        SyntaxTokenType? pendingOperator = null;
-        BooleanOperator? lastExplicitOperator = null;
-        var pendingNot = 0;
+        var nodeStack = new Stack<QueryNode>();
+        var operatorStack = new Stack<ParseTokenType>();
 
         foreach (var token in tokens)
         {
             switch (token.Type)
             {
-                case SyntaxTokenType.Node:
-                    var node = token.NodeValue!;
-                    if (pendingNot % 2 != 0)
+                case ParseTokenType.Node:
+                    nodeStack.Push(token.NodeValue!);
+                    break;
+                case ParseTokenType.Not:
+                    operatorStack.Push(ParseTokenType.Not);
+                    break;
+                case ParseTokenType.And:
+                case ParseTokenType.Or:
+                    while (operatorStack.Count > 0 && ShouldCollapse(operatorStack.Peek(), token.Type))
                     {
-                        node = new NotNode(node);
+                        ApplyOperator(operatorStack.Pop());
                     }
 
-                    pendingNot = 0;
-
-                    if (pendingOperator == SyntaxTokenType.And)
+                    operatorStack.Push(token.Type);
+                    break;
+                case ParseTokenType.OpenParen:
+                    operatorStack.Push(ParseTokenType.OpenParen);
+                    break;
+                case ParseTokenType.CloseParen:
+                    while (operatorStack.Count > 0 && operatorStack.Peek() != ParseTokenType.OpenParen)
                     {
-                        currentAnd.Add(node);
-                    }
-                    else if (pendingOperator == SyntaxTokenType.Or)
-                    {
-                        FinalizeCurrentAnd();
-                        currentAnd.Add(node);
-                    }
-                    else if (currentAnd.Count == 0)
-                    {
-                        currentAnd.Add(node);
-                    }
-                    else if (lastExplicitOperator == BooleanOperator.And)
-                    {
-                        currentAnd.Add(node);
-                    }
-                    else
-                    {
-                        FinalizeCurrentAnd();
-                        currentAnd.Add(node);
+                        ApplyOperator(operatorStack.Pop());
                     }
 
-                    pendingOperator = null;
-                    break;
-                case SyntaxTokenType.And:
-                    pendingOperator = SyntaxTokenType.And;
-                    lastExplicitOperator = BooleanOperator.And;
-                    break;
-                case SyntaxTokenType.Or:
-                    pendingOperator = SyntaxTokenType.Or;
-                    lastExplicitOperator = BooleanOperator.Or;
-                    break;
-                case SyntaxTokenType.Not:
-                    pendingNot++;
+                    if (operatorStack.Count > 0 && operatorStack.Peek() == ParseTokenType.OpenParen)
+                    {
+                        operatorStack.Pop();
+                    }
+
                     break;
             }
         }
 
-        FinalizeCurrentAnd();
-
-        if (orClauses.Count == 0)
+        while (operatorStack.Count > 0)
         {
-            return null;
+            var op = operatorStack.Pop();
+            if (op == ParseTokenType.OpenParen)
+            {
+                continue;
+            }
+
+            ApplyOperator(op);
         }
 
-        return orClauses.Count == 1
-            ? orClauses[0]
-            : builder.Or(orClauses.ToArray());
+        return nodeStack.Count == 0 ? null : nodeStack.Pop();
 
-        void FinalizeCurrentAnd()
+        bool ShouldCollapse(ParseTokenType opOnStack, ParseTokenType incoming)
         {
-            if (currentAnd.Count == 0)
+            if (opOnStack == ParseTokenType.OpenParen)
+            {
+                return false;
+            }
+
+            var stackPrecedence = GetPrecedence(opOnStack);
+            var incomingPrecedence = GetPrecedence(incoming);
+            if (opOnStack == ParseTokenType.Not && incomingPrecedence == GetPrecedence(ParseTokenType.Not))
+            {
+                return false;
+            }
+
+            return stackPrecedence >= incomingPrecedence;
+        }
+
+        void ApplyOperator(ParseTokenType op)
+        {
+            if (op == ParseTokenType.Not)
+            {
+                if (nodeStack.Count == 0)
+                {
+                    return;
+                }
+
+                var operand = nodeStack.Pop();
+                nodeStack.Push(new NotNode(operand));
+                return;
+            }
+
+            if (nodeStack.Count < 2)
             {
                 return;
             }
 
-            QueryNode? node = currentAnd.Count == 1
-                ? currentAnd[0]
-                : builder.And(currentAnd.ToArray());
+            var right = nodeStack.Pop();
+            var left = nodeStack.Pop();
+            var combined = op == ParseTokenType.And
+                ? builder.And(left, right)
+                : builder.Or(left, right);
 
-            if (node is not null)
+            if (combined is not null)
             {
-                orClauses.Add(node);
+                nodeStack.Push(combined);
+            }
+        }
+    }
+
+    private static bool RequiresImplicitAnd(ParseToken previous, ParseToken next)
+    {
+        if (previous.Type is ParseTokenType.Node or ParseTokenType.CloseParen)
+        {
+            return next.Type is ParseTokenType.Node or ParseTokenType.OpenParen or ParseTokenType.Not;
+        }
+
+        return false;
+    }
+
+    private TokenDescriptor AnalyzeToken(string raw)
+    {
+        var trimmed = raw?.Trim() ?? string.Empty;
+        var descriptor = new TokenDescriptor(trimmed, trimmed, QueryTokenType.Term, false, null);
+        if (trimmed.Length == 0)
+        {
+            return descriptor;
+        }
+
+        if (TryStripExplicitFuzzy(trimmed, out var withoutFuzzy, out var maxEdits))
+        {
+            descriptor = descriptor with
+            {
+                Sanitized = withoutFuzzy,
+                Classification = QueryTokenType.Fuzzy,
+                ExplicitFuzzy = true,
+                FuzzyMaxEdits = maxEdits,
+            };
+
+            trimmed = withoutFuzzy;
+        }
+
+        if (trimmed.Length == 0)
+        {
+            return descriptor;
+        }
+
+        var hasQuestion = trimmed.IndexOf('?', StringComparison.Ordinal) >= 0;
+        var firstAsterisk = trimmed.IndexOf('*', StringComparison.Ordinal);
+        if (firstAsterisk >= 0)
+        {
+            var lastAsterisk = trimmed.LastIndexOf('*');
+            var trailingOnly = firstAsterisk == lastAsterisk && lastAsterisk == trimmed.Length - 1;
+            if (trailingOnly && !hasQuestion)
+            {
+                descriptor = descriptor with
+                {
+                    Sanitized = trimmed[..^1],
+                    Classification = QueryTokenType.Prefix,
+                    ExplicitFuzzy = false,
+                    FuzzyMaxEdits = null,
+                };
+            }
+            else
+            {
+                descriptor = descriptor with
+                {
+                    Sanitized = trimmed,
+                    Classification = QueryTokenType.Wildcard,
+                    ExplicitFuzzy = false,
+                    FuzzyMaxEdits = null,
+                };
             }
 
-            currentAnd.Clear();
+            return descriptor;
         }
+
+        if (hasQuestion)
+        {
+            descriptor = descriptor with
+            {
+                Sanitized = trimmed,
+                Classification = QueryTokenType.Wildcard,
+                ExplicitFuzzy = false,
+                FuzzyMaxEdits = null,
+            };
+        }
+
+        return descriptor;
+    }
+
+    private QueryNode? CreatePrefixNode(TokenDescriptor descriptor, string? field)
+    {
+        if (string.IsNullOrWhiteSpace(descriptor.Sanitized))
+        {
+            return null;
+        }
+
+        var normalized = NormalizeSingleToken(descriptor.Sanitized);
+        if (string.IsNullOrWhiteSpace(normalized))
+        {
+            return null;
+        }
+
+        var escaped = TextNormalization.EscapeMatchToken(normalized);
+        if (string.IsNullOrWhiteSpace(escaped))
+        {
+            return null;
+        }
+
+        return new TokenNode(field, escaped + '*', QueryTokenType.Prefix);
+    }
+
+    private QueryNode? CreateWildcardNode(TokenDescriptor descriptor, string? field)
+    {
+        if (string.IsNullOrWhiteSpace(descriptor.Sanitized))
+        {
+            return null;
+        }
+
+        var normalized = NormalizeWildcardToken(descriptor.Sanitized);
+        if (string.IsNullOrWhiteSpace(normalized))
+        {
+            return null;
+        }
+
+        var escaped = TextNormalization.EscapeMatchToken(normalized);
+        if (string.IsNullOrWhiteSpace(escaped))
+        {
+            return null;
+        }
+
+        return new TokenNode(field, escaped, QueryTokenType.Wildcard);
+    }
+
+    private string NormalizeSingleToken(string token)
+    {
+        var tokens = TextNormalization.Tokenize(token, _analyzerFactory)
+            .Where(static part => !string.IsNullOrWhiteSpace(part))
+            .ToArray();
+
+        if (tokens.Length == 0)
+        {
+            return string.Empty;
+        }
+
+        return tokens.Length == 1 ? tokens[0] : string.Join(' ', tokens);
+    }
+
+    private string NormalizeWildcardToken(string token)
+    {
+        var builder = new StringBuilder(token.Length);
+        var segment = new StringBuilder();
+
+        foreach (var ch in token)
+        {
+            if (ch is '*' or '?')
+            {
+                AppendSegment();
+                builder.Append(ch);
+            }
+            else
+            {
+                segment.Append(ch);
+            }
+        }
+
+        AppendSegment();
+        return builder.ToString();
+
+        void AppendSegment()
+        {
+            if (segment.Length == 0)
+            {
+                return;
+            }
+
+            var normalized = NormalizeWildcardSegment(segment.ToString());
+            if (!string.IsNullOrWhiteSpace(normalized))
+            {
+                builder.Append(normalized);
+            }
+
+            segment.Clear();
+        }
+    }
+
+    private string NormalizeWildcardSegment(string segment)
+    {
+        var tokens = TextNormalization.Tokenize(segment, _analyzerFactory)
+            .Where(static part => !string.IsNullOrWhiteSpace(part))
+            .ToArray();
+
+        if (tokens.Length == 0)
+        {
+            return string.Empty;
+        }
+
+        return string.Concat(tokens);
+    }
+
+    private static bool TryExtractField(string rawToken, out string fieldName, out string remainder)
+    {
+        fieldName = string.Empty;
+        remainder = string.Empty;
+
+        var separatorIndex = rawToken.IndexOf(':');
+        if (separatorIndex <= 0)
+        {
+            return false;
+        }
+
+        var candidate = rawToken[..separatorIndex];
+        if (!FieldQualifiers.Contains(candidate))
+        {
+            return false;
+        }
+
+        fieldName = candidate.ToLowerInvariant();
+        remainder = separatorIndex + 1 < rawToken.Length ? rawToken[(separatorIndex + 1)..] : string.Empty;
+        return true;
+    }
+
+    private static bool TryStripExplicitFuzzy(string token, out string withoutSuffix, out int? maxEdits)
+    {
+        withoutSuffix = token;
+        maxEdits = null;
+
+        if (string.IsNullOrWhiteSpace(token))
+        {
+            return false;
+        }
+
+        if (token.EndsWith('~'))
+        {
+            withoutSuffix = token[..^1];
+            maxEdits = 1;
+            return true;
+        }
+
+        if (token.Length > 2 && token[^2] == '~')
+        {
+            var last = token[^1];
+            if (last is '1' or '2')
+            {
+                withoutSuffix = token[..^2];
+                maxEdits = last - '0';
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static int GetPrecedence(ParseTokenType type)
+        => type switch
+        {
+            ParseTokenType.Not => 3,
+            ParseTokenType.And => 2,
+            ParseTokenType.Or => 1,
+            _ => 0,
+        };
+
+    private bool ShouldApplyHeuristicFuzzy(string token)
+    {
+        if (string.IsNullOrWhiteSpace(token) || token.Length < 5)
+        {
+            return false;
+        }
+
+        var lower = token.ToLowerInvariant();
+        return HasRepeatedCharacter(lower) || HasRepeatedBigram(lower) || HasAdjacentSwap(lower);
+    }
+
+    private static bool HasRepeatedCharacter(string text)
+    {
+        for (var index = 1; index < text.Length; index++)
+        {
+            if (text[index] == text[index - 1])
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool HasRepeatedBigram(string text)
+    {
+        if (text.Length < 4)
+        {
+            return false;
+        }
+
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        for (var index = 0; index < text.Length - 1; index++)
+        {
+            var bigram = text.Substring(index, 2);
+            if (!seen.Add(bigram))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool HasAdjacentSwap(string text)
+    {
+        for (var index = 0; index < text.Length - 3; index++)
+        {
+            if (text[index] == text[index + 3] && text[index + 1] == text[index + 2])
+            {
+                return true;
+            }
+        }
+
+        for (var index = 0; index < text.Length - 2; index++)
+        {
+            if (text[index] == text[index + 2] && text[index] != text[index + 1])
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private static bool IsReservedWord(string token)
@@ -334,39 +781,74 @@ public sealed class SearchFilesHandler : IRequestHandler<SearchFilesQuery, IRead
         "near",
     };
 
+    private static readonly HashSet<string> FieldQualifiers = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "title",
+        "author",
+        "mime",
+        "metadata_text",
+    };
+
     private enum LexTokenType
     {
         Word,
         Phrase,
         Operator,
+        Field,
+        OpenParen,
+        CloseParen,
     }
 
-    private enum SyntaxTokenType
+    private enum ParseTokenType
     {
         Node,
         And,
         Or,
         Not,
+        OpenParen,
+        CloseParen,
     }
 
-    private readonly record struct LexToken(LexTokenType Type, string Value, SyntaxTokenType OperatorKind)
+    private readonly record struct LexToken(LexTokenType Type, string Value, ParseTokenType OperatorKind)
     {
         public static LexToken Word(string value)
-            => new(LexTokenType.Word, value, SyntaxTokenType.Node);
+            => new(LexTokenType.Word, value, ParseTokenType.Node);
 
         public static LexToken Phrase(string value)
-            => new(LexTokenType.Phrase, value, SyntaxTokenType.Node);
+            => new(LexTokenType.Phrase, value, ParseTokenType.Node);
 
-        public static LexToken Operator(SyntaxTokenType op)
+        public static LexToken Field(string value)
+            => new(LexTokenType.Field, value, ParseTokenType.Node);
+
+        public static LexToken Operator(ParseTokenType op)
             => new(LexTokenType.Operator, string.Empty, op);
+
+        public static LexToken OpenParen()
+            => new(LexTokenType.OpenParen, string.Empty, ParseTokenType.OpenParen);
+
+        public static LexToken CloseParen()
+            => new(LexTokenType.CloseParen, string.Empty, ParseTokenType.CloseParen);
     }
 
-    private readonly record struct SyntaxToken(SyntaxTokenType Type, QueryNode? NodeValue)
+    private readonly record struct ParseToken(ParseTokenType Type, QueryNode? NodeValue)
     {
-        public static SyntaxToken Node(QueryNode node)
-            => new(SyntaxTokenType.Node, node);
+        public static ParseToken Node(QueryNode node)
+            => new(ParseTokenType.Node, node);
 
-        public static SyntaxToken Operator(SyntaxTokenType op)
+        public static ParseToken Operator(ParseTokenType op)
             => new(op, null);
+
+        public static ParseToken OpenParen()
+            => new(ParseTokenType.OpenParen, null);
+
+        public static ParseToken CloseParen()
+            => new(ParseTokenType.CloseParen, null);
     }
+
+    private readonly record struct TokenDescriptor(
+        string Original,
+        string Sanitized,
+        QueryTokenType Classification,
+        bool ExplicitFuzzy,
+        int? FuzzyMaxEdits);
 }


### PR DESCRIPTION
## Summary
- extend the query node model to capture wildcard and fuzzy metadata
- add configurable parser options alongside the existing search options
- overhaul the search files handler lexing and boolean parsing to support fields, parentheses, prefixes, wildcards, and fuzzy detection

## Testing
- dotnet build *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dc23d79c988326bd82e9dd1b866c67