### PR TITLE
Handle InfoBar opening animation without Opened event

### DIFF
--- a/Veriado.WinUI/Views/Files/FilesPage.xaml
+++ b/Veriado.WinUI/Views/Files/FilesPage.xaml
@@ -239,7 +239,7 @@
                 Severity="Warning"
                 Title="Probíhá indexace"
                 Message="{x:Bind ViewModel.IndexingWarningMessage, Mode=OneWay}"
-                Opened="OnInfoBarOpened"
+                Loaded="OnInfoBarLoaded"
                 Closing="OnInfoBarClosing">
                 <controls:InfoBar.Transitions>
                     <TransitionCollection>
@@ -254,7 +254,7 @@
                 Severity="Error"
                 Title="Chyba načítání"
                 Message="Nepodařilo se načíst výsledky."
-                Opened="OnInfoBarOpened"
+                Loaded="OnInfoBarLoaded"
                 Closing="OnInfoBarClosing">
                 <controls:InfoBar.Transitions>
                     <TransitionCollection>


### PR DESCRIPTION
## Summary
- remove the InfoBar Opened handler usage and hook into Loaded instead to satisfy WinUI markup
- register IsOpen property callbacks to replay the opening animation whenever the bar becomes visible

## Testing
- dotnet build Veriado.sln *(fails: dotnet is not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68deae32a07c8326b9ce45275e8d552e