### PR TITLE
Add composition animations to Import page

### DIFF
--- a/Veriado.WinUI/Views/Import/ImportPage.xaml
+++ b/Veriado.WinUI/Views/Import/ImportPage.xaml
@@ -34,7 +34,10 @@
         </Style>
     </Page.Resources>
 
-    <Grid Padding="24" RowSpacing="24">
+<Grid
+        x:Name="DropZoneHost"
+        Padding="24"
+        RowSpacing="24">
         <Grid.Transitions>
             <TransitionCollection>
                 <animations:EntranceThemeTransition />
@@ -46,6 +49,16 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
+
+        <Border
+            x:Name="DropZoneHighlight"
+            Grid.RowSpan="4"
+            CornerRadius="16"
+            BorderThickness="2"
+            Background="{ThemeResource AccentAcrylicBackgroundFillColorDefaultBrush}"
+            BorderBrush="{ThemeResource AccentStrokeColorDefaultBrush}"
+            Opacity="0"
+            IsHitTestVisible="False" />
 
         <!-- Nadpis a akce -->
         <StackPanel Grid.Row="0" Spacing="12">
@@ -62,7 +75,11 @@
                 </Grid.ColumnDefinitions>
 
                 <StackPanel Orientation="Horizontal" Spacing="12">
-                    <Button Content="Spustit import" Command="{Binding RunImportCommand}" />
+                    <Button
+                        x:Name="RunImportButton"
+                        Content="Spustit import"
+                        Command="{Binding RunImportCommand}"
+                        Style="{StaticResource PulseButton}" />
                     <Button Content="Zastavit" Command="{Binding StopImportCommand}" IsEnabled="{Binding IsImporting}" />
                     <Button Content="Vymazat výsledky" Command="{Binding ClearResultsCommand}" />
                     <Button Content="Exportovat protokol" Command="{Binding ExportLogCommand}" />
@@ -74,56 +91,99 @@
                             <animations:EntranceThemeTransition IsStaggeringEnabled="True" />
                         </TransitionCollection>
                     </StackPanel.Transitions>
-                    <muxc:ProgressBar
-                        Minimum="0"
-                        Maximum="100"
-                        Value="{Binding ProgressPercentValue, Mode=OneWay}"
-                        IsIndeterminate="{Binding IsIndeterminate}" />
-                    <StackPanel Orientation="Horizontal" Spacing="8">
-                        <TextBlock FontWeight="SemiBold" Text="{Binding ProgressPercentDisplay, Mode=OneWay}" />
-                        <TextBlock Text="{Binding ProgressText}" />
-                    </StackPanel>
-                    <TextBlock
-                        FontWeight="SemiBold"
-                        Text="{Binding CurrentFileName, TargetNullValue='(Žádný soubor)'}" />
-                    <TextBlock
-                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                        Text="{Binding CurrentFilePath, TargetNullValue=''}"
-                        TextTrimming="CharacterEllipsis"
-                        MaxLines="2" />
-                    <TextBlock>
-                        <Run Text="Zpracováno: " />
-                        <Run Text="{Binding ProcessedBytes, Converter={StaticResource SizeToHumanConverter}}" />
-                        <Run Text=" / " />
-                        <Run Text="{Binding TotalBytes, Converter={StaticResource SizeToHumanConverter}}" />
-                    </TextBlock>
+                    <Grid x:Name="ProgressPanelsHost">
+                        <StackPanel x:Name="TotalProgressPanel" Spacing="8">
+                            <Grid x:Name="ProgressVisualHost" Height="32">
+                                <muxc:ProgressRing
+                                    x:Name="PreparationProgressRing"
+                                    Width="32"
+                                    Height="32"
+                                    IsActive="{Binding IsIndeterminate}"
+                                    Opacity="0"
+                                    Visibility="Collapsed" />
+                                <muxc:ProgressBar
+                                    x:Name="ExecutionProgressBar"
+                                    Minimum="0"
+                                    Maximum="100"
+                                    Value="{Binding ProgressPercentValue, Mode=OneWay}"
+                                    IsIndeterminate="{Binding IsIndeterminate}" />
+                            </Grid>
+                            <StackPanel Orientation="Horizontal" Spacing="8">
+                                <TextBlock FontWeight="SemiBold" Text="{Binding ProgressPercentDisplay, Mode=OneWay}" />
+                                <TextBlock Text="{Binding ProgressText}" />
+                            </StackPanel>
+                            <TextBlock
+                                FontWeight="SemiBold"
+                                Text="{Binding CurrentFileName, TargetNullValue='(Žádný soubor)'}" />
+                            <TextBlock
+                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                Text="{Binding CurrentFilePath, TargetNullValue=''}"
+                                TextTrimming="CharacterEllipsis"
+                                MaxLines="2" />
+                            <TextBlock>
+                                <Run Text="Zpracováno: " />
+                                <Run Text="{Binding ProcessedBytes, Converter={StaticResource SizeToHumanConverter}}" />
+                                <Run Text=" / " />
+                                <Run Text="{Binding TotalBytes, Converter={StaticResource SizeToHumanConverter}}" />
+                            </TextBlock>
+                        </StackPanel>
+                        <Border
+                            x:Name="SummaryPanel"
+                            Background="{ThemeResource LayerFillColorDefaultBrush}"
+                            CornerRadius="8"
+                            Padding="12"
+                            Opacity="0"
+                            Visibility="Collapsed"
+                            IsHitTestVisible="False">
+                            <StackPanel Spacing="4">
+                                <TextBlock FontWeight="SemiBold" Text="Shrnutí importu" />
+                                <TextBlock Text="{Binding ProgressText}" TextWrapping="Wrap" />
+                                <StackPanel Orientation="Horizontal" Spacing="12">
+                                    <TextBlock Text="{Binding OkCount, StringFormat='OK: {0}'}" />
+                                    <TextBlock Text="{Binding ErrorCount, StringFormat='Chyby: {0}'}" />
+                                    <TextBlock Text="{Binding SkipCount, StringFormat='Přeskočeno: {0}'}" />
+                                </StackPanel>
+                                <TextBlock
+                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                    Text="{Binding ProcessedBytes, Converter={StaticResource SizeToHumanConverter}, StringFormat='Zpracováno dat: {0}'}" />
+                            </StackPanel>
+                        </Border>
+                    </Grid>
                 </StackPanel>
             </Grid>
 
             <muxc:InfoBar
+                x:Name="ActiveStatusInfoBar"
                 Margin="0,8,0,0"
                 IsClosable="True"
                 IsOpen="{Binding IsActiveStatusVisible, Mode=TwoWay}"
                 Severity="{Binding ActiveStatusSeverity}"
                 Title="{Binding ActiveStatusTitle}"
-                Message="{Binding ActiveStatusMessage}">
+                Message="{Binding ActiveStatusMessage}"
+                Opacity="0"
+                Visibility="Collapsed"
+                Closing="OnInfoBarClosing">
                 <muxc:InfoBar.Transitions>
                     <TransitionCollection>
-                        <animations:EntranceThemeTransition />
+                        <ContentThemeTransition />
                     </TransitionCollection>
                 </muxc:InfoBar.Transitions>
             </muxc:InfoBar>
 
             <muxc:InfoBar
+                x:Name="DynamicStatusInfoBar"
                 Margin="0,4,0,0"
                 IsClosable="True"
                 IsOpen="{Binding IsDynamicStatusVisible, Mode=TwoWay}"
                 Severity="{Binding DynamicStatusSeverity}"
                 Title="{Binding DynamicStatusTitle}"
-                Message="{Binding DynamicStatusMessage}">
+                Message="{Binding DynamicStatusMessage}"
+                Opacity="0"
+                Visibility="Collapsed"
+                Closing="OnInfoBarClosing">
                 <muxc:InfoBar.Transitions>
                     <TransitionCollection>
-                        <animations:EntranceThemeTransition />
+                        <ContentThemeTransition />
                     </TransitionCollection>
                 </muxc:InfoBar.Transitions>
             </muxc:InfoBar>
@@ -216,6 +276,84 @@
                 </TransitionCollection>
             </StackPanel.Transitions>
             <TextBlock Text="Protokol importu" FontSize="20" FontWeight="SemiBold" />
+            <StackPanel x:Name="QueueSection" Spacing="8" Visibility="Collapsed">
+                <TextBlock Text="Fronta importu" FontSize="16" FontWeight="SemiBold" />
+                <ScrollViewer MaxHeight="240" VerticalScrollBarVisibility="Auto">
+                    <muxc:ItemsRepeater
+                        x:Name="ImportQueueRepeater"
+                        ItemsSource="{Binding Log}"
+                        ElementPrepared="OnQueueElementPrepared"
+                        ElementClearing="OnQueueElementClearing">
+                        <muxc:ItemsRepeater.Layout>
+                            <muxc:StackLayout Orientation="Vertical" Spacing="6" />
+                        </muxc:ItemsRepeater.Layout>
+                        <muxc:ItemsRepeater.ItemTemplate>
+                            <DataTemplate x:DataType="models:ImportLogItem">
+                                <Border
+                                    Padding="12"
+                                    CornerRadius="8"
+                                    Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                                    BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                                    BorderThickness="1"
+                                    Opacity="0">
+                                    <Border.Transitions>
+                                        <TransitionCollection>
+                                            <EntranceThemeTransition FromVerticalOffset="12" />
+                                        </TransitionCollection>
+                                    </Border.Transitions>
+                                    <Grid ColumnSpacing="12">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="Auto" />
+                                            <ColumnDefinition Width="*" />
+                                        </Grid.ColumnDefinitions>
+                                        <StackPanel Orientation="Vertical" Spacing="2">
+                                            <TextBlock
+                                                FontSize="12"
+                                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                                Text="{x:Bind FormattedTimestamp, Mode=OneWay}" />
+                                            <TextBlock
+                                                FontWeight="SemiBold"
+                                                Text="{x:Bind Title, Mode=OneWay}" />
+                                        </StackPanel>
+                                        <StackPanel Grid.Column="1" Spacing="2">
+                                            <StackPanel Orientation="Horizontal" Spacing="6">
+                                                <FontIcon
+                                                    x:Name="StatusIcon"
+                                                    Glyph="&#xE73E;"
+                                                    FontSize="16"
+                                                    VerticalAlignment="Center">
+                                                    <FontIcon.Transitions>
+                                                        <TransitionCollection>
+                                                            <CrossFadeThemeTransition />
+                                                        </TransitionCollection>
+                                                    </FontIcon.Transitions>
+                                                </FontIcon>
+                                                <TextBlock
+                                                    x:Name="StatusText"
+                                                    FontWeight="SemiBold"
+                                                    Text="{x:Bind Status, Mode=OneWay}"
+                                                    TextTrimming="CharacterEllipsis">
+                                                    <TextBlock.Transitions>
+                                                        <TransitionCollection>
+                                                            <CrossFadeThemeTransition />
+                                                        </TransitionCollection>
+                                                    </TextBlock.Transitions>
+                                                </TextBlock>
+                                            </StackPanel>
+                                            <TextBlock Text="{x:Bind Message, Mode=OneWay}" TextWrapping="Wrap" />
+                                            <TextBlock
+                                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                                Text="{x:Bind Detail, Mode=OneWay}"
+                                                Visibility="{x:Bind HasDetail, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}"
+                                                TextWrapping="WrapWholeWords" />
+                                        </StackPanel>
+                                    </Grid>
+                                </Border>
+                            </DataTemplate>
+                        </muxc:ItemsRepeater.ItemTemplate>
+                    </muxc:ItemsRepeater>
+                </ScrollViewer>
+            </StackPanel>
             <Grid RowSpacing="12">
                 <Grid.RowDefinitions>
                     <RowDefinition Height="*" />

--- a/Veriado.WinUI/Views/Import/ImportPage.xaml.cs
+++ b/Veriado.WinUI/Views/Import/ImportPage.xaml.cs
@@ -1,22 +1,610 @@
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.ComponentModel;
 using System.IO;
 using System.Linq;
+using System.Numerics;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.UI.Composition;
+using Microsoft.UI.ViewManagement;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Hosting;
 using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Navigation;
 using Windows.ApplicationModel.DataTransfer;
 using Windows.Storage;
+using Veriado.WinUI.Helpers;
 using Veriado.WinUI.ViewModels.Import;
 
 namespace Veriado.WinUI.Views.Import;
 
 public sealed partial class ImportPage : Page
 {
+    private readonly HashSet<InfoBar> _closingInfoBars = new();
+    private Compositor? _compositor;
+    private UISettings? _uiSettings;
+    private bool _animationsEnabled = true;
+    private CancellationTokenSource? _animationCts;
+    private Visual? _dropZoneVisual;
+    private Visual? _dropZoneHighlightVisual;
+    private long _activeInfoBarToken = -1;
+    private long _dynamicInfoBarToken = -1;
+
     public ImportPage()
     {
         InitializeComponent();
         DataContext = App.Services.GetRequiredService<ImportPageViewModel>();
+
+        Loaded += OnLoaded;
+        Unloaded += OnUnloaded;
     }
 
     private ImportPageViewModel? ViewModel => DataContext as ImportPageViewModel;
+
+    private CancellationToken AnimationToken => _animationCts?.Token ?? CancellationToken.None;
+
+    protected override void OnNavigatedTo(NavigationEventArgs e)
+    {
+        base.OnNavigatedTo(e);
+        ResetAnimationToken();
+    }
+
+    protected override void OnNavigatedFrom(NavigationEventArgs e)
+    {
+        base.OnNavigatedFrom(e);
+
+        _animationCts?.Cancel();
+        _animationCts?.Dispose();
+        _animationCts = null;
+
+        if (ViewModel is { } vm)
+        {
+            vm.PropertyChanged -= OnViewModelPropertyChanged;
+            vm.Log.CollectionChanged -= OnLogCollectionChanged;
+        }
+
+        DetachInfoBarHandlers();
+
+        if (DropZoneHost is not null)
+        {
+            DropZoneHost.SizeChanged -= OnDropZoneSizeChanged;
+        }
+
+        if (_uiSettings is not null)
+        {
+            _uiSettings.AnimationsEnabledChanged -= OnAnimationsEnabledChanged;
+            _uiSettings = null;
+        }
+    }
+
+    private void OnLoaded(object sender, RoutedEventArgs e)
+    {
+        InitializeComposition();
+        AttachInfoBarHandlers();
+        SubscribeToViewModel();
+        UpdateProgressState(immediate: true);
+        UpdateSummaryState(immediate: true);
+        UpdateQueueVisibility();
+    }
+
+    private void OnUnloaded(object sender, RoutedEventArgs e)
+    {
+        if (ViewModel is { } vm)
+        {
+            vm.PropertyChanged -= OnViewModelPropertyChanged;
+            vm.Log.CollectionChanged -= OnLogCollectionChanged;
+        }
+
+        DetachInfoBarHandlers();
+
+        if (DropZoneHost is not null)
+        {
+            DropZoneHost.SizeChanged -= OnDropZoneSizeChanged;
+        }
+    }
+
+    private void InitializeComposition()
+    {
+        _compositor ??= ElementCompositionPreview.GetElementVisual(this).Compositor;
+
+        if (_uiSettings is null)
+        {
+            try
+            {
+                _uiSettings = new UISettings();
+                _animationsEnabled = _uiSettings.AnimationsEnabled;
+                _uiSettings.AnimationsEnabledChanged += OnAnimationsEnabledChanged;
+            }
+            catch
+            {
+                _animationsEnabled = true;
+            }
+        }
+        else
+        {
+            _animationsEnabled = _uiSettings.AnimationsEnabled;
+        }
+
+        ResetAnimationToken();
+
+        if (DropZoneHost is not null)
+        {
+            _dropZoneVisual = ElementCompositionPreview.GetElementVisual(DropZoneHost);
+            _dropZoneVisual.Scale = Vector3.One;
+            DropZoneHost.SizeChanged -= OnDropZoneSizeChanged;
+            DropZoneHost.SizeChanged += OnDropZoneSizeChanged;
+            UpdateDropZoneCenterPoint();
+        }
+
+        if (DropZoneHighlight is not null)
+        {
+            _dropZoneHighlightVisual = ElementCompositionPreview.GetElementVisual(DropZoneHighlight);
+            _dropZoneHighlightVisual.Opacity = 0f;
+        }
+
+        if (DragOverlay is not null && _compositor is not null)
+        {
+            var overlayVisual = ElementCompositionPreview.GetElementVisual(DragOverlay);
+            overlayVisual.Opacity = 0f;
+        }
+    }
+
+    private void ResetAnimationToken()
+    {
+        _animationCts?.Cancel();
+        _animationCts?.Dispose();
+        _animationCts = new CancellationTokenSource();
+    }
+
+    private void OnAnimationsEnabledChanged(UISettings sender, object args)
+    {
+        _animationsEnabled = sender.AnimationsEnabled;
+    }
+
+    private void SubscribeToViewModel()
+    {
+        if (ViewModel is not { } vm)
+        {
+            return;
+        }
+
+        vm.PropertyChanged -= OnViewModelPropertyChanged;
+        vm.PropertyChanged += OnViewModelPropertyChanged;
+
+        vm.Log.CollectionChanged -= OnLogCollectionChanged;
+        vm.Log.CollectionChanged += OnLogCollectionChanged;
+    }
+
+    private void OnViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName is nameof(ImportPageViewModel.IsIndeterminate))
+        {
+            UpdateProgressState();
+        }
+        else if (e.PropertyName is nameof(ImportPageViewModel.IsImporting)
+                 || e.PropertyName is nameof(ImportPageViewModel.Total)
+                 || e.PropertyName is nameof(ImportPageViewModel.Processed))
+        {
+            UpdateSummaryState();
+            UpdateQueueVisibility();
+        }
+    }
+
+    private void OnLogCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    {
+        if (DispatcherQueue?.HasThreadAccess == true)
+        {
+            UpdateQueueVisibility();
+        }
+        else
+        {
+            _ = DispatcherQueue?.TryEnqueue(UpdateQueueVisibility);
+        }
+    }
+
+    private void UpdateQueueVisibility()
+    {
+        if (QueueSection is null)
+        {
+            return;
+        }
+
+        var hasItems = (ViewModel?.Log.Count ?? 0) > 0;
+        var isImporting = ViewModel?.IsImporting ?? false;
+        QueueSection.Visibility = (hasItems || isImporting) ? Visibility.Visible : Visibility.Collapsed;
+    }
+
+    private void UpdateProgressState(bool immediate = false)
+    {
+        var showRing = ViewModel?.IsIndeterminate == true;
+        _ = CrossFade(ExecutionProgressBar, PreparationProgressRing, !showRing, immediate);
+    }
+
+    private void UpdateSummaryState(bool immediate = false)
+    {
+        if (ViewModel is null)
+        {
+            return;
+        }
+
+        var hasResults = ViewModel.Processed > 0 || ViewModel.OkCount > 0 || ViewModel.ErrorCount > 0 || ViewModel.SkipCount > 0;
+        var showSummary = !ViewModel.IsImporting && hasResults;
+        _ = CrossFade(TotalProgressPanel, SummaryPanel, !showSummary, immediate);
+    }
+
+    private async Task CrossFade(UIElement? first, UIElement? second, bool showFirst, bool immediate = false)
+    {
+        if (first is null || second is null)
+        {
+            return;
+        }
+
+        var visibleElement = showFirst ? first : second;
+        var hiddenElement = showFirst ? second : first;
+
+        if (immediate || !_animationsEnabled || _compositor is null)
+        {
+            SetCrossFadeState(visibleElement, hiddenElement);
+            return;
+        }
+
+        var token = AnimationToken;
+        if (token.IsCancellationRequested)
+        {
+            return;
+        }
+
+        visibleElement.Visibility = Visibility.Visible;
+        hiddenElement.Visibility = Visibility.Visible;
+        visibleElement.IsHitTestVisible = true;
+        hiddenElement.IsHitTestVisible = false;
+
+        var visibleVisual = ElementCompositionPreview.GetElementVisual(visibleElement);
+        var hiddenVisual = ElementCompositionPreview.GetElementVisual(hiddenElement);
+
+        visibleVisual.Opacity = 0f;
+
+        var duration = AnimationResourceHelper.GetDuration(AnimationResourceKeys.Medium);
+        var fadeInEasing = AnimationResourceHelper.CreateEasing(_compositor, AnimationResourceKeys.EaseOut);
+        var fadeOutEasing = AnimationResourceHelper.CreateEasing(_compositor, AnimationResourceKeys.EaseIn);
+
+        var fadeIn = _compositor.CreateScalarKeyFrameAnimation();
+        fadeIn.Duration = duration;
+        fadeIn.InsertKeyFrame(1f, 1f, fadeInEasing);
+
+        var fadeOut = _compositor.CreateScalarKeyFrameAnimation();
+        fadeOut.Duration = duration;
+        fadeOut.InsertKeyFrame(1f, 0f, fadeOutEasing);
+
+        var batch = _compositor.CreateScopedBatch(CompositionBatchTypes.Animation);
+        visibleVisual.StartAnimation(nameof(Visual.Opacity), fadeIn);
+        hiddenVisual.StartAnimation(nameof(Visual.Opacity), fadeOut);
+
+        var tcs = new TaskCompletionSource<object?>();
+        batch.Completed += (s, e) =>
+        {
+            SetCrossFadeState(visibleElement, hiddenElement);
+            tcs.TrySetResult(null);
+        };
+        batch.End();
+
+        using var registration = token.CanBeCanceled ? token.Register(() => tcs.TrySetCanceled(token)) : default;
+        try
+        {
+            await tcs.Task.ConfigureAwait(true);
+        }
+        catch (TaskCanceledException)
+        {
+            // Swallow cancellations triggered by navigation.
+        }
+    }
+
+    private static void SetCrossFadeState(UIElement visibleElement, UIElement hiddenElement)
+    {
+        visibleElement.Visibility = Visibility.Visible;
+        visibleElement.Opacity = 1;
+        visibleElement.IsHitTestVisible = true;
+
+        hiddenElement.Opacity = 0;
+        hiddenElement.Visibility = Visibility.Collapsed;
+        hiddenElement.IsHitTestVisible = false;
+    }
+
+    private async Task AnimateDropZoneHoverAsync(bool isHovering, bool pulseOnDrop)
+    {
+        if (DropZoneHost is null)
+        {
+            return;
+        }
+
+        var highlightTarget = isHovering ? 0.35f : 0f;
+        var scaleTarget = isHovering ? 1.02f : 1f;
+
+        if (!_animationsEnabled || _compositor is null)
+        {
+            if (_dropZoneVisual is null)
+            {
+                _dropZoneVisual = ElementCompositionPreview.GetElementVisual(DropZoneHost);
+            }
+
+            _dropZoneVisual.Scale = new Vector3(scaleTarget, scaleTarget, 1f);
+
+            if (DropZoneHighlight is not null)
+            {
+                DropZoneHighlight.Opacity = highlightTarget;
+            }
+
+            if (!isHovering && pulseOnDrop)
+            {
+                Pulse(DropZoneHost, 1.02);
+            }
+
+            return;
+        }
+
+        _dropZoneVisual ??= ElementCompositionPreview.GetElementVisual(DropZoneHost);
+        _dropZoneHighlightVisual ??= DropZoneHighlight is not null
+            ? ElementCompositionPreview.GetElementVisual(DropZoneHighlight)
+            : null;
+
+        UpdateDropZoneCenterPoint();
+
+        var token = AnimationToken;
+        if (token.IsCancellationRequested)
+        {
+            return;
+        }
+
+        var durationKey = isHovering ? AnimationResourceKeys.Medium : AnimationResourceKeys.Fast;
+        var easingKey = isHovering ? AnimationResourceKeys.EaseOut : AnimationResourceKeys.EaseIn;
+
+        var duration = AnimationResourceHelper.GetDuration(durationKey);
+        var easing = AnimationResourceHelper.CreateEasing(_compositor, easingKey);
+
+        var batch = _compositor.CreateScopedBatch(CompositionBatchTypes.Animation);
+
+        var scaleAnimation = _compositor.CreateVector3KeyFrameAnimation();
+        scaleAnimation.Duration = duration;
+        scaleAnimation.InsertKeyFrame(1f, new Vector3(scaleTarget, scaleTarget, 1f), easing);
+        _dropZoneVisual.StartAnimation(nameof(Visual.Scale), scaleAnimation);
+
+        if (_dropZoneHighlightVisual is not null)
+        {
+            var opacityAnimation = _compositor.CreateScalarKeyFrameAnimation();
+            opacityAnimation.Duration = duration;
+            opacityAnimation.InsertKeyFrame(1f, highlightTarget, easing);
+            _dropZoneHighlightVisual.StartAnimation(nameof(Visual.Opacity), opacityAnimation);
+        }
+        else if (DropZoneHighlight is not null)
+        {
+            DropZoneHighlight.Opacity = highlightTarget;
+        }
+
+        var tcs = new TaskCompletionSource<object?>();
+        batch.Completed += (s, e) =>
+        {
+            DropZoneHighlight?.SetValue(UIElement.OpacityProperty, (double)highlightTarget);
+            tcs.TrySetResult(null);
+        };
+        batch.End();
+
+        using var registration = token.CanBeCanceled ? token.Register(() => tcs.TrySetCanceled(token)) : default;
+        try
+        {
+            await tcs.Task.ConfigureAwait(true);
+        }
+        catch (TaskCanceledException)
+        {
+            return;
+        }
+
+        if (!isHovering && pulseOnDrop)
+        {
+            Pulse(DropZoneHost, 1.02);
+        }
+    }
+
+    private void Pulse(UIElement? target, double peak)
+    {
+        if (target is null || !_animationsEnabled || _compositor is null)
+        {
+            return;
+        }
+
+        if (target.ActualWidth <= 0 || target.ActualHeight <= 0)
+        {
+            return;
+        }
+
+        var visual = ElementCompositionPreview.GetElementVisual(target);
+        visual.CenterPoint = new Vector3((float)(target.ActualWidth / 2), (float)(target.ActualHeight / 2), 0f);
+
+        var duration = AnimationResourceHelper.GetDuration(AnimationResourceKeys.Fast);
+        var easeOut = AnimationResourceHelper.CreateEasing(_compositor, AnimationResourceKeys.EaseOut);
+        var easeIn = AnimationResourceHelper.CreateEasing(_compositor, AnimationResourceKeys.EaseIn);
+
+        var animation = _compositor.CreateVector3KeyFrameAnimation();
+        animation.Duration = duration;
+        animation.InsertKeyFrame(0f, Vector3.One);
+        animation.InsertKeyFrame(0.5f, new Vector3((float)peak, (float)peak, 1f), easeOut);
+        animation.InsertKeyFrame(1f, Vector3.One, easeIn);
+
+        visual.StartAnimation(nameof(Visual.Scale), animation);
+    }
+
+    private void FadeCloseInfoBar(InfoBar bar)
+    {
+        FadeOutInfoBar(bar, updateIsOpen: true);
+    }
+
+    private void FadeOutInfoBar(InfoBar? bar, bool updateIsOpen)
+    {
+        if (bar is null)
+        {
+            return;
+        }
+
+        if (!_closingInfoBars.Add(bar))
+        {
+            return;
+        }
+
+        void Complete()
+        {
+            if (updateIsOpen)
+            {
+                bar.IsOpen = false;
+            }
+
+            bar.IsHitTestVisible = false;
+            bar.Visibility = Visibility.Collapsed;
+            bar.Opacity = 0;
+            _closingInfoBars.Remove(bar);
+        }
+
+        if (!_animationsEnabled || _compositor is null)
+        {
+            Complete();
+            return;
+        }
+
+        var token = AnimationToken;
+        if (token.IsCancellationRequested)
+        {
+            Complete();
+            return;
+        }
+
+        var visual = ElementCompositionPreview.GetElementVisual(bar);
+        var duration = AnimationResourceHelper.GetDuration(AnimationResourceKeys.Fast);
+        var easing = AnimationResourceHelper.CreateEasing(_compositor, AnimationResourceKeys.EaseIn);
+
+        var animation = _compositor.CreateScalarKeyFrameAnimation();
+        animation.Duration = duration;
+        animation.InsertKeyFrame(1f, 0f, easing);
+
+        var batch = _compositor.CreateScopedBatch(CompositionBatchTypes.Animation);
+        visual.StartAnimation(nameof(Visual.Opacity), animation);
+
+        batch.Completed += (s, e) =>
+        {
+            Complete();
+        };
+        batch.End();
+    }
+
+    private void FadeInInfoBar(InfoBar? bar)
+    {
+        if (bar is null)
+        {
+            return;
+        }
+
+        bar.Visibility = Visibility.Visible;
+        bar.IsHitTestVisible = true;
+        _closingInfoBars.Remove(bar);
+
+        if (!_animationsEnabled || _compositor is null)
+        {
+            bar.Opacity = 1;
+            return;
+        }
+
+        var token = AnimationToken;
+        if (token.IsCancellationRequested)
+        {
+            bar.Opacity = 1;
+            return;
+        }
+
+        var visual = ElementCompositionPreview.GetElementVisual(bar);
+        visual.Opacity = 0f;
+
+        var duration = AnimationResourceHelper.GetDuration(AnimationResourceKeys.Medium);
+        var easing = AnimationResourceHelper.CreateEasing(_compositor, AnimationResourceKeys.EaseOut);
+
+        var animation = _compositor.CreateScalarKeyFrameAnimation();
+        animation.Duration = duration;
+        animation.InsertKeyFrame(1f, 1f, easing);
+
+        var batch = _compositor.CreateScopedBatch(CompositionBatchTypes.Animation);
+        visual.StartAnimation(nameof(Visual.Opacity), animation);
+
+        batch.Completed += (s, e) =>
+        {
+            bar.Opacity = 1;
+        };
+        batch.End();
+    }
+
+    private void AttachInfoBarHandlers()
+    {
+        AttachInfoBar(ActiveStatusInfoBar, ref _activeInfoBarToken);
+        AttachInfoBar(DynamicStatusInfoBar, ref _dynamicInfoBarToken);
+    }
+
+    private void AttachInfoBar(InfoBar? bar, ref long token)
+    {
+        if (bar is null)
+        {
+            return;
+        }
+
+        if (token >= 0)
+        {
+            bar.UnregisterPropertyChangedCallback(InfoBar.IsOpenProperty, token);
+        }
+
+        token = bar.RegisterPropertyChangedCallback(InfoBar.IsOpenProperty, OnInfoBarIsOpenChanged);
+
+        if (bar.IsOpen)
+        {
+            FadeInInfoBar(bar);
+        }
+        else
+        {
+            bar.Visibility = Visibility.Collapsed;
+            bar.Opacity = 0;
+            bar.IsHitTestVisible = false;
+        }
+    }
+
+    private void DetachInfoBarHandlers()
+    {
+        DetachInfoBar(ActiveStatusInfoBar, ref _activeInfoBarToken);
+        DetachInfoBar(DynamicStatusInfoBar, ref _dynamicInfoBarToken);
+    }
+
+    private void DetachInfoBar(InfoBar? bar, ref long token)
+    {
+        if (bar is null || token < 0)
+        {
+            return;
+        }
+
+        bar.UnregisterPropertyChangedCallback(InfoBar.IsOpenProperty, token);
+        token = -1;
+    }
+
+    private void OnInfoBarIsOpenChanged(DependencyObject sender, DependencyProperty dependencyProperty)
+    {
+        if (sender is not InfoBar bar)
+        {
+            return;
+        }
+
+        if (bar.IsOpen)
+        {
+            FadeInInfoBar(bar);
+        }
+        else
+        {
+            FadeOutInfoBar(bar, updateIsOpen: false);
+        }
+    }
 
     private void OnPageDragOver(object sender, DragEventArgs e)
     {
@@ -28,6 +616,7 @@ public sealed partial class ImportPage : Page
         }
 
         SetDragOverlayVisibility(true);
+        _ = AnimateDropZoneHoverAsync(true, false);
         e.Handled = true;
     }
 
@@ -76,11 +665,13 @@ public sealed partial class ImportPage : Page
 
         e.Handled = true;
         SetDragOverlayVisibility(false);
+        _ = AnimateDropZoneHoverAsync(false, true);
     }
 
     private void OnPageDragLeave(object sender, DragEventArgs e)
     {
         SetDragOverlayVisibility(false);
+        _ = AnimateDropZoneHoverAsync(false, false);
     }
 
     private void SetDragOverlayVisibility(bool isVisible)
@@ -90,7 +681,57 @@ public sealed partial class ImportPage : Page
             return;
         }
 
-        DragOverlay.Visibility = isVisible ? Visibility.Visible : Visibility.Collapsed;
+        if (!_animationsEnabled || _compositor is null)
+        {
+            DragOverlay.Visibility = isVisible ? Visibility.Visible : Visibility.Collapsed;
+            DragOverlay.Opacity = isVisible ? 1 : 0;
+            return;
+        }
+
+        var token = AnimationToken;
+        if (token.IsCancellationRequested)
+        {
+            DragOverlay.Visibility = isVisible ? Visibility.Visible : Visibility.Collapsed;
+            DragOverlay.Opacity = isVisible ? 1 : 0;
+            return;
+        }
+
+        DragOverlay.Visibility = Visibility.Visible;
+
+        var visual = ElementCompositionPreview.GetElementVisual(DragOverlay);
+        var duration = AnimationResourceHelper.GetDuration(AnimationResourceKeys.Panel);
+        var easing = AnimationResourceHelper.CreateEasing(_compositor, isVisible ? AnimationResourceKeys.EaseOut : AnimationResourceKeys.EaseIn);
+
+        var animation = _compositor.CreateScalarKeyFrameAnimation();
+        animation.Duration = duration;
+        animation.InsertKeyFrame(1f, isVisible ? 1f : 0f, easing);
+
+        var batch = _compositor.CreateScopedBatch(CompositionBatchTypes.Animation);
+        visual.StartAnimation(nameof(Visual.Opacity), animation);
+
+        batch.Completed += (s, e) =>
+        {
+            if (!isVisible)
+            {
+                DragOverlay.Visibility = Visibility.Collapsed;
+            }
+        };
+        batch.End();
+    }
+
+    private void UpdateDropZoneCenterPoint()
+    {
+        if (DropZoneHost is null || _dropZoneVisual is null)
+        {
+            return;
+        }
+
+        _dropZoneVisual.CenterPoint = new Vector3((float)(DropZoneHost.ActualWidth / 2), (float)(DropZoneHost.ActualHeight / 2), 0f);
+    }
+
+    private void OnDropZoneSizeChanged(object sender, SizeChangedEventArgs e)
+    {
+        UpdateDropZoneCenterPoint();
     }
 
     private static string? ResolvePathFromStorageItems(IReadOnlyList<IStorageItem> items)
@@ -189,4 +830,90 @@ public sealed partial class ImportPage : Page
         }
     }
 
+    private void OnQueueElementPrepared(ItemsRepeater sender, ItemsRepeaterElementPreparedEventArgs args)
+    {
+        if (!_animationsEnabled || _compositor is null)
+        {
+            if (args.Element is FrameworkElement element)
+            {
+                element.Opacity = 1;
+            }
+
+            return;
+        }
+
+        var token = AnimationToken;
+        if (token.IsCancellationRequested)
+        {
+            return;
+        }
+
+        var visual = ElementCompositionPreview.GetElementVisual(args.Element);
+        visual.Opacity = 0f;
+        visual.Offset = new Vector3(0f, 10f, 0f);
+
+        var duration = AnimationResourceHelper.GetDuration(AnimationResourceKeys.Medium);
+        var easing = AnimationResourceHelper.CreateEasing(_compositor, AnimationResourceKeys.EaseOut);
+
+        var fade = _compositor.CreateScalarKeyFrameAnimation();
+        fade.Duration = duration;
+        fade.InsertKeyFrame(1f, 1f, easing);
+
+        var offset = _compositor.CreateVector3KeyFrameAnimation();
+        offset.Duration = duration;
+        offset.InsertKeyFrame(1f, Vector3.Zero, easing);
+
+        var batch = _compositor.CreateScopedBatch(CompositionBatchTypes.Animation);
+        visual.StartAnimation(nameof(Visual.Opacity), fade);
+        visual.StartAnimation(nameof(Visual.Offset), offset);
+
+        batch.Completed += (s, e) =>
+        {
+            if (args.Element is FrameworkElement element)
+            {
+                element.Opacity = 1;
+            }
+        };
+        batch.End();
+    }
+
+    private void OnQueueElementClearing(ItemsRepeater sender, ItemsRepeaterElementClearingEventArgs args)
+    {
+        if (!_animationsEnabled || _compositor is null)
+        {
+            return;
+        }
+
+        var token = AnimationToken;
+        if (token.IsCancellationRequested)
+        {
+            return;
+        }
+
+        var visual = ElementCompositionPreview.GetElementVisual(args.Element);
+        var duration = AnimationResourceHelper.GetDuration(AnimationResourceKeys.Fast);
+        var easing = AnimationResourceHelper.CreateEasing(_compositor, AnimationResourceKeys.EaseIn);
+
+        var fade = _compositor.CreateScalarKeyFrameAnimation();
+        fade.Duration = duration;
+        fade.InsertKeyFrame(1f, 0f, easing);
+
+        var batch = _compositor.CreateScopedBatch(CompositionBatchTypes.Animation);
+        visual.StartAnimation(nameof(Visual.Opacity), fade);
+
+        batch.Completed += (s, e) =>
+        {
+            if (args.Element is FrameworkElement element)
+            {
+                element.Opacity = 0;
+            }
+        };
+        batch.End();
+    }
+
+    private void OnInfoBarClosing(InfoBar sender, InfoBarClosingEventArgs args)
+    {
+        args.Cancel = true;
+        FadeCloseInfoBar(sender);
+    }
 }


### PR DESCRIPTION
## Summary
- add composition-driven hover and overlay effects for the import drop zone that honor system animation settings
- introduce cross-fades between preparation ring, progress bar, and completion summary with helper animation infrastructure
- animate import queue entries, info bars, and overlay transitions for clearer status updates while keeping animations lightweight

## Testing
- ⚠️ `dotnet build Veriado.sln` *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68de7dfed1448326b9cf326e4d2a3ec5