### PR TITLE
Introduce theme resources for consistent light and dark modes

### DIFF
--- a/Veriado.WinUI/App.xaml
+++ b/Veriado.WinUI/App.xaml
@@ -8,6 +8,7 @@
     <ResourceDictionary>
       <ResourceDictionary.MergedDictionaries>
         <XamlControlsResources xmlns="using:Microsoft.UI.Xaml.Controls" />
+        <ResourceDictionary Source="Resources/Theme.xaml" />
         <ResourceDictionary Source="Resources/Styles.xaml" />
       </ResourceDictionary.MergedDictionaries>
       <conv:BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />

--- a/Veriado.WinUI/Resources/Styles.xaml
+++ b/Veriado.WinUI/Resources/Styles.xaml
@@ -1,9 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:controls="using:Microsoft.UI.Xaml.Controls">
+  <Style TargetType="Page">
+    <Setter Property="Background" Value="{ThemeResource AppBackgroundBrush}" />
+  </Style>
+
+  <Style TargetType="controls:NavigationViewItem">
+    <Setter Property="Foreground" Value="{ThemeResource AppNavigationForegroundBrush}" />
+  </Style>
+
   <Style TargetType="TextBlock" x:Key="SectionTitleTextBlockStyle" BasedOn="{StaticResource HeaderTextBlockStyle}">
     <Setter Property="Margin" Value="0,24,0,12" />
     <Setter Property="TextWrapping" Value="Wrap" />
+    <Setter Property="Foreground" Value="{ThemeResource AppTextPrimaryBrush}" />
   </Style>
 </ResourceDictionary>

--- a/Veriado.WinUI/Resources/Theme.xaml
+++ b/Veriado.WinUI/Resources/Theme.xaml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+  <ResourceDictionary.ThemeDictionaries>
+    <ResourceDictionary x:Key="Light">
+      <Color x:Key="AppAccentColor">#FF0063B1</Color>
+      <Color x:Key="AppBackgroundColor">#FFF7F8FC</Color>
+      <Color x:Key="AppSurfaceColor">#FFFFFFFF</Color>
+      <Color x:Key="AppNavigationBackgroundColor">#FFF0F2F7</Color>
+      <Color x:Key="AppNavigationForegroundColor">#FF101820</Color>
+      <Color x:Key="AppTextPrimaryColor">#FF1B1F23</Color>
+    </ResourceDictionary>
+    <ResourceDictionary x:Key="Dark">
+      <Color x:Key="AppAccentColor">#FF4CC2FF</Color>
+      <Color x:Key="AppBackgroundColor">#FF1B1E23</Color>
+      <Color x:Key="AppSurfaceColor">#FF252932</Color>
+      <Color x:Key="AppNavigationBackgroundColor">#FF2C313C</Color>
+      <Color x:Key="AppNavigationForegroundColor">#FFE7ECF4</Color>
+      <Color x:Key="AppTextPrimaryColor">#FFE7ECF4</Color>
+    </ResourceDictionary>
+  </ResourceDictionary.ThemeDictionaries>
+
+  <SolidColorBrush x:Key="AppAccentBrush" Color="{ThemeResource AppAccentColor}" />
+  <SolidColorBrush x:Key="AppBackgroundBrush" Color="{ThemeResource AppBackgroundColor}" />
+  <SolidColorBrush x:Key="AppSurfaceBrush" Color="{ThemeResource AppSurfaceColor}" />
+  <SolidColorBrush x:Key="AppNavigationBackgroundBrush" Color="{ThemeResource AppNavigationBackgroundColor}" />
+  <SolidColorBrush x:Key="AppNavigationForegroundBrush" Color="{ThemeResource AppNavigationForegroundColor}" />
+  <SolidColorBrush x:Key="AppTextPrimaryBrush" Color="{ThemeResource AppTextPrimaryColor}" />
+</ResourceDictionary>

--- a/Veriado.WinUI/Views/Shell/MainShell.xaml
+++ b/Veriado.WinUI/Views/Shell/MainShell.xaml
@@ -5,6 +5,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:controls="using:Microsoft.UI.Xaml.Controls"
+    Background="{ThemeResource AppBackgroundBrush}"
     mc:Ignorable="d">
     <controls:NavigationView
         x:Name="RootNavigation"
@@ -14,20 +15,33 @@
         OpenPaneLength="320"
         IsPaneToggleButtonVisible="True"
         IsPaneOpen="{Binding IsNavOpen, Mode=TwoWay}"
+        Background="{ThemeResource AppSurfaceBrush}"
+        PaneBackground="{ThemeResource AppNavigationBackgroundBrush}"
+        ContentBackground="{ThemeResource AppBackgroundBrush}"
+        Foreground="{ThemeResource AppNavigationForegroundBrush}"
         ItemInvoked="OnNavigationViewItemInvoked">
         <controls:NavigationView.Resources>
             <SolidColorBrush
                 x:Key="NavigationViewDefaultPaneBackground"
-                Color="{ThemeResource SystemChromeHighColor}" />
+                Color="{ThemeResource AppNavigationBackgroundColor}" />
             <SolidColorBrush
                 x:Key="NavigationViewExpandedPaneBackground"
-                Color="{ThemeResource SystemChromeHighColor}" />
+                Color="{ThemeResource AppNavigationBackgroundColor}" />
             <SolidColorBrush
                 x:Key="NavigationViewMinimalPaneBackground"
-                Color="{ThemeResource SystemChromeHighColor}" />
+                Color="{ThemeResource AppNavigationBackgroundColor}" />
             <SolidColorBrush
                 x:Key="NavigationViewTopPaneBackground"
-                Color="{ThemeResource SystemChromeHighColor}" />
+                Color="{ThemeResource AppNavigationBackgroundColor}" />
+            <SolidColorBrush
+                x:Key="NavigationViewItemForeground"
+                Color="{ThemeResource AppNavigationForegroundColor}" />
+            <SolidColorBrush
+                x:Key="NavigationViewItemForegroundSelected"
+                Color="{ThemeResource AppNavigationForegroundColor}" />
+            <SolidColorBrush
+                x:Key="NavigationViewSelectionIndicatorForeground"
+                Color="{ThemeResource AppAccentColor}" />
         </controls:NavigationView.Resources>
         <controls:NavigationView.MenuItems>
             <controls:NavigationViewItem Tag="files" Content="Správa souborů" Icon="Document" />
@@ -35,9 +49,11 @@
             <controls:NavigationViewItem Tag="settings" Content="Nastavení" Icon="Setting" />
         </controls:NavigationView.MenuItems>
         <controls:NavigationView.Content>
-            <ContentPresenter
-                x:Name="ContentHost"
-                Content="{x:Bind CurrentContent, Mode=OneWay}" />
+            <Grid Background="{ThemeResource AppBackgroundBrush}">
+                <ContentPresenter
+                    x:Name="ContentHost"
+                    Content="{x:Bind CurrentContent, Mode=OneWay}" />
+            </Grid>
         </controls:NavigationView.Content>
     </controls:NavigationView>
 </Window>

--- a/Veriado.WinUI/Views/StartupWindow.xaml
+++ b/Veriado.WinUI/Views/StartupWindow.xaml
@@ -3,8 +3,9 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:winui="using:Microsoft.UI.Xaml.Controls"
+    Background="{ThemeResource AppBackgroundBrush}"
     Title="Veriado">
-    <Grid>
+    <Grid Background="{ThemeResource AppBackgroundBrush}">
         <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="12" Width="320">
             <winui:ProgressRing
                 Width="48"
@@ -15,12 +16,14 @@
                 Text="{Binding StatusMessage}"
                 TextAlignment="Center"
                 TextWrapping="Wrap"
+                Foreground="{ThemeResource AppTextPrimaryBrush}"
                 Style="{ThemeResource BodyStrongTextBlockStyle}" />
             <TextBlock
                 Margin="0,0,0,8"
                 Text="{Binding DetailsMessage}"
                 TextAlignment="Center"
                 TextWrapping="Wrap"
+                Foreground="{ThemeResource AppTextPrimaryBrush}"
                 Visibility="{Binding HasError, Converter={StaticResource BooleanToVisibilityConverter}}" />
             <Button
                 Width="160"


### PR DESCRIPTION
## Summary
- add a dedicated theme resource dictionary that defines cohesive colors for light and dark modes
- apply the new palette to the shell navigation view and startup window so the menu and content share consistent styling
- update shared styles to reuse the application brushes across pages and section titles

## Testing
- not run (dotnet CLI is unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68de3e134b10832690311594a559ddeb