### PR TITLE
Add automatic trigram fallback policy to hybrid search

### DIFF
--- a/Veriado.Application/Search/SearchParseOptions.cs
+++ b/Veriado.Application/Search/SearchParseOptions.cs
@@ -9,4 +9,19 @@ public sealed class SearchParseOptions
     /// Gets or sets a value indicating whether heuristic fuzzy detection is enabled.
     /// </summary>
     public bool EnableHeuristicFuzzy { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets the minimum number of FTS hits required for prefix queries to avoid trigram fallback.
+    /// </summary>
+    public int PrefixMinResults { get; set; } = 3;
+
+    /// <summary>
+    /// Gets or sets the minimum number of FTS hits required for fuzzy queries to avoid trigram fallback.
+    /// </summary>
+    public int FuzzyMinResults { get; set; } = 5;
+
+    /// <summary>
+    /// Gets or sets the minimum top normalized score required for fuzzy queries to avoid trigram fallback.
+    /// </summary>
+    public double FuzzyScoreThreshold { get; set; } = 0.45d;
 }

--- a/Veriado.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/Veriado.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
@@ -105,6 +105,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton(sp => sp.GetRequiredService<IOptions<SearchOptions>>().Value);
         services.AddSingleton(sp => sp.GetRequiredService<SearchOptions>().Analyzer);
         services.AddSingleton(sp => sp.GetRequiredService<SearchOptions>().Score);
+        services.AddSingleton(sp => sp.GetRequiredService<SearchOptions>().Parse);
         services.AddSingleton(sp => sp.GetRequiredService<SearchOptions>().Trigram);
         services.AddSingleton(sp => sp.GetRequiredService<SearchOptions>().Facets);
         services.AddSingleton(sp => sp.GetRequiredService<SearchOptions>().Synonyms);
@@ -112,6 +113,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton(sp => sp.GetRequiredService<SearchOptions>().Spell);
         services.AddSingleton<IOptions<AnalyzerOptions>>(sp => Options.Create(sp.GetRequiredService<SearchOptions>().Analyzer));
         services.AddSingleton<IOptions<SearchScoreOptions>>(sp => Options.Create(sp.GetRequiredService<SearchOptions>().Score));
+        services.AddSingleton<IOptions<SearchParseOptions>>(sp => Options.Create(sp.GetRequiredService<SearchOptions>().Parse));
         services.AddSingleton<IOptions<TrigramIndexOptions>>(sp => Options.Create(sp.GetRequiredService<SearchOptions>().Trigram));
 
         services.AddSingleton<IAnalyzerFactory, AnalyzerFactory>();


### PR DESCRIPTION
## Summary
- extend search parse options with configurable trigram fallback thresholds
- capture FTS diagnostic metadata and evaluate automatic trigram fallback rules in the hybrid search service

## Testing
- dotnet build *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dc2e71123c832690a2af8702a7c877