### PR TITLE
Add EU localization resources and expand supported cultures

### DIFF
--- a/Veriado.WinUI/Localization/LocalizationConfiguration.cs
+++ b/Veriado.WinUI/Localization/LocalizationConfiguration.cs
@@ -9,7 +9,30 @@ internal static class LocalizationConfiguration
     private static readonly CultureInfo[] SupportedCultureDefinitions =
     {
         CultureInfo.GetCultureInfo("en-US"),
+        CultureInfo.GetCultureInfo("bg-BG"),
         CultureInfo.GetCultureInfo("cs-CZ"),
+        CultureInfo.GetCultureInfo("da-DK"),
+        CultureInfo.GetCultureInfo("de-DE"),
+        CultureInfo.GetCultureInfo("el-GR"),
+        CultureInfo.GetCultureInfo("en-IE"),
+        CultureInfo.GetCultureInfo("es-ES"),
+        CultureInfo.GetCultureInfo("et-EE"),
+        CultureInfo.GetCultureInfo("fi-FI"),
+        CultureInfo.GetCultureInfo("fr-FR"),
+        CultureInfo.GetCultureInfo("ga-IE"),
+        CultureInfo.GetCultureInfo("hr-HR"),
+        CultureInfo.GetCultureInfo("hu-HU"),
+        CultureInfo.GetCultureInfo("it-IT"),
+        CultureInfo.GetCultureInfo("lt-LT"),
+        CultureInfo.GetCultureInfo("lv-LV"),
+        CultureInfo.GetCultureInfo("mt-MT"),
+        CultureInfo.GetCultureInfo("nl-NL"),
+        CultureInfo.GetCultureInfo("pl-PL"),
+        CultureInfo.GetCultureInfo("pt-PT"),
+        CultureInfo.GetCultureInfo("ro-RO"),
+        CultureInfo.GetCultureInfo("sk-SK"),
+        CultureInfo.GetCultureInfo("sl-SI"),
+        CultureInfo.GetCultureInfo("sv-SE"),
     };
 
     public static IReadOnlyList<CultureInfo> SupportedCultures { get; } =

--- a/Veriado.WinUI/Strings/bg-BG/Resources.resw
+++ b/Veriado.WinUI/Strings/bg-BG/Resources.resw
@@ -1,0 +1,66 @@
+<?xml version='1.0' encoding='utf-8'?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Common.OperationCancelled" xml:space="preserve">
+    <value>Операцията беше отменена.</value>
+  </data>
+  <data name="Settings.ThemeApplied" xml:space="preserve">
+    <value>Темата беше приложена.</value>
+  </data>
+  <data name="Settings.PageSizeInvalid" xml:space="preserve">
+    <value>Въведете положителен размер на страницата.</value>
+  </data>
+  <data name="Settings.PageSizeUpdated" xml:space="preserve">
+    <value>Размерът на страницата е зададен на {0} елемента.</value>
+  </data>
+  <data name="Settings.LanguageApplied" xml:space="preserve">
+    <value>Езикът е променен на {0}.</value>
+  </data>
+  <data name="SettingsPage_Title.Text" xml:space="preserve">
+    <value>Настройки</value>
+  </data>
+  <data name="SettingsPage_ThemeCombo.Header" xml:space="preserve">
+    <value>Тема на приложението</value>
+  </data>
+  <data name="SettingsPage_LanguageCombo.Header" xml:space="preserve">
+    <value>Език на приложението</value>
+  </data>
+  <data name="SettingsPage_PageSizeBox.Header" xml:space="preserve">
+    <value>Размер на страницата</value>
+  </data>
+  <data name="SettingsPage_FolderBox.Header" xml:space="preserve">
+    <value>Последна папка</value>
+  </data>
+  <data name="SettingsPage_FolderBox.PlaceholderText" xml:space="preserve">
+    <value>Път към папката</value>
+  </data>
+  <data name="SettingsPage_ApplyThemeButton.Content" xml:space="preserve">
+    <value>Приложи тема</value>
+  </data>
+  <data name="SettingsPage_ApplyLanguageButton.Content" xml:space="preserve">
+    <value>Приложи език</value>
+  </data>
+  <data name="Startup.InitializingServices" xml:space="preserve">
+    <value>Стартиране на услугите на приложението…</value>
+  </data>
+  <data name="Startup.StartupFailed" xml:space="preserve">
+    <value>Неуспешно стартиране на приложението.</value>
+  </data>
+  <data name="StartupWindow.Title" xml:space="preserve">
+    <value>Veriado</value>
+  </data>
+  <data name="StartupWindow_RetryButton.Content" xml:space="preserve">
+    <value>Опитайте отново</value>
+  </data>
+</root>

--- a/Veriado.WinUI/Strings/da-DK/Resources.resw
+++ b/Veriado.WinUI/Strings/da-DK/Resources.resw
@@ -1,0 +1,66 @@
+<?xml version='1.0' encoding='utf-8'?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Common.OperationCancelled" xml:space="preserve">
+    <value>Handlingen blev annulleret.</value>
+  </data>
+  <data name="Settings.ThemeApplied" xml:space="preserve">
+    <value>Tema anvendt.</value>
+  </data>
+  <data name="Settings.PageSizeInvalid" xml:space="preserve">
+    <value>Angiv en positiv sidestørrelse.</value>
+  </data>
+  <data name="Settings.PageSizeUpdated" xml:space="preserve">
+    <value>Sidestørrelse sat til {0} elementer.</value>
+  </data>
+  <data name="Settings.LanguageApplied" xml:space="preserve">
+    <value>Sproget er skiftet til {0}.</value>
+  </data>
+  <data name="SettingsPage_Title.Text" xml:space="preserve">
+    <value>Indstillinger</value>
+  </data>
+  <data name="SettingsPage_ThemeCombo.Header" xml:space="preserve">
+    <value>Programtema</value>
+  </data>
+  <data name="SettingsPage_LanguageCombo.Header" xml:space="preserve">
+    <value>Programsprog</value>
+  </data>
+  <data name="SettingsPage_PageSizeBox.Header" xml:space="preserve">
+    <value>Sidestørrelse</value>
+  </data>
+  <data name="SettingsPage_FolderBox.Header" xml:space="preserve">
+    <value>Seneste mappe</value>
+  </data>
+  <data name="SettingsPage_FolderBox.PlaceholderText" xml:space="preserve">
+    <value>Mappesti</value>
+  </data>
+  <data name="SettingsPage_ApplyThemeButton.Content" xml:space="preserve">
+    <value>Anvend tema</value>
+  </data>
+  <data name="SettingsPage_ApplyLanguageButton.Content" xml:space="preserve">
+    <value>Anvend sprog</value>
+  </data>
+  <data name="Startup.InitializingServices" xml:space="preserve">
+    <value>Starter programtjenester…</value>
+  </data>
+  <data name="Startup.StartupFailed" xml:space="preserve">
+    <value>Kunne ikke starte programmet.</value>
+  </data>
+  <data name="StartupWindow.Title" xml:space="preserve">
+    <value>Veriado</value>
+  </data>
+  <data name="StartupWindow_RetryButton.Content" xml:space="preserve">
+    <value>Prøv igen</value>
+  </data>
+</root>

--- a/Veriado.WinUI/Strings/de-DE/Resources.resw
+++ b/Veriado.WinUI/Strings/de-DE/Resources.resw
@@ -1,0 +1,66 @@
+<?xml version='1.0' encoding='utf-8'?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Common.OperationCancelled" xml:space="preserve">
+    <value>Vorgang wurde abgebrochen.</value>
+  </data>
+  <data name="Settings.ThemeApplied" xml:space="preserve">
+    <value>Design angewendet.</value>
+  </data>
+  <data name="Settings.PageSizeInvalid" xml:space="preserve">
+    <value>Geben Sie eine positive Seitengröße ein.</value>
+  </data>
+  <data name="Settings.PageSizeUpdated" xml:space="preserve">
+    <value>Seitengröße auf {0} Elemente festgelegt.</value>
+  </data>
+  <data name="Settings.LanguageApplied" xml:space="preserve">
+    <value>Sprache auf {0} umgestellt.</value>
+  </data>
+  <data name="SettingsPage_Title.Text" xml:space="preserve">
+    <value>Einstellungen</value>
+  </data>
+  <data name="SettingsPage_ThemeCombo.Header" xml:space="preserve">
+    <value>App-Design</value>
+  </data>
+  <data name="SettingsPage_LanguageCombo.Header" xml:space="preserve">
+    <value>App-Sprache</value>
+  </data>
+  <data name="SettingsPage_PageSizeBox.Header" xml:space="preserve">
+    <value>Seitengröße</value>
+  </data>
+  <data name="SettingsPage_FolderBox.Header" xml:space="preserve">
+    <value>Letzter Ordner</value>
+  </data>
+  <data name="SettingsPage_FolderBox.PlaceholderText" xml:space="preserve">
+    <value>Ordnerpfad</value>
+  </data>
+  <data name="SettingsPage_ApplyThemeButton.Content" xml:space="preserve">
+    <value>Design anwenden</value>
+  </data>
+  <data name="SettingsPage_ApplyLanguageButton.Content" xml:space="preserve">
+    <value>Sprache anwenden</value>
+  </data>
+  <data name="Startup.InitializingServices" xml:space="preserve">
+    <value>Anwendungsdienste werden gestartet…</value>
+  </data>
+  <data name="Startup.StartupFailed" xml:space="preserve">
+    <value>Die Anwendung konnte nicht gestartet werden.</value>
+  </data>
+  <data name="StartupWindow.Title" xml:space="preserve">
+    <value>Veriado</value>
+  </data>
+  <data name="StartupWindow_RetryButton.Content" xml:space="preserve">
+    <value>Erneut versuchen</value>
+  </data>
+</root>

--- a/Veriado.WinUI/Strings/el-GR/Resources.resw
+++ b/Veriado.WinUI/Strings/el-GR/Resources.resw
@@ -1,0 +1,66 @@
+<?xml version='1.0' encoding='utf-8'?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Common.OperationCancelled" xml:space="preserve">
+    <value>Η λειτουργία ακυρώθηκε.</value>
+  </data>
+  <data name="Settings.ThemeApplied" xml:space="preserve">
+    <value>Εφαρμόστηκε το θέμα.</value>
+  </data>
+  <data name="Settings.PageSizeInvalid" xml:space="preserve">
+    <value>Εισαγάγετε ένα θετικό μέγεθος σελίδας.</value>
+  </data>
+  <data name="Settings.PageSizeUpdated" xml:space="preserve">
+    <value>Το μέγεθος σελίδας ορίστηκε σε {0} στοιχεία.</value>
+  </data>
+  <data name="Settings.LanguageApplied" xml:space="preserve">
+    <value>Η γλώσσα άλλαξε σε {0}.</value>
+  </data>
+  <data name="SettingsPage_Title.Text" xml:space="preserve">
+    <value>Ρυθμίσεις</value>
+  </data>
+  <data name="SettingsPage_ThemeCombo.Header" xml:space="preserve">
+    <value>Θέμα εφαρμογής</value>
+  </data>
+  <data name="SettingsPage_LanguageCombo.Header" xml:space="preserve">
+    <value>Γλώσσα εφαρμογής</value>
+  </data>
+  <data name="SettingsPage_PageSizeBox.Header" xml:space="preserve">
+    <value>Μέγεθος σελίδας</value>
+  </data>
+  <data name="SettingsPage_FolderBox.Header" xml:space="preserve">
+    <value>Τελευταίος φάκελος</value>
+  </data>
+  <data name="SettingsPage_FolderBox.PlaceholderText" xml:space="preserve">
+    <value>Διαδρομή φακέλου</value>
+  </data>
+  <data name="SettingsPage_ApplyThemeButton.Content" xml:space="preserve">
+    <value>Εφαρμογή θέματος</value>
+  </data>
+  <data name="SettingsPage_ApplyLanguageButton.Content" xml:space="preserve">
+    <value>Εφαρμογή γλώσσας</value>
+  </data>
+  <data name="Startup.InitializingServices" xml:space="preserve">
+    <value>Εκκίνηση υπηρεσιών εφαρμογής…</value>
+  </data>
+  <data name="Startup.StartupFailed" xml:space="preserve">
+    <value>Αποτυχία εκκίνησης της εφαρμογής.</value>
+  </data>
+  <data name="StartupWindow.Title" xml:space="preserve">
+    <value>Veriado</value>
+  </data>
+  <data name="StartupWindow_RetryButton.Content" xml:space="preserve">
+    <value>Δοκιμάστε ξανά</value>
+  </data>
+</root>

--- a/Veriado.WinUI/Strings/en-IE/Resources.resw
+++ b/Veriado.WinUI/Strings/en-IE/Resources.resw
@@ -1,0 +1,66 @@
+<?xml version='1.0' encoding='utf-8'?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Common.OperationCancelled" xml:space="preserve">
+    <value>Operation was cancelled.</value>
+  </data>
+  <data name="Settings.ThemeApplied" xml:space="preserve">
+    <value>Theme applied.</value>
+  </data>
+  <data name="Settings.PageSizeInvalid" xml:space="preserve">
+    <value>Enter a positive page size.</value>
+  </data>
+  <data name="Settings.PageSizeUpdated" xml:space="preserve">
+    <value>Page size set to {0} items.</value>
+  </data>
+  <data name="Settings.LanguageApplied" xml:space="preserve">
+    <value>Language switched to {0}.</value>
+  </data>
+  <data name="SettingsPage_Title.Text" xml:space="preserve">
+    <value>Settings</value>
+  </data>
+  <data name="SettingsPage_ThemeCombo.Header" xml:space="preserve">
+    <value>Application theme</value>
+  </data>
+  <data name="SettingsPage_LanguageCombo.Header" xml:space="preserve">
+    <value>Application language</value>
+  </data>
+  <data name="SettingsPage_PageSizeBox.Header" xml:space="preserve">
+    <value>Page size</value>
+  </data>
+  <data name="SettingsPage_FolderBox.Header" xml:space="preserve">
+    <value>Last folder</value>
+  </data>
+  <data name="SettingsPage_FolderBox.PlaceholderText" xml:space="preserve">
+    <value>Folder path</value>
+  </data>
+  <data name="SettingsPage_ApplyThemeButton.Content" xml:space="preserve">
+    <value>Apply theme</value>
+  </data>
+  <data name="SettingsPage_ApplyLanguageButton.Content" xml:space="preserve">
+    <value>Apply language</value>
+  </data>
+  <data name="Startup.InitializingServices" xml:space="preserve">
+    <value>Starting application services…</value>
+  </data>
+  <data name="Startup.StartupFailed" xml:space="preserve">
+    <value>Failed to start the application.</value>
+  </data>
+  <data name="StartupWindow.Title" xml:space="preserve">
+    <value>Veriado</value>
+  </data>
+  <data name="StartupWindow_RetryButton.Content" xml:space="preserve">
+    <value>Try again</value>
+  </data>
+</root>

--- a/Veriado.WinUI/Strings/es-ES/Resources.resw
+++ b/Veriado.WinUI/Strings/es-ES/Resources.resw
@@ -1,0 +1,66 @@
+<?xml version='1.0' encoding='utf-8'?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Common.OperationCancelled" xml:space="preserve">
+    <value>La operación se canceló.</value>
+  </data>
+  <data name="Settings.ThemeApplied" xml:space="preserve">
+    <value>Tema aplicado.</value>
+  </data>
+  <data name="Settings.PageSizeInvalid" xml:space="preserve">
+    <value>Introduzca un tamaño de página positivo.</value>
+  </data>
+  <data name="Settings.PageSizeUpdated" xml:space="preserve">
+    <value>Tamaño de página establecido en {0} elementos.</value>
+  </data>
+  <data name="Settings.LanguageApplied" xml:space="preserve">
+    <value>Idioma cambiado a {0}.</value>
+  </data>
+  <data name="SettingsPage_Title.Text" xml:space="preserve">
+    <value>Configuración</value>
+  </data>
+  <data name="SettingsPage_ThemeCombo.Header" xml:space="preserve">
+    <value>Tema de la aplicación</value>
+  </data>
+  <data name="SettingsPage_LanguageCombo.Header" xml:space="preserve">
+    <value>Idioma de la aplicación</value>
+  </data>
+  <data name="SettingsPage_PageSizeBox.Header" xml:space="preserve">
+    <value>Tamaño de página</value>
+  </data>
+  <data name="SettingsPage_FolderBox.Header" xml:space="preserve">
+    <value>Última carpeta</value>
+  </data>
+  <data name="SettingsPage_FolderBox.PlaceholderText" xml:space="preserve">
+    <value>Ruta de la carpeta</value>
+  </data>
+  <data name="SettingsPage_ApplyThemeButton.Content" xml:space="preserve">
+    <value>Aplicar tema</value>
+  </data>
+  <data name="SettingsPage_ApplyLanguageButton.Content" xml:space="preserve">
+    <value>Aplicar idioma</value>
+  </data>
+  <data name="Startup.InitializingServices" xml:space="preserve">
+    <value>Iniciando los servicios de la aplicación…</value>
+  </data>
+  <data name="Startup.StartupFailed" xml:space="preserve">
+    <value>No se pudo iniciar la aplicación.</value>
+  </data>
+  <data name="StartupWindow.Title" xml:space="preserve">
+    <value>Veriado</value>
+  </data>
+  <data name="StartupWindow_RetryButton.Content" xml:space="preserve">
+    <value>Volver a intentarlo</value>
+  </data>
+</root>

--- a/Veriado.WinUI/Strings/et-EE/Resources.resw
+++ b/Veriado.WinUI/Strings/et-EE/Resources.resw
@@ -1,0 +1,66 @@
+<?xml version='1.0' encoding='utf-8'?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Common.OperationCancelled" xml:space="preserve">
+    <value>Toiming katkestati.</value>
+  </data>
+  <data name="Settings.ThemeApplied" xml:space="preserve">
+    <value>Teema rakendatud.</value>
+  </data>
+  <data name="Settings.PageSizeInvalid" xml:space="preserve">
+    <value>Sisestage lehe suurus positiivse arvuna.</value>
+  </data>
+  <data name="Settings.PageSizeUpdated" xml:space="preserve">
+    <value>Lehe suurus on seatud {0} elemendile.</value>
+  </data>
+  <data name="Settings.LanguageApplied" xml:space="preserve">
+    <value>Keel vahetati {0} peale.</value>
+  </data>
+  <data name="SettingsPage_Title.Text" xml:space="preserve">
+    <value>Seaded</value>
+  </data>
+  <data name="SettingsPage_ThemeCombo.Header" xml:space="preserve">
+    <value>Rakenduse teema</value>
+  </data>
+  <data name="SettingsPage_LanguageCombo.Header" xml:space="preserve">
+    <value>Rakenduse keel</value>
+  </data>
+  <data name="SettingsPage_PageSizeBox.Header" xml:space="preserve">
+    <value>Lehe suurus</value>
+  </data>
+  <data name="SettingsPage_FolderBox.Header" xml:space="preserve">
+    <value>Viimane kaust</value>
+  </data>
+  <data name="SettingsPage_FolderBox.PlaceholderText" xml:space="preserve">
+    <value>Kausta tee</value>
+  </data>
+  <data name="SettingsPage_ApplyThemeButton.Content" xml:space="preserve">
+    <value>Rakenda teema</value>
+  </data>
+  <data name="SettingsPage_ApplyLanguageButton.Content" xml:space="preserve">
+    <value>Rakenda keel</value>
+  </data>
+  <data name="Startup.InitializingServices" xml:space="preserve">
+    <value>Rakenduse teenuste käivitamine…</value>
+  </data>
+  <data name="Startup.StartupFailed" xml:space="preserve">
+    <value>Rakendust ei õnnestunud käivitada.</value>
+  </data>
+  <data name="StartupWindow.Title" xml:space="preserve">
+    <value>Veriado</value>
+  </data>
+  <data name="StartupWindow_RetryButton.Content" xml:space="preserve">
+    <value>Proovi uuesti</value>
+  </data>
+</root>

--- a/Veriado.WinUI/Strings/fi-FI/Resources.resw
+++ b/Veriado.WinUI/Strings/fi-FI/Resources.resw
@@ -1,0 +1,66 @@
+<?xml version='1.0' encoding='utf-8'?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Common.OperationCancelled" xml:space="preserve">
+    <value>Toiminto peruttiin.</value>
+  </data>
+  <data name="Settings.ThemeApplied" xml:space="preserve">
+    <value>Teema otettiin käyttöön.</value>
+  </data>
+  <data name="Settings.PageSizeInvalid" xml:space="preserve">
+    <value>Syötä positiivinen sivukoko.</value>
+  </data>
+  <data name="Settings.PageSizeUpdated" xml:space="preserve">
+    <value>Sivukooksi asetettiin {0} kohdetta.</value>
+  </data>
+  <data name="Settings.LanguageApplied" xml:space="preserve">
+    <value>Kieli vaihdettiin kieleen {0}.</value>
+  </data>
+  <data name="SettingsPage_Title.Text" xml:space="preserve">
+    <value>Asetukset</value>
+  </data>
+  <data name="SettingsPage_ThemeCombo.Header" xml:space="preserve">
+    <value>Sovelluksen teema</value>
+  </data>
+  <data name="SettingsPage_LanguageCombo.Header" xml:space="preserve">
+    <value>Sovelluksen kieli</value>
+  </data>
+  <data name="SettingsPage_PageSizeBox.Header" xml:space="preserve">
+    <value>Sivukoko</value>
+  </data>
+  <data name="SettingsPage_FolderBox.Header" xml:space="preserve">
+    <value>Viimeisin kansio</value>
+  </data>
+  <data name="SettingsPage_FolderBox.PlaceholderText" xml:space="preserve">
+    <value>Kansiopolku</value>
+  </data>
+  <data name="SettingsPage_ApplyThemeButton.Content" xml:space="preserve">
+    <value>Käytä teemaa</value>
+  </data>
+  <data name="SettingsPage_ApplyLanguageButton.Content" xml:space="preserve">
+    <value>Käytä kieltä</value>
+  </data>
+  <data name="Startup.InitializingServices" xml:space="preserve">
+    <value>Käynnistetään sovelluksen palveluja…</value>
+  </data>
+  <data name="Startup.StartupFailed" xml:space="preserve">
+    <value>Sovelluksen käynnistäminen epäonnistui.</value>
+  </data>
+  <data name="StartupWindow.Title" xml:space="preserve">
+    <value>Veriado</value>
+  </data>
+  <data name="StartupWindow_RetryButton.Content" xml:space="preserve">
+    <value>Yritä uudelleen</value>
+  </data>
+</root>

--- a/Veriado.WinUI/Strings/fr-FR/Resources.resw
+++ b/Veriado.WinUI/Strings/fr-FR/Resources.resw
@@ -1,0 +1,66 @@
+<?xml version='1.0' encoding='utf-8'?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Common.OperationCancelled" xml:space="preserve">
+    <value>L’opération a été annulée.</value>
+  </data>
+  <data name="Settings.ThemeApplied" xml:space="preserve">
+    <value>Thème appliqué.</value>
+  </data>
+  <data name="Settings.PageSizeInvalid" xml:space="preserve">
+    <value>Entrez une taille de page positive.</value>
+  </data>
+  <data name="Settings.PageSizeUpdated" xml:space="preserve">
+    <value>Taille de page définie sur {0} éléments.</value>
+  </data>
+  <data name="Settings.LanguageApplied" xml:space="preserve">
+    <value>Langue changée en {0}.</value>
+  </data>
+  <data name="SettingsPage_Title.Text" xml:space="preserve">
+    <value>Paramètres</value>
+  </data>
+  <data name="SettingsPage_ThemeCombo.Header" xml:space="preserve">
+    <value>Thème de l’application</value>
+  </data>
+  <data name="SettingsPage_LanguageCombo.Header" xml:space="preserve">
+    <value>Langue de l’application</value>
+  </data>
+  <data name="SettingsPage_PageSizeBox.Header" xml:space="preserve">
+    <value>Taille de page</value>
+  </data>
+  <data name="SettingsPage_FolderBox.Header" xml:space="preserve">
+    <value>Dernier dossier</value>
+  </data>
+  <data name="SettingsPage_FolderBox.PlaceholderText" xml:space="preserve">
+    <value>Chemin du dossier</value>
+  </data>
+  <data name="SettingsPage_ApplyThemeButton.Content" xml:space="preserve">
+    <value>Appliquer le thème</value>
+  </data>
+  <data name="SettingsPage_ApplyLanguageButton.Content" xml:space="preserve">
+    <value>Appliquer la langue</value>
+  </data>
+  <data name="Startup.InitializingServices" xml:space="preserve">
+    <value>Démarrage des services de l’application…</value>
+  </data>
+  <data name="Startup.StartupFailed" xml:space="preserve">
+    <value>Échec du démarrage de l’application.</value>
+  </data>
+  <data name="StartupWindow.Title" xml:space="preserve">
+    <value>Veriado</value>
+  </data>
+  <data name="StartupWindow_RetryButton.Content" xml:space="preserve">
+    <value>Réessayer</value>
+  </data>
+</root>

--- a/Veriado.WinUI/Strings/ga-IE/Resources.resw
+++ b/Veriado.WinUI/Strings/ga-IE/Resources.resw
@@ -1,0 +1,66 @@
+<?xml version='1.0' encoding='utf-8'?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Common.OperationCancelled" xml:space="preserve">
+    <value>Cealaíodh an oibríocht.</value>
+  </data>
+  <data name="Settings.ThemeApplied" xml:space="preserve">
+    <value>Cuireadh an téama i bhfeidhm.</value>
+  </data>
+  <data name="Settings.PageSizeInvalid" xml:space="preserve">
+    <value>Iontráil méid leathanaigh dearfach.</value>
+  </data>
+  <data name="Settings.PageSizeUpdated" xml:space="preserve">
+    <value>Socraíodh méid na leathanaigh go {0} mír.</value>
+  </data>
+  <data name="Settings.LanguageApplied" xml:space="preserve">
+    <value>Athraíodh an teanga go {0}.</value>
+  </data>
+  <data name="SettingsPage_Title.Text" xml:space="preserve">
+    <value>Socruithe</value>
+  </data>
+  <data name="SettingsPage_ThemeCombo.Header" xml:space="preserve">
+    <value>Téama an fheidhmchláir</value>
+  </data>
+  <data name="SettingsPage_LanguageCombo.Header" xml:space="preserve">
+    <value>Teanga an fheidhmchláir</value>
+  </data>
+  <data name="SettingsPage_PageSizeBox.Header" xml:space="preserve">
+    <value>Méid leathanaigh</value>
+  </data>
+  <data name="SettingsPage_FolderBox.Header" xml:space="preserve">
+    <value>An fillteán is déanaí</value>
+  </data>
+  <data name="SettingsPage_FolderBox.PlaceholderText" xml:space="preserve">
+    <value>Conair an fhillteáin</value>
+  </data>
+  <data name="SettingsPage_ApplyThemeButton.Content" xml:space="preserve">
+    <value>Cuir an téama i bhfeidhm</value>
+  </data>
+  <data name="SettingsPage_ApplyLanguageButton.Content" xml:space="preserve">
+    <value>Cuir an teanga i bhfeidhm</value>
+  </data>
+  <data name="Startup.InitializingServices" xml:space="preserve">
+    <value>Seirbhísí an fheidhmchláir á dtosú…</value>
+  </data>
+  <data name="Startup.StartupFailed" xml:space="preserve">
+    <value>Theip ar thosú an fheidhmchláir.</value>
+  </data>
+  <data name="StartupWindow.Title" xml:space="preserve">
+    <value>Veriado</value>
+  </data>
+  <data name="StartupWindow_RetryButton.Content" xml:space="preserve">
+    <value>Bain triail eile as</value>
+  </data>
+</root>

--- a/Veriado.WinUI/Strings/hr-HR/Resources.resw
+++ b/Veriado.WinUI/Strings/hr-HR/Resources.resw
@@ -1,0 +1,66 @@
+<?xml version='1.0' encoding='utf-8'?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Common.OperationCancelled" xml:space="preserve">
+    <value>Radnja je otkazana.</value>
+  </data>
+  <data name="Settings.ThemeApplied" xml:space="preserve">
+    <value>Tema je primijenjena.</value>
+  </data>
+  <data name="Settings.PageSizeInvalid" xml:space="preserve">
+    <value>Unesite pozitivan broj elemenata na stranici.</value>
+  </data>
+  <data name="Settings.PageSizeUpdated" xml:space="preserve">
+    <value>Veličina stranice postavljena je na {0} stavki.</value>
+  </data>
+  <data name="Settings.LanguageApplied" xml:space="preserve">
+    <value>Jezik je promijenjen na {0}.</value>
+  </data>
+  <data name="SettingsPage_Title.Text" xml:space="preserve">
+    <value>Postavke</value>
+  </data>
+  <data name="SettingsPage_ThemeCombo.Header" xml:space="preserve">
+    <value>Tema aplikacije</value>
+  </data>
+  <data name="SettingsPage_LanguageCombo.Header" xml:space="preserve">
+    <value>Jezik aplikacije</value>
+  </data>
+  <data name="SettingsPage_PageSizeBox.Header" xml:space="preserve">
+    <value>Veličina stranice</value>
+  </data>
+  <data name="SettingsPage_FolderBox.Header" xml:space="preserve">
+    <value>Posljednja mapa</value>
+  </data>
+  <data name="SettingsPage_FolderBox.PlaceholderText" xml:space="preserve">
+    <value>Put do mape</value>
+  </data>
+  <data name="SettingsPage_ApplyThemeButton.Content" xml:space="preserve">
+    <value>Primijeni temu</value>
+  </data>
+  <data name="SettingsPage_ApplyLanguageButton.Content" xml:space="preserve">
+    <value>Primijeni jezik</value>
+  </data>
+  <data name="Startup.InitializingServices" xml:space="preserve">
+    <value>Pokretanje usluga aplikacije…</value>
+  </data>
+  <data name="Startup.StartupFailed" xml:space="preserve">
+    <value>Pokretanje aplikacije nije uspjelo.</value>
+  </data>
+  <data name="StartupWindow.Title" xml:space="preserve">
+    <value>Veriado</value>
+  </data>
+  <data name="StartupWindow_RetryButton.Content" xml:space="preserve">
+    <value>Pokušaj ponovno</value>
+  </data>
+</root>

--- a/Veriado.WinUI/Strings/hu-HU/Resources.resw
+++ b/Veriado.WinUI/Strings/hu-HU/Resources.resw
@@ -1,0 +1,66 @@
+<?xml version='1.0' encoding='utf-8'?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Common.OperationCancelled" xml:space="preserve">
+    <value>A művelet megszakadt.</value>
+  </data>
+  <data name="Settings.ThemeApplied" xml:space="preserve">
+    <value>A téma alkalmazva.</value>
+  </data>
+  <data name="Settings.PageSizeInvalid" xml:space="preserve">
+    <value>Adjon meg pozitív oldalméretet.</value>
+  </data>
+  <data name="Settings.PageSizeUpdated" xml:space="preserve">
+    <value>Az oldalméret {0} elemre lett beállítva.</value>
+  </data>
+  <data name="Settings.LanguageApplied" xml:space="preserve">
+    <value>A nyelv {0} értékre lett váltva.</value>
+  </data>
+  <data name="SettingsPage_Title.Text" xml:space="preserve">
+    <value>Beállítások</value>
+  </data>
+  <data name="SettingsPage_ThemeCombo.Header" xml:space="preserve">
+    <value>Alkalmazás témája</value>
+  </data>
+  <data name="SettingsPage_LanguageCombo.Header" xml:space="preserve">
+    <value>Alkalmazás nyelve</value>
+  </data>
+  <data name="SettingsPage_PageSizeBox.Header" xml:space="preserve">
+    <value>Oldalméret</value>
+  </data>
+  <data name="SettingsPage_FolderBox.Header" xml:space="preserve">
+    <value>Utolsó mappa</value>
+  </data>
+  <data name="SettingsPage_FolderBox.PlaceholderText" xml:space="preserve">
+    <value>Mappa elérési útja</value>
+  </data>
+  <data name="SettingsPage_ApplyThemeButton.Content" xml:space="preserve">
+    <value>Téma alkalmazása</value>
+  </data>
+  <data name="SettingsPage_ApplyLanguageButton.Content" xml:space="preserve">
+    <value>Nyelv alkalmazása</value>
+  </data>
+  <data name="Startup.InitializingServices" xml:space="preserve">
+    <value>Alkalmazásszolgáltatások indítása…</value>
+  </data>
+  <data name="Startup.StartupFailed" xml:space="preserve">
+    <value>Az alkalmazást nem sikerült elindítani.</value>
+  </data>
+  <data name="StartupWindow.Title" xml:space="preserve">
+    <value>Veriado</value>
+  </data>
+  <data name="StartupWindow_RetryButton.Content" xml:space="preserve">
+    <value>Próbálja újra</value>
+  </data>
+</root>

--- a/Veriado.WinUI/Strings/it-IT/Resources.resw
+++ b/Veriado.WinUI/Strings/it-IT/Resources.resw
@@ -1,0 +1,66 @@
+<?xml version='1.0' encoding='utf-8'?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Common.OperationCancelled" xml:space="preserve">
+    <value>Operazione annullata.</value>
+  </data>
+  <data name="Settings.ThemeApplied" xml:space="preserve">
+    <value>Tema applicato.</value>
+  </data>
+  <data name="Settings.PageSizeInvalid" xml:space="preserve">
+    <value>Inserisci una dimensione di pagina positiva.</value>
+  </data>
+  <data name="Settings.PageSizeUpdated" xml:space="preserve">
+    <value>Dimensione pagina impostata su {0} elementi.</value>
+  </data>
+  <data name="Settings.LanguageApplied" xml:space="preserve">
+    <value>Lingua cambiata in {0}.</value>
+  </data>
+  <data name="SettingsPage_Title.Text" xml:space="preserve">
+    <value>Impostazioni</value>
+  </data>
+  <data name="SettingsPage_ThemeCombo.Header" xml:space="preserve">
+    <value>Tema dell’applicazione</value>
+  </data>
+  <data name="SettingsPage_LanguageCombo.Header" xml:space="preserve">
+    <value>Lingua dell’applicazione</value>
+  </data>
+  <data name="SettingsPage_PageSizeBox.Header" xml:space="preserve">
+    <value>Dimensione pagina</value>
+  </data>
+  <data name="SettingsPage_FolderBox.Header" xml:space="preserve">
+    <value>Ultima cartella</value>
+  </data>
+  <data name="SettingsPage_FolderBox.PlaceholderText" xml:space="preserve">
+    <value>Percorso cartella</value>
+  </data>
+  <data name="SettingsPage_ApplyThemeButton.Content" xml:space="preserve">
+    <value>Applica tema</value>
+  </data>
+  <data name="SettingsPage_ApplyLanguageButton.Content" xml:space="preserve">
+    <value>Applica lingua</value>
+  </data>
+  <data name="Startup.InitializingServices" xml:space="preserve">
+    <value>Avvio dei servizi dell’applicazione…</value>
+  </data>
+  <data name="Startup.StartupFailed" xml:space="preserve">
+    <value>Impossibile avviare l’applicazione.</value>
+  </data>
+  <data name="StartupWindow.Title" xml:space="preserve">
+    <value>Veriado</value>
+  </data>
+  <data name="StartupWindow_RetryButton.Content" xml:space="preserve">
+    <value>Riprova</value>
+  </data>
+</root>

--- a/Veriado.WinUI/Strings/lt-LT/Resources.resw
+++ b/Veriado.WinUI/Strings/lt-LT/Resources.resw
@@ -1,0 +1,66 @@
+<?xml version='1.0' encoding='utf-8'?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Common.OperationCancelled" xml:space="preserve">
+    <value>Operacija atšaukta.</value>
+  </data>
+  <data name="Settings.ThemeApplied" xml:space="preserve">
+    <value>Tema pritaikyta.</value>
+  </data>
+  <data name="Settings.PageSizeInvalid" xml:space="preserve">
+    <value>Įveskite teigiamą puslapio dydį.</value>
+  </data>
+  <data name="Settings.PageSizeUpdated" xml:space="preserve">
+    <value>Puslapio dydis nustatytas į {0} elementus.</value>
+  </data>
+  <data name="Settings.LanguageApplied" xml:space="preserve">
+    <value>Kalba pakeista į {0}.</value>
+  </data>
+  <data name="SettingsPage_Title.Text" xml:space="preserve">
+    <value>Nustatymai</value>
+  </data>
+  <data name="SettingsPage_ThemeCombo.Header" xml:space="preserve">
+    <value>Programėlės tema</value>
+  </data>
+  <data name="SettingsPage_LanguageCombo.Header" xml:space="preserve">
+    <value>Programėlės kalba</value>
+  </data>
+  <data name="SettingsPage_PageSizeBox.Header" xml:space="preserve">
+    <value>Puslapio dydis</value>
+  </data>
+  <data name="SettingsPage_FolderBox.Header" xml:space="preserve">
+    <value>Paskutinis aplankas</value>
+  </data>
+  <data name="SettingsPage_FolderBox.PlaceholderText" xml:space="preserve">
+    <value>Aplanko kelias</value>
+  </data>
+  <data name="SettingsPage_ApplyThemeButton.Content" xml:space="preserve">
+    <value>Taikyti temą</value>
+  </data>
+  <data name="SettingsPage_ApplyLanguageButton.Content" xml:space="preserve">
+    <value>Taikyti kalbą</value>
+  </data>
+  <data name="Startup.InitializingServices" xml:space="preserve">
+    <value>Paleidžiamos programėlės paslaugos…</value>
+  </data>
+  <data name="Startup.StartupFailed" xml:space="preserve">
+    <value>Nepavyko paleisti programėlės.</value>
+  </data>
+  <data name="StartupWindow.Title" xml:space="preserve">
+    <value>Veriado</value>
+  </data>
+  <data name="StartupWindow_RetryButton.Content" xml:space="preserve">
+    <value>Bandyti dar kartą</value>
+  </data>
+</root>

--- a/Veriado.WinUI/Strings/lv-LV/Resources.resw
+++ b/Veriado.WinUI/Strings/lv-LV/Resources.resw
@@ -1,0 +1,66 @@
+<?xml version='1.0' encoding='utf-8'?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Common.OperationCancelled" xml:space="preserve">
+    <value>Darbība tika atcelta.</value>
+  </data>
+  <data name="Settings.ThemeApplied" xml:space="preserve">
+    <value>Tēma piemērota.</value>
+  </data>
+  <data name="Settings.PageSizeInvalid" xml:space="preserve">
+    <value>Ievadiet pozitīvu lapas lielumu.</value>
+  </data>
+  <data name="Settings.PageSizeUpdated" xml:space="preserve">
+    <value>Lapas lielums iestatīts uz {0} vienībām.</value>
+  </data>
+  <data name="Settings.LanguageApplied" xml:space="preserve">
+    <value>Valoda nomainīta uz {0}.</value>
+  </data>
+  <data name="SettingsPage_Title.Text" xml:space="preserve">
+    <value>Iestatījumi</value>
+  </data>
+  <data name="SettingsPage_ThemeCombo.Header" xml:space="preserve">
+    <value>Lietotnes tēma</value>
+  </data>
+  <data name="SettingsPage_LanguageCombo.Header" xml:space="preserve">
+    <value>Lietotnes valoda</value>
+  </data>
+  <data name="SettingsPage_PageSizeBox.Header" xml:space="preserve">
+    <value>Lapas lielums</value>
+  </data>
+  <data name="SettingsPage_FolderBox.Header" xml:space="preserve">
+    <value>Pēdējā mape</value>
+  </data>
+  <data name="SettingsPage_FolderBox.PlaceholderText" xml:space="preserve">
+    <value>Mapes ceļš</value>
+  </data>
+  <data name="SettingsPage_ApplyThemeButton.Content" xml:space="preserve">
+    <value>Piemērot tēmu</value>
+  </data>
+  <data name="SettingsPage_ApplyLanguageButton.Content" xml:space="preserve">
+    <value>Piemērot valodu</value>
+  </data>
+  <data name="Startup.InitializingServices" xml:space="preserve">
+    <value>Tiek startēti lietotnes pakalpojumi…</value>
+  </data>
+  <data name="Startup.StartupFailed" xml:space="preserve">
+    <value>Neizdevās palaist lietotni.</value>
+  </data>
+  <data name="StartupWindow.Title" xml:space="preserve">
+    <value>Veriado</value>
+  </data>
+  <data name="StartupWindow_RetryButton.Content" xml:space="preserve">
+    <value>Mēģināt vēlreiz</value>
+  </data>
+</root>

--- a/Veriado.WinUI/Strings/mt-MT/Resources.resw
+++ b/Veriado.WinUI/Strings/mt-MT/Resources.resw
@@ -1,0 +1,66 @@
+<?xml version='1.0' encoding='utf-8'?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Common.OperationCancelled" xml:space="preserve">
+    <value>L-operazzjoni ġiet ikkanċellata.</value>
+  </data>
+  <data name="Settings.ThemeApplied" xml:space="preserve">
+    <value>It-tema ġiet applikata.</value>
+  </data>
+  <data name="Settings.PageSizeInvalid" xml:space="preserve">
+    <value>Daħħal daqs ta’ paġna pożittiv.</value>
+  </data>
+  <data name="Settings.PageSizeUpdated" xml:space="preserve">
+    <value>Id-daqs tal-paġna ssettjat għal {0} oġġetti.</value>
+  </data>
+  <data name="Settings.LanguageApplied" xml:space="preserve">
+    <value>Il-lingwa nbidlet għal {0}.</value>
+  </data>
+  <data name="SettingsPage_Title.Text" xml:space="preserve">
+    <value>Issettjar</value>
+  </data>
+  <data name="SettingsPage_ThemeCombo.Header" xml:space="preserve">
+    <value>Tema tal-applikazzjoni</value>
+  </data>
+  <data name="SettingsPage_LanguageCombo.Header" xml:space="preserve">
+    <value>Lingwa tal-applikazzjoni</value>
+  </data>
+  <data name="SettingsPage_PageSizeBox.Header" xml:space="preserve">
+    <value>Daqs tal-paġna</value>
+  </data>
+  <data name="SettingsPage_FolderBox.Header" xml:space="preserve">
+    <value>L-aħħar fowlder</value>
+  </data>
+  <data name="SettingsPage_FolderBox.PlaceholderText" xml:space="preserve">
+    <value>Triq tal-fowlder</value>
+  </data>
+  <data name="SettingsPage_ApplyThemeButton.Content" xml:space="preserve">
+    <value>Applika t-tema</value>
+  </data>
+  <data name="SettingsPage_ApplyLanguageButton.Content" xml:space="preserve">
+    <value>Applika l-lingwa</value>
+  </data>
+  <data name="Startup.InitializingServices" xml:space="preserve">
+    <value>Qed jitniedu s-servizzi tal-applikazzjoni…</value>
+  </data>
+  <data name="Startup.StartupFailed" xml:space="preserve">
+    <value>It-tnedija tal-applikazzjoni falliet.</value>
+  </data>
+  <data name="StartupWindow.Title" xml:space="preserve">
+    <value>Veriado</value>
+  </data>
+  <data name="StartupWindow_RetryButton.Content" xml:space="preserve">
+    <value>Erġa’ ipprova</value>
+  </data>
+</root>

--- a/Veriado.WinUI/Strings/nl-NL/Resources.resw
+++ b/Veriado.WinUI/Strings/nl-NL/Resources.resw
@@ -1,0 +1,66 @@
+<?xml version='1.0' encoding='utf-8'?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Common.OperationCancelled" xml:space="preserve">
+    <value>De bewerking is geannuleerd.</value>
+  </data>
+  <data name="Settings.ThemeApplied" xml:space="preserve">
+    <value>Thema toegepast.</value>
+  </data>
+  <data name="Settings.PageSizeInvalid" xml:space="preserve">
+    <value>Voer een positieve paginagrootte in.</value>
+  </data>
+  <data name="Settings.PageSizeUpdated" xml:space="preserve">
+    <value>Paginagrootte ingesteld op {0} items.</value>
+  </data>
+  <data name="Settings.LanguageApplied" xml:space="preserve">
+    <value>Taal gewijzigd naar {0}.</value>
+  </data>
+  <data name="SettingsPage_Title.Text" xml:space="preserve">
+    <value>Instellingen</value>
+  </data>
+  <data name="SettingsPage_ThemeCombo.Header" xml:space="preserve">
+    <value>Applicatiethema</value>
+  </data>
+  <data name="SettingsPage_LanguageCombo.Header" xml:space="preserve">
+    <value>Applicatietaal</value>
+  </data>
+  <data name="SettingsPage_PageSizeBox.Header" xml:space="preserve">
+    <value>Paginagrootte</value>
+  </data>
+  <data name="SettingsPage_FolderBox.Header" xml:space="preserve">
+    <value>Laatste map</value>
+  </data>
+  <data name="SettingsPage_FolderBox.PlaceholderText" xml:space="preserve">
+    <value>Mappad</value>
+  </data>
+  <data name="SettingsPage_ApplyThemeButton.Content" xml:space="preserve">
+    <value>Thema toepassen</value>
+  </data>
+  <data name="SettingsPage_ApplyLanguageButton.Content" xml:space="preserve">
+    <value>Taal toepassen</value>
+  </data>
+  <data name="Startup.InitializingServices" xml:space="preserve">
+    <value>Applicatiediensten starten…</value>
+  </data>
+  <data name="Startup.StartupFailed" xml:space="preserve">
+    <value>Het is niet gelukt de applicatie te starten.</value>
+  </data>
+  <data name="StartupWindow.Title" xml:space="preserve">
+    <value>Veriado</value>
+  </data>
+  <data name="StartupWindow_RetryButton.Content" xml:space="preserve">
+    <value>Probeer opnieuw</value>
+  </data>
+</root>

--- a/Veriado.WinUI/Strings/pl-PL/Resources.resw
+++ b/Veriado.WinUI/Strings/pl-PL/Resources.resw
@@ -1,0 +1,66 @@
+<?xml version='1.0' encoding='utf-8'?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Common.OperationCancelled" xml:space="preserve">
+    <value>Operacja została anulowana.</value>
+  </data>
+  <data name="Settings.ThemeApplied" xml:space="preserve">
+    <value>Motyw zastosowano.</value>
+  </data>
+  <data name="Settings.PageSizeInvalid" xml:space="preserve">
+    <value>Podaj dodatni rozmiar strony.</value>
+  </data>
+  <data name="Settings.PageSizeUpdated" xml:space="preserve">
+    <value>Rozmiar strony ustawiono na {0} elementów.</value>
+  </data>
+  <data name="Settings.LanguageApplied" xml:space="preserve">
+    <value>Język zmieniono na {0}.</value>
+  </data>
+  <data name="SettingsPage_Title.Text" xml:space="preserve">
+    <value>Ustawienia</value>
+  </data>
+  <data name="SettingsPage_ThemeCombo.Header" xml:space="preserve">
+    <value>Motyw aplikacji</value>
+  </data>
+  <data name="SettingsPage_LanguageCombo.Header" xml:space="preserve">
+    <value>Język aplikacji</value>
+  </data>
+  <data name="SettingsPage_PageSizeBox.Header" xml:space="preserve">
+    <value>Rozmiar strony</value>
+  </data>
+  <data name="SettingsPage_FolderBox.Header" xml:space="preserve">
+    <value>Ostatni folder</value>
+  </data>
+  <data name="SettingsPage_FolderBox.PlaceholderText" xml:space="preserve">
+    <value>Ścieżka folderu</value>
+  </data>
+  <data name="SettingsPage_ApplyThemeButton.Content" xml:space="preserve">
+    <value>Zastosuj motyw</value>
+  </data>
+  <data name="SettingsPage_ApplyLanguageButton.Content" xml:space="preserve">
+    <value>Zastosuj język</value>
+  </data>
+  <data name="Startup.InitializingServices" xml:space="preserve">
+    <value>Uruchamianie usług aplikacji…</value>
+  </data>
+  <data name="Startup.StartupFailed" xml:space="preserve">
+    <value>Nie udało się uruchomić aplikacji.</value>
+  </data>
+  <data name="StartupWindow.Title" xml:space="preserve">
+    <value>Veriado</value>
+  </data>
+  <data name="StartupWindow_RetryButton.Content" xml:space="preserve">
+    <value>Spróbuj ponownie</value>
+  </data>
+</root>

--- a/Veriado.WinUI/Strings/pt-PT/Resources.resw
+++ b/Veriado.WinUI/Strings/pt-PT/Resources.resw
@@ -1,0 +1,66 @@
+<?xml version='1.0' encoding='utf-8'?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Common.OperationCancelled" xml:space="preserve">
+    <value>A operação foi cancelada.</value>
+  </data>
+  <data name="Settings.ThemeApplied" xml:space="preserve">
+    <value>Tema aplicado.</value>
+  </data>
+  <data name="Settings.PageSizeInvalid" xml:space="preserve">
+    <value>Introduza um tamanho de página positivo.</value>
+  </data>
+  <data name="Settings.PageSizeUpdated" xml:space="preserve">
+    <value>Tamanho de página definido para {0} itens.</value>
+  </data>
+  <data name="Settings.LanguageApplied" xml:space="preserve">
+    <value>Idioma alterado para {0}.</value>
+  </data>
+  <data name="SettingsPage_Title.Text" xml:space="preserve">
+    <value>Definições</value>
+  </data>
+  <data name="SettingsPage_ThemeCombo.Header" xml:space="preserve">
+    <value>Tema da aplicação</value>
+  </data>
+  <data name="SettingsPage_LanguageCombo.Header" xml:space="preserve">
+    <value>Idioma da aplicação</value>
+  </data>
+  <data name="SettingsPage_PageSizeBox.Header" xml:space="preserve">
+    <value>Tamanho de página</value>
+  </data>
+  <data name="SettingsPage_FolderBox.Header" xml:space="preserve">
+    <value>Última pasta</value>
+  </data>
+  <data name="SettingsPage_FolderBox.PlaceholderText" xml:space="preserve">
+    <value>Caminho da pasta</value>
+  </data>
+  <data name="SettingsPage_ApplyThemeButton.Content" xml:space="preserve">
+    <value>Aplicar tema</value>
+  </data>
+  <data name="SettingsPage_ApplyLanguageButton.Content" xml:space="preserve">
+    <value>Aplicar idioma</value>
+  </data>
+  <data name="Startup.InitializingServices" xml:space="preserve">
+    <value>A iniciar os serviços da aplicação…</value>
+  </data>
+  <data name="Startup.StartupFailed" xml:space="preserve">
+    <value>Falha ao iniciar a aplicação.</value>
+  </data>
+  <data name="StartupWindow.Title" xml:space="preserve">
+    <value>Veriado</value>
+  </data>
+  <data name="StartupWindow_RetryButton.Content" xml:space="preserve">
+    <value>Tente novamente</value>
+  </data>
+</root>

--- a/Veriado.WinUI/Strings/ro-RO/Resources.resw
+++ b/Veriado.WinUI/Strings/ro-RO/Resources.resw
@@ -1,0 +1,66 @@
+<?xml version='1.0' encoding='utf-8'?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Common.OperationCancelled" xml:space="preserve">
+    <value>Operația a fost anulată.</value>
+  </data>
+  <data name="Settings.ThemeApplied" xml:space="preserve">
+    <value>Tema a fost aplicată.</value>
+  </data>
+  <data name="Settings.PageSizeInvalid" xml:space="preserve">
+    <value>Introduceți o dimensiune pozitivă a paginii.</value>
+  </data>
+  <data name="Settings.PageSizeUpdated" xml:space="preserve">
+    <value>Dimensiunea paginii a fost setată la {0} elemente.</value>
+  </data>
+  <data name="Settings.LanguageApplied" xml:space="preserve">
+    <value>Limba a fost schimbată în {0}.</value>
+  </data>
+  <data name="SettingsPage_Title.Text" xml:space="preserve">
+    <value>Setări</value>
+  </data>
+  <data name="SettingsPage_ThemeCombo.Header" xml:space="preserve">
+    <value>Tema aplicației</value>
+  </data>
+  <data name="SettingsPage_LanguageCombo.Header" xml:space="preserve">
+    <value>Limba aplicației</value>
+  </data>
+  <data name="SettingsPage_PageSizeBox.Header" xml:space="preserve">
+    <value>Dimensiunea paginii</value>
+  </data>
+  <data name="SettingsPage_FolderBox.Header" xml:space="preserve">
+    <value>Ultimul folder</value>
+  </data>
+  <data name="SettingsPage_FolderBox.PlaceholderText" xml:space="preserve">
+    <value>Calea către folder</value>
+  </data>
+  <data name="SettingsPage_ApplyThemeButton.Content" xml:space="preserve">
+    <value>Aplică tema</value>
+  </data>
+  <data name="SettingsPage_ApplyLanguageButton.Content" xml:space="preserve">
+    <value>Aplică limba</value>
+  </data>
+  <data name="Startup.InitializingServices" xml:space="preserve">
+    <value>Se pornesc serviciile aplicației…</value>
+  </data>
+  <data name="Startup.StartupFailed" xml:space="preserve">
+    <value>Pornirea aplicației a eșuat.</value>
+  </data>
+  <data name="StartupWindow.Title" xml:space="preserve">
+    <value>Veriado</value>
+  </data>
+  <data name="StartupWindow_RetryButton.Content" xml:space="preserve">
+    <value>Încercați din nou</value>
+  </data>
+</root>

--- a/Veriado.WinUI/Strings/sk-SK/Resources.resw
+++ b/Veriado.WinUI/Strings/sk-SK/Resources.resw
@@ -1,0 +1,66 @@
+<?xml version='1.0' encoding='utf-8'?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Common.OperationCancelled" xml:space="preserve">
+    <value>Operácia bola zrušená.</value>
+  </data>
+  <data name="Settings.ThemeApplied" xml:space="preserve">
+    <value>Téma bola použitá.</value>
+  </data>
+  <data name="Settings.PageSizeInvalid" xml:space="preserve">
+    <value>Zadajte kladnú veľkosť stránky.</value>
+  </data>
+  <data name="Settings.PageSizeUpdated" xml:space="preserve">
+    <value>Veľkosť stránky nastavená na {0} položiek.</value>
+  </data>
+  <data name="Settings.LanguageApplied" xml:space="preserve">
+    <value>Jazyk bol zmenený na {0}.</value>
+  </data>
+  <data name="SettingsPage_Title.Text" xml:space="preserve">
+    <value>Nastavenia</value>
+  </data>
+  <data name="SettingsPage_ThemeCombo.Header" xml:space="preserve">
+    <value>Téma aplikácie</value>
+  </data>
+  <data name="SettingsPage_LanguageCombo.Header" xml:space="preserve">
+    <value>Jazyk aplikácie</value>
+  </data>
+  <data name="SettingsPage_PageSizeBox.Header" xml:space="preserve">
+    <value>Veľkosť stránky</value>
+  </data>
+  <data name="SettingsPage_FolderBox.Header" xml:space="preserve">
+    <value>Posledný priečinok</value>
+  </data>
+  <data name="SettingsPage_FolderBox.PlaceholderText" xml:space="preserve">
+    <value>Cesta k priečinku</value>
+  </data>
+  <data name="SettingsPage_ApplyThemeButton.Content" xml:space="preserve">
+    <value>Použiť tému</value>
+  </data>
+  <data name="SettingsPage_ApplyLanguageButton.Content" xml:space="preserve">
+    <value>Použiť jazyk</value>
+  </data>
+  <data name="Startup.InitializingServices" xml:space="preserve">
+    <value>Spúšťajú sa služby aplikácie…</value>
+  </data>
+  <data name="Startup.StartupFailed" xml:space="preserve">
+    <value>Aplikáciu sa nepodarilo spustiť.</value>
+  </data>
+  <data name="StartupWindow.Title" xml:space="preserve">
+    <value>Veriado</value>
+  </data>
+  <data name="StartupWindow_RetryButton.Content" xml:space="preserve">
+    <value>Skúsiť znova</value>
+  </data>
+</root>

--- a/Veriado.WinUI/Strings/sl-SI/Resources.resw
+++ b/Veriado.WinUI/Strings/sl-SI/Resources.resw
@@ -1,0 +1,66 @@
+<?xml version='1.0' encoding='utf-8'?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Common.OperationCancelled" xml:space="preserve">
+    <value>Operacija je bila preklicana.</value>
+  </data>
+  <data name="Settings.ThemeApplied" xml:space="preserve">
+    <value>Tema je bila uporabljena.</value>
+  </data>
+  <data name="Settings.PageSizeInvalid" xml:space="preserve">
+    <value>Vnesite pozitivno velikost strani.</value>
+  </data>
+  <data name="Settings.PageSizeUpdated" xml:space="preserve">
+    <value>Velikost strani je nastavljena na {0} elementov.</value>
+  </data>
+  <data name="Settings.LanguageApplied" xml:space="preserve">
+    <value>Jezik je bil spremenjen v {0}.</value>
+  </data>
+  <data name="SettingsPage_Title.Text" xml:space="preserve">
+    <value>Nastavitve</value>
+  </data>
+  <data name="SettingsPage_ThemeCombo.Header" xml:space="preserve">
+    <value>Tema aplikacije</value>
+  </data>
+  <data name="SettingsPage_LanguageCombo.Header" xml:space="preserve">
+    <value>Jezik aplikacije</value>
+  </data>
+  <data name="SettingsPage_PageSizeBox.Header" xml:space="preserve">
+    <value>Velikost strani</value>
+  </data>
+  <data name="SettingsPage_FolderBox.Header" xml:space="preserve">
+    <value>Zadnja mapa</value>
+  </data>
+  <data name="SettingsPage_FolderBox.PlaceholderText" xml:space="preserve">
+    <value>Pot do mape</value>
+  </data>
+  <data name="SettingsPage_ApplyThemeButton.Content" xml:space="preserve">
+    <value>Uporabi temo</value>
+  </data>
+  <data name="SettingsPage_ApplyLanguageButton.Content" xml:space="preserve">
+    <value>Uporabi jezik</value>
+  </data>
+  <data name="Startup.InitializingServices" xml:space="preserve">
+    <value>Zaganjanje storitev aplikacije…</value>
+  </data>
+  <data name="Startup.StartupFailed" xml:space="preserve">
+    <value>Zagon aplikacije ni uspel.</value>
+  </data>
+  <data name="StartupWindow.Title" xml:space="preserve">
+    <value>Veriado</value>
+  </data>
+  <data name="StartupWindow_RetryButton.Content" xml:space="preserve">
+    <value>Poskusi znova</value>
+  </data>
+</root>

--- a/Veriado.WinUI/Strings/sv-SE/Resources.resw
+++ b/Veriado.WinUI/Strings/sv-SE/Resources.resw
@@ -1,0 +1,66 @@
+<?xml version='1.0' encoding='utf-8'?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Common.OperationCancelled" xml:space="preserve">
+    <value>Åtgärden avbröts.</value>
+  </data>
+  <data name="Settings.ThemeApplied" xml:space="preserve">
+    <value>Tema tillämpat.</value>
+  </data>
+  <data name="Settings.PageSizeInvalid" xml:space="preserve">
+    <value>Ange en positiv sidstorlek.</value>
+  </data>
+  <data name="Settings.PageSizeUpdated" xml:space="preserve">
+    <value>Sidstorlek inställd på {0} objekt.</value>
+  </data>
+  <data name="Settings.LanguageApplied" xml:space="preserve">
+    <value>Språk bytt till {0}.</value>
+  </data>
+  <data name="SettingsPage_Title.Text" xml:space="preserve">
+    <value>Inställningar</value>
+  </data>
+  <data name="SettingsPage_ThemeCombo.Header" xml:space="preserve">
+    <value>Appens tema</value>
+  </data>
+  <data name="SettingsPage_LanguageCombo.Header" xml:space="preserve">
+    <value>Appens språk</value>
+  </data>
+  <data name="SettingsPage_PageSizeBox.Header" xml:space="preserve">
+    <value>Sidstorlek</value>
+  </data>
+  <data name="SettingsPage_FolderBox.Header" xml:space="preserve">
+    <value>Senaste mapp</value>
+  </data>
+  <data name="SettingsPage_FolderBox.PlaceholderText" xml:space="preserve">
+    <value>Mappsökväg</value>
+  </data>
+  <data name="SettingsPage_ApplyThemeButton.Content" xml:space="preserve">
+    <value>Tillämpa tema</value>
+  </data>
+  <data name="SettingsPage_ApplyLanguageButton.Content" xml:space="preserve">
+    <value>Tillämpa språk</value>
+  </data>
+  <data name="Startup.InitializingServices" xml:space="preserve">
+    <value>Startar apptjänster…</value>
+  </data>
+  <data name="Startup.StartupFailed" xml:space="preserve">
+    <value>Det gick inte att starta appen.</value>
+  </data>
+  <data name="StartupWindow.Title" xml:space="preserve">
+    <value>Veriado</value>
+  </data>
+  <data name="StartupWindow_RetryButton.Content" xml:space="preserve">
+    <value>Försök igen</value>
+  </data>
+</root>


### PR DESCRIPTION
## Summary
- add localized resource files for EU member languages plus English (Ireland)
- expand the WinUI localization configuration to advertise the newly supported cultures

## Testing
- dotnet build Veriado.sln *(fails: dotnet CLI is unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68de9fda7b988326840639579d0dfa74