### PR TITLE
Remove unsupported AutoSuggestBox property

### DIFF
--- a/Veriado.WinUI/Views/Files/FilesPage.xaml
+++ b/Veriado.WinUI/Views/Files/FilesPage.xaml
@@ -41,7 +41,6 @@
                     Grid.Column="0"
                     PlaceholderText="Hledat soubory"
                     ItemsSource="{x:Bind ViewModel.SearchSuggestions}"
-                    IsTextCompletionEnabled="True"
                     Text="{x:Bind ViewModel.SearchText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                     UpdateTextOnSelect="True" />
                 <ToggleSwitch


### PR DESCRIPTION
## Summary
- remove the IsTextCompletionEnabled property from FilesPage search AutoSuggestBox because it is not available in WinUI 3

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de5d1a668483268ac89b74168924f6