### PR TITLE
Add composition-driven animations to Files page

### DIFF
--- a/Veriado.WinUI/App.xaml
+++ b/Veriado.WinUI/App.xaml
@@ -8,6 +8,7 @@
     <ResourceDictionary>
       <ResourceDictionary.MergedDictionaries>
         <XamlControlsResources xmlns="using:Microsoft.UI.Xaml.Controls" />
+        <ResourceDictionary Source="Resources/Animations.xaml" />
         <ResourceDictionary Source="Resources/Theme.xaml" />
         <ResourceDictionary Source="Resources/Styles.xaml" />
       </ResourceDictionary.MergedDictionaries>

--- a/Veriado.WinUI/Resources/Animations.xaml
+++ b/Veriado.WinUI/Resources/Animations.xaml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:controls="using:Microsoft.UI.Xaml.Controls"
+    xmlns:helpers="using:Veriado.WinUI.Helpers">
+  <x:TimeSpan x:Key="Anim.Fast">0:0:0.12</x:TimeSpan>
+  <x:TimeSpan x:Key="Anim.Med">0:0:0.18</x:TimeSpan>
+  <x:TimeSpan x:Key="Anim.Panel">0:0:0.15</x:TimeSpan>
+
+  <CubicBezierEasingFunction x:Key="Ease.Out" ControlPoint1="0.17,0.17" ControlPoint2="0,1" />
+  <CubicBezierEasingFunction x:Key="Ease.In" ControlPoint1="0.4,0" ControlPoint2="1,1" />
+
+  <Style x:Key="AnimatedExpander" TargetType="controls:Expander">
+    <Setter Property="helpers:ExpanderAnimationHelper.IsEnabled" Value="True" />
+    <Setter Property="ContentTransitions">
+      <Setter.Value>
+        <TransitionCollection>
+          <EntranceThemeTransition IsStaggeringEnabled="False" FromVerticalOffset="12" />
+        </TransitionCollection>
+      </Setter.Value>
+    </Setter>
+  </Style>
+
+  <Style x:Key="PulseButton" TargetType="Button">
+    <Setter Property="helpers:PulseButtonHelper.IsEnabled" Value="True" />
+  </Style>
+</ResourceDictionary>

--- a/Veriado.WinUI/Views/Files/FilesPage.xaml
+++ b/Veriado.WinUI/Views/Files/FilesPage.xaml
@@ -59,7 +59,11 @@
                 VerticalScrollMode="Auto"
                 VerticalScrollBarVisibility="Auto">
                 <StackPanel Spacing="12">
-                    <controls:Expander x:Uid="FilesPage_AttributesExpander" Header="Atributy" IsExpanded="True">
+                    <controls:Expander
+                        x:Uid="FilesPage_AttributesExpander"
+                        Header="Atributy"
+                        IsExpanded="True"
+                        Style="{StaticResource AnimatedExpander}">
                         <StackPanel Spacing="8">
                             <TextBox
                                 x:Uid="FilesPage_ExtensionTextBox"
@@ -80,7 +84,11 @@
                         </StackPanel>
                     </controls:Expander>
 
-                    <controls:Expander x:Uid="FilesPage_ValidityExpander" Header="Platnost" IsExpanded="True">
+                    <controls:Expander
+                        x:Uid="FilesPage_ValidityExpander"
+                        Header="Platnost"
+                        IsExpanded="True"
+                        Style="{StaticResource AnimatedExpander}">
                         <StackPanel Spacing="8">
                             <CheckBox
                                 x:Uid="FilesPage_ReadOnlyCheckBox"
@@ -112,7 +120,11 @@
                         </StackPanel>
                     </controls:Expander>
 
-                    <controls:Expander x:Uid="FilesPage_DatesExpander" Header="Data" IsExpanded="False">
+                    <controls:Expander
+                        x:Uid="FilesPage_DatesExpander"
+                        Header="Data"
+                        IsExpanded="False"
+                        Style="{StaticResource AnimatedExpander}">
                         <StackPanel Spacing="8">
                             <CalendarDatePicker
                                 x:Uid="FilesPage_CreatedFromPicker"
@@ -133,7 +145,11 @@
                         </StackPanel>
                     </controls:Expander>
 
-                    <controls:Expander x:Uid="FilesPage_SizeExpander" Header="Velikost" IsExpanded="False">
+                    <controls:Expander
+                        x:Uid="FilesPage_SizeExpander"
+                        Header="Velikost"
+                        IsExpanded="False"
+                        Style="{StaticResource AnimatedExpander}">
                         <StackPanel Spacing="8">
                             <controls:NumberBox
                                 x:Uid="FilesPage_SizeMinNumberBox"
@@ -161,18 +177,25 @@
                     x:Uid="FilesPage_ApplyButton"
                     Grid.Column="0"
                     Content="Použít"
-                    Command="{x:Bind ViewModel.RefreshCommand}" />
+                    Command="{x:Bind ViewModel.RefreshCommand}"
+                    Style="{StaticResource PulseButton}" />
                 <Button
                     x:Uid="FilesPage_ClearButton"
                     Grid.Column="1"
                     Content="Vyčistit"
-                    Command="{x:Bind ViewModel.ClearFiltersCommand}" />
+                    Command="{x:Bind ViewModel.ClearFiltersCommand}"
+                    Style="{StaticResource PulseButton}" />
             </Grid>
         </Grid>
 
         <StackPanel Grid.Row="0" Grid.Column="1" Orientation="Vertical" Spacing="8">
             <StackPanel Orientation="Horizontal" Spacing="12" VerticalAlignment="Center">
-                <ProgressRing Width="20" Height="20" IsActive="{x:Bind ViewModel.IsBusy}" />
+                <ProgressRing
+                    x:Name="LoadingRing"
+                    Width="20"
+                    Height="20"
+                    IsActive="{x:Bind ViewModel.IsBusy}"
+                    Opacity="0" />
                 <TextBlock
                     x:Uid="FilesPage_StatusText"
                     VerticalAlignment="Center"
@@ -215,17 +238,33 @@
                 IsOpen="{x:Bind ViewModel.IsIndexingPending, Mode=OneWay}"
                 Severity="Warning"
                 Title="Probíhá indexace"
-                Message="{x:Bind ViewModel.IndexingWarningMessage, Mode=OneWay}" />
+                Message="{x:Bind ViewModel.IndexingWarningMessage, Mode=OneWay}"
+                Opened="OnInfoBarOpened"
+                Closing="OnInfoBarClosing">
+                <controls:InfoBar.Transitions>
+                    <TransitionCollection>
+                        <ContentThemeTransition />
+                    </TransitionCollection>
+                </controls:InfoBar.Transitions>
+            </controls:InfoBar>
             <controls:InfoBar
                 x:Uid="FilesPage_ErrorInfoBar"
                 IsClosable="False"
                 IsOpen="{x:Bind ViewModel.HasError, Mode=OneWay}"
                 Severity="Error"
                 Title="Chyba načítání"
-                Message="Nepodařilo se načíst výsledky." />
+                Message="Nepodařilo se načíst výsledky."
+                Opened="OnInfoBarOpened"
+                Closing="OnInfoBarClosing">
+                <controls:InfoBar.Transitions>
+                    <TransitionCollection>
+                        <ContentThemeTransition />
+                    </TransitionCollection>
+                </controls:InfoBar.Transitions>
+            </controls:InfoBar>
         </StackPanel>
 
-        <controls:ItemsRepeaterScrollHost Grid.Row="1" Grid.Column="1">
+        <controls:ItemsRepeaterScrollHost x:Name="ResultsHost" Grid.Row="1" Grid.Column="1" Opacity="1">
             <controls:ScrollViewer
         x:Name="FilesScrollViewer"
         HorizontalScrollMode="Disabled"
@@ -234,6 +273,7 @@
         VerticalScrollBarVisibility="Auto">
 
                 <controls:ItemsRepeater
+                    x:Name="FilesRepeater"
                     ItemsSource="{x:Bind ViewModel.Items}"
                     HorizontalAlignment="Stretch">
                     <controls:ItemsRepeater.Layout>
@@ -249,6 +289,11 @@
                                 BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}"
                                 BorderThickness="1"
                                 HorizontalAlignment="Stretch">
+                                <Border.Transitions>
+                                    <TransitionCollection>
+                                        <EntranceThemeTransition IsStaggeringEnabled="False" FromVerticalOffset="16" />
+                                    </TransitionCollection>
+                                </Border.Transitions>
                                 <StackPanel Spacing="4">
                                     <TextBlock
                                         Text="{x:Bind Name}"

--- a/Veriado.WinUI/Views/Files/FilesPage.xaml.cs
+++ b/Veriado.WinUI/Views/Files/FilesPage.xaml.cs
@@ -1,16 +1,29 @@
 using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Numerics;
+using Microsoft.UI.Composition;
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Hosting;
+using Veriado.WinUI.Helpers;
 using Veriado.WinUI.ViewModels.Files;
 
 namespace Veriado.WinUI.Views.Files;
 
 public sealed partial class FilesPage : Page
 {
+    private readonly HashSet<InfoBar> _closingInfoBars = new();
+    private ImplicitAnimationCollection? _itemAnimations;
+
     public FilesPage(FilesPageViewModel viewModel)
     {
         ViewModel = viewModel ?? throw new ArgumentNullException(nameof(viewModel));
         DataContext = ViewModel;
         InitializeComponent();
+        FilesRepeater.ElementPrepared += OnFilesRepeaterElementPrepared;
+        FilesRepeater.ElementClearing += OnFilesRepeaterElementClearing;
+        UpdateLoadingState(ViewModel.IsBusy, animate: false);
         Loaded += OnLoaded;
         Unloaded += OnUnloaded;
     }
@@ -20,17 +33,198 @@ public sealed partial class FilesPage : Page
     private async void OnLoaded(object sender, RoutedEventArgs e)
     {
         Loaded -= OnLoaded;
+        ViewModel.PropertyChanged += OnViewModelPropertyChanged;
         ViewModel.StartHealthMonitoring();
         await ExecuteInitialRefreshAsync().ConfigureAwait(true);
     }
 
     private void OnUnloaded(object sender, RoutedEventArgs e)
     {
+        ViewModel.PropertyChanged -= OnViewModelPropertyChanged;
         ViewModel.StopHealthMonitoring();
     }
 
     private Task ExecuteInitialRefreshAsync()
     {
         return ViewModel.RefreshCommand.ExecuteAsync(null);
+    }
+
+    private void OnViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(FilesPageViewModel.IsBusy))
+        {
+            _ = DispatcherQueue.TryEnqueue(() => UpdateLoadingState(ViewModel.IsBusy, animate: true));
+        }
+    }
+
+    private void UpdateLoadingState(bool isBusy, bool animate)
+    {
+        if (!animate || !AnimationSettings.AreEnabled)
+        {
+            LoadingRing.Visibility = isBusy ? Visibility.Visible : Visibility.Collapsed;
+            LoadingRing.Opacity = isBusy ? 1d : 0d;
+            ResultsHost.Opacity = isBusy ? 0d : 1d;
+            ResultsHost.IsHitTestVisible = !isBusy;
+            return;
+        }
+
+        LoadingRing.Visibility = Visibility.Visible;
+        ResultsHost.Visibility = Visibility.Visible;
+        ResultsHost.IsHitTestVisible = !isBusy;
+
+        var resultsVisual = ElementCompositionPreview.GetElementVisual(ResultsHost);
+        var loadingVisual = ElementCompositionPreview.GetElementVisual(LoadingRing);
+        var compositor = resultsVisual.Compositor;
+        var duration = AnimationResourceHelper.GetDuration(AnimationResourceKeys.Medium);
+        var easing = AnimationResourceHelper.CreateEasing(compositor, AnimationResourceKeys.EaseOut);
+
+        AnimateOpacity(compositor, loadingVisual, isBusy ? 1f : 0f, duration, easing, () =>
+        {
+            if (!isBusy)
+            {
+                LoadingRing.Visibility = Visibility.Collapsed;
+            }
+        });
+
+        AnimateOpacity(compositor, resultsVisual, isBusy ? 0f : 1f, duration, easing, null);
+    }
+
+    private static void AnimateOpacity(Compositor compositor, Visual visual, float targetOpacity, TimeSpan duration, CompositionEasingFunction easing, Action? completed)
+    {
+        var animation = compositor.CreateScalarKeyFrameAnimation();
+        animation.Target = nameof(Visual.Opacity);
+        animation.Duration = duration;
+        animation.InsertKeyFrame(0f, visual.Opacity);
+        animation.InsertKeyFrame(1f, targetOpacity, easing);
+
+        var batch = compositor.CreateScopedBatch(CompositionBatchTypes.Animation);
+        visual.StartAnimation(nameof(Visual.Opacity), animation);
+        if (completed is not null)
+        {
+            batch.Completed += (_, __) => completed();
+        }
+        batch.End();
+    }
+
+    private void OnFilesRepeaterElementPrepared(ItemsRepeater sender, ItemsRepeaterElementPreparedEventArgs args)
+    {
+        if (args.Element is not UIElement element)
+        {
+            return;
+        }
+
+        if (!AnimationSettings.AreEnabled)
+        {
+            element.Opacity = 1d;
+            return;
+        }
+
+        ElementCompositionPreview.SetIsTranslationEnabled(element, true);
+        var visual = ElementCompositionPreview.GetElementVisual(element);
+        visual.Opacity = 0f;
+        visual.Translation = new Vector3(0f, 12f, 0f);
+
+        if (_itemAnimations is null)
+        {
+            var compositor = visual.Compositor;
+            var duration = AnimationResourceHelper.GetDuration(AnimationResourceKeys.Medium);
+            var easing = AnimationResourceHelper.CreateEasing(compositor, AnimationResourceKeys.EaseOut);
+
+            var fadeAnimation = compositor.CreateScalarKeyFrameAnimation();
+            fadeAnimation.Target = nameof(Visual.Opacity);
+            fadeAnimation.Duration = duration;
+            fadeAnimation.InsertKeyFrame(0f, 0f);
+            fadeAnimation.InsertKeyFrame(1f, 1f, easing);
+
+            var translationAnimation = compositor.CreateVector3KeyFrameAnimation();
+            translationAnimation.Target = nameof(Visual.Translation);
+            translationAnimation.Duration = duration;
+            translationAnimation.InsertKeyFrame(0f, new Vector3(0f, 12f, 0f));
+            translationAnimation.InsertKeyFrame(1f, Vector3.Zero, easing);
+
+            _itemAnimations = compositor.CreateImplicitAnimationCollection();
+            _itemAnimations[nameof(Visual.Opacity)] = fadeAnimation;
+            _itemAnimations[nameof(Visual.Translation)] = translationAnimation;
+        }
+
+        visual.ImplicitAnimations = _itemAnimations;
+        visual.Opacity = 1f;
+        visual.Translation = Vector3.Zero;
+    }
+
+    private void OnFilesRepeaterElementClearing(ItemsRepeater sender, ItemsRepeaterElementClearingEventArgs args)
+    {
+        if (args.Element is UIElement element)
+        {
+            var visual = ElementCompositionPreview.GetElementVisual(element);
+            visual.Opacity = 1f;
+            visual.Translation = Vector3.Zero;
+        }
+    }
+
+    private void OnInfoBarOpened(object sender, object e)
+    {
+        if (sender is not InfoBar infoBar)
+        {
+            return;
+        }
+
+        if (!AnimationSettings.AreEnabled)
+        {
+            infoBar.Opacity = 1d;
+            return;
+        }
+
+        var visual = ElementCompositionPreview.GetElementVisual(infoBar);
+        var compositor = visual.Compositor;
+        var duration = AnimationResourceHelper.GetDuration(AnimationResourceKeys.Fast);
+        var easing = AnimationResourceHelper.CreateEasing(compositor, AnimationResourceKeys.EaseOut);
+
+        visual.Opacity = 0f;
+
+        var animation = compositor.CreateScalarKeyFrameAnimation();
+        animation.Target = nameof(Visual.Opacity);
+        animation.Duration = duration;
+        animation.InsertKeyFrame(0f, 0f);
+        animation.InsertKeyFrame(1f, 1f, easing);
+
+        visual.StartAnimation(nameof(Visual.Opacity), animation);
+    }
+
+    private void OnInfoBarClosing(InfoBar sender, InfoBarClosingEventArgs args)
+    {
+        if (!AnimationSettings.AreEnabled)
+        {
+            sender.Opacity = 0d;
+            return;
+        }
+
+        if (_closingInfoBars.Contains(sender))
+        {
+            _closingInfoBars.Remove(sender);
+            return;
+        }
+
+        args.Cancel = true;
+
+        var visual = ElementCompositionPreview.GetElementVisual(sender);
+        var compositor = visual.Compositor;
+        var duration = AnimationResourceHelper.GetDuration(AnimationResourceKeys.Fast);
+        var easing = AnimationResourceHelper.CreateEasing(compositor, AnimationResourceKeys.EaseOut);
+
+        var animation = compositor.CreateScalarKeyFrameAnimation();
+        animation.Target = nameof(Visual.Opacity);
+        animation.Duration = duration;
+        animation.InsertKeyFrame(0f, visual.Opacity);
+        animation.InsertKeyFrame(1f, 0f, easing);
+
+        var batch = compositor.CreateScopedBatch(CompositionBatchTypes.Animation);
+        batch.Completed += (_, __) =>
+        {
+            _closingInfoBars.Add(sender);
+            sender.IsOpen = false;
+        };
+        visual.StartAnimation(nameof(Visual.Opacity), animation);
+        batch.End();
     }
 }


### PR DESCRIPTION
## Summary
- add shared animation resources and register them globally
- introduce helper behaviors for expander and button composition animations that respect system preferences
- update FilesPage to animate filters, buttons, info bars, loading state, and results entrance

## Testing
- dotnet build Veriado.sln *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68de77c6bea88326b34d881ad1affb34