### PR TITLE
Improve import logging and status display

### DIFF
--- a/Veriado.WinUI/Views/Import/ImportPage.xaml
+++ b/Veriado.WinUI/Views/Import/ImportPage.xaml
@@ -103,24 +103,10 @@
             <muxc:InfoBar
                 Margin="0,8,0,0"
                 IsClosable="True"
-                IsOpen="{Binding IsActiveStatusVisible, Mode=TwoWay}"
-                Severity="{Binding ActiveStatusSeverity}"
-                Title="{Binding ActiveStatusTitle}"
-                Message="{Binding ActiveStatusMessage}">
-                <muxc:InfoBar.Transitions>
-                    <TransitionCollection>
-                        <animations:EntranceThemeTransition />
-                    </TransitionCollection>
-                </muxc:InfoBar.Transitions>
-            </muxc:InfoBar>
-
-            <muxc:InfoBar
-                Margin="0,4,0,0"
-                IsClosable="True"
-                IsOpen="{Binding IsDynamicStatusVisible, Mode=TwoWay}"
-                Severity="{Binding DynamicStatusSeverity}"
-                Title="{Binding DynamicStatusTitle}"
-                Message="{Binding DynamicStatusMessage}">
+                IsOpen="{Binding IsStatusVisible, Mode=TwoWay}"
+                Severity="{Binding StatusSeverity}"
+                Title="{Binding StatusTitle}"
+                Message="{Binding StatusMessage}">
                 <muxc:InfoBar.Transitions>
                     <TransitionCollection>
                         <animations:EntranceThemeTransition />


### PR DESCRIPTION
## Summary
- log the reason when files are skipped or fail during import so it appears in the activity log
- include failure reasons when displaying errors returned from the batch import API
- consolidate the Import page status indicators into a single InfoBar backed by shared view model state

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ddf0cfda8483269c5f40100d195188