### PR TITLE
Fix StartupWindow bindings for WinUI window

### DIFF
--- a/Veriado.WinUI/Views/StartupWindow.xaml
+++ b/Veriado.WinUI/Views/StartupWindow.xaml
@@ -77,32 +77,32 @@
                                 </Grid.ColumnDefinitions>
                                 <FontIcon
                                     Grid.Column="0"
-                                    Glyph="{x:Bind Glyph}"
+                                    Glyph="{Binding Glyph}"
                                     FontSize="16"
                                     VerticalAlignment="Top" />
                                 <StackPanel Grid.Column="1" Spacing="2">
                                     <TextBlock
-                                        Text="{x:Bind Title}"
+                                        Text="{Binding Title}"
                                         Foreground="{ThemeResource AppTextPrimaryBrush}"
                                         Style="{ThemeResource BodyStrongTextBlockStyle}" />
                                     <TextBlock
-                                        Text="{x:Bind Message}"
+                                        Text="{Binding Message}"
                                         TextWrapping="WrapWholeWords"
                                         Foreground="{ThemeResource AppTextSecondaryBrush}" />
                                     <TextBlock
-                                        Text="{x:Bind ErrorMessage}"
+                                        Text="{Binding ErrorMessage}"
                                         TextWrapping="WrapWholeWords"
                                         Foreground="{ThemeResource SystemFillColorCriticalBrush}"
-                                        Visibility="{x:Bind HasError, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                                        Visibility="{Binding HasError, Converter={StaticResource BooleanToVisibilityConverter}}" />
                                 </StackPanel>
                                 <StackPanel Grid.Column="2" HorizontalAlignment="Right" Spacing="4">
                                     <TextBlock
-                                        Text="{x:Bind StatusText}"
+                                        Text="{Binding StatusText}"
                                         Foreground="{ThemeResource AppTextSecondaryBrush}" />
                                     <TextBlock
-                                        Text="{x:Bind DurationText}"
+                                        Text="{Binding DurationText}"
                                         Foreground="{ThemeResource AppTextSecondaryBrush}"
-                                        Visibility="{x:Bind HasDuration, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                                        Visibility="{Binding HasDuration, Converter={StaticResource BooleanToVisibilityConverter}}" />
                                 </StackPanel>
                             </Grid>
                         </DataTemplate>


### PR DESCRIPTION
## Summary
- replace x:Bind expressions in the StartupWindow step template with classic bindings
- ensure BooleanToVisibilityConverter is referenced correctly to avoid Window binding compilation errors

## Testing
- not run (environment missing dotnet SDK)


------
https://chatgpt.com/codex/tasks/task_e_68df98fd918483269926ebb19dd5af2e