### PR TITLE
Fix SQLite MATCH usage for trigram and suggestion queries

### DIFF
--- a/Veriado.Infrastructure/Search/SuggestionService.cs
+++ b/Veriado.Infrastructure/Search/SuggestionService.cs
@@ -46,7 +46,7 @@ internal sealed class SuggestionService : ISearchSuggestionService
             var builder = new StringBuilder();
             builder.Append("SELECT s.term, s.weight, s.lang, s.source_field FROM suggestions_fts f ");
             builder.Append("JOIN suggestions s ON s.id = f.rowid ");
-            builder.Append("WHERE f MATCH $match ");
+            builder.Append("WHERE suggestions_fts MATCH $match ");
             if (!string.IsNullOrWhiteSpace(lang))
             {
                 builder.Append("AND s.lang = $lang ");

--- a/Veriado.Infrastructure/Search/TrigramQueryService.cs
+++ b/Veriado.Infrastructure/Search/TrigramQueryService.cs
@@ -96,7 +96,7 @@ internal sealed class TrigramQueryService
             "FROM file_trgm AS fts " +
             "JOIN file_trgm_map m ON fts.rowid = m.rowid " +
             "JOIN files f ON f.id = m.file_id " +
-            "WHERE fts MATCH $query ");
+            "WHERE file_trgm MATCH $query ");
         AppendWhereClauses(builder, plan);
         builder.Append("ORDER BY bm25(file_trgm) ASC, m.rowid ASC LIMIT $limit;");
         command.CommandText = builder.ToString();
@@ -213,7 +213,7 @@ internal sealed class TrigramQueryService
             "JOIN file_search_map sm ON sm.file_id = tm.file_id " +
             "JOIN file_search s ON s.rowid = sm.rowid " +
             "JOIN files f ON f.id = tm.file_id " +
-            "WHERE fts MATCH $query ");
+            "WHERE file_trgm MATCH $query ");
         AppendWhereClauses(builder, plan);
         builder.Append("ORDER BY bm25(file_trgm) ASC, tm.rowid ASC LIMIT $limit;");
         command.CommandText = builder.ToString();


### PR DESCRIPTION
## Summary
- update trigram queries to reference the underlying FTS table name in MATCH clauses
- adjust the suggestion service MATCH clause to avoid using a table alias that SQLite does not resolve

## Testing
- `dotnet build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dfe8ea82bc8326a64cdf69972352e3