### PR TITLE
Fix StartupWindow title assignment

### DIFF
--- a/Veriado.WinUI/Views/StartupWindow.xaml
+++ b/Veriado.WinUI/Views/StartupWindow.xaml
@@ -2,8 +2,7 @@
     x:Class="Veriado.WinUI.Views.StartupWindow"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:winui="using:Microsoft.UI.Xaml.Controls"
-    x:Uid="StartupWindow">
+    xmlns:winui="using:Microsoft.UI.Xaml.Controls">
     <Grid Background="{ThemeResource AppBackgroundBrush}">
         <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="12" Width="320">
             <winui:ProgressRing

--- a/Veriado.WinUI/Views/StartupWindow.xaml.cs
+++ b/Veriado.WinUI/Views/StartupWindow.xaml.cs
@@ -1,3 +1,4 @@
+using Veriado.WinUI.Localization;
 using Veriado.WinUI.ViewModels.Startup;
 
 namespace Veriado.WinUI.Views;
@@ -9,6 +10,8 @@ public sealed partial class StartupWindow : Window
         InitializeComponent();
 
         ViewModel = viewModel ?? throw new ArgumentNullException(nameof(viewModel));
+
+        Title = LocalizedStrings.Get("StartupWindow.Title");
 
         if (Content is FrameworkElement contentRoot)
         {


### PR DESCRIPTION
## Summary
- remove the XAML UID that attempted to localize the window title
- set the startup window title in code using the localization helper so parsing succeeds

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68decbd5f34c832692562cf810118a18