### PR TITLE
Adjust localization reset for WinUI

### DIFF
--- a/Veriado.WinUI/Services/LocalizationService.cs
+++ b/Veriado.WinUI/Services/LocalizationService.cs
@@ -107,7 +107,7 @@ public sealed class LocalizationService : ILocalizationService
 
         UpdateQualifierLanguage(resolved.Name);
         ApplyCultureToThread(resolved);
-        ResetViewContexts();
+        ResetResourceContexts();
 
         if (persist)
         {
@@ -179,26 +179,15 @@ public sealed class LocalizationService : ILocalizationService
         CultureInfo.DefaultThreadCurrentUICulture = culture;
     }
 
-    private static void ResetViewContexts()
+    private void ResetResourceContexts()
     {
         try
         {
-            var viewContext = ResourceContext.GetForCurrentView();
-            viewContext.Reset();
+            _resourceContext.Reset();
         }
         catch
         {
-            // Ignore failures – view contexts might be unavailable during startup or in tests.
-        }
-
-        try
-        {
-            var appContext = ResourceContext.GetForViewIndependentUse();
-            appContext.Reset();
-        }
-        catch
-        {
-            // Ignore failures when the platform does not support independent contexts yet.
+            // Ignore failures when the resource context is not yet available (e.g. during tests).
         }
     }
 }

--- a/docs/winui-animations-localization.md
+++ b/docs/winui-animations-localization.md
@@ -37,7 +37,7 @@
 ### Lokalizace
 1. **Deklarativní lokalizace importu** – převést `ImportPage` na `x:Uid` + `resw` klíče (včetně binding textů a `Content` tlačítek) a přidat nové řetězce do základního `Resources.resw`. Následně generovat prázdné položky pro všechny jazykové soubory, aby překladatelé snadno identifikovali nové texty.【F:Veriado.WinUI/Views/Import/ImportPage.xaml†L64-L162】【F:Veriado.WinUI/Strings/Resources.resw†L15-L66】
 2. **Standardizace workflow** – vytvořit guideline: (a) pojmenovat `x:Uid` podle `{Page}_{Control}`; (b) používat `LocalizedStrings.Get` pouze ve ViewModel/servis vrstvě; (c) přidat kontrolu v CI, která porovná klíče mezi jednotlivými `.resw` soubory.
-3. **Reakce na změnu kultury** – poskytovat helper (např. `CultureAwarePage`) naslouchající `ILocalizationService.CultureChanged`, který zavolá `ResourceContext.GetForCurrentView().Reset()`, případně znovu naváže `x:Bind`. Tím se zajistí, že již otevřená okna přeladí obsah bez nutnosti restartu.【F:Veriado.WinUI/Services/LocalizationService.cs†L32-L88】
+3. **Reakce na změnu kultury** – poskytovat helper (např. `CultureAwarePage`) naslouchající `ILocalizationService.CultureChanged`, který po změně kultury vyresetuje vlastní `ResourceContext` a případně znovu naváže `x:Bind`. Tím se zajistí, že již otevřená okna přeladí obsah bez nutnosti restartu i v prostředí WinUI.【F:Veriado.WinUI/Services/LocalizationService.cs†L32-L188】
 4. **Formátovací testy** – pro řetězce s parametry (např. `Settings.PageSizeUpdated`) přidejte unit testy, které projdou všemi kulturami a ověří, že `string.Format` nevyhazuje výjimky. To minimalizuje riziko run-time chyb v lokalizovaném prostředí.【F:Veriado.WinUI/Strings/Resources.resw†L21-L29】
 
 ## Doporučený postup implementace


### PR DESCRIPTION
## Summary
- replace the UWP-specific resource context reset with a WinUI-compatible implementation in `LocalizationService`
- update the localization guidance documentation to reflect the WinUI-specific reset behaviour

## Testing
- not run (environment does not provide required tooling)


------
https://chatgpt.com/codex/tasks/task_e_68df73eec5e48326a5da49c3aa5a945c