### PR TITLE
Fix Files page pagination bindings

### DIFF
--- a/Veriado.WinUI/ViewModels/Files/FilesPageViewModel.cs
+++ b/Veriado.WinUI/ViewModels/Files/FilesPageViewModel.cs
@@ -149,6 +149,13 @@ public partial class FilesPageViewModel : ViewModelBase
     [ObservableProperty]
     private string? indexingWarningMessage;
 
+    public double TargetPageMaximum => TotalPages > 0 ? TotalPages : 1d;
+
+    partial void OnTotalPagesChanged(int value)
+    {
+        OnPropertyChanged(nameof(TargetPageMaximum));
+    }
+
     public void StartHealthMonitoring()
     {
         lock (_healthMonitorGate)

--- a/Veriado.WinUI/Views/Files/FilesPage.xaml
+++ b/Veriado.WinUI/Views/Files/FilesPage.xaml
@@ -185,8 +185,8 @@
                             x:Uid="FilesPage_PageNumberBox"
                             Width="80"
                             HorizontalAlignment="Left"
-                            Minimum="0"
-                            Maximum="{x:Bind ViewModel.TotalPages > 0 ? (double)ViewModel.TotalPages : 1d, Mode=OneWay}"
+                            Minimum="1"
+                            Maximum="{x:Bind ViewModel.TargetPageMaximum, Mode=OneWay}"
                             SmallChange="1"
                             Value="{x:Bind ViewModel.TargetPage, Mode=TwoWay}" />
                         <TextBlock Text="/" VerticalAlignment="Center" />


### PR DESCRIPTION
## Summary
- add a dedicated TargetPageMaximum property to expose a valid maximum page value
- raise change notifications when TotalPages updates so the bound maximum refreshes
- simplify the NumberBox bindings to use the new property and a fixed minimum value

## Testing
- not run (WinUI project requires Windows to build)


------
https://chatgpt.com/codex/tasks/task_e_68de521a4fb88326b91c28918d6fbde8