### PR TITLE
Add localization infrastructure and language settings

### DIFF
--- a/Veriado.WinUI/AppHost.cs
+++ b/Veriado.WinUI/AppHost.cs
@@ -43,6 +43,7 @@ internal sealed class AppHost : IAsyncDisposable
 
                 services.AddSingleton<IWindowProvider, WindowProvider>();
                 services.AddSingleton<ISettingsService, JsonSettingsService>();
+                services.AddSingleton<ILocalizationService, LocalizationService>();
                 services.AddSingleton<IDispatcherService, DispatcherService>();
                 services.AddSingleton<IThemeService, ThemeService>();
                 services.AddSingleton<IExceptionHandler, ExceptionHandler>();

--- a/Veriado.WinUI/Localization/CultureHelper.cs
+++ b/Veriado.WinUI/Localization/CultureHelper.cs
@@ -1,0 +1,24 @@
+using System.Globalization;
+using Microsoft.Windows.ApplicationModel.Resources;
+using Windows.Globalization;
+
+namespace Veriado.WinUI.Localization;
+
+internal static class CultureHelper
+{
+    public static void ApplyCulture(CultureInfo culture)
+    {
+        ArgumentNullException.ThrowIfNull(culture);
+
+        CultureInfo.CurrentCulture = culture;
+        CultureInfo.CurrentUICulture = culture;
+        CultureInfo.DefaultThreadCurrentCulture = culture;
+        CultureInfo.DefaultThreadCurrentUICulture = culture;
+
+        ResourceContext.SetGlobalQualifierValue("Language", culture.Name);
+        if (OperatingSystem.IsWindows())
+        {
+            ApplicationLanguages.PrimaryLanguageOverride = culture.Name;
+        }
+    }
+}

--- a/Veriado.WinUI/Localization/LocalizationConfiguration.cs
+++ b/Veriado.WinUI/Localization/LocalizationConfiguration.cs
@@ -1,0 +1,56 @@
+using System.Collections.ObjectModel;
+using System.Globalization;
+using System.Linq;
+
+namespace Veriado.WinUI.Localization;
+
+internal static class LocalizationConfiguration
+{
+    private static readonly CultureInfo[] SupportedCultureDefinitions =
+    {
+        CultureInfo.GetCultureInfo("en-US"),
+        CultureInfo.GetCultureInfo("cs-CZ"),
+    };
+
+    public static IReadOnlyList<CultureInfo> SupportedCultures { get; } =
+        new ReadOnlyCollection<CultureInfo>(SupportedCultureDefinitions);
+
+    public static CultureInfo DefaultCulture => SupportedCultureDefinitions[0];
+
+    public static CultureInfo NormalizeCulture(string? cultureName)
+    {
+        if (string.IsNullOrWhiteSpace(cultureName))
+        {
+            return DefaultCulture;
+        }
+
+        try
+        {
+            var culture = CultureInfo.GetCultureInfo(cultureName);
+            return NormalizeCulture(culture);
+        }
+        catch (CultureNotFoundException)
+        {
+            return DefaultCulture;
+        }
+    }
+
+    public static CultureInfo NormalizeCulture(CultureInfo? culture)
+    {
+        if (culture is null)
+        {
+            return DefaultCulture;
+        }
+
+        var exactMatch = SupportedCultureDefinitions.FirstOrDefault(candidate =>
+            string.Equals(candidate.Name, culture.Name, StringComparison.OrdinalIgnoreCase));
+        if (exactMatch is not null)
+        {
+            return exactMatch;
+        }
+
+        var twoLetterMatch = SupportedCultureDefinitions.FirstOrDefault(candidate =>
+            string.Equals(candidate.TwoLetterISOLanguageName, culture.TwoLetterISOLanguageName, StringComparison.OrdinalIgnoreCase));
+        return twoLetterMatch ?? DefaultCulture;
+    }
+}

--- a/Veriado.WinUI/Localization/LocalizedStrings.cs
+++ b/Veriado.WinUI/Localization/LocalizedStrings.cs
@@ -1,0 +1,45 @@
+using System.Globalization;
+using Microsoft.Windows.ApplicationModel.Resources;
+
+namespace Veriado.WinUI.Localization;
+
+internal static class LocalizedStrings
+{
+    private static readonly ResourceManager ResourceManager = new();
+    private static readonly ResourceMap? ResourceMap = ResourceManager.MainResourceMap.TryGetSubtree("Resources");
+    private static readonly ResourceContext ResourceContext = ResourceManager.CreateResourceContext();
+
+    public static string Get(string resourceKey, string? defaultValue = null, params object?[] arguments)
+    {
+        if (string.IsNullOrWhiteSpace(resourceKey))
+        {
+            throw new ArgumentException("Resource key must be provided.", nameof(resourceKey));
+        }
+
+        var template = TryGetString(resourceKey) ?? defaultValue ?? resourceKey;
+        if (arguments is { Length: > 0 })
+        {
+            try
+            {
+                return string.Format(CultureInfo.CurrentCulture, template, arguments);
+            }
+            catch (FormatException)
+            {
+                // Ignore formatting issues and return the template to avoid user-facing crashes.
+            }
+        }
+
+        return template;
+    }
+
+    private static string? TryGetString(string resourceKey)
+    {
+        if (ResourceMap is null)
+        {
+            return null;
+        }
+
+        var candidate = ResourceMap.TryGetValue(resourceKey, ResourceContext);
+        return candidate?.ValueAsString;
+    }
+}

--- a/Veriado.WinUI/Services/Abstractions/ILocalizationService.cs
+++ b/Veriado.WinUI/Services/Abstractions/ILocalizationService.cs
@@ -1,0 +1,18 @@
+using System.Globalization;
+
+namespace Veriado.WinUI.Services.Abstractions;
+
+public interface ILocalizationService
+{
+    event EventHandler<CultureInfo>? CultureChanged;
+
+    CultureInfo CurrentCulture { get; }
+
+    IReadOnlyList<CultureInfo> SupportedCultures { get; }
+
+    Task InitializeAsync(CancellationToken cancellationToken = default);
+
+    Task SetCultureAsync(CultureInfo culture, CancellationToken cancellationToken = default);
+
+    string GetString(string resourceKey, string? defaultValue = null, params object?[] arguments);
+}

--- a/Veriado.WinUI/Services/Abstractions/ISettingsService.cs
+++ b/Veriado.WinUI/Services/Abstractions/ISettingsService.cs
@@ -17,6 +17,9 @@ public sealed class AppSettings
 
     public int PageSize { get; set; } = DefaultPageSize;
 
+    public string? Language { get; set; }
+        = null;
+
     public string? LastFolder { get; set; }
         = null;
 

--- a/Veriado.WinUI/Services/LocalizationService.cs
+++ b/Veriado.WinUI/Services/LocalizationService.cs
@@ -1,0 +1,111 @@
+using System.Globalization;
+using Microsoft.Windows.ApplicationModel.Resources;
+using Veriado.WinUI.Localization;
+
+namespace Veriado.WinUI.Services;
+
+public sealed class LocalizationService : ILocalizationService
+{
+    private readonly ISettingsService _settingsService;
+    private readonly ResourceManager _resourceManager = new();
+    private readonly ResourceMap? _resourceMap;
+    private readonly ResourceContext _resourceContext;
+    private readonly IReadOnlyList<CultureInfo> _supportedCultures;
+    private CultureInfo _currentCulture;
+
+    public LocalizationService(ISettingsService settingsService)
+    {
+        _settingsService = settingsService ?? throw new ArgumentNullException(nameof(settingsService));
+        _resourceMap = _resourceManager.MainResourceMap.TryGetSubtree("Resources");
+        _resourceContext = _resourceManager.CreateResourceContext();
+        _supportedCultures = LocalizationConfiguration.SupportedCultures;
+        _currentCulture = LocalizationConfiguration.NormalizeCulture(CultureInfo.CurrentUICulture);
+        UpdateCulture(_currentCulture, force: true);
+    }
+
+    public event EventHandler<CultureInfo>? CultureChanged;
+
+    public CultureInfo CurrentCulture => _currentCulture;
+
+    public IReadOnlyList<CultureInfo> SupportedCultures => _supportedCultures;
+
+    public async Task InitializeAsync(CancellationToken cancellationToken = default)
+    {
+        var settings = await _settingsService.GetAsync(cancellationToken).ConfigureAwait(false);
+        var culture = LocalizationConfiguration.NormalizeCulture(settings.Language);
+        await ApplyCultureAsync(culture, persist: false, force: true, cancellationToken).ConfigureAwait(false);
+    }
+
+    public Task SetCultureAsync(CultureInfo culture, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(culture);
+        return ApplyCultureAsync(culture, persist: true, force: false, cancellationToken);
+    }
+
+    public string GetString(string resourceKey, string? defaultValue = null, params object?[] arguments)
+    {
+        if (string.IsNullOrWhiteSpace(resourceKey))
+        {
+            throw new ArgumentException("Resource key must be provided.", nameof(resourceKey));
+        }
+
+        var template = TryGetString(resourceKey) ?? defaultValue ?? resourceKey;
+        if (arguments is { Length: > 0 })
+        {
+            try
+            {
+                return string.Format(_currentCulture, template, arguments);
+            }
+            catch (FormatException)
+            {
+                // Ignore formatting errors to prevent crashing the UI when resources are misconfigured.
+            }
+        }
+
+        return template;
+    }
+
+    private async Task ApplyCultureAsync(CultureInfo culture, bool persist, bool force, CancellationToken cancellationToken)
+    {
+        var normalized = LocalizationConfiguration.NormalizeCulture(culture);
+        var hasChanged = !string.Equals(normalized.Name, _currentCulture.Name, StringComparison.OrdinalIgnoreCase);
+
+        if (hasChanged || force)
+        {
+            UpdateCulture(normalized, force);
+            if (hasChanged)
+            {
+                CultureChanged?.Invoke(this, normalized);
+            }
+        }
+
+        if (persist)
+        {
+            await _settingsService.UpdateAsync(settings => settings.Language = normalized.Name, cancellationToken)
+                .ConfigureAwait(false);
+        }
+    }
+
+    private void UpdateCulture(CultureInfo culture, bool force)
+    {
+        if (!force && string.Equals(_currentCulture.Name, culture.Name, StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        _currentCulture = culture;
+        CultureHelper.ApplyCulture(culture);
+        _resourceContext.QualifierValues["Language"] = culture.Name;
+    }
+
+    private string? TryGetString(string resourceKey)
+    {
+        if (_resourceMap is null)
+        {
+            return null;
+        }
+
+        var candidate = _resourceMap.TryGetValue(resourceKey, _resourceContext);
+        return candidate?.ValueAsString;
+    }
+}

--- a/Veriado.WinUI/Strings/Resources.resw
+++ b/Veriado.WinUI/Strings/Resources.resw
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Common.OperationCancelled" xml:space="preserve">
+    <value>Operation was cancelled.</value>
+  </data>
+  <data name="Settings.ThemeApplied" xml:space="preserve">
+    <value>Theme applied.</value>
+  </data>
+  <data name="Settings.PageSizeInvalid" xml:space="preserve">
+    <value>Enter a positive page size.</value>
+  </data>
+  <data name="Settings.PageSizeUpdated" xml:space="preserve">
+    <value>Page size set to {0} items.</value>
+  </data>
+  <data name="Settings.LanguageApplied" xml:space="preserve">
+    <value>Language switched to {0}.</value>
+  </data>
+  <data name="SettingsPage_Title.Text" xml:space="preserve">
+    <value>Settings</value>
+  </data>
+  <data name="SettingsPage_ThemeCombo.Header" xml:space="preserve">
+    <value>Application theme</value>
+  </data>
+  <data name="SettingsPage_LanguageCombo.Header" xml:space="preserve">
+    <value>Application language</value>
+  </data>
+  <data name="SettingsPage_PageSizeBox.Header" xml:space="preserve">
+    <value>Page size</value>
+  </data>
+  <data name="SettingsPage_FolderBox.Header" xml:space="preserve">
+    <value>Last folder</value>
+  </data>
+  <data name="SettingsPage_FolderBox.PlaceholderText" xml:space="preserve">
+    <value>Folder path</value>
+  </data>
+  <data name="SettingsPage_ApplyThemeButton.Content" xml:space="preserve">
+    <value>Apply theme</value>
+  </data>
+  <data name="SettingsPage_ApplyLanguageButton.Content" xml:space="preserve">
+    <value>Apply language</value>
+  </data>
+  <data name="Startup.InitializingServices" xml:space="preserve">
+    <value>Starting application services…</value>
+  </data>
+  <data name="Startup.StartupFailed" xml:space="preserve">
+    <value>Failed to start the application.</value>
+  </data>
+  <data name="StartupWindow.Title" xml:space="preserve">
+    <value>Veriado</value>
+  </data>
+  <data name="StartupWindow_RetryButton.Content" xml:space="preserve">
+    <value>Try again</value>
+  </data>
+</root>

--- a/Veriado.WinUI/Strings/cs-CZ/Resources.resw
+++ b/Veriado.WinUI/Strings/cs-CZ/Resources.resw
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Common.OperationCancelled" xml:space="preserve">
+    <value>Operace byla zrušena.</value>
+  </data>
+  <data name="Settings.ThemeApplied" xml:space="preserve">
+    <value>Motiv byl použit.</value>
+  </data>
+  <data name="Settings.PageSizeInvalid" xml:space="preserve">
+    <value>Zadejte kladnou velikost stránky.</value>
+  </data>
+  <data name="Settings.PageSizeUpdated" xml:space="preserve">
+    <value>Velikost stránky nastavena na {0} položek.</value>
+  </data>
+  <data name="Settings.LanguageApplied" xml:space="preserve">
+    <value>Jazyk byl změněn na {0}.</value>
+  </data>
+  <data name="SettingsPage_Title.Text" xml:space="preserve">
+    <value>Nastavení</value>
+  </data>
+  <data name="SettingsPage_ThemeCombo.Header" xml:space="preserve">
+    <value>Motiv aplikace</value>
+  </data>
+  <data name="SettingsPage_LanguageCombo.Header" xml:space="preserve">
+    <value>Jazyk aplikace</value>
+  </data>
+  <data name="SettingsPage_PageSizeBox.Header" xml:space="preserve">
+    <value>Velikost stránky</value>
+  </data>
+  <data name="SettingsPage_FolderBox.Header" xml:space="preserve">
+    <value>Poslední složka</value>
+  </data>
+  <data name="SettingsPage_FolderBox.PlaceholderText" xml:space="preserve">
+    <value>Cesta ke složce</value>
+  </data>
+  <data name="SettingsPage_ApplyThemeButton.Content" xml:space="preserve">
+    <value>Použít motiv</value>
+  </data>
+  <data name="SettingsPage_ApplyLanguageButton.Content" xml:space="preserve">
+    <value>Použít jazyk</value>
+  </data>
+  <data name="Startup.InitializingServices" xml:space="preserve">
+    <value>Spouštím služby aplikace…</value>
+  </data>
+  <data name="Startup.StartupFailed" xml:space="preserve">
+    <value>Nepodařilo se spustit aplikaci.</value>
+  </data>
+  <data name="StartupWindow.Title" xml:space="preserve">
+    <value>Veriado</value>
+  </data>
+  <data name="StartupWindow_RetryButton.Content" xml:space="preserve">
+    <value>Zkusit znovu</value>
+  </data>
+</root>

--- a/Veriado.WinUI/Veriado.csproj
+++ b/Veriado.WinUI/Veriado.csproj
@@ -32,6 +32,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PRIResource Include="Strings\**\*.resw" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0"/>
     <PackageReference Include="CommunityToolkit.WinUI.Controls.HeaderedControls" Version="8.2.250402" />
     <PackageReference Include="CommunityToolkit.WinUI.Controls.Primitives" Version="8.2.250402" />

--- a/Veriado.WinUI/ViewModels/Base/ViewModelBase.cs
+++ b/Veriado.WinUI/ViewModels/Base/ViewModelBase.cs
@@ -9,18 +9,21 @@ public abstract partial class ViewModelBase : ObservableObject
     private readonly IStatusService _statusService;
     private readonly IDispatcherService _dispatcher;
     private readonly IExceptionHandler _exceptionHandler;
+    private readonly ILocalizationService _localizationService;
     private CancellationTokenSource? _cancellationSource;
 
     protected ViewModelBase(
         IMessenger messenger,
         IStatusService statusService,
         IDispatcherService dispatcher,
-        IExceptionHandler exceptionHandler)
+        IExceptionHandler exceptionHandler,
+        ILocalizationService localizationService)
     {
         _messenger = messenger ?? throw new ArgumentNullException(nameof(messenger));
         _statusService = statusService ?? throw new ArgumentNullException(nameof(statusService));
         _dispatcher = dispatcher ?? throw new ArgumentNullException(nameof(dispatcher));
         _exceptionHandler = exceptionHandler ?? throw new ArgumentNullException(nameof(exceptionHandler));
+        _localizationService = localizationService ?? throw new ArgumentNullException(nameof(localizationService));
     }
 
     protected IMessenger Messenger => _messenger;
@@ -28,6 +31,8 @@ public abstract partial class ViewModelBase : ObservableObject
     protected IStatusService StatusService => _statusService;
 
     protected IDispatcherService Dispatcher => _dispatcher;
+
+    protected ILocalizationService LocalizationService => _localizationService;
 
     [ObservableProperty]
     private bool isBusy;
@@ -85,7 +90,7 @@ public abstract partial class ViewModelBase : ObservableObject
         catch (OperationCanceledException)
         {
             await _dispatcher.Enqueue(() => HasError = false);
-            _statusService.Info("Operace byla zrušena.");
+            _statusService.Info(GetString("Common.OperationCancelled"));
         }
         catch (Exception ex)
         {
@@ -107,4 +112,7 @@ public abstract partial class ViewModelBase : ObservableObject
             }
         }
     }
+
+    protected string GetString(string resourceKey, string? defaultValue = null, params object?[] arguments)
+        => _localizationService.GetString(resourceKey, defaultValue, arguments);
 }

--- a/Veriado.WinUI/ViewModels/Files/FilesPageViewModel.cs
+++ b/Veriado.WinUI/ViewModels/Files/FilesPageViewModel.cs
@@ -47,8 +47,9 @@ public partial class FilesPageViewModel : ViewModelBase
         IMessenger messenger,
         IStatusService statusService,
         IDispatcherService dispatcher,
-        IExceptionHandler exceptionHandler)
-        : base(messenger, statusService, dispatcher, exceptionHandler)
+        IExceptionHandler exceptionHandler,
+        ILocalizationService localizationService)
+        : base(messenger, statusService, dispatcher, exceptionHandler, localizationService)
     {
         _fileQueryService = fileQueryService ?? throw new ArgumentNullException(nameof(fileQueryService));
         _hotStateService = hotStateService ?? throw new ArgumentNullException(nameof(hotStateService));

--- a/Veriado.WinUI/ViewModels/Import/ImportPageViewModel.cs
+++ b/Veriado.WinUI/ViewModels/Import/ImportPageViewModel.cs
@@ -43,8 +43,9 @@ public partial class ImportPageViewModel : ViewModelBase
         IExceptionHandler exceptionHandler,
         IDialogService dialogService,
         IHotStateService? hotStateService = null,
-        IPickerService? pickerService = null)
-        : base(messenger, statusService, dispatcher, exceptionHandler)
+        IPickerService? pickerService = null,
+        ILocalizationService localizationService)
+        : base(messenger, statusService, dispatcher, exceptionHandler, localizationService)
     {
         _importService = importService ?? throw new ArgumentNullException(nameof(importService));
         _dialogService = dialogService ?? throw new ArgumentNullException(nameof(dialogService));

--- a/Veriado.WinUI/ViewModels/Settings/SettingsPageViewModel.cs
+++ b/Veriado.WinUI/ViewModels/Settings/SettingsPageViewModel.cs
@@ -1,12 +1,16 @@
+using System.Globalization;
+using Veriado.WinUI.Localization;
 using Veriado.WinUI.ViewModels.Base;
 
 namespace Veriado.WinUI.ViewModels.Settings;
 
-public partial class SettingsPageViewModel : ViewModelBase
+public partial class SettingsPageViewModel : ViewModelBase, IDisposable
 {
     private readonly IHotStateService _hotStateService;
     private readonly IThemeService _themeService;
     private readonly AsyncRelayCommand _applyThemeCommand;
+    private readonly AsyncRelayCommand _applyLanguageCommand;
+    private readonly ILocalizationService _localizationService;
 
     public SettingsPageViewModel(
         IHotStateService hotStateService,
@@ -14,21 +18,31 @@ public partial class SettingsPageViewModel : ViewModelBase
         IMessenger messenger,
         IStatusService statusService,
         IDispatcherService dispatcher,
-        IExceptionHandler exceptionHandler)
-        : base(messenger, statusService, dispatcher, exceptionHandler)
+        IExceptionHandler exceptionHandler,
+        ILocalizationService localizationService)
+        : base(messenger, statusService, dispatcher, exceptionHandler, localizationService)
     {
         _hotStateService = hotStateService ?? throw new ArgumentNullException(nameof(hotStateService));
         _themeService = themeService ?? throw new ArgumentNullException(nameof(themeService));
+        _localizationService = localizationService ?? throw new ArgumentNullException(nameof(localizationService));
 
         ThemeMode = _themeService.CurrentTheme;
         PageSize = _hotStateService.PageSize;
         LastFolder = _hotStateService.LastFolder;
+        SelectedLanguage = _localizationService.CurrentCulture;
 
         ThemeOptions = Array.AsReadOnly(Enum.GetValues<AppTheme>());
+        LanguageOptions = _localizationService.SupportedCultures;
+
         _applyThemeCommand = new AsyncRelayCommand(ApplyThemeAsync);
+        _applyLanguageCommand = new AsyncRelayCommand(ApplyLanguageAsync, CanApplyLanguage);
+
+        _localizationService.CultureChanged += OnCultureChanged;
     }
 
     public IReadOnlyList<AppTheme> ThemeOptions { get; }
+
+    public IReadOnlyList<CultureInfo> LanguageOptions { get; }
 
     [ObservableProperty]
     private AppTheme themeMode;
@@ -39,14 +53,33 @@ public partial class SettingsPageViewModel : ViewModelBase
     [ObservableProperty]
     private string? lastFolder;
 
+    [ObservableProperty]
+    private CultureInfo selectedLanguage = LocalizationConfiguration.DefaultCulture;
+
     public IAsyncRelayCommand ApplyThemeCommand => _applyThemeCommand;
+
+    public IAsyncRelayCommand ApplyLanguageCommand => _applyLanguageCommand;
 
     private Task ApplyThemeAsync()
     {
         return SafeExecuteAsync(async cancellationToken =>
         {
             await _themeService.SetThemeAsync(ThemeMode, cancellationToken).ConfigureAwait(false);
-            StatusService.Info("Motiv byl použit.");
+            StatusService.Info(GetString("Settings.ThemeApplied"));
+        });
+    }
+
+    private Task ApplyLanguageAsync()
+    {
+        if (SelectedLanguage is null)
+        {
+            return Task.CompletedTask;
+        }
+
+        return SafeExecuteAsync(async cancellationToken =>
+        {
+            await _localizationService.SetCultureAsync(SelectedLanguage, cancellationToken).ConfigureAwait(false);
+            StatusService.Info(GetString("Settings.LanguageApplied", null, SelectedLanguage.NativeName));
         });
     }
 
@@ -54,17 +87,42 @@ public partial class SettingsPageViewModel : ViewModelBase
     {
         if (value <= 0)
         {
-            StatusService.Error("Zadejte kladnou velikost stránky.");
+            StatusService.Error(GetString("Settings.PageSizeInvalid"));
             PageSize = _hotStateService.PageSize;
             return;
         }
 
         _hotStateService.PageSize = value;
-        StatusService.Info($"Velikost stránky nastavena na {value} položek.");
+        StatusService.Info(GetString("Settings.PageSizeUpdated", null, value));
     }
 
     partial void OnLastFolderChanged(string? value)
     {
         _hotStateService.LastFolder = value;
+    }
+
+    partial void OnSelectedLanguageChanged(CultureInfo value)
+    {
+        _applyLanguageCommand.NotifyCanExecuteChanged();
+    }
+
+    private bool CanApplyLanguage()
+    {
+        return SelectedLanguage is not null
+            && !string.Equals(SelectedLanguage.Name, _localizationService.CurrentCulture.Name, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private void OnCultureChanged(object? sender, CultureInfo culture)
+    {
+        if (!string.Equals(SelectedLanguage.Name, culture.Name, StringComparison.OrdinalIgnoreCase))
+        {
+            SelectedLanguage = culture;
+        }
+    }
+
+    public void Dispose()
+    {
+        _localizationService.CultureChanged -= OnCultureChanged;
+        GC.SuppressFinalize(this);
     }
 }

--- a/Veriado.WinUI/Views/Settings/SettingsPage.xaml
+++ b/Veriado.WinUI/Views/Settings/SettingsPage.xaml
@@ -7,24 +7,32 @@
     xmlns:controls="using:Microsoft.UI.Xaml.Controls"
     mc:Ignorable="d">
     <StackPanel Padding="24" Spacing="12">
-        <TextBlock Text="Nastavení" FontSize="20" FontWeight="SemiBold" />
+        <TextBlock x:Uid="SettingsPage_Title" FontSize="20" FontWeight="SemiBold" />
 
         <ComboBox
-            Header="Motiv aplikace"
+            x:Uid="SettingsPage_ThemeCombo"
             ItemsSource="{Binding ThemeOptions}"
             SelectedItem="{Binding ThemeMode, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
 
+        <ComboBox
+            x:Uid="SettingsPage_LanguageCombo"
+            ItemsSource="{Binding LanguageOptions}"
+            SelectedItem="{Binding SelectedLanguage, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+            DisplayMemberPath="NativeName" />
+
         <controls:NumberBox
-            Header="Velikost stránky"
+            x:Uid="SettingsPage_PageSizeBox"
             Minimum="1"
             SmallChange="1"
             Value="{Binding PageSize, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
 
         <TextBox
-            Header="Poslední složka"
-            PlaceholderText="Cesta ke složce"
+            x:Uid="SettingsPage_FolderBox"
             Text="{Binding LastFolder, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
 
-        <Button Content="Použít motiv" Command="{Binding ApplyThemeCommand}" />
+        <StackPanel Orientation="Horizontal" Spacing="8">
+            <Button x:Uid="SettingsPage_ApplyThemeButton" Command="{Binding ApplyThemeCommand}" />
+            <Button x:Uid="SettingsPage_ApplyLanguageButton" Command="{Binding ApplyLanguageCommand}" />
+        </StackPanel>
     </StackPanel>
 </Page>

--- a/Veriado.WinUI/Views/Settings/SettingsPage.xaml.cs
+++ b/Veriado.WinUI/Views/Settings/SettingsPage.xaml.cs
@@ -5,5 +5,14 @@ public sealed partial class SettingsPage : Page
     public SettingsPage()
     {
         InitializeComponent();
+        Unloaded += OnUnloaded;
+    }
+
+    private void OnUnloaded(object sender, RoutedEventArgs e)
+    {
+        if (DataContext is IDisposable disposable)
+        {
+            disposable.Dispose();
+        }
     }
 }

--- a/Veriado.WinUI/Views/StartupWindow.xaml
+++ b/Veriado.WinUI/Views/StartupWindow.xaml
@@ -3,7 +3,7 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:winui="using:Microsoft.UI.Xaml.Controls"
-    Title="Veriado">
+    x:Uid="StartupWindow">
     <Grid Background="{ThemeResource AppBackgroundBrush}">
         <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="12" Width="320">
             <winui:ProgressRing
@@ -25,9 +25,9 @@
                 Foreground="{ThemeResource AppTextPrimaryBrush}"
                 Visibility="{Binding HasError, Converter={StaticResource BooleanToVisibilityConverter}}" />
             <Button
+                x:Uid="StartupWindow_RetryButton"
                 Width="160"
                 HorizontalAlignment="Center"
-                Content="Zkusit znovu"
                 Command="{Binding RetryCommand}"
                 Visibility="{Binding HasError, Converter={StaticResource BooleanToVisibilityConverter}}" />
         </StackPanel>


### PR DESCRIPTION
## Summary
- add localization service, resource helpers, and culture bootstrap logic
- register localization support in the host and expose language selection in the settings UI
- move key UI and status strings into RESW resources and update view models to consume them

## Testing
- `dotnet build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68de98f4a970832697321ff5204ad51f