### PR TITLE
Fix diagnostics log text binding in StartupWindow

### DIFF
--- a/Veriado.WinUI/Views/StartupWindow.xaml
+++ b/Veriado.WinUI/Views/StartupWindow.xaml
@@ -39,11 +39,13 @@
                 Foreground="{ThemeResource AppTextPrimaryBrush}"
                 Visibility="{Binding SafeMode, Converter={StaticResource BooleanToVisibilityConverter}}" />
             <TextBlock
-                Text="{Binding DiagnosticsLogPath, Mode=OneWay, StringFormat='Podrobný log: {0}'}"
                 TextAlignment="Center"
                 TextWrapping="Wrap"
                 Foreground="{ThemeResource AppTextSecondaryBrush}"
-                Visibility="{Binding HasDiagnosticsLog, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                Visibility="{Binding HasDiagnosticsLog, Converter={StaticResource BooleanToVisibilityConverter}}">
+                <Run Text="Podrobný log: " />
+                <Run Text="{Binding DiagnosticsLogPath, Mode=OneWay}" />
+            </TextBlock>
             <Button
                 x:Uid="StartupWindow_RetryButton"
                 Width="160"


### PR DESCRIPTION
## Summary
- replace the unsupported StringFormat binding in StartupWindow with inline runs to show the diagnostics log path

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df97f133cc8326a440c32b347f48c6