### PR TITLE
Remove unsupported Frame cache setting

### DIFF
--- a/Veriado.WinUI/Views/Shell/MainShell.xaml
+++ b/Veriado.WinUI/Views/Shell/MainShell.xaml
@@ -49,7 +49,6 @@
             <Grid Background="{ThemeResource AppBackgroundBrush}">
                 <Frame
                     x:Name="ContentFrame"
-                    NavigationCacheMode="Disabled"
                     IsNavigationStackEnabled="False" />
             </Grid>
         </controls:NavigationView.Content>


### PR DESCRIPTION
## Summary
- remove the NavigationCacheMode attribute from the shell frame because it is not supported in WinUI

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68df6e1155e88326b8569062eea7a457