### PR TITLE
Fix TimeSpan resource declarations in XAML

### DIFF
--- a/Veriado.WinUI/Resources/Animations.xaml
+++ b/Veriado.WinUI/Resources/Animations.xaml
@@ -4,10 +4,11 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:controls="using:Microsoft.UI.Xaml.Controls"
     xmlns:helpers="using:Veriado.WinUI.Helpers"
-    xmlns:media="using:Microsoft.UI.Xaml.Media.Animation">
-  <x:TimeSpan x:Key="Anim.Fast">0:0:0.12</x:TimeSpan>
-  <x:TimeSpan x:Key="Anim.Med">0:0:0.18</x:TimeSpan>
-  <x:TimeSpan x:Key="Anim.Panel">0:0:0.15</x:TimeSpan>
+    xmlns:media="using:Microsoft.UI.Xaml.Media.Animation"
+    xmlns:sys="using:System">
+  <sys:TimeSpan x:Key="Anim.Fast">0:0:0.12</sys:TimeSpan>
+  <sys:TimeSpan x:Key="Anim.Med">0:0:0.18</sys:TimeSpan>
+  <sys:TimeSpan x:Key="Anim.Panel">0:0:0.15</sys:TimeSpan>
 
   <media:PowerEase x:Key="Ease.Out" EasingMode="EaseOut" Power="0.3" />
   <media:PowerEase x:Key="Ease.In" EasingMode="EaseIn" Power="0.3" />


### PR DESCRIPTION
## Summary
- add the System namespace to the animations resource dictionary
- declare animation durations using System.TimeSpan to avoid XAML schema errors

## Testing
- dotnet build Veriado.sln *(fails: dotnet not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68deb277e5308326bb8a336cbe86da61