### PR TITLE
Enable autosuggest for files search box

### DIFF
--- a/Veriado.WinUI/Views/Files/FilesPage.xaml
+++ b/Veriado.WinUI/Views/Files/FilesPage.xaml
@@ -40,7 +40,10 @@
                     x:Uid="FilesPage_SearchBox"
                     Grid.Column="0"
                     PlaceholderText="Hledat soubory"
-                    Text="{x:Bind ViewModel.SearchText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                    ItemsSource="{x:Bind ViewModel.SearchSuggestions}"
+                    IsTextCompletionEnabled="True"
+                    Text="{x:Bind ViewModel.SearchText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                    UpdateTextOnSelect="True" />
                 <ToggleSwitch
                     x:Uid="FilesPage_FuzzyToggle"
                     Grid.Column="1"


### PR DESCRIPTION
## Summary
- integrate the files search box with the search suggestions provider so favorites and history can be surfaced
- expose the suggestion list to the UI with debounced loading and filtering based on the current query
- bind the AutoSuggestBox to the suggestion collection and enable text completion for easier reuse of saved searches

## Testing
- not run (dotnet CLI is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68de5a485b3c8326bb90693278fa189c