### PR TITLE
Implement pagination controls on Files page

### DIFF
--- a/Veriado.WinUI/Views/Files/FilesPage.xaml
+++ b/Veriado.WinUI/Views/Files/FilesPage.xaml
@@ -175,6 +175,37 @@
                     x:Uid="FilesPage_StatusText"
                     VerticalAlignment="Center"
                     Text="{x:Bind ViewModel.StatusText, Mode=OneWay}" />
+                <StackPanel Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
+                    <Button
+                        x:Uid="FilesPage_PreviousPageButton"
+                        Content="Předchozí"
+                        Command="{x:Bind ViewModel.PreviousPageCommand}" />
+                    <StackPanel Orientation="Horizontal" Spacing="4" VerticalAlignment="Center">
+                        <controls:NumberBox
+                            x:Uid="FilesPage_PageNumberBox"
+                            Width="80"
+                            HorizontalAlignment="Left"
+                            Minimum="0"
+                            Maximum="{x:Bind ViewModel.TotalPages > 0 ? (double)ViewModel.TotalPages : 1d, Mode=OneWay}"
+                            SmallChange="1"
+                            Value="{x:Bind ViewModel.TargetPage, Mode=TwoWay}" />
+                        <TextBlock Text="/" VerticalAlignment="Center" />
+                        <TextBlock Text="{x:Bind ViewModel.TotalPages, Mode=OneWay}" VerticalAlignment="Center" />
+                    </StackPanel>
+                    <Button
+                        x:Uid="FilesPage_NextPageButton"
+                        Content="Další"
+                        Command="{x:Bind ViewModel.NextPageCommand}" />
+                </StackPanel>
+                <StackPanel Orientation="Horizontal" Spacing="4" VerticalAlignment="Center">
+                    <TextBlock x:Uid="FilesPage_PageSizeLabel" VerticalAlignment="Center" Text="Na stránce" />
+                    <ComboBox
+                        x:Uid="FilesPage_PageSizeComboBox"
+                        Width="90"
+                        HorizontalAlignment="Left"
+                        ItemsSource="{x:Bind ViewModel.PageSizeOptions, Mode=OneWay}"
+                        SelectedItem="{x:Bind ViewModel.PageSize, Mode=TwoWay}" />
+                </StackPanel>
             </StackPanel>
             <controls:InfoBar
                 x:Uid="FilesPage_IndexingInfoBar"


### PR DESCRIPTION
## Summary
- add pagination state management, navigation commands, and page size options to the files page view model
- update the files page UI with pager controls and a page size selector bound to the new state

## Testing
- dotnet build Veriado.sln *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68de4eae3d588326ad0a7d4f6efa7a1d