### PR TITLE
Fix FilesPage TargetPageMaximum binding

### DIFF
--- a/Veriado.WinUI/ViewModels/Files/FilesPageViewModel.cs
+++ b/Veriado.WinUI/ViewModels/Files/FilesPageViewModel.cs
@@ -149,7 +149,18 @@ public partial class FilesPageViewModel : ViewModelBase
     [ObservableProperty]
     private string? indexingWarningMessage;
 
-    public double TargetPageMaximum => TotalPages > 0 ? TotalPages : 1d;
+    public double TargetPageMaximum
+    {
+        get
+        {
+            if (TotalPages > 0)
+            {
+                return TotalPages;
+            }
+
+            return 1;
+        }
+    }
 
     partial void OnTotalPagesChanged(int value)
     {


### PR DESCRIPTION
## Summary
- replace the expression-bodied TargetPageMaximum getter with a block-bodied implementation
- ensure the NumberBox maximum binding resolves to a simple property access without design-time parsing errors

## Testing
- dotnet build Veriado.sln *(fails: `dotnet` not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68de52cd01548326a4272b8bee7914a7