### PR TITLE
Refine localization and animations for WinUI pages

### DIFF
--- a/Veriado.WinUI/Helpers/AnimationHelpers.cs
+++ b/Veriado.WinUI/Helpers/AnimationHelpers.cs
@@ -5,6 +5,7 @@ using Microsoft.UI.Composition;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Hosting;
+using Microsoft.UI.Xaml.Media.Animation;
 using Microsoft.Win32;
 
 namespace Veriado.WinUI.Helpers;
@@ -413,5 +414,218 @@ public static class ExpanderAnimationHelper
     {
         var width = content.RenderSize.Width > 0 ? content.RenderSize.Width : expander.ActualWidth;
         visual.CenterPoint = new Vector3((float)(width / 2), 0f, 0f);
+    }
+}
+
+public static class NavigationAnimations
+{
+    public static void Attach(Frame frame, bool enabled)
+    {
+        if (frame is null)
+        {
+            throw new ArgumentNullException(nameof(frame));
+        }
+
+        if (!enabled)
+        {
+            frame.ContentTransitions = null;
+            return;
+        }
+
+        var transitions = new TransitionCollection
+        {
+            new NavigationThemeTransition
+            {
+                DefaultNavigationTransitionInfo = new EntranceNavigationTransitionInfo()
+            }
+        };
+
+        frame.ContentTransitions = transitions;
+    }
+}
+
+public static class ImplicitListAnimations
+{
+    private sealed class ItemsRepeaterAnimationConfig
+    {
+        public bool IsEnabled { get; set; }
+
+        public ImplicitAnimationCollection? Animations { get; set; }
+
+        public float Offset { get; set; }
+
+        public TimeSpan Duration { get; set; }
+    }
+
+    private static readonly DependencyProperty ItemsRepeaterConfigProperty = DependencyProperty.RegisterAttached(
+        "ItemsRepeaterConfig",
+        typeof(ItemsRepeaterAnimationConfig),
+        typeof(ImplicitListAnimations),
+        new PropertyMetadata(null));
+
+    public static void Attach(FrameworkElement host, bool enabled, float offset = 12f, int ms = 160)
+    {
+        if (host is null)
+        {
+            throw new ArgumentNullException(nameof(host));
+        }
+
+        var clampedDuration = TimeSpan.FromMilliseconds(Math.Clamp(ms, 120, 200));
+
+        if (host is ItemsRepeater repeater)
+        {
+            AttachToItemsRepeater(repeater, enabled, offset, clampedDuration);
+            return;
+        }
+
+        ApplyImplicitAnimations(host, enabled, offset, clampedDuration);
+    }
+
+    private static void AttachToItemsRepeater(ItemsRepeater repeater, bool enabled, float offset, TimeSpan duration)
+    {
+        if (repeater.GetValue(ItemsRepeaterConfigProperty) is not ItemsRepeaterAnimationConfig config)
+        {
+            config = new ItemsRepeaterAnimationConfig();
+            repeater.SetValue(ItemsRepeaterConfigProperty, config);
+            repeater.ElementPrepared += OnItemsRepeaterElementPrepared;
+            repeater.ElementClearing += OnItemsRepeaterElementClearing;
+        }
+
+        config.IsEnabled = enabled && AnimationSettings.AreEnabled;
+        config.Offset = offset;
+        config.Duration = duration;
+
+        if (!config.IsEnabled)
+        {
+            config.Animations = null;
+            ResetRealizedElements(repeater);
+        }
+        else
+        {
+            EnsureRealizedElementsInitialized(repeater, config);
+        }
+    }
+
+    private static void ApplyImplicitAnimations(FrameworkElement element, bool enabled, float offset, TimeSpan duration)
+    {
+        var visual = ElementCompositionPreview.GetElementVisual(element);
+
+        if (!enabled || !AnimationSettings.AreEnabled)
+        {
+            visual.ImplicitAnimations = null;
+            visual.Offset = Vector3.Zero;
+            visual.Opacity = 1f;
+            return;
+        }
+
+        visual.ImplicitAnimations = CreateImplicitAnimations(visual.Compositor, offset, duration);
+    }
+
+    private static void OnItemsRepeaterElementPrepared(ItemsRepeater sender, ItemsRepeaterElementPreparedEventArgs args)
+    {
+        if (args.Element is not UIElement element)
+        {
+            return;
+        }
+
+        if (sender.GetValue(ItemsRepeaterConfigProperty) is not ItemsRepeaterAnimationConfig config)
+        {
+            return;
+        }
+
+        var visual = ElementCompositionPreview.GetElementVisual(element);
+
+        if (!config.IsEnabled)
+        {
+            visual.ImplicitAnimations = null;
+            visual.Opacity = 1f;
+            visual.Offset = Vector3.Zero;
+            return;
+        }
+
+        config.Animations ??= CreateImplicitAnimations(visual.Compositor, config.Offset, config.Duration);
+
+        visual.ImplicitAnimations = config.Animations;
+        visual.Opacity = 0f;
+        visual.Offset = new Vector3(0f, config.Offset, 0f);
+        visual.Opacity = 1f;
+        visual.Offset = Vector3.Zero;
+    }
+
+    private static void OnItemsRepeaterElementClearing(ItemsRepeater sender, ItemsRepeaterElementClearingEventArgs args)
+    {
+        if (args.Element is not UIElement element)
+        {
+            return;
+        }
+
+        var visual = ElementCompositionPreview.GetElementVisual(element);
+        visual.ImplicitAnimations = null;
+        visual.Opacity = 1f;
+        visual.Offset = Vector3.Zero;
+    }
+
+    private static ImplicitAnimationCollection CreateImplicitAnimations(Compositor compositor, float offset, TimeSpan duration)
+    {
+        var easing = AnimationResourceHelper.CreateEasing(compositor, AnimationResourceKeys.EaseOut);
+
+        var fadeAnimation = compositor.CreateScalarKeyFrameAnimation();
+        fadeAnimation.Target = nameof(Visual.Opacity);
+        fadeAnimation.Duration = duration;
+        fadeAnimation.InsertKeyFrame(0f, 0f);
+        fadeAnimation.InsertKeyFrame(1f, 1f, easing);
+
+        var offsetAnimation = compositor.CreateVector3KeyFrameAnimation();
+        offsetAnimation.Target = nameof(Visual.Offset);
+        offsetAnimation.Duration = duration;
+        offsetAnimation.InsertKeyFrame(0f, new Vector3(0f, offset, 0f));
+        offsetAnimation.InsertKeyFrame(1f, Vector3.Zero, easing);
+
+        var animations = compositor.CreateImplicitAnimationCollection();
+        animations[nameof(Visual.Opacity)] = fadeAnimation;
+        animations[nameof(Visual.Offset)] = offsetAnimation;
+
+        return animations;
+    }
+
+    private static void ResetRealizedElements(ItemsRepeater repeater)
+    {
+        if (repeater.ItemsSourceView is null)
+        {
+            return;
+        }
+
+        var count = repeater.ItemsSourceView.Count;
+        for (var i = 0; i < count; i++)
+        {
+            if (repeater.TryGetElement(i) is UIElement element)
+            {
+                var visual = ElementCompositionPreview.GetElementVisual(element);
+                visual.ImplicitAnimations = null;
+                visual.Opacity = 1f;
+                visual.Offset = Vector3.Zero;
+            }
+        }
+    }
+
+    private static void EnsureRealizedElementsInitialized(ItemsRepeater repeater, ItemsRepeaterAnimationConfig config)
+    {
+        if (repeater.ItemsSourceView is null)
+        {
+            return;
+        }
+
+        var count = repeater.ItemsSourceView.Count;
+        for (var i = 0; i < count; i++)
+        {
+            if (repeater.TryGetElement(i) is UIElement element)
+            {
+                var visual = ElementCompositionPreview.GetElementVisual(element);
+                config.Animations ??= CreateImplicitAnimations(visual.Compositor, config.Offset, config.Duration);
+                visual.ImplicitAnimations = config.Animations;
+                visual.Opacity = 1f;
+                visual.Offset = Vector3.Zero;
+            }
+        }
     }
 }

--- a/Veriado.WinUI/Localization/CultureHelper.cs
+++ b/Veriado.WinUI/Localization/CultureHelper.cs
@@ -1,11 +1,17 @@
 using System.Globalization;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Windows.ApplicationModel.Resources;
 using Windows.Globalization;
+using Veriado.WinUI.Services;
+using Veriado.WinUI.Services.Abstractions;
 
 namespace Veriado.WinUI.Localization;
 
 internal static class CultureHelper
 {
+    private static readonly ResourceManager ResourceManager = new();
+    private static ResourceContext _resourceContext = new(ResourceManager);
+
     public static void ApplyCulture(CultureInfo culture)
     {
         ArgumentNullException.ThrowIfNull(culture);
@@ -15,11 +21,46 @@ internal static class CultureHelper
         CultureInfo.DefaultThreadCurrentCulture = culture;
         CultureInfo.DefaultThreadCurrentUICulture = culture;
 
-        ResourceContext.SetGlobalQualifierValue("Language", culture.Name);
-        LocalizedStrings.SetLanguageQualifier(culture.Name);
+        _resourceContext = new ResourceContext(ResourceManager);
+        _resourceContext.QualifierValues["Language"] = culture.Name;
+
         if (OperatingSystem.IsWindows())
         {
             ApplicationLanguages.PrimaryLanguageOverride = culture.Name;
+        }
+
+        AppServicesLocator.GetLocalizationService()?.RaiseCultureChanged();
+    }
+
+    public static string GetString(string key)
+    {
+        if (string.IsNullOrWhiteSpace(key))
+        {
+            throw new ArgumentException("Resource key must be provided.", nameof(key));
+        }
+
+        return ResourceManager.MainResourceMap
+                   .GetValue($"Resources/{key}", _resourceContext)?.ValueAsString
+               ?? key;
+    }
+
+    private static class AppServicesLocator
+    {
+        public static LocalizationService? GetLocalizationService()
+        {
+            try
+            {
+                if (App.Services.GetService<ILocalizationService>() is LocalizationService localizationService)
+                {
+                    return localizationService;
+                }
+            }
+            catch
+            {
+                // Services may not be available during early startup. Ignore failures.
+            }
+
+            return null;
         }
     }
 }

--- a/Veriado.WinUI/Localization/LocalizedStrings.cs
+++ b/Veriado.WinUI/Localization/LocalizedStrings.cs
@@ -1,14 +1,9 @@
 using System.Globalization;
-using Microsoft.Windows.ApplicationModel.Resources;
 
 namespace Veriado.WinUI.Localization;
 
 internal static class LocalizedStrings
 {
-    private static readonly ResourceManager ResourceManager = new();
-    private static readonly ResourceMap? ResourceMap = ResourceManager.MainResourceMap.TryGetSubtree("Resources");
-    private static readonly ResourceContext ResourceContext = ResourceManager.CreateResourceContext();
-
     public static string Get(string resourceKey, string? defaultValue = null, params object?[] arguments)
     {
         if (string.IsNullOrWhiteSpace(resourceKey))
@@ -16,7 +11,11 @@ internal static class LocalizedStrings
             throw new ArgumentException("Resource key must be provided.", nameof(resourceKey));
         }
 
-        var template = TryGetString(resourceKey) ?? defaultValue ?? resourceKey;
+        var template = CultureHelper.GetString(resourceKey);
+        if (string.Equals(template, resourceKey, StringComparison.Ordinal))
+        {
+            template = defaultValue ?? resourceKey;
+        }
         if (arguments is { Length: > 0 })
         {
             try
@@ -30,24 +29,5 @@ internal static class LocalizedStrings
         }
 
         return template;
-    }
-
-    public static void SetLanguageQualifier(string language)
-    {
-        if (!string.IsNullOrWhiteSpace(language))
-        {
-            ResourceContext.QualifierValues["Language"] = language;
-        }
-    }
-
-    private static string? TryGetString(string resourceKey)
-    {
-        if (ResourceMap is null)
-        {
-            return null;
-        }
-
-        var candidate = ResourceMap.TryGetValue(resourceKey, ResourceContext);
-        return candidate?.ValueAsString;
     }
 }

--- a/Veriado.WinUI/Services/Abstractions/INavigationService.cs
+++ b/Veriado.WinUI/Services/Abstractions/INavigationService.cs
@@ -1,3 +1,4 @@
+using Microsoft.UI.Xaml.Controls;
 using Veriado.WinUI.Navigation;
 
 namespace Veriado.WinUI.Services.Abstractions;
@@ -11,5 +12,5 @@ public interface INavigationService
 
 public interface INavigationHost
 {
-    object? CurrentContent { get; set; }
+    Frame NavigationFrame { get; }
 }

--- a/Veriado.WinUI/Strings/Resources.resw
+++ b/Veriado.WinUI/Strings/Resources.resw
@@ -63,4 +63,187 @@
   <data name="StartupWindow_RetryButton.Content" xml:space="preserve">
     <value>Try again</value>
   </data>
+  <data name="ImportPage_TitleTextBlock.Text" xml:space="preserve">
+    <value>Import files</value>
+  </data>
+
+  <data name="ImportPage_RunImportButton.Content" xml:space="preserve">
+    <value>Start import</value>
+  </data>
+
+  <data name="ImportPage_StopButton.Content" xml:space="preserve">
+    <value>Stop</value>
+  </data>
+
+  <data name="ImportPage_ClearResultsButton.Content" xml:space="preserve">
+    <value>Clear results</value>
+  </data>
+
+  <data name="ImportPage_ExportLogButton.Content" xml:space="preserve">
+    <value>Export log</value>
+  </data>
+
+  <data name="ImportPage_CurrentFileNameTextBlock.[using:Microsoft.UI.Xaml.Data.Binding].TargetNullValue" xml:space="preserve">
+    <value>(No file)</value>
+  </data>
+
+  <data name="ImportPage_ProcessedLabelRun.Text" xml:space="preserve">
+    <value>Processed: </value>
+  </data>
+
+  <data name="ImportPage_ProcessedSeparatorRun.Text" xml:space="preserve">
+    <value> / </value>
+  </data>
+
+  <data name="ImportPage_SummaryTitleTextBlock.Text" xml:space="preserve">
+    <value>Import summary</value>
+  </data>
+
+  <data name="ImportPage_SummaryOkLabelRun.Text" xml:space="preserve">
+    <value>OK: </value>
+  </data>
+
+  <data name="ImportPage_SummaryErrorLabelRun.Text" xml:space="preserve">
+    <value>Errors: </value>
+  </data>
+
+  <data name="ImportPage_SummarySkippedLabelRun.Text" xml:space="preserve">
+    <value>Skipped: </value>
+  </data>
+
+  <data name="ImportPage_SummaryDataLabelRun.Text" xml:space="preserve">
+    <value>Processed data: </value>
+  </data>
+
+  <data name="ImportPage_SourceTitleTextBlock.Text" xml:space="preserve">
+    <value>Import source</value>
+  </data>
+
+  <data name="ImportPage_PickFolderButton.Content" xml:space="preserve">
+    <value>Choose folder</value>
+  </data>
+
+  <data name="ImportPage_OptionsTitleTextBlock.Text" xml:space="preserve">
+    <value>Import options</value>
+  </data>
+
+  <data name="ImportPage_RecursiveCheckBox.Content" xml:space="preserve">
+    <value>Recursive</value>
+  </data>
+
+  <data name="ImportPage_PreserveMetadataCheckBox.Content" xml:space="preserve">
+    <value>Preserve file system metadata</value>
+  </data>
+
+  <data name="ImportPage_ReadOnlyCheckBox.Content" xml:space="preserve">
+    <value>Set read-only</value>
+  </data>
+
+  <data name="ImportPage_ParallelCheckBox.Content" xml:space="preserve">
+    <value>Parallel</value>
+  </data>
+
+  <data name="ImportPage_MaxThreadsNumberBox.Header" xml:space="preserve">
+    <value>Max parallel threads</value>
+  </data>
+
+  <data name="ImportPage_MaxThreadsInfoBar.Title" xml:space="preserve">
+    <value>Invalid thread count</value>
+  </data>
+
+  <data name="ImportPage_MaxThreadsInfoBar.Message" xml:space="preserve">
+    <value>Enter a positive integer greater than zero.</value>
+  </data>
+
+  <data name="ImportPage_DefaultAuthorTextBox.Header" xml:space="preserve">
+    <value>Default author</value>
+  </data>
+
+  <data name="ImportPage_DefaultAuthorTextBox.PlaceholderText" xml:space="preserve">
+    <value>(not set)</value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeNumberBox.Header" xml:space="preserve">
+    <value>Max file size (MB)</value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeInfoBar.Title" xml:space="preserve">
+    <value>Invalid file size</value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeInfoBar.Message" xml:space="preserve">
+    <value>Enter a non-negative value or leave 0 for no limit.</value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeHintTextBlock.Text" xml:space="preserve">
+    <value>0 = no limit</value>
+  </data>
+
+  <data name="ImportPage_LogTitleTextBlock.Text" xml:space="preserve">
+    <value>Import log</value>
+  </data>
+
+  <data name="ImportPage_QueueTitleTextBlock.Text" xml:space="preserve">
+    <value>Import queue</value>
+  </data>
+
+  <data name="ImportPage_LogTimeColumn.Header" xml:space="preserve">
+    <value>Time</value>
+  </data>
+
+  <data name="ImportPage_LogEventColumn.Header" xml:space="preserve">
+    <value>Event</value>
+  </data>
+
+  <data name="ImportPage_LogMessageColumn.Header" xml:space="preserve">
+    <value>Message</value>
+  </data>
+
+  <data name="ImportPage_LogStatusColumn.Header" xml:space="preserve">
+    <value>Status</value>
+  </data>
+
+  <data name="ImportPage_LogDetailColumn.Header" xml:space="preserve">
+    <value>Detail</value>
+  </data>
+
+  <data name="ImportPage_FilterLabelTextBlock.Text" xml:space="preserve">
+    <value>Filter:</value>
+  </data>
+
+  <data name="ImportPage_ErrorTimeColumn.Header" xml:space="preserve">
+    <value>Time</value>
+  </data>
+
+  <data name="ImportPage_ErrorFileColumn.Header" xml:space="preserve">
+    <value>File</value>
+  </data>
+
+  <data name="ImportPage_ErrorCodeColumn.Header" xml:space="preserve">
+    <value>Code</value>
+  </data>
+
+  <data name="ImportPage_ErrorSeverityColumn.Header" xml:space="preserve">
+    <value>Severity</value>
+  </data>
+
+  <data name="ImportPage_ErrorMessageColumn.Header" xml:space="preserve">
+    <value>Message</value>
+  </data>
+
+  <data name="ImportPage_OpenDetailButton.Content" xml:space="preserve">
+    <value>Open detail</value>
+  </data>
+
+  <data name="ImportPage_NoErrorsTextBlock.Text" xml:space="preserve">
+    <value>No errors match the selected filter.</value>
+  </data>
+
+  <data name="ImportPage_DropPromptTextBlock.Text" xml:space="preserve">
+    <value>Drop a folder to import</value>
+  </data>
+
+  <data name="ImportPage_DropHintTextBlock.Text" xml:space="preserve">
+    <value>You can also choose a folder using the button.</value>
+  </data>
 </root>

--- a/Veriado.WinUI/Strings/bg-BG/Resources.resw
+++ b/Veriado.WinUI/Strings/bg-BG/Resources.resw
@@ -63,4 +63,187 @@
   <data name="StartupWindow_RetryButton.Content" xml:space="preserve">
     <value>Опитайте отново</value>
   </data>
+  <data name="ImportPage_TitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_RunImportButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_StopButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ClearResultsButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ExportLogButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_CurrentFileNameTextBlock.[using:Microsoft.UI.Xaml.Data.Binding].TargetNullValue" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ProcessedLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ProcessedSeparatorRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummaryTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummaryOkLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummaryErrorLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummarySkippedLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummaryDataLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SourceTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_PickFolderButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_OptionsTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_RecursiveCheckBox.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_PreserveMetadataCheckBox.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ReadOnlyCheckBox.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ParallelCheckBox.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxThreadsNumberBox.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxThreadsInfoBar.Title" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxThreadsInfoBar.Message" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_DefaultAuthorTextBox.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_DefaultAuthorTextBox.PlaceholderText" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeNumberBox.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeInfoBar.Title" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeInfoBar.Message" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeHintTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_QueueTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogTimeColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogEventColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogMessageColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogStatusColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogDetailColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_FilterLabelTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorTimeColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorFileColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorCodeColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorSeverityColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorMessageColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_OpenDetailButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_NoErrorsTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_DropPromptTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_DropHintTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
 </root>

--- a/Veriado.WinUI/Strings/cs-CZ/Resources.resw
+++ b/Veriado.WinUI/Strings/cs-CZ/Resources.resw
@@ -63,4 +63,187 @@
   <data name="StartupWindow_RetryButton.Content" xml:space="preserve">
     <value>Zkusit znovu</value>
   </data>
+  <data name="ImportPage_TitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_RunImportButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_StopButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ClearResultsButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ExportLogButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_CurrentFileNameTextBlock.[using:Microsoft.UI.Xaml.Data.Binding].TargetNullValue" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ProcessedLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ProcessedSeparatorRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummaryTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummaryOkLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummaryErrorLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummarySkippedLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummaryDataLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SourceTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_PickFolderButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_OptionsTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_RecursiveCheckBox.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_PreserveMetadataCheckBox.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ReadOnlyCheckBox.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ParallelCheckBox.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxThreadsNumberBox.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxThreadsInfoBar.Title" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxThreadsInfoBar.Message" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_DefaultAuthorTextBox.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_DefaultAuthorTextBox.PlaceholderText" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeNumberBox.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeInfoBar.Title" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeInfoBar.Message" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeHintTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_QueueTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogTimeColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogEventColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogMessageColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogStatusColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogDetailColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_FilterLabelTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorTimeColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorFileColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorCodeColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorSeverityColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorMessageColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_OpenDetailButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_NoErrorsTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_DropPromptTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_DropHintTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
 </root>

--- a/Veriado.WinUI/Strings/da-DK/Resources.resw
+++ b/Veriado.WinUI/Strings/da-DK/Resources.resw
@@ -63,4 +63,187 @@
   <data name="StartupWindow_RetryButton.Content" xml:space="preserve">
     <value>Prøv igen</value>
   </data>
+  <data name="ImportPage_TitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_RunImportButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_StopButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ClearResultsButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ExportLogButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_CurrentFileNameTextBlock.[using:Microsoft.UI.Xaml.Data.Binding].TargetNullValue" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ProcessedLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ProcessedSeparatorRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummaryTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummaryOkLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummaryErrorLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummarySkippedLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummaryDataLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SourceTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_PickFolderButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_OptionsTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_RecursiveCheckBox.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_PreserveMetadataCheckBox.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ReadOnlyCheckBox.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ParallelCheckBox.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxThreadsNumberBox.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxThreadsInfoBar.Title" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxThreadsInfoBar.Message" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_DefaultAuthorTextBox.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_DefaultAuthorTextBox.PlaceholderText" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeNumberBox.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeInfoBar.Title" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeInfoBar.Message" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeHintTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_QueueTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogTimeColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogEventColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogMessageColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogStatusColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogDetailColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_FilterLabelTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorTimeColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorFileColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorCodeColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorSeverityColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorMessageColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_OpenDetailButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_NoErrorsTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_DropPromptTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_DropHintTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
 </root>

--- a/Veriado.WinUI/Strings/de-DE/Resources.resw
+++ b/Veriado.WinUI/Strings/de-DE/Resources.resw
@@ -63,4 +63,187 @@
   <data name="StartupWindow_RetryButton.Content" xml:space="preserve">
     <value>Erneut versuchen</value>
   </data>
+  <data name="ImportPage_TitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_RunImportButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_StopButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ClearResultsButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ExportLogButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_CurrentFileNameTextBlock.[using:Microsoft.UI.Xaml.Data.Binding].TargetNullValue" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ProcessedLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ProcessedSeparatorRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummaryTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummaryOkLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummaryErrorLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummarySkippedLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummaryDataLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SourceTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_PickFolderButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_OptionsTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_RecursiveCheckBox.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_PreserveMetadataCheckBox.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ReadOnlyCheckBox.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ParallelCheckBox.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxThreadsNumberBox.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxThreadsInfoBar.Title" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxThreadsInfoBar.Message" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_DefaultAuthorTextBox.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_DefaultAuthorTextBox.PlaceholderText" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeNumberBox.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeInfoBar.Title" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeInfoBar.Message" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeHintTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_QueueTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogTimeColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogEventColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogMessageColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogStatusColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogDetailColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_FilterLabelTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorTimeColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorFileColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorCodeColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorSeverityColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorMessageColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_OpenDetailButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_NoErrorsTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_DropPromptTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_DropHintTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
 </root>

--- a/Veriado.WinUI/Strings/el-GR/Resources.resw
+++ b/Veriado.WinUI/Strings/el-GR/Resources.resw
@@ -63,4 +63,187 @@
   <data name="StartupWindow_RetryButton.Content" xml:space="preserve">
     <value>Δοκιμάστε ξανά</value>
   </data>
+  <data name="ImportPage_TitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_RunImportButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_StopButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ClearResultsButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ExportLogButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_CurrentFileNameTextBlock.[using:Microsoft.UI.Xaml.Data.Binding].TargetNullValue" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ProcessedLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ProcessedSeparatorRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummaryTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummaryOkLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummaryErrorLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummarySkippedLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummaryDataLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SourceTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_PickFolderButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_OptionsTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_RecursiveCheckBox.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_PreserveMetadataCheckBox.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ReadOnlyCheckBox.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ParallelCheckBox.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxThreadsNumberBox.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxThreadsInfoBar.Title" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxThreadsInfoBar.Message" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_DefaultAuthorTextBox.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_DefaultAuthorTextBox.PlaceholderText" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeNumberBox.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeInfoBar.Title" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeInfoBar.Message" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeHintTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_QueueTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogTimeColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogEventColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogMessageColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogStatusColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogDetailColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_FilterLabelTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorTimeColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorFileColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorCodeColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorSeverityColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorMessageColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_OpenDetailButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_NoErrorsTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_DropPromptTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_DropHintTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
 </root>

--- a/Veriado.WinUI/Strings/en-IE/Resources.resw
+++ b/Veriado.WinUI/Strings/en-IE/Resources.resw
@@ -63,4 +63,187 @@
   <data name="StartupWindow_RetryButton.Content" xml:space="preserve">
     <value>Try again</value>
   </data>
+  <data name="ImportPage_TitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_RunImportButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_StopButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ClearResultsButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ExportLogButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_CurrentFileNameTextBlock.[using:Microsoft.UI.Xaml.Data.Binding].TargetNullValue" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ProcessedLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ProcessedSeparatorRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummaryTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummaryOkLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummaryErrorLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummarySkippedLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummaryDataLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SourceTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_PickFolderButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_OptionsTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_RecursiveCheckBox.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_PreserveMetadataCheckBox.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ReadOnlyCheckBox.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ParallelCheckBox.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxThreadsNumberBox.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxThreadsInfoBar.Title" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxThreadsInfoBar.Message" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_DefaultAuthorTextBox.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_DefaultAuthorTextBox.PlaceholderText" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeNumberBox.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeInfoBar.Title" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeInfoBar.Message" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeHintTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_QueueTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogTimeColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogEventColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogMessageColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogStatusColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogDetailColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_FilterLabelTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorTimeColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorFileColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorCodeColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorSeverityColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorMessageColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_OpenDetailButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_NoErrorsTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_DropPromptTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_DropHintTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
 </root>

--- a/Veriado.WinUI/Strings/es-ES/Resources.resw
+++ b/Veriado.WinUI/Strings/es-ES/Resources.resw
@@ -63,4 +63,187 @@
   <data name="StartupWindow_RetryButton.Content" xml:space="preserve">
     <value>Volver a intentarlo</value>
   </data>
+  <data name="ImportPage_TitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_RunImportButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_StopButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ClearResultsButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ExportLogButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_CurrentFileNameTextBlock.[using:Microsoft.UI.Xaml.Data.Binding].TargetNullValue" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ProcessedLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ProcessedSeparatorRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummaryTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummaryOkLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummaryErrorLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummarySkippedLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummaryDataLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SourceTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_PickFolderButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_OptionsTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_RecursiveCheckBox.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_PreserveMetadataCheckBox.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ReadOnlyCheckBox.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ParallelCheckBox.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxThreadsNumberBox.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxThreadsInfoBar.Title" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxThreadsInfoBar.Message" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_DefaultAuthorTextBox.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_DefaultAuthorTextBox.PlaceholderText" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeNumberBox.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeInfoBar.Title" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeInfoBar.Message" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeHintTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_QueueTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogTimeColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogEventColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogMessageColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogStatusColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogDetailColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_FilterLabelTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorTimeColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorFileColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorCodeColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorSeverityColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorMessageColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_OpenDetailButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_NoErrorsTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_DropPromptTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_DropHintTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
 </root>

--- a/Veriado.WinUI/Strings/et-EE/Resources.resw
+++ b/Veriado.WinUI/Strings/et-EE/Resources.resw
@@ -63,4 +63,187 @@
   <data name="StartupWindow_RetryButton.Content" xml:space="preserve">
     <value>Proovi uuesti</value>
   </data>
+  <data name="ImportPage_TitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_RunImportButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_StopButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ClearResultsButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ExportLogButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_CurrentFileNameTextBlock.[using:Microsoft.UI.Xaml.Data.Binding].TargetNullValue" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ProcessedLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ProcessedSeparatorRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummaryTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummaryOkLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummaryErrorLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummarySkippedLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummaryDataLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SourceTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_PickFolderButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_OptionsTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_RecursiveCheckBox.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_PreserveMetadataCheckBox.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ReadOnlyCheckBox.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ParallelCheckBox.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxThreadsNumberBox.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxThreadsInfoBar.Title" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxThreadsInfoBar.Message" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_DefaultAuthorTextBox.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_DefaultAuthorTextBox.PlaceholderText" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeNumberBox.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeInfoBar.Title" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeInfoBar.Message" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeHintTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_QueueTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogTimeColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogEventColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogMessageColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogStatusColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogDetailColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_FilterLabelTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorTimeColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorFileColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorCodeColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorSeverityColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorMessageColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_OpenDetailButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_NoErrorsTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_DropPromptTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_DropHintTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
 </root>

--- a/Veriado.WinUI/Strings/fi-FI/Resources.resw
+++ b/Veriado.WinUI/Strings/fi-FI/Resources.resw
@@ -63,4 +63,187 @@
   <data name="StartupWindow_RetryButton.Content" xml:space="preserve">
     <value>Yritä uudelleen</value>
   </data>
+  <data name="ImportPage_TitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_RunImportButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_StopButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ClearResultsButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ExportLogButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_CurrentFileNameTextBlock.[using:Microsoft.UI.Xaml.Data.Binding].TargetNullValue" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ProcessedLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ProcessedSeparatorRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummaryTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummaryOkLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummaryErrorLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummarySkippedLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummaryDataLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SourceTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_PickFolderButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_OptionsTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_RecursiveCheckBox.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_PreserveMetadataCheckBox.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ReadOnlyCheckBox.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ParallelCheckBox.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxThreadsNumberBox.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxThreadsInfoBar.Title" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxThreadsInfoBar.Message" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_DefaultAuthorTextBox.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_DefaultAuthorTextBox.PlaceholderText" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeNumberBox.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeInfoBar.Title" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeInfoBar.Message" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeHintTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_QueueTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogTimeColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogEventColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogMessageColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogStatusColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogDetailColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_FilterLabelTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorTimeColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorFileColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorCodeColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorSeverityColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorMessageColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_OpenDetailButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_NoErrorsTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_DropPromptTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_DropHintTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
 </root>

--- a/Veriado.WinUI/Strings/fr-FR/Resources.resw
+++ b/Veriado.WinUI/Strings/fr-FR/Resources.resw
@@ -63,4 +63,187 @@
   <data name="StartupWindow_RetryButton.Content" xml:space="preserve">
     <value>Réessayer</value>
   </data>
+  <data name="ImportPage_TitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_RunImportButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_StopButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ClearResultsButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ExportLogButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_CurrentFileNameTextBlock.[using:Microsoft.UI.Xaml.Data.Binding].TargetNullValue" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ProcessedLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ProcessedSeparatorRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummaryTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummaryOkLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummaryErrorLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummarySkippedLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummaryDataLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SourceTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_PickFolderButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_OptionsTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_RecursiveCheckBox.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_PreserveMetadataCheckBox.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ReadOnlyCheckBox.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ParallelCheckBox.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxThreadsNumberBox.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxThreadsInfoBar.Title" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxThreadsInfoBar.Message" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_DefaultAuthorTextBox.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_DefaultAuthorTextBox.PlaceholderText" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeNumberBox.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeInfoBar.Title" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeInfoBar.Message" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeHintTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_QueueTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogTimeColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogEventColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogMessageColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogStatusColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogDetailColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_FilterLabelTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorTimeColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorFileColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorCodeColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorSeverityColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorMessageColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_OpenDetailButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_NoErrorsTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_DropPromptTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_DropHintTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
 </root>

--- a/Veriado.WinUI/Strings/ga-IE/Resources.resw
+++ b/Veriado.WinUI/Strings/ga-IE/Resources.resw
@@ -63,4 +63,187 @@
   <data name="StartupWindow_RetryButton.Content" xml:space="preserve">
     <value>Bain triail eile as</value>
   </data>
+  <data name="ImportPage_TitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_RunImportButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_StopButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ClearResultsButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ExportLogButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_CurrentFileNameTextBlock.[using:Microsoft.UI.Xaml.Data.Binding].TargetNullValue" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ProcessedLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ProcessedSeparatorRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummaryTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummaryOkLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummaryErrorLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummarySkippedLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummaryDataLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SourceTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_PickFolderButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_OptionsTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_RecursiveCheckBox.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_PreserveMetadataCheckBox.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ReadOnlyCheckBox.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ParallelCheckBox.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxThreadsNumberBox.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxThreadsInfoBar.Title" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxThreadsInfoBar.Message" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_DefaultAuthorTextBox.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_DefaultAuthorTextBox.PlaceholderText" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeNumberBox.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeInfoBar.Title" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeInfoBar.Message" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeHintTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_QueueTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogTimeColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogEventColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogMessageColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogStatusColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogDetailColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_FilterLabelTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorTimeColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorFileColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorCodeColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorSeverityColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorMessageColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_OpenDetailButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_NoErrorsTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_DropPromptTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_DropHintTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
 </root>

--- a/Veriado.WinUI/Strings/hr-HR/Resources.resw
+++ b/Veriado.WinUI/Strings/hr-HR/Resources.resw
@@ -63,4 +63,187 @@
   <data name="StartupWindow_RetryButton.Content" xml:space="preserve">
     <value>Pokušaj ponovno</value>
   </data>
+  <data name="ImportPage_TitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_RunImportButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_StopButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ClearResultsButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ExportLogButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_CurrentFileNameTextBlock.[using:Microsoft.UI.Xaml.Data.Binding].TargetNullValue" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ProcessedLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ProcessedSeparatorRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummaryTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummaryOkLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummaryErrorLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummarySkippedLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummaryDataLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SourceTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_PickFolderButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_OptionsTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_RecursiveCheckBox.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_PreserveMetadataCheckBox.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ReadOnlyCheckBox.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ParallelCheckBox.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxThreadsNumberBox.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxThreadsInfoBar.Title" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxThreadsInfoBar.Message" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_DefaultAuthorTextBox.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_DefaultAuthorTextBox.PlaceholderText" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeNumberBox.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeInfoBar.Title" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeInfoBar.Message" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeHintTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_QueueTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogTimeColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogEventColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogMessageColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogStatusColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogDetailColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_FilterLabelTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorTimeColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorFileColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorCodeColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorSeverityColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorMessageColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_OpenDetailButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_NoErrorsTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_DropPromptTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_DropHintTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
 </root>

--- a/Veriado.WinUI/Strings/hu-HU/Resources.resw
+++ b/Veriado.WinUI/Strings/hu-HU/Resources.resw
@@ -63,4 +63,187 @@
   <data name="StartupWindow_RetryButton.Content" xml:space="preserve">
     <value>Próbálja újra</value>
   </data>
+  <data name="ImportPage_TitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_RunImportButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_StopButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ClearResultsButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ExportLogButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_CurrentFileNameTextBlock.[using:Microsoft.UI.Xaml.Data.Binding].TargetNullValue" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ProcessedLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ProcessedSeparatorRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummaryTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummaryOkLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummaryErrorLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummarySkippedLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummaryDataLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SourceTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_PickFolderButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_OptionsTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_RecursiveCheckBox.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_PreserveMetadataCheckBox.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ReadOnlyCheckBox.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ParallelCheckBox.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxThreadsNumberBox.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxThreadsInfoBar.Title" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxThreadsInfoBar.Message" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_DefaultAuthorTextBox.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_DefaultAuthorTextBox.PlaceholderText" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeNumberBox.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeInfoBar.Title" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeInfoBar.Message" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeHintTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_QueueTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogTimeColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogEventColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogMessageColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogStatusColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogDetailColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_FilterLabelTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorTimeColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorFileColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorCodeColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorSeverityColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorMessageColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_OpenDetailButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_NoErrorsTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_DropPromptTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_DropHintTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
 </root>

--- a/Veriado.WinUI/Strings/it-IT/Resources.resw
+++ b/Veriado.WinUI/Strings/it-IT/Resources.resw
@@ -63,4 +63,187 @@
   <data name="StartupWindow_RetryButton.Content" xml:space="preserve">
     <value>Riprova</value>
   </data>
+  <data name="ImportPage_TitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_RunImportButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_StopButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ClearResultsButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ExportLogButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_CurrentFileNameTextBlock.[using:Microsoft.UI.Xaml.Data.Binding].TargetNullValue" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ProcessedLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ProcessedSeparatorRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummaryTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummaryOkLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummaryErrorLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummarySkippedLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummaryDataLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SourceTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_PickFolderButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_OptionsTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_RecursiveCheckBox.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_PreserveMetadataCheckBox.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ReadOnlyCheckBox.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ParallelCheckBox.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxThreadsNumberBox.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxThreadsInfoBar.Title" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxThreadsInfoBar.Message" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_DefaultAuthorTextBox.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_DefaultAuthorTextBox.PlaceholderText" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeNumberBox.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeInfoBar.Title" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeInfoBar.Message" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeHintTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_QueueTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogTimeColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogEventColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogMessageColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogStatusColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogDetailColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_FilterLabelTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorTimeColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorFileColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorCodeColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorSeverityColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorMessageColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_OpenDetailButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_NoErrorsTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_DropPromptTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_DropHintTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
 </root>

--- a/Veriado.WinUI/Strings/lt-LT/Resources.resw
+++ b/Veriado.WinUI/Strings/lt-LT/Resources.resw
@@ -63,4 +63,187 @@
   <data name="StartupWindow_RetryButton.Content" xml:space="preserve">
     <value>Bandyti dar kartą</value>
   </data>
+  <data name="ImportPage_TitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_RunImportButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_StopButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ClearResultsButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ExportLogButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_CurrentFileNameTextBlock.[using:Microsoft.UI.Xaml.Data.Binding].TargetNullValue" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ProcessedLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ProcessedSeparatorRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummaryTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummaryOkLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummaryErrorLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummarySkippedLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummaryDataLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SourceTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_PickFolderButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_OptionsTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_RecursiveCheckBox.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_PreserveMetadataCheckBox.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ReadOnlyCheckBox.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ParallelCheckBox.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxThreadsNumberBox.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxThreadsInfoBar.Title" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxThreadsInfoBar.Message" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_DefaultAuthorTextBox.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_DefaultAuthorTextBox.PlaceholderText" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeNumberBox.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeInfoBar.Title" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeInfoBar.Message" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeHintTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_QueueTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogTimeColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogEventColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogMessageColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogStatusColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogDetailColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_FilterLabelTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorTimeColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorFileColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorCodeColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorSeverityColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorMessageColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_OpenDetailButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_NoErrorsTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_DropPromptTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_DropHintTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
 </root>

--- a/Veriado.WinUI/Strings/lv-LV/Resources.resw
+++ b/Veriado.WinUI/Strings/lv-LV/Resources.resw
@@ -63,4 +63,187 @@
   <data name="StartupWindow_RetryButton.Content" xml:space="preserve">
     <value>Mēģināt vēlreiz</value>
   </data>
+  <data name="ImportPage_TitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_RunImportButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_StopButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ClearResultsButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ExportLogButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_CurrentFileNameTextBlock.[using:Microsoft.UI.Xaml.Data.Binding].TargetNullValue" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ProcessedLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ProcessedSeparatorRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummaryTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummaryOkLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummaryErrorLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummarySkippedLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummaryDataLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SourceTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_PickFolderButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_OptionsTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_RecursiveCheckBox.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_PreserveMetadataCheckBox.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ReadOnlyCheckBox.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ParallelCheckBox.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxThreadsNumberBox.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxThreadsInfoBar.Title" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxThreadsInfoBar.Message" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_DefaultAuthorTextBox.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_DefaultAuthorTextBox.PlaceholderText" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeNumberBox.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeInfoBar.Title" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeInfoBar.Message" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeHintTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_QueueTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogTimeColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogEventColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogMessageColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogStatusColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogDetailColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_FilterLabelTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorTimeColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorFileColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorCodeColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorSeverityColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorMessageColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_OpenDetailButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_NoErrorsTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_DropPromptTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_DropHintTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
 </root>

--- a/Veriado.WinUI/Strings/mt-MT/Resources.resw
+++ b/Veriado.WinUI/Strings/mt-MT/Resources.resw
@@ -63,4 +63,187 @@
   <data name="StartupWindow_RetryButton.Content" xml:space="preserve">
     <value>Erġa’ ipprova</value>
   </data>
+  <data name="ImportPage_TitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_RunImportButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_StopButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ClearResultsButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ExportLogButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_CurrentFileNameTextBlock.[using:Microsoft.UI.Xaml.Data.Binding].TargetNullValue" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ProcessedLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ProcessedSeparatorRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummaryTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummaryOkLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummaryErrorLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummarySkippedLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummaryDataLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SourceTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_PickFolderButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_OptionsTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_RecursiveCheckBox.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_PreserveMetadataCheckBox.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ReadOnlyCheckBox.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ParallelCheckBox.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxThreadsNumberBox.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxThreadsInfoBar.Title" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxThreadsInfoBar.Message" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_DefaultAuthorTextBox.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_DefaultAuthorTextBox.PlaceholderText" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeNumberBox.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeInfoBar.Title" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeInfoBar.Message" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeHintTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_QueueTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogTimeColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogEventColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogMessageColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogStatusColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogDetailColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_FilterLabelTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorTimeColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorFileColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorCodeColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorSeverityColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorMessageColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_OpenDetailButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_NoErrorsTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_DropPromptTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_DropHintTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
 </root>

--- a/Veriado.WinUI/Strings/nl-NL/Resources.resw
+++ b/Veriado.WinUI/Strings/nl-NL/Resources.resw
@@ -63,4 +63,187 @@
   <data name="StartupWindow_RetryButton.Content" xml:space="preserve">
     <value>Probeer opnieuw</value>
   </data>
+  <data name="ImportPage_TitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_RunImportButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_StopButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ClearResultsButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ExportLogButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_CurrentFileNameTextBlock.[using:Microsoft.UI.Xaml.Data.Binding].TargetNullValue" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ProcessedLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ProcessedSeparatorRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummaryTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummaryOkLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummaryErrorLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummarySkippedLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummaryDataLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SourceTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_PickFolderButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_OptionsTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_RecursiveCheckBox.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_PreserveMetadataCheckBox.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ReadOnlyCheckBox.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ParallelCheckBox.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxThreadsNumberBox.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxThreadsInfoBar.Title" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxThreadsInfoBar.Message" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_DefaultAuthorTextBox.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_DefaultAuthorTextBox.PlaceholderText" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeNumberBox.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeInfoBar.Title" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeInfoBar.Message" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeHintTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_QueueTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogTimeColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogEventColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogMessageColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogStatusColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogDetailColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_FilterLabelTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorTimeColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorFileColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorCodeColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorSeverityColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorMessageColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_OpenDetailButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_NoErrorsTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_DropPromptTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_DropHintTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
 </root>

--- a/Veriado.WinUI/Strings/pl-PL/Resources.resw
+++ b/Veriado.WinUI/Strings/pl-PL/Resources.resw
@@ -63,4 +63,187 @@
   <data name="StartupWindow_RetryButton.Content" xml:space="preserve">
     <value>Spróbuj ponownie</value>
   </data>
+  <data name="ImportPage_TitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_RunImportButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_StopButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ClearResultsButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ExportLogButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_CurrentFileNameTextBlock.[using:Microsoft.UI.Xaml.Data.Binding].TargetNullValue" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ProcessedLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ProcessedSeparatorRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummaryTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummaryOkLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummaryErrorLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummarySkippedLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummaryDataLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SourceTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_PickFolderButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_OptionsTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_RecursiveCheckBox.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_PreserveMetadataCheckBox.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ReadOnlyCheckBox.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ParallelCheckBox.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxThreadsNumberBox.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxThreadsInfoBar.Title" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxThreadsInfoBar.Message" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_DefaultAuthorTextBox.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_DefaultAuthorTextBox.PlaceholderText" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeNumberBox.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeInfoBar.Title" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeInfoBar.Message" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeHintTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_QueueTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogTimeColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogEventColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogMessageColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogStatusColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogDetailColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_FilterLabelTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorTimeColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorFileColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorCodeColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorSeverityColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorMessageColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_OpenDetailButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_NoErrorsTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_DropPromptTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_DropHintTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
 </root>

--- a/Veriado.WinUI/Strings/pt-PT/Resources.resw
+++ b/Veriado.WinUI/Strings/pt-PT/Resources.resw
@@ -63,4 +63,187 @@
   <data name="StartupWindow_RetryButton.Content" xml:space="preserve">
     <value>Tente novamente</value>
   </data>
+  <data name="ImportPage_TitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_RunImportButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_StopButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ClearResultsButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ExportLogButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_CurrentFileNameTextBlock.[using:Microsoft.UI.Xaml.Data.Binding].TargetNullValue" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ProcessedLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ProcessedSeparatorRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummaryTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummaryOkLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummaryErrorLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummarySkippedLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummaryDataLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SourceTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_PickFolderButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_OptionsTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_RecursiveCheckBox.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_PreserveMetadataCheckBox.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ReadOnlyCheckBox.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ParallelCheckBox.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxThreadsNumberBox.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxThreadsInfoBar.Title" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxThreadsInfoBar.Message" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_DefaultAuthorTextBox.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_DefaultAuthorTextBox.PlaceholderText" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeNumberBox.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeInfoBar.Title" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeInfoBar.Message" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeHintTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_QueueTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogTimeColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogEventColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogMessageColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogStatusColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogDetailColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_FilterLabelTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorTimeColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorFileColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorCodeColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorSeverityColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorMessageColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_OpenDetailButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_NoErrorsTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_DropPromptTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_DropHintTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
 </root>

--- a/Veriado.WinUI/Strings/ro-RO/Resources.resw
+++ b/Veriado.WinUI/Strings/ro-RO/Resources.resw
@@ -63,4 +63,187 @@
   <data name="StartupWindow_RetryButton.Content" xml:space="preserve">
     <value>Încercați din nou</value>
   </data>
+  <data name="ImportPage_TitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_RunImportButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_StopButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ClearResultsButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ExportLogButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_CurrentFileNameTextBlock.[using:Microsoft.UI.Xaml.Data.Binding].TargetNullValue" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ProcessedLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ProcessedSeparatorRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummaryTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummaryOkLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummaryErrorLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummarySkippedLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummaryDataLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SourceTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_PickFolderButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_OptionsTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_RecursiveCheckBox.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_PreserveMetadataCheckBox.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ReadOnlyCheckBox.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ParallelCheckBox.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxThreadsNumberBox.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxThreadsInfoBar.Title" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxThreadsInfoBar.Message" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_DefaultAuthorTextBox.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_DefaultAuthorTextBox.PlaceholderText" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeNumberBox.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeInfoBar.Title" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeInfoBar.Message" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeHintTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_QueueTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogTimeColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogEventColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogMessageColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogStatusColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogDetailColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_FilterLabelTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorTimeColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorFileColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorCodeColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorSeverityColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorMessageColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_OpenDetailButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_NoErrorsTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_DropPromptTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_DropHintTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
 </root>

--- a/Veriado.WinUI/Strings/sk-SK/Resources.resw
+++ b/Veriado.WinUI/Strings/sk-SK/Resources.resw
@@ -63,4 +63,187 @@
   <data name="StartupWindow_RetryButton.Content" xml:space="preserve">
     <value>Skúsiť znova</value>
   </data>
+  <data name="ImportPage_TitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_RunImportButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_StopButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ClearResultsButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ExportLogButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_CurrentFileNameTextBlock.[using:Microsoft.UI.Xaml.Data.Binding].TargetNullValue" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ProcessedLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ProcessedSeparatorRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummaryTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummaryOkLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummaryErrorLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummarySkippedLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummaryDataLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SourceTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_PickFolderButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_OptionsTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_RecursiveCheckBox.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_PreserveMetadataCheckBox.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ReadOnlyCheckBox.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ParallelCheckBox.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxThreadsNumberBox.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxThreadsInfoBar.Title" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxThreadsInfoBar.Message" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_DefaultAuthorTextBox.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_DefaultAuthorTextBox.PlaceholderText" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeNumberBox.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeInfoBar.Title" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeInfoBar.Message" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeHintTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_QueueTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogTimeColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogEventColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogMessageColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogStatusColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogDetailColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_FilterLabelTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorTimeColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorFileColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorCodeColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorSeverityColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorMessageColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_OpenDetailButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_NoErrorsTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_DropPromptTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_DropHintTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
 </root>

--- a/Veriado.WinUI/Strings/sl-SI/Resources.resw
+++ b/Veriado.WinUI/Strings/sl-SI/Resources.resw
@@ -63,4 +63,187 @@
   <data name="StartupWindow_RetryButton.Content" xml:space="preserve">
     <value>Poskusi znova</value>
   </data>
+  <data name="ImportPage_TitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_RunImportButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_StopButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ClearResultsButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ExportLogButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_CurrentFileNameTextBlock.[using:Microsoft.UI.Xaml.Data.Binding].TargetNullValue" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ProcessedLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ProcessedSeparatorRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummaryTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummaryOkLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummaryErrorLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummarySkippedLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummaryDataLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SourceTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_PickFolderButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_OptionsTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_RecursiveCheckBox.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_PreserveMetadataCheckBox.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ReadOnlyCheckBox.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ParallelCheckBox.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxThreadsNumberBox.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxThreadsInfoBar.Title" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxThreadsInfoBar.Message" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_DefaultAuthorTextBox.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_DefaultAuthorTextBox.PlaceholderText" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeNumberBox.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeInfoBar.Title" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeInfoBar.Message" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeHintTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_QueueTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogTimeColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogEventColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogMessageColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogStatusColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogDetailColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_FilterLabelTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorTimeColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorFileColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorCodeColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorSeverityColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorMessageColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_OpenDetailButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_NoErrorsTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_DropPromptTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_DropHintTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
 </root>

--- a/Veriado.WinUI/Strings/sv-SE/Resources.resw
+++ b/Veriado.WinUI/Strings/sv-SE/Resources.resw
@@ -63,4 +63,187 @@
   <data name="StartupWindow_RetryButton.Content" xml:space="preserve">
     <value>Försök igen</value>
   </data>
+  <data name="ImportPage_TitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_RunImportButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_StopButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ClearResultsButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ExportLogButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_CurrentFileNameTextBlock.[using:Microsoft.UI.Xaml.Data.Binding].TargetNullValue" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ProcessedLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ProcessedSeparatorRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummaryTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummaryOkLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummaryErrorLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummarySkippedLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SummaryDataLabelRun.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_SourceTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_PickFolderButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_OptionsTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_RecursiveCheckBox.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_PreserveMetadataCheckBox.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ReadOnlyCheckBox.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ParallelCheckBox.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxThreadsNumberBox.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxThreadsInfoBar.Title" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxThreadsInfoBar.Message" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_DefaultAuthorTextBox.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_DefaultAuthorTextBox.PlaceholderText" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeNumberBox.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeInfoBar.Title" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeInfoBar.Message" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_MaxFileSizeHintTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_QueueTitleTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogTimeColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogEventColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogMessageColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogStatusColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_LogDetailColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_FilterLabelTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorTimeColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorFileColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorCodeColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorSeverityColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_ErrorMessageColumn.Header" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_OpenDetailButton.Content" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_NoErrorsTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_DropPromptTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
+
+  <data name="ImportPage_DropHintTextBlock.Text" xml:space="preserve">
+    <value></value>
+  </data>
 </root>

--- a/Veriado.WinUI/Views/CultureAwarePage.cs
+++ b/Veriado.WinUI/Views/CultureAwarePage.cs
@@ -1,0 +1,82 @@
+using System.Globalization;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media.Animation;
+using Veriado.WinUI.Services.Abstractions;
+
+namespace Veriado.WinUI.Views;
+
+public abstract class CultureAwarePage : Page
+{
+    private ILocalizationService? _localizationService;
+
+    protected CultureAwarePage()
+    {
+        Loaded += OnLoaded;
+        Unloaded += OnUnloaded;
+    }
+
+    protected virtual void OnCultureChanged(CultureInfo culture)
+    {
+    }
+
+    private void OnLoaded(object sender, RoutedEventArgs e)
+    {
+        AttachLocalizationService();
+    }
+
+    private void OnUnloaded(object sender, RoutedEventArgs e)
+    {
+        if (_localizationService is null)
+        {
+            return;
+        }
+
+        _localizationService.CultureChanged -= OnLocalizationServiceCultureChanged;
+    }
+
+    private void AttachLocalizationService()
+    {
+        if (_localizationService is null)
+        {
+            try
+            {
+                _localizationService = App.Services.GetService<ILocalizationService>();
+            }
+            catch
+            {
+                _localizationService = null;
+            }
+        }
+
+        if (_localizationService is not null)
+        {
+            _localizationService.CultureChanged -= OnLocalizationServiceCultureChanged;
+            _localizationService.CultureChanged += OnLocalizationServiceCultureChanged;
+        }
+    }
+
+    private void OnLocalizationServiceCultureChanged(object? sender, CultureInfo culture)
+    {
+        if (DispatcherQueue is null)
+        {
+            return;
+        }
+
+        _ = DispatcherQueue.TryEnqueue(() => HandleCultureChanged(culture));
+    }
+
+    private void HandleCultureChanged(CultureInfo culture)
+    {
+        if (Frame?.Content is not Page currentPage || !ReferenceEquals(currentPage, this))
+        {
+            return;
+        }
+
+        OnCultureChanged(culture);
+
+        var transition = new SuppressNavigationTransitionInfo();
+        Frame.Navigate(GetType(), null, transition);
+    }
+}

--- a/Veriado.WinUI/Views/Files/FilesPage.xaml
+++ b/Veriado.WinUI/Views/Files/FilesPage.xaml
@@ -1,4 +1,4 @@
-<Page
+<views:CultureAwarePage
     x:Class="Veriado.WinUI.Views.Files.FilesPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -7,11 +7,12 @@
     xmlns:controls="using:Microsoft.UI.Xaml.Controls"
     xmlns:converters="using:Veriado.WinUI.Converters"
     xmlns:contracts="using:Veriado.Contracts.Files"
+    xmlns:views="using:Veriado.WinUI.Views"
     mc:Ignorable="d">
-    <Page.Resources>
+    <views:CultureAwarePage.Resources>
         <converters:NullableIntToDoubleConverter x:Key="NullableIntToDoubleConverter" />
         <converters:NullableLongToDoubleConverter x:Key="NullableLongToDoubleConverter" />
-    </Page.Resources>
+    </views:CultureAwarePage.Resources>
 
     <Grid Padding="24" RowSpacing="16" ColumnSpacing="24">
         <Grid.RowDefinitions>
@@ -289,11 +290,6 @@
                                 BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}"
                                 BorderThickness="1"
                                 HorizontalAlignment="Stretch">
-                                <Border.Transitions>
-                                    <TransitionCollection>
-                                        <EntranceThemeTransition IsStaggeringEnabled="False" FromVerticalOffset="16" />
-                                    </TransitionCollection>
-                                </Border.Transitions>
                                 <StackPanel Spacing="4">
                                     <TextBlock
                                         Text="{x:Bind Name}"
@@ -316,4 +312,4 @@
             </controls:ScrollViewer>
         </controls:ItemsRepeaterScrollHost>
     </Grid>
-</Page>
+</views:CultureAwarePage>

--- a/Veriado.WinUI/Views/Import/ImportPage.xaml
+++ b/Veriado.WinUI/Views/Import/ImportPage.xaml
@@ -1,4 +1,4 @@
-<Page
+<views:CultureAwarePage
     x:Class="Veriado.WinUI.Views.Import.ImportPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -11,6 +11,7 @@
     xmlns:import="using:Veriado.WinUI.ViewModels.Import"
     xmlns:converters="using:Veriado.WinUI.Converters"
     xmlns:animations="using:Microsoft.UI.Xaml.Media.Animation"
+    xmlns:views="using:Veriado.WinUI.Views"
     d:DataContext="{d:DesignInstance Type=import:ImportPageViewModel}"
     AllowDrop="True"
     DragOver="OnPageDragOver"
@@ -18,13 +19,13 @@
     DragLeave="OnPageDragLeave"
     mc:Ignorable="d">
 
-    <Page.KeyboardAccelerators>
+    <views:CultureAwarePage.KeyboardAccelerators>
         <KeyboardAccelerator Key="Enter" Invoked="OnEnterAcceleratorInvoked" />
         <KeyboardAccelerator Key="Escape" Invoked="OnEscapeAcceleratorInvoked" />
         <KeyboardAccelerator Key="O" Modifiers="Control" Invoked="OnOpenAcceleratorInvoked" />
-    </Page.KeyboardAccelerators>
+    </views:CultureAwarePage.KeyboardAccelerators>
 
-    <Page.Resources>
+    <views:CultureAwarePage.Resources>
         <converters:SizeToHumanConverter x:Key="SizeToHumanConverter" />
         <converters:ImportErrorSeverityToStringConverter x:Key="ErrorSeverityToStringConverter" />
         <converters:NullableIntToDoubleConverter x:Key="NullableIntToDoubleConverter" />
@@ -32,7 +33,7 @@
         <Style x:Key="WrapTextBlockStyle" TargetType="TextBlock">
             <Setter Property="TextWrapping" Value="Wrap" />
         </Style>
-    </Page.Resources>
+    </views:CultureAwarePage.Resources>
 
 <Grid
         x:Name="DropZoneHost"
@@ -67,7 +68,7 @@
                     <animations:EntranceThemeTransition IsStaggeringEnabled="True" />
                 </TransitionCollection>
             </StackPanel.Transitions>
-            <TextBlock Text="Import souborů" FontSize="28" FontWeight="SemiBold" />
+            <TextBlock x:Uid="ImportPage_TitleTextBlock" FontSize="28" FontWeight="SemiBold" />
             <Grid ColumnSpacing="16">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="Auto" />
@@ -77,12 +78,15 @@
                 <StackPanel Orientation="Horizontal" Spacing="12">
                     <Button
                         x:Name="RunImportButton"
-                        Content="Spustit import"
+                        x:Uid="ImportPage_RunImportButton"
                         Command="{Binding RunImportCommand}"
                         Style="{StaticResource PulseButton}" />
-                    <Button Content="Zastavit" Command="{Binding StopImportCommand}" IsEnabled="{Binding IsImporting}" />
-                    <Button Content="Vymazat výsledky" Command="{Binding ClearResultsCommand}" />
-                    <Button Content="Exportovat protokol" Command="{Binding ExportLogCommand}" />
+                    <Button
+                        x:Uid="ImportPage_StopButton"
+                        Command="{Binding StopImportCommand}"
+                        IsEnabled="{Binding IsImporting}" />
+                    <Button x:Uid="ImportPage_ClearResultsButton" Command="{Binding ClearResultsCommand}" />
+                    <Button x:Uid="ImportPage_ExportLogButton" Command="{Binding ExportLogCommand}" />
                 </StackPanel>
 
                 <StackPanel Grid.Column="1" Orientation="Vertical" Spacing="4">
@@ -112,18 +116,20 @@
                                 <TextBlock FontWeight="SemiBold" Text="{Binding ProgressPercentDisplay, Mode=OneWay}" />
                                 <TextBlock Text="{Binding ProgressText}" />
                             </StackPanel>
-                            <TextBlock
-                                FontWeight="SemiBold"
-                                Text="{Binding CurrentFileName, TargetNullValue='(Žádný soubor)'}" />
+                            <TextBlock x:Uid="ImportPage_CurrentFileNameTextBlock" FontWeight="SemiBold">
+                                <TextBlock.Text>
+                                    <Binding Path="CurrentFileName" />
+                                </TextBlock.Text>
+                            </TextBlock>
                             <TextBlock
                                 Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                 Text="{Binding CurrentFilePath, TargetNullValue=''}"
                                 TextTrimming="CharacterEllipsis"
                                 MaxLines="2" />
                             <TextBlock>
-                                <Run Text="Zpracováno: " />
+                                <Run x:Uid="ImportPage_ProcessedLabelRun" />
                                 <Run Text="{Binding ProcessedBytes, Converter={StaticResource SizeToHumanConverter}}" />
-                                <Run Text=" / " />
+                                <Run x:Uid="ImportPage_ProcessedSeparatorRun" />
                                 <Run Text="{Binding TotalBytes, Converter={StaticResource SizeToHumanConverter}}" />
                             </TextBlock>
                         </StackPanel>
@@ -136,26 +142,26 @@
                             Visibility="Collapsed"
                             IsHitTestVisible="False">
                             <StackPanel Spacing="4">
-                                <TextBlock FontWeight="SemiBold" Text="Shrnutí importu" />
+                                <TextBlock x:Uid="ImportPage_SummaryTitleTextBlock" FontWeight="SemiBold" />
                                 <TextBlock Text="{Binding ProgressText}" TextWrapping="Wrap" />
                                 <StackPanel Orientation="Horizontal" Spacing="12">
                                     <TextBlock>
-                                        <Run Text="OK: " />
+                                        <Run x:Uid="ImportPage_SummaryOkLabelRun" />
                                         <Run Text="{Binding OkCount}" />
                                     </TextBlock>
                                     <TextBlock>
-                                        <Run Text="Chyby: " />
+                                        <Run x:Uid="ImportPage_SummaryErrorLabelRun" />
                                         <Run Text="{Binding ErrorCount}" />
                                     </TextBlock>
                                     <TextBlock>
-                                        <Run Text="Přeskočeno: " />
+                                        <Run x:Uid="ImportPage_SummarySkippedLabelRun" />
                                         <Run Text="{Binding SkipCount}" />
                                     </TextBlock>
                                 </StackPanel>
                                 <TextBlock
                                     Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                     TextWrapping="Wrap">
-                                    <Run Text="Zpracováno dat: " />
+                                    <Run x:Uid="ImportPage_SummaryDataLabelRun" />
                                     <Run Text="{Binding ProcessedBytes, Converter={StaticResource SizeToHumanConverter}}" />
                                 </TextBlock>
                             </StackPanel>
@@ -208,13 +214,16 @@
                     <animations:EntranceThemeTransition IsStaggeringEnabled="True" />
                 </TransitionCollection>
             </StackPanel.Transitions>
-            <TextBlock Text="Zdroj importu" FontSize="20" FontWeight="SemiBold" />
+            <TextBlock x:Uid="ImportPage_SourceTitleTextBlock" FontSize="20" FontWeight="SemiBold" />
             <Grid ColumnSpacing="12">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="Auto" />
                     <ColumnDefinition Width="*" />
                 </Grid.ColumnDefinitions>
-                <Button Grid.Column="0" Content="Vybrat složku" Command="{Binding PickFolderCommand}" />
+                <Button
+                    Grid.Column="0"
+                    x:Uid="ImportPage_PickFolderButton"
+                    Command="{Binding PickFolderCommand}" />
                 <TextBox
                     Grid.Column="1"
                     MinWidth="320"
@@ -230,17 +239,17 @@
                     <animations:EntranceThemeTransition IsStaggeringEnabled="True" />
                 </TransitionCollection>
             </StackPanel.Transitions>
-            <TextBlock Text="Volby importu" FontSize="20" FontWeight="SemiBold" />
+            <TextBlock x:Uid="ImportPage_OptionsTitleTextBlock" FontSize="20" FontWeight="SemiBold" />
             <StackPanel Orientation="Horizontal" Spacing="16">
                 <StackPanel Orientation="Vertical" Spacing="8">
-                    <CheckBox Content="Rekurzivně" IsChecked="{Binding Recursive, Mode=TwoWay}" />
-                    <CheckBox Content="Zachovat FS metadata" IsChecked="{Binding KeepFsMetadata, Mode=TwoWay}" />
+                    <CheckBox x:Uid="ImportPage_RecursiveCheckBox" IsChecked="{Binding Recursive, Mode=TwoWay}" />
+                    <CheckBox x:Uid="ImportPage_PreserveMetadataCheckBox" IsChecked="{Binding KeepFsMetadata, Mode=TwoWay}" />
                 </StackPanel>
                 <StackPanel Orientation="Vertical" Spacing="8">
-                    <CheckBox Content="Nastavit jen pro čtení" IsChecked="{Binding SetReadOnly, Mode=TwoWay}" />
-                    <CheckBox Content="Paralelně" IsChecked="{Binding UseParallel, Mode=TwoWay}" />
+                    <CheckBox x:Uid="ImportPage_ReadOnlyCheckBox" IsChecked="{Binding SetReadOnly, Mode=TwoWay}" />
+                    <CheckBox x:Uid="ImportPage_ParallelCheckBox" IsChecked="{Binding UseParallel, Mode=TwoWay}" />
                     <NumberBox
-                        Header="Max. paralelních vláken"
+                        x:Uid="ImportPage_MaxThreadsNumberBox"
                         Minimum="1"
                         SpinButtonPlacementMode="Compact"
                         IsEnabled="{Binding UseParallel}"
@@ -250,17 +259,15 @@
                         Margin="0,4,0,0"
                         IsOpen="{Binding HasParallelismError}"
                         Severity="Error"
-                        Title="Neplatný počet vláken"
-                        Message="Zadejte kladné celé číslo větší než nula."
+                        x:Uid="ImportPage_MaxThreadsInfoBar"
                         IsClosable="False" />
                 </StackPanel>
                 <StackPanel Orientation="Vertical" Spacing="8" Width="200">
                     <TextBox
-                        Header="Výchozí autor"
-                        PlaceholderText="(nevyplněno)"
+                        x:Uid="ImportPage_DefaultAuthorTextBox"
                         Text="{Binding DefaultAuthor, Mode=TwoWay}" />
                     <NumberBox
-                        Header="Max. velikost souboru (MB)"
+                        x:Uid="ImportPage_MaxFileSizeNumberBox"
                         Minimum="0"
                         SpinButtonPlacementMode="Compact"
                         ValidationMode="InvalidInputOverwritten"
@@ -269,13 +276,12 @@
                         Margin="0,4,0,0"
                         IsOpen="{Binding HasMaxFileSizeError}"
                         Severity="Warning"
-                        Title="Neplatná velikost souboru"
-                        Message="Zadejte nezápornou hodnotu nebo ponechte 0 pro bez limitu."
+                        x:Uid="ImportPage_MaxFileSizeInfoBar"
                         IsClosable="False" />
                     <TextBlock
+                        x:Uid="ImportPage_MaxFileSizeHintTextBlock"
                         FontSize="12"
-                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                        Text="0 = bez limitu" />
+                        Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
                 </StackPanel>
             </StackPanel>
         </StackPanel>
@@ -287,15 +293,13 @@
                     <animations:EntranceThemeTransition IsStaggeringEnabled="True" />
                 </TransitionCollection>
             </StackPanel.Transitions>
-            <TextBlock Text="Protokol importu" FontSize="20" FontWeight="SemiBold" />
+            <TextBlock x:Uid="ImportPage_LogTitleTextBlock" FontSize="20" FontWeight="SemiBold" />
             <StackPanel x:Name="QueueSection" Spacing="8" Visibility="Collapsed">
-                <TextBlock Text="Fronta importu" FontSize="16" FontWeight="SemiBold" />
+                <TextBlock x:Uid="ImportPage_QueueTitleTextBlock" FontSize="16" FontWeight="SemiBold" />
                 <ScrollViewer MaxHeight="240" VerticalScrollBarVisibility="Auto">
                     <muxc:ItemsRepeater
                         x:Name="ImportQueueRepeater"
-                        ItemsSource="{Binding Log}"
-                        ElementPrepared="OnQueueElementPrepared"
-                        ElementClearing="OnQueueElementClearing">
+                        ItemsSource="{Binding Log}">
                         <muxc:ItemsRepeater.Layout>
                             <muxc:StackLayout Orientation="Vertical" Spacing="6" />
                         </muxc:ItemsRepeater.Layout>
@@ -308,11 +312,6 @@
                                     BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
                                     BorderThickness="1"
                                     Opacity="0">
-                                    <Border.Transitions>
-                                        <TransitionCollection>
-                                            <EntranceThemeTransition FromVerticalOffset="12" />
-                                        </TransitionCollection>
-                                    </Border.Transitions>
                                     <Grid ColumnSpacing="12">
                                         <Grid.ColumnDefinitions>
                                             <ColumnDefinition Width="Auto" />
@@ -387,19 +386,19 @@
                     ScrollViewer.VerticalScrollBarVisibility="Auto"
                     ScrollViewer.HorizontalScrollBarVisibility="Auto">
                     <datagrid:DataGrid.Columns>
-                        <datagrid:DataGridTextColumn Header="Čas" Binding="{Binding FormattedTimestamp}" Width="Auto" />
-                        <datagrid:DataGridTextColumn Header="Událost" Binding="{Binding Title}" Width="2*">
+                        <datagrid:DataGridTextColumn x:Uid="ImportPage_LogTimeColumn" Binding="{Binding FormattedTimestamp}" Width="Auto" />
+                        <datagrid:DataGridTextColumn x:Uid="ImportPage_LogEventColumn" Binding="{Binding Title}" Width="2*">
                             <datagrid:DataGridTextColumn.ElementStyle>
                                 <Style TargetType="TextBlock" BasedOn="{StaticResource WrapTextBlockStyle}" />
                             </datagrid:DataGridTextColumn.ElementStyle>
                         </datagrid:DataGridTextColumn>
-                        <datagrid:DataGridTextColumn Header="Zpráva" Binding="{Binding Message}" Width="3*">
+                        <datagrid:DataGridTextColumn x:Uid="ImportPage_LogMessageColumn" Binding="{Binding Message}" Width="3*">
                             <datagrid:DataGridTextColumn.ElementStyle>
                                 <Style TargetType="TextBlock" BasedOn="{StaticResource WrapTextBlockStyle}" />
                             </datagrid:DataGridTextColumn.ElementStyle>
                         </datagrid:DataGridTextColumn>
-                        <datagrid:DataGridTextColumn Header="Stav" Binding="{Binding Status}" Width="Auto" />
-                        <datagrid:DataGridTextColumn Header="Detail" Binding="{Binding Detail}" Width="3*">
+                        <datagrid:DataGridTextColumn x:Uid="ImportPage_LogStatusColumn" Binding="{Binding Status}" Width="Auto" />
+                        <datagrid:DataGridTextColumn x:Uid="ImportPage_LogDetailColumn" Binding="{Binding Detail}" Width="3*">
                             <datagrid:DataGridTextColumn.ElementStyle>
                                 <Style TargetType="TextBlock" BasedOn="{StaticResource WrapTextBlockStyle}" />
                             </datagrid:DataGridTextColumn.ElementStyle>
@@ -435,7 +434,7 @@
                         <StackPanel Orientation="Horizontal" Spacing="8">
                             <TextBlock
                                 VerticalAlignment="Center"
-                                Text="Filtrovat:" />
+                                x:Uid="ImportPage_FilterLabelTextBlock" />
                             <ComboBox
                                 Width="180"
                                 ItemsSource="{Binding ErrorFilterOptions}"
@@ -468,17 +467,17 @@
                         ScrollViewer.VerticalScrollBarVisibility="Auto"
                         ScrollViewer.HorizontalScrollBarVisibility="Auto">
                         <datagrid:DataGrid.Columns>
-                            <datagrid:DataGridTextColumn Header="Čas" Binding="{Binding FormattedTimestamp}" Width="Auto" />
-                            <datagrid:DataGridTextColumn Header="Soubor" Binding="{Binding FileName}" Width="2*">
+                            <datagrid:DataGridTextColumn x:Uid="ImportPage_ErrorTimeColumn" Binding="{Binding FormattedTimestamp}" Width="Auto" />
+                            <datagrid:DataGridTextColumn x:Uid="ImportPage_ErrorFileColumn" Binding="{Binding FileName}" Width="2*">
                                 <datagrid:DataGridTextColumn.ElementStyle>
                                     <Style TargetType="TextBlock" BasedOn="{StaticResource WrapTextBlockStyle}">
                                         <Setter Property="ToolTipService.ToolTip" Value="{Binding FilePath}" />
                                     </Style>
                                 </datagrid:DataGridTextColumn.ElementStyle>
                             </datagrid:DataGridTextColumn>
-                            <datagrid:DataGridTextColumn Header="Kód" Binding="{Binding Code}" Width="Auto" />
-                            <datagrid:DataGridTextColumn Header="Závažnost" Binding="{Binding Severity, Converter={StaticResource ErrorSeverityToStringConverter}}" Width="Auto" />
-                            <datagrid:DataGridTextColumn Header="Zpráva" Binding="{Binding ErrorMessage}" Width="3*">
+                            <datagrid:DataGridTextColumn x:Uid="ImportPage_ErrorCodeColumn" Binding="{Binding Code}" Width="Auto" />
+                            <datagrid:DataGridTextColumn x:Uid="ImportPage_ErrorSeverityColumn" Binding="{Binding Severity, Converter={StaticResource ErrorSeverityToStringConverter}}" Width="Auto" />
+                            <datagrid:DataGridTextColumn x:Uid="ImportPage_ErrorMessageColumn" Binding="{Binding ErrorMessage}" Width="3*">
                                 <datagrid:DataGridTextColumn.ElementStyle>
                                     <Style TargetType="TextBlock" BasedOn="{StaticResource WrapTextBlockStyle}" />
                                 </datagrid:DataGridTextColumn.ElementStyle>
@@ -500,7 +499,7 @@
                                         TextWrapping="Wrap"
                                         Visibility="{Binding HasSuggestion, Converter={StaticResource BooleanToVisibilityConverter}}" />
                                     <Button
-                                        Content="Otevřít detail"
+                                        x:Uid="ImportPage_OpenDetailButton"
                                         HorizontalAlignment="Left"
                                         Command="{Binding ElementName=ErrorsDataGrid, Path=DataContext.OpenErrorDetailCommand}"
                                         CommandParameter="{Binding Source}" />
@@ -513,7 +512,7 @@
                         Grid.Row="3"
                         Margin="0,8,0,0"
                         Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                        Text="Žádné chyby neodpovídají vybranému filtru."
+                        x:Uid="ImportPage_NoErrorsTextBlock"
                         Visibility="{Binding HasNoFilteredErrors, Converter={StaticResource BooleanToVisibilityConverter}}" />
                 </Grid>
             </Grid>
@@ -532,10 +531,10 @@
                 HorizontalAlignment="Center"
                 VerticalAlignment="Center">
                 <StackPanel Spacing="8" HorizontalAlignment="Center">
-                    <TextBlock Text="Pusťte složku pro import" FontSize="24" FontWeight="SemiBold" HorizontalAlignment="Center" />
-                    <TextBlock Text="Složku můžete také vybrat pomocí tlačítka." HorizontalAlignment="Center" />
+                    <TextBlock x:Uid="ImportPage_DropPromptTextBlock" FontSize="24" FontWeight="SemiBold" HorizontalAlignment="Center" />
+                    <TextBlock x:Uid="ImportPage_DropHintTextBlock" HorizontalAlignment="Center" />
                 </StackPanel>
             </Border>
         </Grid>
     </Grid>
-</Page>
+</views:CultureAwarePage>

--- a/Veriado.WinUI/Views/Shell/MainShell.xaml
+++ b/Veriado.WinUI/Views/Shell/MainShell.xaml
@@ -47,9 +47,10 @@
         </controls:NavigationView.MenuItems>
         <controls:NavigationView.Content>
             <Grid Background="{ThemeResource AppBackgroundBrush}">
-                <ContentPresenter
-                    x:Name="ContentHost"
-                    Content="{x:Bind CurrentContent, Mode=OneWay}" />
+                <Frame
+                    x:Name="ContentFrame"
+                    NavigationCacheMode="Disabled"
+                    IsNavigationStackEnabled="False" />
             </Grid>
         </controls:NavigationView.Content>
     </controls:NavigationView>

--- a/Veriado.WinUI/Views/Shell/MainShell.xaml.cs
+++ b/Veriado.WinUI/Views/Shell/MainShell.xaml.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using System.Linq;
+using Microsoft.UI.Xaml.Controls;
 using Veriado.WinUI.Navigation;
 using Veriado.WinUI.ViewModels.Shell;
 
@@ -25,11 +26,7 @@ public sealed partial class MainShell : Window, INavigationHost
         Closed += OnClosed;
     }
 
-    public object? CurrentContent
-    {
-        get => ContentHost.Content;
-        set => ContentHost.Content = value;
-    }
+    public Frame NavigationFrame => ContentFrame;
 
     private void OnLoaded(object sender, RoutedEventArgs e)
     {


### PR DESCRIPTION
## Summary
- update the localization infrastructure to use Microsoft.Windows.ApplicationModel.Resources.ResourceManager with per-context qualifiers
- add a culture-aware page base and navigation/list animation helpers gated by system animation settings
- migrate ImportPage strings to x:Uid resources and extend .resw files for new localization keys

## Testing
- dotnet build *(fails: dotnet not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dedb713cb483268b788536a690fb86