### PR TITLE
Fix WinUI resource manager usage when applying culture

### DIFF
--- a/Veriado.WinUI/Localization/CultureHelper.cs
+++ b/Veriado.WinUI/Localization/CultureHelper.cs
@@ -6,6 +6,8 @@ namespace Veriado.WinUI.Localization;
 
 internal static class CultureHelper
 {
+    private static readonly ResourceManager ResourceManager = new();
+
     public static void ApplyCulture(CultureInfo culture)
     {
         ArgumentNullException.ThrowIfNull(culture);
@@ -15,7 +17,8 @@ internal static class CultureHelper
         CultureInfo.DefaultThreadCurrentCulture = culture;
         CultureInfo.DefaultThreadCurrentUICulture = culture;
 
-        ResourceManager.Current.DefaultContext.QualifierValues["Language"] = culture.Name;
+        ResourceManager.DefaultContext.QualifierValues["Language"] = culture.Name;
+        LocalizedStrings.SetLanguageQualifier(culture.Name);
         if (OperatingSystem.IsWindows())
         {
             ApplicationLanguages.PrimaryLanguageOverride = culture.Name;

--- a/Veriado.WinUI/Localization/LocalizedStrings.cs
+++ b/Veriado.WinUI/Localization/LocalizedStrings.cs
@@ -32,6 +32,14 @@ internal static class LocalizedStrings
         return template;
     }
 
+    public static void SetLanguageQualifier(string language)
+    {
+        if (!string.IsNullOrWhiteSpace(language))
+        {
+            ResourceContext.QualifierValues["Language"] = language;
+        }
+    }
+
     private static string? TryGetString(string resourceKey)
     {
         if (ResourceMap is null)


### PR DESCRIPTION
## Summary
- replace the unavailable `ResourceManager.Current` usage with a shared instance
- refresh the localization resource context when the culture changes

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dec6bfadac8326b9b1daced9d50eff