### PR TITLE
Add analyzer signature tracking and reindex evaluation

### DIFF
--- a/Veriado.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/Veriado.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
@@ -150,6 +150,8 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<ISearchSuggestionService, SuggestionService>();
         services.AddSingleton<ISpellSuggestionService, SpellSuggestionService>();
         services.AddSingleton<IFulltextIntegrityService, FulltextIntegrityService>();
+        services.AddSingleton<ISearchIndexSignatureCalculator, SearchIndexSignatureCalculator>();
+        services.AddSingleton<INeedsReindexEvaluator, NeedsReindexEvaluator>();
         services.AddSingleton<IEventPublisher, AuditEventPublisher>();
         services.AddSingleton<IIdempotencyStore, SqliteIdempotencyStore>();
 

--- a/Veriado.Infrastructure/Migrations/20251001045018_Add_SearchIndexState_AnalyzerSignature.Designer.cs
+++ b/Veriado.Infrastructure/Migrations/20251001045018_Add_SearchIndexState_AnalyzerSignature.Designer.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Veriado.Infrastructure.Persistence;
 
@@ -10,9 +11,11 @@ using Veriado.Infrastructure.Persistence;
 namespace Veriado.Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20251001045018_Add_SearchIndexState_AnalyzerSignature")]
+    partial class Add_SearchIndexState_AnalyzerSignature
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "9.0.9");

--- a/Veriado.Infrastructure/Migrations/20251001045018_Add_SearchIndexState_AnalyzerSignature.cs
+++ b/Veriado.Infrastructure/Migrations/20251001045018_Add_SearchIndexState_AnalyzerSignature.cs
@@ -1,0 +1,41 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Veriado.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class Add_SearchIndexState_AnalyzerSignature : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "fts_analyzer_version",
+                table: "files",
+                type: "TEXT",
+                maxLength: 32,
+                nullable: false,
+                defaultValue: "v1");
+
+            migrationBuilder.AddColumn<string>(
+                name: "fts_token_hash",
+                table: "files",
+                type: "TEXT",
+                maxLength: 64,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "fts_analyzer_version",
+                table: "files");
+
+            migrationBuilder.DropColumn(
+                name: "fts_token_hash",
+                table: "files");
+        }
+    }
+}

--- a/Veriado.Infrastructure/Persistence/Configurations/FileEntityConfiguration.cs
+++ b/Veriado.Infrastructure/Persistence/Configurations/FileEntityConfiguration.cs
@@ -107,6 +107,16 @@ internal sealed class FileEntityConfiguration : IEntityTypeConfiguration<FileEnt
             owned.Property(index => index.IndexedTitle)
                 .HasColumnName("fts_indexed_title")
                 .HasMaxLength(300);
+
+            owned.Property(index => index.AnalyzerVersion)
+                .HasColumnName("fts_analyzer_version")
+                .HasMaxLength(32)
+                .HasDefaultValue(SearchIndexState.DefaultAnalyzerVersion)
+                .IsRequired();
+
+            owned.Property(index => index.TokenHash)
+                .HasColumnName("fts_token_hash")
+                .HasMaxLength(64);
         });
 
         builder.ComplexProperty(file => file.SystemMetadata, complex =>

--- a/Veriado.Infrastructure/Search/INeedsReindexEvaluator.cs
+++ b/Veriado.Infrastructure/Search/INeedsReindexEvaluator.cs
@@ -1,0 +1,6 @@
+namespace Veriado.Infrastructure.Search;
+
+public interface INeedsReindexEvaluator
+{
+    Task<bool> NeedsReindexAsync(FileEntity file, SearchIndexState state, CancellationToken ct);
+}

--- a/Veriado.Infrastructure/Search/ISearchIndexSignatureCalculator.cs
+++ b/Veriado.Infrastructure/Search/ISearchIndexSignatureCalculator.cs
@@ -1,0 +1,6 @@
+namespace Veriado.Infrastructure.Search;
+
+public interface ISearchIndexSignatureCalculator
+{
+    SearchIndexSignature Compute(FileEntity file);
+}

--- a/Veriado.Infrastructure/Search/NeedsReindexEvaluator.cs
+++ b/Veriado.Infrastructure/Search/NeedsReindexEvaluator.cs
@@ -1,0 +1,31 @@
+namespace Veriado.Infrastructure.Search;
+
+public sealed class NeedsReindexEvaluator : INeedsReindexEvaluator
+{
+    private readonly ISearchIndexSignatureCalculator _signatureCalculator;
+
+    public NeedsReindexEvaluator(ISearchIndexSignatureCalculator signatureCalculator)
+    {
+        _signatureCalculator = signatureCalculator ?? throw new ArgumentNullException(nameof(signatureCalculator));
+    }
+
+    public Task<bool> NeedsReindexAsync(FileEntity file, SearchIndexState state, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(file);
+        ArgumentNullException.ThrowIfNull(state);
+        ct.ThrowIfCancellationRequested();
+
+        var signature = _signatureCalculator.Compute(file);
+        var normalizedTitle = signature.NormalizedTitle;
+        var analyzerVersion = signature.AnalyzerVersion;
+        var tokenHash = signature.TokenHash;
+        var contentHash = file.Content.Hash.Value;
+
+        var needsReindex = !string.Equals(state.IndexedContentHash, contentHash, StringComparison.Ordinal)
+            || !string.Equals(state.IndexedTitle, normalizedTitle, StringComparison.Ordinal)
+            || !string.Equals(state.AnalyzerVersion, analyzerVersion, StringComparison.Ordinal)
+            || !string.Equals(state.TokenHash, tokenHash, StringComparison.Ordinal);
+
+        return Task.FromResult(needsReindex);
+    }
+}

--- a/Veriado.Infrastructure/Search/SearchIndexSignatureCalculator.cs
+++ b/Veriado.Infrastructure/Search/SearchIndexSignatureCalculator.cs
@@ -1,0 +1,88 @@
+using System.Security.Cryptography;
+using System.Text;
+using Veriado.Appl.Search;
+
+namespace Veriado.Infrastructure.Search;
+
+internal sealed class SearchIndexSignatureCalculator : ISearchIndexSignatureCalculator
+{
+    private readonly IAnalyzerFactory _analyzerFactory;
+    private readonly TrigramIndexOptions _trigramOptions;
+
+    public SearchIndexSignatureCalculator(IAnalyzerFactory analyzerFactory, TrigramIndexOptions trigramOptions)
+    {
+        _analyzerFactory = analyzerFactory ?? throw new ArgumentNullException(nameof(analyzerFactory));
+        _trigramOptions = trigramOptions ?? throw new ArgumentNullException(nameof(trigramOptions));
+    }
+
+    public SearchIndexSignature Compute(FileEntity file)
+    {
+        ArgumentNullException.ThrowIfNull(file);
+
+        var analyzer = _analyzerFactory.Create();
+        var tokens = new List<string>();
+        var maxTokens = Math.Max(1, _trigramOptions.MaxTokens);
+        var totalTokens = 0;
+        var fields = _trigramOptions.Fields ?? Array.Empty<string>();
+        var document = file.ToSearchDocument();
+
+        foreach (var field in fields)
+        {
+            if (string.IsNullOrWhiteSpace(field))
+            {
+                continue;
+            }
+
+            var candidate = ResolveFieldValue(field, document);
+            if (string.IsNullOrWhiteSpace(candidate))
+            {
+                continue;
+            }
+
+            foreach (var token in analyzer.Tokenize(candidate))
+            {
+                if (string.IsNullOrWhiteSpace(token))
+                {
+                    continue;
+                }
+
+                tokens.Add(token);
+                totalTokens++;
+                if (totalTokens >= maxTokens)
+                {
+                    goto LimitReached;
+                }
+            }
+        }
+
+    LimitReached:
+        var tokenHash = tokens.Count == 0 ? null : ComputeHash(tokens);
+        var normalizedTitle = string.IsNullOrWhiteSpace(file.Title) ? file.Name.Value : file.Title!;
+        return new SearchIndexSignature(SearchIndexState.DefaultAnalyzerVersion, tokenHash, normalizedTitle);
+    }
+
+    private static string? ResolveFieldValue(string field, SearchDocument document)
+    {
+        return field.Trim().ToLowerInvariant() switch
+        {
+            "title" => document.Title,
+            "author" => document.Author,
+            "filename" => document.FileName,
+            "metadata_text" => document.MetadataText,
+            _ => null,
+        };
+    }
+
+    private static string ComputeHash(IReadOnlyList<string> tokens)
+    {
+        var joined = string.Join("\n", tokens);
+        using var sha = SHA256.Create();
+        var bytes = sha.ComputeHash(Encoding.UTF8.GetBytes(joined));
+        return Convert.ToHexString(bytes).ToLowerInvariant();
+    }
+}
+
+public readonly record struct SearchIndexSignature(
+    string AnalyzerVersion,
+    string? TokenHash,
+    string NormalizedTitle);


### PR DESCRIPTION
## Summary
- extend the search index state with analyzer version and token hash fields and persist them through a new migration
- add a reusable search index signature calculator and a NeedsReindexEvaluator service wired into dependency injection
- update WriteWorker, outbox draining, and integrity flows to recompute signatures, flag stale entries, and store analyzer metadata when confirming indexing

## Testing
- dotnet build Veriado.Services/Veriado.Services.csproj
- dotnet test Veriado.Application.Tests/Veriado.Application.Tests.csproj *(fails: package downgrade to Microsoft.Data.Sqlite 8.0.6)*
- dotnet test Veriado.sln *(fails: solution nesting references missing project entry)*

------
https://chatgpt.com/codex/tasks/task_e_68dcafd564a88326af2d35e34661f031