### PR TITLE
Fix WinUI import page build issues

### DIFF
--- a/Veriado.WinUI/ViewModels/Import/ImportPageViewModel.cs
+++ b/Veriado.WinUI/ViewModels/Import/ImportPageViewModel.cs
@@ -42,9 +42,9 @@ public partial class ImportPageViewModel : ViewModelBase
         IDispatcherService dispatcher,
         IExceptionHandler exceptionHandler,
         IDialogService dialogService,
+        ILocalizationService localizationService,
         IHotStateService? hotStateService = null,
-        IPickerService? pickerService = null,
-        ILocalizationService localizationService)
+        IPickerService? pickerService = null)
         : base(messenger, statusService, dispatcher, exceptionHandler, localizationService)
     {
         _importService = importService ?? throw new ArgumentNullException(nameof(importService));

--- a/Veriado.WinUI/Views/Import/ImportPage.xaml.cs
+++ b/Veriado.WinUI/Views/Import/ImportPage.xaml.cs
@@ -8,7 +8,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.UI.Composition;
-using Microsoft.UI.ViewManagement;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Hosting;
@@ -18,6 +17,7 @@ using Windows.ApplicationModel.DataTransfer;
 using Windows.Storage;
 using Veriado.WinUI.Helpers;
 using Veriado.WinUI.ViewModels.Import;
+using Windows.UI.ViewManagement;
 
 namespace Veriado.WinUI.Views.Import;
 
@@ -409,18 +409,18 @@ public sealed partial class ImportPage : Page
 
     private void Pulse(UIElement? target, double peak)
     {
-        if (target is null || !_animationsEnabled || _compositor is null)
+        if (target is not FrameworkElement element || !_animationsEnabled || _compositor is null)
         {
             return;
         }
 
-        if (target.ActualWidth <= 0 || target.ActualHeight <= 0)
+        if (element.ActualWidth <= 0 || element.ActualHeight <= 0)
         {
             return;
         }
 
-        var visual = ElementCompositionPreview.GetElementVisual(target);
-        visual.CenterPoint = new Vector3((float)(target.ActualWidth / 2), (float)(target.ActualHeight / 2), 0f);
+        var visual = ElementCompositionPreview.GetElementVisual(element);
+        visual.CenterPoint = new Vector3((float)(element.ActualWidth / 2), (float)(element.ActualHeight / 2), 0f);
 
         var duration = AnimationResourceHelper.GetDuration(AnimationResourceKeys.Fast);
         var easeOut = AnimationResourceHelper.CreateEasing(_compositor, AnimationResourceKeys.EaseOut);


### PR DESCRIPTION
## Summary
- reorder the ImportPageViewModel constructor so optional parameters follow required ones
- switch UISettings references to Windows.UI.ViewManagement and adjust pulse helper to use FrameworkElement metrics
- rework expander animation handling to rely on property change callbacks instead of the missing Collapsing event

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68deb465c2148326865d208be06aa57a