### PR TITLE
Improve fuzzy term handling and field qualifier support

### DIFF
--- a/Veriado.Application/Search/SearchQueryBuilder.cs
+++ b/Veriado.Application/Search/SearchQueryBuilder.cs
@@ -408,6 +408,7 @@ public sealed class SearchQueryBuilder : ISearchQueryBuilder
         return token.TokenType switch
         {
             QueryTokenType.Term => FormatTerm(fieldPrefix, token.Value),
+            QueryTokenType.Fuzzy => FormatTerm(fieldPrefix, token.Value),
             QueryTokenType.Phrase => fieldPrefix + '"' + EscapeQuotes(token.Value) + '"',
             QueryTokenType.Proximity => fieldPrefix + token.Value,
             QueryTokenType.Prefix => fieldPrefix + token.Value,
@@ -516,13 +517,15 @@ public sealed class SearchQueryBuilder : ISearchQueryBuilder
         }
 
         var expanded = _synonymProvider.Expand(_language, term);
-        if (expanded.Count == 0)
+        var unique = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var ordered = new List<string>(expanded.Count + 1);
+
+        var original = NormalizeText(term);
+        if (!string.IsNullOrWhiteSpace(original) && unique.Add(original))
         {
-            return Array.Empty<string>();
+            ordered.Add(original);
         }
 
-        var unique = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        var ordered = new List<string>(expanded.Count);
         foreach (var candidate in expanded)
         {
             var normalised = NormalizeText(candidate);
@@ -534,15 +537,6 @@ public sealed class SearchQueryBuilder : ISearchQueryBuilder
             if (unique.Add(normalised))
             {
                 ordered.Add(normalised);
-            }
-        }
-
-        if (ordered.Count == 0)
-        {
-            var fallback = NormalizeText(term);
-            if (!string.IsNullOrWhiteSpace(fallback))
-            {
-                ordered.Add(fallback);
             }
         }
 

--- a/Veriado.Application/UseCases/Search/SearchFilesHandler.cs
+++ b/Veriado.Application/UseCases/Search/SearchFilesHandler.cs
@@ -787,6 +787,9 @@ public sealed class SearchFilesHandler : IRequestHandler<SearchFilesQuery, IRead
         "author",
         "mime",
         "metadata_text",
+        "metadata",
+        "content",
+        "any",
     };
 
     private enum LexTokenType


### PR DESCRIPTION
## Summary
- include fuzzy tokens in the generated MATCH expression so exact hits continue to score via FTS
- keep the original token when expanding synonyms to avoid dropping user terms during synonym expansion
- allow metadata, content and any field qualifiers when parsing user queries

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68dff19d4ba88326b1d760d98f99f5e5