### PR TITLE
Remove unsupported Background attribute from StartupWindow

### DIFF
--- a/Veriado.WinUI/Views/StartupWindow.xaml
+++ b/Veriado.WinUI/Views/StartupWindow.xaml
@@ -3,7 +3,6 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:winui="using:Microsoft.UI.Xaml.Controls"
-    Background="{ThemeResource AppBackgroundBrush}"
     Title="Veriado">
     <Grid Background="{ThemeResource AppBackgroundBrush}">
         <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="12" Width="320">


### PR DESCRIPTION
## Summary
- remove the unsupported Background property from the StartupWindow root Window to resolve the XLS0413 build error

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de4cb34ae483269e09cf33afe8a5a7