### PR TITLE
Fix resource context usage for localization

### DIFF
--- a/Veriado.WinUI/Localization/LocalizedStrings.cs
+++ b/Veriado.WinUI/Localization/LocalizedStrings.cs
@@ -5,15 +5,10 @@ namespace Veriado.WinUI.Localization;
 
 internal static class LocalizedStrings
 {
+    private static readonly CultureInfo DefaultCulture = CultureInfo.GetCultureInfo("en-US");
     private static readonly ResourceManager ResourceManager = new();
     private static readonly ResourceMap? ResourceMap = ResourceManager.MainResourceMap.TryGetSubtree("Resources");
-    private static readonly ResourceContext ResourceContext = new(ResourceManager);
-    private static readonly CultureInfo DefaultCulture = CultureInfo.GetCultureInfo("en-US");
-
-    static LocalizedStrings()
-    {
-        ResourceContext.QualifierValues["Language"] = DefaultCulture.Name;
-    }
+    private static readonly ResourceContext ResourceContext = CreateResourceContext();
 
     public static string Get(string resourceKey, string? defaultValue = null, params object?[] arguments)
     {
@@ -47,5 +42,19 @@ internal static class LocalizedStrings
 
         var candidate = ResourceMap.TryGetValue(resourceKey, ResourceContext);
         return candidate?.ValueAsString;
+    }
+    private static ResourceContext CreateResourceContext()
+    {
+        var context = ResourceManager.CreateResourceContext();
+        if (context.QualifierValues.ContainsKey("Language"))
+        {
+            context.QualifierValues["Language"] = DefaultCulture.Name;
+        }
+        else
+        {
+            context.QualifierValues.Add("Language", DefaultCulture.Name);
+        }
+
+        return context;
     }
 }

--- a/Veriado.WinUI/Services/LocalizationService.cs
+++ b/Veriado.WinUI/Services/LocalizationService.cs
@@ -13,7 +13,7 @@ public sealed class LocalizationService : ILocalizationService
     private readonly ISettingsService _settingsService;
     private readonly ResourceManager _resourceManager = new();
     private readonly ResourceMap? _resourceMap;
-    private readonly ResourceContext _resourceContext;
+    private ResourceContext _resourceContext;
 
     private CultureInfo _currentCulture = DefaultCulture;
     private bool _isInitialized;
@@ -161,14 +161,7 @@ public sealed class LocalizationService : ILocalizationService
 
     private void UpdateQualifierLanguage(string language)
     {
-        if (_resourceContext.QualifierValues.ContainsKey("Language"))
-        {
-            _resourceContext.QualifierValues["Language"] = language;
-        }
-        else
-        {
-            _resourceContext.QualifierValues.Add("Language", language);
-        }
+        SetQualifierLanguage(_resourceContext, language);
     }
 
     private static void ApplyCultureToThread(CultureInfo culture)
@@ -181,13 +174,19 @@ public sealed class LocalizationService : ILocalizationService
 
     private void ResetResourceContexts()
     {
-        try
+        _resourceContext = _resourceManager.CreateResourceContext();
+        SetQualifierLanguage(_resourceContext, _currentCulture.Name);
+    }
+
+    private static void SetQualifierLanguage(ResourceContext context, string language)
+    {
+        if (context.QualifierValues.ContainsKey("Language"))
         {
-            _resourceContext.Reset();
+            context.QualifierValues["Language"] = language;
         }
-        catch
+        else
         {
-            // Ignore failures when the resource context is not yet available (e.g. during tests).
+            context.QualifierValues.Add("Language", language);
         }
     }
 }


### PR DESCRIPTION
## Summary
- initialize WinUI localization contexts using ResourceManager.CreateResourceContext instead of unavailable constructors
- recreate the resource context when cultures change rather than calling the removed Reset API

## Testing
- dotnet build *(fails: `dotnet` CLI is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df76345f0c83268e5c619715b27c4c