### PR TITLE
Centralize file grid search SQL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# CHANGELOG
+
+## What changed
+- Added the `v_file_search_base` view and supporting SQL infrastructure for centralised grid queries.
+- Introduced a consolidated grid search pipeline that hydrates `FileSummaryDto` results directly from SQLite.
+- Added indexes optimised for server-side filtering and ordering in the file grid workflow.
+
+## Why
+- Reduce the number of round-trips required to serve the file grid and remove duplicated filtering logic.
+- Push ordering and pagination work into SQLite for better performance and simpler application code.
+- Ensure the database can satisfy the new server-side filters efficiently.
+
+## How to rollback
+- Drop the `v_file_search_base` view and the new supporting indexes, then deploy the previous application binaries.
+- Revert commits `aeef453`, `f4b714a`, `37ae869`, and `c5e4a97` to restore the prior query pipeline and schema.

--- a/Veriado.Application/Search/Abstractions/SearchServices.cs
+++ b/Veriado.Application/Search/Abstractions/SearchServices.cs
@@ -1,4 +1,5 @@
 using Veriado.Appl.Search;
+using Veriado.Contracts.Files;
 using Veriado.Domain.Search;
 
 namespace Veriado.Appl.Search.Abstractions;
@@ -34,6 +35,27 @@ public interface ISearchQueryService
         SearchQueryPlan plan,
         int skip,
         int take,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Executes a grid-oriented search query using the centralised SQL pipeline.
+    /// </summary>
+    /// <param name="matchQuery">The optional FTS5 match query.</param>
+    /// <param name="parameters">The grid filter parameters.</param>
+    /// <param name="sort">The requested sort specification.</param>
+    /// <param name="today">Reference timestamp used for validity filters.</param>
+    /// <param name="offset">The zero-based offset.</param>
+    /// <param name="limit">The requested page size.</param>
+    /// <param name="candidateLimit">The number of candidates evaluated before filtering.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    Task<FileGridSearchResult> SearchGridAsync(
+        string? matchQuery,
+        FileGridQueryDto parameters,
+        IReadOnlyList<FileSortSpecDto> sort,
+        DateTimeOffset today,
+        int offset,
+        int limit,
+        int candidateLimit,
         CancellationToken cancellationToken);
 
     /// <summary>

--- a/Veriado.Application/Search/FileGridSearchResult.cs
+++ b/Veriado.Application/Search/FileGridSearchResult.cs
@@ -1,0 +1,18 @@
+using System.Collections.Generic;
+using Veriado.Contracts.Files;
+
+namespace Veriado.Appl.Search;
+
+/// <summary>
+/// Represents the materialised result returned by the centralised grid search query.
+/// </summary>
+public sealed record FileGridSearchResult(
+    IReadOnlyList<FileSummaryDto> Items,
+    int TotalCount,
+    bool HasMore)
+{
+    /// <summary>
+    /// Gets an empty result instance.
+    /// </summary>
+    public static FileGridSearchResult Empty { get; } = new(Array.Empty<FileSummaryDto>(), 0, false);
+}

--- a/Veriado.Infrastructure/Migrations/20251003123000_FileSearchView.cs
+++ b/Veriado.Infrastructure/Migrations/20251003123000_FileSearchView.cs
@@ -1,0 +1,52 @@
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Veriado.Infrastructure.Persistence;
+
+#nullable disable
+
+namespace Veriado.Infrastructure.Migrations;
+
+/// <inheritdoc />
+[DbContext(typeof(AppDbContext))]
+[Migration("20251003123000_FileSearchView")]
+public partial class FileSearchView : Migration
+{
+    /// <inheritdoc />
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.Sql(@"
+CREATE VIEW IF NOT EXISTS v_file_search_base AS
+SELECT
+    f.id                 AS id,
+    f.name               AS name,
+    f.title              AS title,
+    f.author             AS author,
+    f.mime               AS mime_type,
+    f.extension          AS extension,
+    f.size_bytes         AS size_bytes,
+    f.created_utc        AS created_utc,
+    f.modified_utc       AS modified_utc,
+    f.version            AS version,
+    f.is_read_only       AS is_read_only,
+    f.fts_is_stale       AS fts_is_stale,
+    f.fts_last_indexed_utc AS fts_last_indexed_utc,
+    f.fts_indexed_title  AS fts_indexed_title,
+    f.fts_schema_version AS fts_schema_version,
+    f.fts_indexed_hash   AS fts_indexed_hash,
+    v.issued_at          AS validity_issued_at,
+    v.valid_until        AS validity_valid_until,
+    v.has_physical       AS validity_has_physical,
+    v.has_electronic     AS validity_has_electronic,
+    s.rowid              AS fts_rowid
+FROM files f
+LEFT JOIN files_validity v ON v.file_id = f.id
+LEFT JOIN file_search s ON s.rowid = f.id;
+");
+    }
+
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.Sql("DROP VIEW IF EXISTS v_file_search_base;");
+    }
+}

--- a/Veriado.Infrastructure/Migrations/20251003124500_FileGridIndexes.cs
+++ b/Veriado.Infrastructure/Migrations/20251003124500_FileGridIndexes.cs
@@ -1,0 +1,33 @@
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Veriado.Infrastructure.Persistence;
+
+#nullable disable
+
+namespace Veriado.Infrastructure.Migrations;
+
+/// <inheritdoc />
+[DbContext(typeof(AppDbContext))]
+[Migration("20251003124500_FileGridIndexes")]
+public partial class FileGridIndexes : Migration
+{
+    /// <inheritdoc />
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.Sql("CREATE INDEX IF NOT EXISTS idx_files_modified_utc ON files(modified_utc, id);");
+        migrationBuilder.Sql("CREATE INDEX IF NOT EXISTS idx_files_size_bytes ON files(size_bytes, id);");
+        migrationBuilder.Sql("CREATE INDEX IF NOT EXISTS idx_files_flags ON files(is_read_only, fts_is_stale, id);");
+        migrationBuilder.Sql("CREATE INDEX IF NOT EXISTS idx_files_name_nocase ON files(name COLLATE NOCASE, id);");
+        migrationBuilder.Sql("CREATE INDEX IF NOT EXISTS idx_files_author_nocase ON files(author COLLATE NOCASE, id);");
+    }
+
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.Sql("DROP INDEX IF EXISTS idx_files_author_nocase;");
+        migrationBuilder.Sql("DROP INDEX IF EXISTS idx_files_name_nocase;");
+        migrationBuilder.Sql("DROP INDEX IF EXISTS idx_files_flags;");
+        migrationBuilder.Sql("DROP INDEX IF EXISTS idx_files_size_bytes;");
+        migrationBuilder.Sql("DROP INDEX IF EXISTS idx_files_modified_utc;");
+    }
+}

--- a/Veriado.Infrastructure/Search/HybridSearchQueryService.cs
+++ b/Veriado.Infrastructure/Search/HybridSearchQueryService.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using Veriado.Appl.Search;
+using Veriado.Contracts.Files;
 using Veriado.Domain.Search;
 
 namespace Veriado.Infrastructure.Search;
@@ -45,6 +46,19 @@ internal sealed class HybridSearchQueryService : ISearchQueryService
         CancellationToken cancellationToken)
     {
         return _trigramService.SearchWithScoresAsync(plan, skip, take, cancellationToken);
+    }
+
+    public Task<FileGridSearchResult> SearchGridAsync(
+        string? matchQuery,
+        FileGridQueryDto parameters,
+        IReadOnlyList<FileSortSpecDto> sort,
+        DateTimeOffset today,
+        int offset,
+        int limit,
+        int candidateLimit,
+        CancellationToken cancellationToken)
+    {
+        return _ftsService.SearchGridAsync(matchQuery, parameters, sort, today, offset, limit, candidateLimit, cancellationToken);
     }
 
     public Task<int> CountAsync(SearchQueryPlan plan, CancellationToken cancellationToken)


### PR DESCRIPTION
## Summary
- add the v_file_search_base view and supporting helper to drive grid queries directly from SQLite
- expose a consolidated SearchGridAsync pipeline that hydrates FileSummaryDto results and updates the file grid handler
- create supporting indexes and document the changes in a changelog

## Testing
- no automated tests were run (dotnet CLI unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68e00a74b3488326aa2553574be36141