### PR TITLE
Remove duplicate PRI resource entries from WinUI project

### DIFF
--- a/Veriado.WinUI/Veriado.csproj
+++ b/Veriado.WinUI/Veriado.csproj
@@ -32,10 +32,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PRIResource Include="Strings\**\*.resw" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0"/>
     <PackageReference Include="CommunityToolkit.WinUI.Controls.HeaderedControls" Version="8.2.250402" />
     <PackageReference Include="CommunityToolkit.WinUI.Controls.Primitives" Version="8.2.250402" />


### PR DESCRIPTION
## Summary
- remove the explicit PRIResource include from the WinUI project file to avoid duplicate PRI entries provided by the SDK

## Testing
- not run (dotnet CLI unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68dead5f16f08326b4d7c237dacae305