### PR TITLE
Fix startup window DataContext assignment

### DIFF
--- a/Veriado.WinUI/App.xaml.cs
+++ b/Veriado.WinUI/App.xaml.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using System.Globalization;
 using Microsoft.Extensions.Logging;
 using Microsoft.UI.Dispatching;
+using Microsoft.UI.Xaml;
 using Microsoft.Windows.ApplicationModel.DynamicDependency;
 using Veriado.WinUI.Errors;
 using Veriado.WinUI.Helpers;
@@ -39,7 +40,11 @@ public partial class App : Application
 
         var startupWindow = new StartupWindow();
         var startupViewModel = new StartupViewModel();
-        startupWindow.DataContext = startupViewModel;
+
+        if (startupWindow.Content is FrameworkElement rootElement)
+        {
+            rootElement.DataContext = startupViewModel;
+        }
         startupWindow.Activate();
 
         async Task<bool> RunAsync() => await startupViewModel.RunStartupAsync().ConfigureAwait(true);


### PR DESCRIPTION
## Summary
- set the StartupWindow root element's DataContext to the StartupViewModel since Window itself does not expose DataContext in WinUI 3
- add the required Microsoft.UI.Xaml namespace import

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68df96e3ad588326a0c869250d311716