### PR TITLE
Remove unsupported WinUI background properties

### DIFF
--- a/Veriado.WinUI/Views/Shell/MainShell.xaml
+++ b/Veriado.WinUI/Views/Shell/MainShell.xaml
@@ -5,7 +5,6 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:controls="using:Microsoft.UI.Xaml.Controls"
-    Background="{ThemeResource AppBackgroundBrush}"
     mc:Ignorable="d">
     <controls:NavigationView
         x:Name="RootNavigation"
@@ -16,8 +15,6 @@
         IsPaneToggleButtonVisible="True"
         IsPaneOpen="{Binding IsNavOpen, Mode=TwoWay}"
         Background="{ThemeResource AppSurfaceBrush}"
-        PaneBackground="{ThemeResource AppNavigationBackgroundBrush}"
-        ContentBackground="{ThemeResource AppBackgroundBrush}"
         Foreground="{ThemeResource AppNavigationForegroundBrush}"
         ItemInvoked="OnNavigationViewItemInvoked">
         <controls:NavigationView.Resources>


### PR DESCRIPTION
## Summary
- remove background attributes on MainShell that are not supported by the current WinUI version
- rely on existing resource overrides to keep navigation and content colors consistent

## Testing
- ❌ `dotnet build Veriado.sln` (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68de4b70483483269ca697ce89d0964e