### PR TITLE
Fix culture helper language qualifier update

### DIFF
--- a/Veriado.WinUI/Localization/CultureHelper.cs
+++ b/Veriado.WinUI/Localization/CultureHelper.cs
@@ -6,8 +6,6 @@ namespace Veriado.WinUI.Localization;
 
 internal static class CultureHelper
 {
-    private static readonly ResourceManager ResourceManager = new();
-
     public static void ApplyCulture(CultureInfo culture)
     {
         ArgumentNullException.ThrowIfNull(culture);
@@ -17,7 +15,7 @@ internal static class CultureHelper
         CultureInfo.DefaultThreadCurrentCulture = culture;
         CultureInfo.DefaultThreadCurrentUICulture = culture;
 
-        ResourceManager.DefaultContext.QualifierValues["Language"] = culture.Name;
+        ResourceContext.SetGlobalQualifierValue("Language", culture.Name);
         LocalizedStrings.SetLanguageQualifier(culture.Name);
         if (OperatingSystem.IsWindows())
         {


### PR DESCRIPTION
## Summary
- replace the unsupported ResourceManager.DefaultContext access in CultureHelper with ResourceContext.SetGlobalQualifierValue
- keep localization qualifier updates in sync with LocalizedStrings

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68decd844b608326838f61ac1dbc2af3