### PR TITLE
Adjust FilesPage layout for full file names

### DIFF
--- a/Veriado.WinUI/Views/Files/FilesPage.xaml
+++ b/Veriado.WinUI/Views/Files/FilesPage.xaml
@@ -200,27 +200,35 @@
         VerticalScrollMode="Auto"
         VerticalScrollBarVisibility="Auto">
 
-                <controls:ItemsRepeater ItemsSource="{x:Bind ViewModel.Items}">
+                <controls:ItemsRepeater
+                    ItemsSource="{x:Bind ViewModel.Items}"
+                    HorizontalAlignment="Stretch">
                     <controls:ItemsRepeater.Layout>
-                        <controls:UniformGridLayout
-                    Orientation="Vertical"
-                    MinItemWidth="220"
-                    MinItemHeight="120"
-                    ItemsJustification="Start" />
+                        <controls:StackLayout Orientation="Vertical" Spacing="8" />
                     </controls:ItemsRepeater.Layout>
 
                     <controls:ItemsRepeater.ItemTemplate>
                         <DataTemplate x:DataType="contracts:FileSummaryDto">
                             <Border
-                        Margin="8"
-                        Padding="12"
-                        CornerRadius="6"
-                        BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}"
-                        BorderThickness="1">
+                                Margin="8"
+                                Padding="12"
+                                CornerRadius="6"
+                                BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}"
+                                BorderThickness="1"
+                                HorizontalAlignment="Stretch">
                                 <StackPanel Spacing="4">
-                                    <TextBlock Text="{x:Bind Name}" FontWeight="SemiBold" TextTrimming="CharacterEllipsis" />
-                                    <TextBlock Text="{x:Bind Mime}" FontSize="12" Opacity="0.7" TextTrimming="CharacterEllipsis" />
-                                    <TextBlock Text="{x:Bind Size, Converter={StaticResource SizeToHumanConverter}}" FontSize="12" />
+                                    <TextBlock
+                                        Text="{x:Bind Name}"
+                                        FontWeight="SemiBold"
+                                        TextWrapping="Wrap" />
+                                    <TextBlock
+                                        Text="{x:Bind Mime}"
+                                        FontSize="12"
+                                        Opacity="0.7"
+                                        TextTrimming="CharacterEllipsis" />
+                                    <TextBlock
+                                        Text="{x:Bind Size, Converter={StaticResource SizeToHumanConverter}}"
+                                        FontSize="12" />
                                 </StackPanel>
                             </Border>
                         </DataTemplate>


### PR DESCRIPTION
## Summary
- change the FilesPage items repeater to a vertical stack layout and stretch entries so file names can use the available width
- allow file names to wrap instead of trimming so long titles remain fully visible

## Testing
- ⚠️ `dotnet build Veriado.sln` *(fails: `dotnet` is not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68de0b5ea55c8326a90d45597c57eb4c