### PR TITLE
Extend trigram planning for search queries

### DIFF
--- a/Veriado.Application/Search/QueryNode.cs
+++ b/Veriado.Application/Search/QueryNode.cs
@@ -20,7 +20,8 @@ public sealed record TokenNode(
     string Value,
     QueryTokenType TokenType,
     string? TrigramExpression = null,
-    bool RequiresAllTrigramTerms = false) : QueryNode;
+    bool RequiresAllTrigramTerms = false,
+    bool IsExplicitFuzzy = false) : QueryNode;
 
 /// <summary>
 /// Represents a boolean combination of nodes.

--- a/Veriado.Application/Search/SearchQueryPlan.cs
+++ b/Veriado.Application/Search/SearchQueryPlan.cs
@@ -13,6 +13,10 @@ using Microsoft.Data.Sqlite;
 /// <param name="RequiresTrigramFallback">Indicates whether the query needs trigram evaluation.</param>
 /// <param name="TrigramExpression">The optional trigram query expression.</param>
 /// <param name="RawQueryText">The user supplied raw text for diagnostics.</param>
+/// <param name="RequiresTrigramForWildcard">Indicates whether wildcard clauses require trigram evaluation.</param>
+/// <param name="HasPrefix">Indicates whether the plan contains prefix terms.</param>
+/// <param name="HasExplicitFuzzy">Indicates whether the query explicitly requested fuzzy matching.</param>
+/// <param name="HasHeuristicFuzzy">Indicates whether fuzzy matching was applied heuristically.</param>
 public sealed record SearchQueryPlan(
     string MatchExpression,
     IReadOnlyList<string> WhereClauses,
@@ -20,7 +24,11 @@ public sealed record SearchQueryPlan(
     SearchScorePlan ScorePlan,
     bool RequiresTrigramFallback,
     string? TrigramExpression,
-    string? RawQueryText = null);
+    string? RawQueryText = null,
+    bool RequiresTrigramForWildcard = false,
+    bool HasPrefix = false,
+    bool HasExplicitFuzzy = false,
+    bool HasHeuristicFuzzy = false);
 
 /// <summary>
 /// Provides factory helpers for creating simple search plans.
@@ -40,7 +48,11 @@ public static class SearchQueryPlanFactory
             new SearchScorePlan(),
             false,
             null,
-            rawQueryText ?? matchExpression);
+            rawQueryText ?? matchExpression,
+            false,
+            false,
+            false,
+            false);
     }
 
     /// <summary>
@@ -56,7 +68,11 @@ public static class SearchQueryPlanFactory
             new SearchScorePlan(),
             true,
             trigramExpression,
-            rawQueryText ?? trigramExpression);
+            rawQueryText ?? trigramExpression,
+            false,
+            false,
+            false,
+            false);
     }
 }
 

--- a/Veriado.Infrastructure/Search/TrigramQueryService.cs
+++ b/Veriado.Infrastructure/Search/TrigramQueryService.cs
@@ -55,21 +55,36 @@ internal sealed class TrigramQueryService
             return Array.Empty<(Guid, double)>();
         }
 
-        var trigramSource = !string.IsNullOrWhiteSpace(plan.TrigramExpression)
-            ? plan.TrigramExpression
-            : plan.MatchExpression;
-        if (string.IsNullOrWhiteSpace(trigramSource))
+        string trigramQuery;
+        string tokenSource;
+
+        if (!string.IsNullOrWhiteSpace(plan.TrigramExpression))
+        {
+            trigramQuery = plan.TrigramExpression!;
+            tokenSource = plan.RawQueryText ?? plan.TrigramExpression!;
+        }
+        else
+        {
+            if (string.IsNullOrWhiteSpace(plan.MatchExpression))
+            {
+                return Array.Empty<(Guid, double)>();
+            }
+
+            var normalizedQuery = NormalizeForTrigram(plan.MatchExpression);
+            if (!TrigramQueryBuilder.TryBuild(normalizedQuery, requireAllTerms: false, out trigramQuery))
+            {
+                return Array.Empty<(Guid, double)>();
+            }
+
+            tokenSource = plan.RawQueryText ?? normalizedQuery;
+        }
+
+        if (string.IsNullOrWhiteSpace(trigramQuery))
         {
             return Array.Empty<(Guid, double)>();
         }
 
-        var normalizedQuery = NormalizeForTrigram(trigramSource);
-        if (!TrigramQueryBuilder.TryBuild(normalizedQuery, requireAllTerms: false, out var trigramQuery))
-        {
-            return Array.Empty<(Guid, double)>();
-        }
-
-        var queryTokens = BuildTokenSet(plan.RawQueryText ?? normalizedQuery);
+        var queryTokens = BuildTokenSet(tokenSource);
         if (queryTokens.Count == 0)
         {
             return Array.Empty<(Guid, double)>();
@@ -152,21 +167,36 @@ internal sealed class TrigramQueryService
             return Array.Empty<SearchHit>();
         }
 
-        var trigramQuery = !string.IsNullOrWhiteSpace(plan.TrigramExpression)
-            ? plan.TrigramExpression
-            : plan.MatchExpression;
-        if (string.IsNullOrWhiteSpace(trigramQuery))
+        string matchQuery;
+        string tokenSource;
+
+        if (!string.IsNullOrWhiteSpace(plan.TrigramExpression))
+        {
+            matchQuery = plan.TrigramExpression!;
+            tokenSource = plan.RawQueryText ?? plan.TrigramExpression!;
+        }
+        else
+        {
+            if (string.IsNullOrWhiteSpace(plan.MatchExpression))
+            {
+                return Array.Empty<SearchHit>();
+            }
+
+            var normalizedQuery = NormalizeForTrigram(plan.MatchExpression);
+            if (!TrigramQueryBuilder.TryBuild(normalizedQuery, requireAllTerms: false, out matchQuery))
+            {
+                return Array.Empty<SearchHit>();
+            }
+
+            tokenSource = plan.RawQueryText ?? normalizedQuery;
+        }
+
+        if (string.IsNullOrWhiteSpace(matchQuery))
         {
             return Array.Empty<SearchHit>();
         }
 
-        var normalizedQuery = NormalizeForTrigram(trigramQuery);
-        if (!TrigramQueryBuilder.TryBuild(normalizedQuery, requireAllTerms: false, out var matchQuery))
-        {
-            return Array.Empty<SearchHit>();
-        }
-
-        var queryTokens = BuildTokenSet(plan.RawQueryText ?? trigramQuery);
+        var queryTokens = BuildTokenSet(tokenSource);
         if (queryTokens.Count == 0)
         {
             return Array.Empty<SearchHit>();


### PR DESCRIPTION
## Summary
- extend `SearchQueryBuilder` to derive trigram expressions for prefix/proximity tokens and capture plan flags for fuzzy handling
- add new plan flag fields to `SearchQueryPlan` so downstream services can reason about prefixes, wildcards, and fuzzy modes
- update `TrigramQueryService` to honour builder-supplied trigram expressions instead of rebuilding queries internally

## Testing
- Not run (dotnet CLI not available in environment)


------
https://chatgpt.com/codex/tasks/task_e_68dc27844ad88326a0243ce4e2b92d3d