### PR TITLE
Update localization service for WinUI 3 resource APIs

### DIFF
--- a/Veriado.WinUI/Services/LocalizationService.cs
+++ b/Veriado.WinUI/Services/LocalizationService.cs
@@ -10,34 +10,50 @@ public sealed class LocalizationService : ILocalizationService
     private static readonly IReadOnlyList<CultureInfo> SupportedCultureList =
         Array.AsReadOnly(new[] { DefaultCulture });
 
+    private readonly ISettingsService _settingsService;
     private readonly ResourceManager _resourceManager = new();
     private readonly ResourceMap? _resourceMap;
     private readonly ResourceContext _resourceContext;
 
+    private CultureInfo _currentCulture = DefaultCulture;
+    private bool _isInitialized;
+
     public LocalizationService(ISettingsService settingsService)
     {
-        ArgumentNullException.ThrowIfNull(settingsService);
+        _settingsService = settingsService ?? throw new ArgumentNullException(nameof(settingsService));
 
         _resourceMap = _resourceManager.MainResourceMap.TryGetSubtree("Resources");
-        _resourceContext = new ResourceContext(_resourceManager);
-        _resourceContext.QualifierValues["Language"] = DefaultCulture.Name;
+        _resourceContext = _resourceManager.CreateResourceContext();
+        UpdateQualifierLanguage(DefaultCulture.Name);
+        ApplyCultureToThread(DefaultCulture);
     }
 
     public event EventHandler<CultureInfo>? CultureChanged;
 
-    public CultureInfo CurrentCulture => DefaultCulture;
+    public CultureInfo CurrentCulture => _currentCulture;
 
     public IReadOnlyList<CultureInfo> SupportedCultures => SupportedCultureList;
 
-    public Task InitializeAsync(CancellationToken cancellationToken = default)
+    public async Task InitializeAsync(CancellationToken cancellationToken = default)
     {
-        return Task.CompletedTask;
+        if (_isInitialized)
+        {
+            return;
+        }
+
+        var settings = await _settingsService.GetAsync(cancellationToken).ConfigureAwait(false);
+        var desiredCulture = TryGetCulture(settings.Language) ?? DefaultCulture;
+
+        await ApplyCultureAsync(desiredCulture, persist: false, cancellationToken).ConfigureAwait(false);
+
+        _isInitialized = true;
     }
 
     public Task SetCultureAsync(CultureInfo culture, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(culture);
-        return Task.CompletedTask;
+
+        return ApplyCultureAsync(culture, persist: true, cancellationToken);
     }
 
     public string GetString(string resourceKey, string? defaultValue = null, params object?[] arguments)
@@ -52,7 +68,7 @@ public sealed class LocalizationService : ILocalizationService
         {
             try
             {
-                return string.Format(DefaultCulture, template, arguments);
+                return string.Format(_currentCulture, template, arguments);
             }
             catch (FormatException)
             {
@@ -72,5 +88,117 @@ public sealed class LocalizationService : ILocalizationService
 
         var candidate = _resourceMap.TryGetValue(resourceKey, _resourceContext);
         return candidate?.ValueAsString;
+    }
+
+    private async Task ApplyCultureAsync(CultureInfo culture, bool persist, CancellationToken cancellationToken)
+    {
+        var resolved = ResolveCulture(culture);
+        if (string.Equals(resolved.Name, _currentCulture.Name, StringComparison.OrdinalIgnoreCase))
+        {
+            if (persist)
+            {
+                await PersistCultureAsync(resolved, cancellationToken).ConfigureAwait(false);
+            }
+
+            return;
+        }
+
+        _currentCulture = resolved;
+
+        UpdateQualifierLanguage(resolved.Name);
+        ApplyCultureToThread(resolved);
+        ResetViewContexts();
+
+        if (persist)
+        {
+            await PersistCultureAsync(resolved, cancellationToken).ConfigureAwait(false);
+        }
+
+        CultureChanged?.Invoke(this, _currentCulture);
+    }
+
+    private CultureInfo ResolveCulture(CultureInfo culture)
+    {
+        foreach (var supported in SupportedCultureList)
+        {
+            if (string.Equals(supported.Name, culture.Name, StringComparison.OrdinalIgnoreCase))
+            {
+                return supported;
+            }
+        }
+
+        try
+        {
+            return CultureInfo.GetCultureInfo(culture.Name);
+        }
+        catch (CultureNotFoundException)
+        {
+            return DefaultCulture;
+        }
+    }
+
+    private static CultureInfo? TryGetCulture(string? cultureName)
+    {
+        if (string.IsNullOrWhiteSpace(cultureName))
+        {
+            return null;
+        }
+
+        try
+        {
+            return CultureInfo.GetCultureInfo(cultureName);
+        }
+        catch (CultureNotFoundException)
+        {
+            return null;
+        }
+    }
+
+    private Task PersistCultureAsync(CultureInfo culture, CancellationToken cancellationToken)
+    {
+        return _settingsService.UpdateAsync(settings => settings.Language = culture.Name, cancellationToken);
+    }
+
+    private void UpdateQualifierLanguage(string language)
+    {
+        if (_resourceContext.QualifierValues.ContainsKey("Language"))
+        {
+            _resourceContext.QualifierValues["Language"] = language;
+        }
+        else
+        {
+            _resourceContext.QualifierValues.Add("Language", language);
+        }
+    }
+
+    private static void ApplyCultureToThread(CultureInfo culture)
+    {
+        CultureInfo.CurrentCulture = culture;
+        CultureInfo.CurrentUICulture = culture;
+        CultureInfo.DefaultThreadCurrentCulture = culture;
+        CultureInfo.DefaultThreadCurrentUICulture = culture;
+    }
+
+    private static void ResetViewContexts()
+    {
+        try
+        {
+            var viewContext = ResourceContext.GetForCurrentView();
+            viewContext.Reset();
+        }
+        catch
+        {
+            // Ignore failures – view contexts might be unavailable during startup or in tests.
+        }
+
+        try
+        {
+            var appContext = ResourceContext.GetForViewIndependentUse();
+            appContext.Reset();
+        }
+        catch
+        {
+            // Ignore failures when the platform does not support independent contexts yet.
+        }
     }
 }


### PR DESCRIPTION
## Summary
- create the localization resource context with the WinAppSDK helper and keep the current culture in sync with the UI thread
- read and persist the chosen language via the settings service and raise CultureChanged when switching cultures
- reset view contexts after a culture update so bound XAML resources refresh when the language changes

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68df719b8ebc832682ab66cd4bf84b20