### PR TITLE
Extend search builder with trigram artifacts

### DIFF
--- a/Veriado.Application/Search/SearchQueryPlan.cs
+++ b/Veriado.Application/Search/SearchQueryPlan.cs
@@ -13,6 +13,10 @@ using Microsoft.Data.Sqlite;
 /// <param name="RequiresTrigramFallback">Indicates whether the query needs trigram evaluation.</param>
 /// <param name="TrigramExpression">The optional trigram query expression.</param>
 /// <param name="RawQueryText">The user supplied raw text for diagnostics.</param>
+/// <param name="RequiresTrigramForWildcard">Indicates whether wildcard terms require trigram evaluation.</param>
+/// <param name="HasPrefix">Indicates whether the query contains prefix tokens.</param>
+/// <param name="HasExplicitFuzzy">Indicates whether the query contains explicit fuzzy tokens.</param>
+/// <param name="HasHeuristicFuzzy">Indicates whether the query contains heuristic fuzzy tokens.</param>
 public sealed record SearchQueryPlan(
     string MatchExpression,
     IReadOnlyList<string> WhereClauses,
@@ -20,7 +24,11 @@ public sealed record SearchQueryPlan(
     SearchScorePlan ScorePlan,
     bool RequiresTrigramFallback,
     string? TrigramExpression,
-    string? RawQueryText = null);
+    string? RawQueryText = null,
+    bool RequiresTrigramForWildcard = false,
+    bool HasPrefix = false,
+    bool HasExplicitFuzzy = false,
+    bool HasHeuristicFuzzy = false);
 
 /// <summary>
 /// Provides factory helpers for creating simple search plans.
@@ -40,7 +48,11 @@ public static class SearchQueryPlanFactory
             new SearchScorePlan(),
             false,
             null,
-            rawQueryText ?? matchExpression);
+            rawQueryText ?? matchExpression,
+            false,
+            false,
+            false,
+            false);
     }
 
     /// <summary>
@@ -56,7 +68,11 @@ public static class SearchQueryPlanFactory
             new SearchScorePlan(),
             true,
             trigramExpression,
-            rawQueryText ?? trigramExpression);
+            rawQueryText ?? trigramExpression,
+            false,
+            false,
+            false,
+            false);
     }
 }
 


### PR DESCRIPTION
## Summary
- extend `SearchQueryBuilder` to derive trigram expressions, wildcard requirements, and fuzzy/prefix flags from the AST
- add new plan metadata fields and let `TrigramQueryService` consume builder-provided trigram expressions when available

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68dc2bae018c8326984237ee44b154b8