### PR TITLE
Reset pooled SQLite connections during full-text repairs

### DIFF
--- a/Veriado.Infrastructure/Integrity/FulltextIntegrityService.cs
+++ b/Veriado.Infrastructure/Integrity/FulltextIntegrityService.cs
@@ -13,6 +13,7 @@ internal sealed class FulltextIntegrityService : IFulltextIntegrityService
     private readonly IDbContextFactory<ReadOnlyDbContext> _readFactory;
     private readonly IDbContextFactory<AppDbContext> _writeFactory;
     private readonly ISearchIndexer _searchIndexer;
+    private readonly ISqliteConnectionFactory _connectionFactory;
     private readonly InfrastructureOptions _options;
     private readonly ILogger<FulltextIntegrityService> _logger;
     private readonly IClock _clock;
@@ -21,6 +22,7 @@ internal sealed class FulltextIntegrityService : IFulltextIntegrityService
         IDbContextFactory<ReadOnlyDbContext> readFactory,
         IDbContextFactory<AppDbContext> writeFactory,
         ISearchIndexer searchIndexer,
+        ISqliteConnectionFactory connectionFactory,
         InfrastructureOptions options,
         ILogger<FulltextIntegrityService> logger,
         IClock clock)
@@ -28,6 +30,7 @@ internal sealed class FulltextIntegrityService : IFulltextIntegrityService
         _readFactory = readFactory;
         _writeFactory = writeFactory;
         _searchIndexer = searchIndexer;
+        _connectionFactory = connectionFactory;
         _options = options;
         _logger = logger;
         _clock = clock;
@@ -159,6 +162,7 @@ internal sealed class FulltextIntegrityService : IFulltextIntegrityService
             // Ensure we are working with a clean connection pool before we attempt to
             // rebuild the virtual tables. Otherwise pooled connections may continue to
             // serve corrupted pages and cause the rebuild to fail.
+            await _connectionFactory.ResetAsync(cancellationToken).ConfigureAwait(false);
             SqliteConnection.ClearAllPools();
             await RecreateFulltextSchemaAsync(cancellationToken).ConfigureAwait(false);
         }


### PR DESCRIPTION
## Summary
- add a reset hook to the pooled SQLite connection factory so stale connections are disposed when corruption is detected
- ensure the full-text repair routine clears pooled connections before recreating the FTS schema

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68dc3cfe72d883268279271124aee1ff