### PR TITLE
Fix null returns for disabled FTS support

### DIFF
--- a/Veriado.Infrastructure/Search/SqliteFts5Transactional.cs
+++ b/Veriado.Infrastructure/Search/SqliteFts5Transactional.cs
@@ -37,7 +37,7 @@ internal sealed class SqliteFts5Transactional
             ArgumentNullException.ThrowIfNull(document);
             if (!SqliteFulltextSupport.IsAvailable)
             {
-                return;
+                return null;
             }
             var normalizedTitle = NormalizeOptional(document.Title);
             var normalizedAuthor = NormalizeOptional(document.Author);
@@ -134,7 +134,7 @@ internal sealed class SqliteFts5Transactional
             ArgumentNullException.ThrowIfNull(transaction);
             if (!SqliteFulltextSupport.IsAvailable)
             {
-                return;
+                return null;
             }
             var fileKey = fileId.ToByteArray();
             var journalTransaction = enlistJournal ? transaction : null;


### PR DESCRIPTION
## Summary
- ensure the transactional helper returns null when FTS is unavailable for both index and delete operations

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dcbfa76dec83268975b3ea3b52709a