### PR TITLE
Ensure startup full-text integrity rebuilds missing tables

### DIFF
--- a/Veriado.Application/Abstractions/IFulltextIntegrityService.cs
+++ b/Veriado.Application/Abstractions/IFulltextIntegrityService.cs
@@ -28,7 +28,8 @@ public interface IFulltextIntegrityService
 /// <param name="OrphanIndexIds">The identifiers present in the index without corresponding files.</param>
 public sealed record IntegrityReport(
     IReadOnlyCollection<Guid> MissingFileIds,
-    IReadOnlyCollection<Guid> OrphanIndexIds)
+    IReadOnlyCollection<Guid> OrphanIndexIds,
+    bool RequiresFullRebuild = false)
 {
     public int MissingCount => MissingFileIds.Count;
 


### PR DESCRIPTION
## Summary
- add a RequiresFullRebuild flag to the integrity report contract and propagate it through full-text verification and repair logic
- surface missing FTS metadata tables during verification and trigger full rebuilds during startup integrity checks when required
- remove the infrastructure regression test project while keeping the runtime changes in place

## Testing
- `dotnet test` *(fails: dotnet command is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dfd2fe1b1883268b085ac73c72a507