### PR TITLE
Fix InfoBar open handling and remove unsupported StringFormat

### DIFF
--- a/Veriado.WinUI/Views/Files/FilesPage.xaml
+++ b/Veriado.WinUI/Views/Files/FilesPage.xaml
@@ -233,13 +233,13 @@
                 </StackPanel>
             </StackPanel>
             <controls:InfoBar
+                x:Name="IndexingInfoBar"
                 x:Uid="FilesPage_IndexingInfoBar"
                 IsClosable="False"
                 IsOpen="{x:Bind ViewModel.IsIndexingPending, Mode=OneWay}"
                 Severity="Warning"
                 Title="Probíhá indexace"
                 Message="{x:Bind ViewModel.IndexingWarningMessage, Mode=OneWay}"
-                Opened="OnInfoBarOpened"
                 Closing="OnInfoBarClosing">
                 <controls:InfoBar.Transitions>
                     <TransitionCollection>
@@ -248,13 +248,13 @@
                 </controls:InfoBar.Transitions>
             </controls:InfoBar>
             <controls:InfoBar
+                x:Name="ErrorInfoBar"
                 x:Uid="FilesPage_ErrorInfoBar"
                 IsClosable="False"
                 IsOpen="{x:Bind ViewModel.HasError, Mode=OneWay}"
                 Severity="Error"
                 Title="Chyba načítání"
                 Message="Nepodařilo se načíst výsledky."
-                Opened="OnInfoBarOpened"
                 Closing="OnInfoBarClosing">
                 <controls:InfoBar.Transitions>
                     <TransitionCollection>

--- a/Veriado.WinUI/Views/Import/ImportPage.xaml
+++ b/Veriado.WinUI/Views/Import/ImportPage.xaml
@@ -139,13 +139,23 @@
                                 <TextBlock FontWeight="SemiBold" Text="Shrnutí importu" />
                                 <TextBlock Text="{Binding ProgressText}" TextWrapping="Wrap" />
                                 <StackPanel Orientation="Horizontal" Spacing="12">
-                                    <TextBlock Text="{Binding OkCount, StringFormat='OK: {0}'}" />
-                                    <TextBlock Text="{Binding ErrorCount, StringFormat='Chyby: {0}'}" />
-                                    <TextBlock Text="{Binding SkipCount, StringFormat='Přeskočeno: {0}'}" />
+                                    <TextBlock>
+                                        <Run Text="OK: " />
+                                        <Run Text="{Binding OkCount}" />
+                                    </TextBlock>
+                                    <TextBlock>
+                                        <Run Text="Chyby: " />
+                                        <Run Text="{Binding ErrorCount}" />
+                                    </TextBlock>
+                                    <TextBlock>
+                                        <Run Text="Přeskočeno: " />
+                                        <Run Text="{Binding SkipCount}" />
+                                    </TextBlock>
                                 </StackPanel>
-                                <TextBlock
-                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                    Text="{Binding ProcessedBytes, Converter={StaticResource SizeToHumanConverter}, StringFormat='Zpracováno dat: {0}'}" />
+                                <TextBlock Foreground="{ThemeResource TextFillColorSecondaryBrush}">
+                                    <Run Text="Zpracováno dat: " />
+                                    <Run Text="{Binding ProcessedBytes, Converter={StaticResource SizeToHumanConverter}}" />
+                                </TextBlock>
                             </StackPanel>
                         </Border>
                     </Grid>


### PR DESCRIPTION
## Summary
- register FilesPage InfoBars for IsOpen property changes and animate their visibility without using the unsupported Opened event
- ensure InfoBar callbacks are cleaned up when the page unloads
- replace unsupported StringFormat bindings in ImportPage summary with explicit Run elements

## Testing
- not run (dotnet CLI is unavailable in the container)

------
https://chatgpt.com/codex/tasks/task_e_68deae407d9c83268c6cc42ce4b2737d