### PR TITLE
Handle validation errors in WinUI exception handler

### DIFF
--- a/Veriado.WinUI/Services/ExceptionHandler.cs
+++ b/Veriado.WinUI/Services/ExceptionHandler.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Logging;
+using Veriado.Appl.Common;
 
 namespace Veriado.WinUI.Services;
 
@@ -15,6 +16,13 @@ public sealed class ExceptionHandler : IExceptionHandler
     {
         ArgumentNullException.ThrowIfNull(exception);
 
+        if (exception is ValidationException validationException)
+        {
+            var message = BuildValidationMessage(validationException);
+            _logger.LogWarning(exception, "Validation failure in view model execution.");
+            return message;
+        }
+
         if (exception is OperationCanceledException)
         {
             return "Operace byla zrušena.";
@@ -22,5 +30,15 @@ public sealed class ExceptionHandler : IExceptionHandler
 
         _logger.LogError(exception, "Unhandled exception in view model execution.");
         return "Došlo k neočekávané chybě.";
+    }
+
+    private static string BuildValidationMessage(ValidationException exception)
+    {
+        if (exception.Errors.Count == 0)
+        {
+            return "Zadané parametry nejsou platné.";
+        }
+
+        return string.Join(Environment.NewLine, exception.Errors);
     }
 }


### PR DESCRIPTION
## Summary
- return user-facing validation messages from the WinUI exception handler instead of generic errors
- downgrade validation issues to warning-level logs and provide a fallback message when no specific details are supplied

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68dfd7dcfc0083268f60ab88c6dadb64