### PR TITLE
Refine import result accounting and messaging

### DIFF
--- a/Veriado.Contracts/Import/ImportAggregateResult.cs
+++ b/Veriado.Contracts/Import/ImportAggregateResult.cs
@@ -4,20 +4,24 @@ namespace Veriado.Contracts.Import;
 /// Represents the aggregated outcome of a streaming import batch.
 /// </summary>
 /// <param name="Status">The resulting status of the batch.</param>
-/// <param name="Total">The total number of processed files.</param>
+/// <param name="Total">The total number of files discovered in the batch.</param>
+/// <param name="Processed">The number of files that were actually processed.</param>
 /// <param name="Succeeded">The number of successfully imported files.</param>
 /// <param name="Failed">The number of files that failed to import.</param>
+/// <param name="Skipped">The number of files that were intentionally skipped.</param>
 /// <param name="Errors">The collection of captured errors.</param>
 public sealed record class ImportAggregateResult(
     ImportBatchStatus Status,
     int Total,
+    int Processed,
     int Succeeded,
     int Failed,
+    int Skipped,
     IReadOnlyList<ImportError> Errors)
 {
     /// <summary>
     /// Gets an empty success result.
     /// </summary>
     public static ImportAggregateResult EmptySuccess { get; }
-        = new(ImportBatchStatus.Success, 0, 0, 0, Array.Empty<ImportError>());
+        = new(ImportBatchStatus.Success, 0, 0, 0, 0, 0, Array.Empty<ImportError>());
 }

--- a/Veriado.Contracts/Import/ImportBatchResult.cs
+++ b/Veriado.Contracts/Import/ImportBatchResult.cs
@@ -4,13 +4,17 @@ namespace Veriado.Contracts.Import;
 /// Represents the aggregated outcome of a folder import operation.
 /// </summary>
 /// <param name="Status">The resulting status of the batch import.</param>
-/// <param name="Total">The total number of processed files.</param>
+/// <param name="Total">The total number of files discovered for import.</param>
+/// <param name="Processed">The number of files that were actually processed.</param>
 /// <param name="Succeeded">The number of files imported successfully.</param>
 /// <param name="Failed">The number of files that failed to import.</param>
+/// <param name="Skipped">The number of files that were intentionally skipped.</param>
 /// <param name="Errors">The collection of import errors captured during processing.</param>
 public sealed record ImportBatchResult(
     ImportBatchStatus Status,
     int Total,
+    int Processed,
     int Succeeded,
     int Failed,
+    int Skipped,
     IReadOnlyList<ImportError> Errors);


### PR DESCRIPTION
## Summary
- capture processed and skipped file counts across import results and progress events
- adjust import service status calculation and emitted progress messages to include skip metrics
- refresh WinUI import page summaries and logs to display the richer counts and improved wording

## Testing
- Not run (environment missing dotnet CLI)

------
https://chatgpt.com/codex/tasks/task_e_68ddfbb7590083269203eadd3ca6e962