### PR TITLE
Improve import import log clarity and pending metrics

### DIFF
--- a/Veriado.WinUI/Models/Import/ImportLogItem.cs
+++ b/Veriado.WinUI/Models/Import/ImportLogItem.cs
@@ -25,5 +25,21 @@ public sealed class ImportLogItem
 
     public string FormattedTimestamp => Timestamp.ToString("HH:mm:ss", CultureInfo.CurrentCulture);
 
+    public string StatusDisplay
+    {
+        get
+        {
+            var status = string.IsNullOrWhiteSpace(Status) ? "info" : Status;
+            return status.ToLowerInvariant() switch
+            {
+                "success" => "Úspěch",
+                "warning" => "Varování",
+                "error" => "Chyba",
+                "info" => "Informace",
+                _ => CultureInfo.CurrentCulture.TextInfo.ToTitleCase(status),
+            };
+        }
+    }
+
     public bool HasDetail => !string.IsNullOrWhiteSpace(Detail);
 }

--- a/Veriado.WinUI/ViewModels/Import/ImportPageViewModel.cs
+++ b/Veriado.WinUI/ViewModels/Import/ImportPageViewModel.cs
@@ -188,6 +188,7 @@ public partial class ImportPageViewModel : ViewModelBase
             if (SetProperty(ref _okCount, value))
             {
                 OnPropertyChanged(nameof(ProgressText));
+                OnPropertyChanged(nameof(PendingCount));
                 _clearResultsCommand.NotifyCanExecuteChanged();
             }
         }
@@ -201,6 +202,7 @@ public partial class ImportPageViewModel : ViewModelBase
             if (SetProperty(ref _errorCount, value))
             {
                 OnPropertyChanged(nameof(ProgressText));
+                OnPropertyChanged(nameof(PendingCount));
                 _clearResultsCommand.NotifyCanExecuteChanged();
             }
         }
@@ -214,13 +216,16 @@ public partial class ImportPageViewModel : ViewModelBase
             if (SetProperty(ref _skipCount, value))
             {
                 OnPropertyChanged(nameof(ProgressText));
+                OnPropertyChanged(nameof(PendingCount));
                 _clearResultsCommand.NotifyCanExecuteChanged();
             }
         }
     }
 
     public string ProgressText =>
-        $"Zpracováno {Processed}/{(Total > 0 ? Total : 0)} • OK {OkCount} • Chyby {ErrorCount} • Skip {SkipCount}";
+        $"Zpracováno {Processed}/{(Total > 0 ? Total : 0)} • OK {OkCount} • Chyby {ErrorCount} • Skip {SkipCount} • Čeká {PendingCount}";
+
+    public int PendingCount => CalculatePendingCount(Total, Processed, OkCount, ErrorCount, SkipCount);
 
     public bool HasErrors => Errors.Count > 0;
 
@@ -796,17 +801,25 @@ public partial class ImportPageViewModel : ViewModelBase
             aggregate.Skipped,
             aggregate.Errors);
 
-        var skippedSummary = aggregate.Skipped > 0
-            ? $" (přeskočeno {aggregate.Skipped})"
+        var skipped = Math.Max(0, aggregate.Skipped);
+        var pending = CalculatePendingCount(aggregate.Total, aggregate.Processed, aggregate.Succeeded, aggregate.Failed, skipped);
+        var skippedSummary = skipped > 0
+            ? $" (přeskočeno {skipped})"
+            : string.Empty;
+        var pendingSummary = pending > 0
+            ? $" (čeká {pending})"
+            : string.Empty;
+        var pendingSentence = pending > 0
+            ? $" Zbývá zpracovat {pending} souborů."
             : string.Empty;
 
         var summary = aggregate.Status switch
         {
-            ImportBatchStatus.Success => $"Import dokončen. Úspěšně importováno {aggregate.Succeeded} z {aggregate.Total} souborů{skippedSummary}.",
-            ImportBatchStatus.PartialSuccess => $"Import dokončen s částečným úspěchem ({aggregate.Succeeded}/{aggregate.Total}{skippedSummary}). Zkontrolujte prosím chyby.",
-            ImportBatchStatus.Failure => "Import se nezdařil. Zkontrolujte chyby.",
-            ImportBatchStatus.FatalError => "Import byl zastaven kvůli fatální chybě. Opravte problém a zkuste to znovu.",
-            _ => "Import dokončen.",
+            ImportBatchStatus.Success => $"Import dokončen. Úspěšně importováno {aggregate.Succeeded} z {aggregate.Total} souborů{skippedSummary}{pendingSummary}.",
+            ImportBatchStatus.PartialSuccess => $"Import dokončen s částečným úspěchem ({aggregate.Succeeded}/{aggregate.Total}{skippedSummary}{pendingSummary}). Zkontrolujte prosím chyby.",
+            ImportBatchStatus.Failure => $"Import se nezdařil.{pendingSentence} Zkontrolujte chyby.",
+            ImportBatchStatus.FatalError => $"Import byl zastaven kvůli fatální chybě.{pendingSentence} Opravte problém a zkuste to znovu.",
+            _ => $"Import dokončen.{pendingSentence}",
         };
 
         var logStatus = aggregate.Status switch
@@ -930,13 +943,25 @@ public partial class ImportPageViewModel : ViewModelBase
             });
         }
 
+        var skipped = Math.Max(0, result.Skipped);
+        var pending = CalculatePendingCount(result.Total, result.Processed, result.Succeeded, result.Failed, skipped);
+        var skippedSummary = skipped > 0
+            ? $" (přeskočeno {skipped})"
+            : string.Empty;
+        var pendingSummary = pending > 0
+            ? $" (čeká {pending})"
+            : string.Empty;
+        var pendingSentence = pending > 0
+            ? $" Zbývá zpracovat {pending} souborů."
+            : string.Empty;
+
         var summary = result.Status switch
         {
-            ImportBatchStatus.Success => $"Import dokončen. Úspěšně importováno {result.Succeeded} z {result.Total} souborů.",
-            ImportBatchStatus.PartialSuccess => $"Import dokončen s částečným úspěchem ({result.Succeeded}/{result.Total}). Zkontrolujte prosím chyby.",
-            ImportBatchStatus.Failure => "Import se nezdařil. Zkontrolujte chyby.",
-            ImportBatchStatus.FatalError => "Import byl zastaven kvůli fatální chybě. Opravte problém a zkuste to znovu.",
-            _ => "Import dokončen.",
+            ImportBatchStatus.Success => $"Import dokončen. Úspěšně importováno {result.Succeeded} z {result.Total} souborů{skippedSummary}{pendingSummary}.",
+            ImportBatchStatus.PartialSuccess => $"Import dokončen s částečným úspěchem ({result.Succeeded}/{result.Total}{skippedSummary}{pendingSummary}). Zkontrolujte prosím chyby.",
+            ImportBatchStatus.Failure => $"Import se nezdařil.{pendingSentence} Zkontrolujte chyby.",
+            ImportBatchStatus.FatalError => $"Import byl zastaven kvůli fatální chybě.{pendingSentence} Opravte problém a zkuste to znovu.",
+            _ => $"Import dokončen.{pendingSentence}",
         };
 
         var logStatus = result.Status switch
@@ -1020,7 +1045,8 @@ public partial class ImportPageViewModel : ViewModelBase
             builder.AppendLine($"Zpracováno: {Processed}");
             builder.AppendLine($"Úspěšně: {OkCount}");
             builder.AppendLine($"Chyby: {ErrorCount}");
-            builder.Append($"Přeskočeno: {skipped}");
+            builder.AppendLine($"Přeskočeno: {skipped}");
+            builder.Append($"Čeká: {PendingCount}");
 
             if (ErrorCount > 0)
             {
@@ -1044,7 +1070,9 @@ public partial class ImportPageViewModel : ViewModelBase
         builder.AppendLine($"Zpracováno: {result.Processed}");
         builder.AppendLine($"Úspěšně: {result.Succeeded}");
         builder.AppendLine($"Chyby: {result.Failed}");
-        builder.Append($"Přeskočeno: {skipped}");
+        builder.AppendLine($"Přeskočeno: {skipped}");
+        var pending = CalculatePendingCount(result.Total, result.Processed, result.Succeeded, result.Failed, skipped);
+        builder.Append($"Čeká: {pending}");
 
         if (result.Errors?.Count > 0)
         {
@@ -1054,6 +1082,30 @@ public partial class ImportPageViewModel : ViewModelBase
         }
 
         return builder.ToString();
+    }
+
+    private static int CalculatePendingCount(int total, int processed, int succeeded, int failed, int skipped)
+    {
+        var normalizedProcessed = Math.Max(processed, succeeded + failed + skipped);
+        return Math.Max(0, total - normalizedProcessed);
+    }
+
+    private static string NormalizeLogStatus(string? status)
+    {
+        if (string.IsNullOrWhiteSpace(status))
+        {
+            return "info";
+        }
+
+        var trimmed = status.Trim();
+        return trimmed.ToLowerInvariant() switch
+        {
+            "success" or "ok" or "completed" => "success",
+            "warning" or "warn" or "caution" => "warning",
+            "error" or "fail" or "failure" or "fatal" => "error",
+            "info" or "information" or "status" => "info",
+            _ => trimmed.ToLowerInvariant(),
+        };
     }
 
     private async Task SetActiveStatusAsync(string title, string? message, InfoBarSeverity severity)
@@ -1123,7 +1175,16 @@ public partial class ImportPageViewModel : ViewModelBase
 
         if (progress.ProcessedFiles.HasValue && progress.TotalFiles.HasValue)
         {
-            return $"Zpracováno {progress.ProcessedFiles}/{progress.TotalFiles} souborů.";
+            var total = progress.TotalFiles.Value;
+            var processed = progress.ProcessedFiles.Value;
+            var succeeded = progress.SucceededFiles ?? processed;
+            var failed = progress.FailedFiles ?? 0;
+            var skipped = progress.SkippedFiles ?? 0;
+            var pending = CalculatePendingCount(total, processed, succeeded, failed, skipped);
+            var baseMessage = $"Zpracováno {processed}/{total} souborů.";
+            return pending > 0
+                ? $"{baseMessage} Čeká {pending}."
+                : baseMessage;
         }
 
         if (progress.ProcessedFiles.HasValue)
@@ -1170,9 +1231,10 @@ public partial class ImportPageViewModel : ViewModelBase
 
     private async Task AddLogAsync(string title, string message, string status, string? detail = null)
     {
+        var normalizedStatus = NormalizeLogStatus(status);
         await Dispatcher.Enqueue(() =>
         {
-            Log.Add(new ImportLogItem(DateTimeOffset.Now, title, message, status, detail));
+            Log.Add(new ImportLogItem(DateTimeOffset.Now, title, message, normalizedStatus, detail));
             TrimLog();
             _clearResultsCommand.NotifyCanExecuteChanged();
             _exportLogCommand.NotifyCanExecuteChanged();
@@ -1393,12 +1455,14 @@ public partial class ImportPageViewModel : ViewModelBase
     partial void OnProcessedChanged(int value)
     {
         OnPropertyChanged(nameof(ProgressText));
+        OnPropertyChanged(nameof(PendingCount));
         _clearResultsCommand.NotifyCanExecuteChanged();
     }
 
     partial void OnTotalChanged(int value)
     {
         OnPropertyChanged(nameof(ProgressText));
+        OnPropertyChanged(nameof(PendingCount));
         _clearResultsCommand.NotifyCanExecuteChanged();
     }
 

--- a/Veriado.WinUI/Views/Import/ImportPage.xaml
+++ b/Veriado.WinUI/Views/Import/ImportPage.xaml
@@ -248,7 +248,7 @@
                                 <Style TargetType="TextBlock" BasedOn="{StaticResource WrapTextBlockStyle}" />
                             </datagrid:DataGridTextColumn.ElementStyle>
                         </datagrid:DataGridTextColumn>
-                        <datagrid:DataGridTextColumn Header="Stav" Binding="{Binding Status}" Width="Auto" />
+                        <datagrid:DataGridTextColumn Header="Stav" Binding="{Binding StatusDisplay}" Width="Auto" />
                         <datagrid:DataGridTextColumn Header="Detail" Binding="{Binding Detail}" Width="3*">
                             <datagrid:DataGridTextColumn.ElementStyle>
                                 <Style TargetType="TextBlock" BasedOn="{StaticResource WrapTextBlockStyle}" />


### PR DESCRIPTION
## Summary
- normalize log status codes and display localized status text for import log entries
- surface pending file counts in progress text, status details, and completion summaries
- enrich dynamic status messages so users can track remaining work during imports

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68de008cfbf48326b9df9523d798b168