### PR TITLE
Improve FTS paging, extension filtering, and files view handling

### DIFF
--- a/Veriado.Application/Search/Abstractions/SearchServices.cs
+++ b/Veriado.Application/Search/Abstractions/SearchServices.cs
@@ -369,4 +369,27 @@ public interface ISearchTelemetry
     /// </summary>
     /// <param name="driftCount">The number of entries detected as missing or drifted.</param>
     void RecordIndexDrift(int driftCount);
+
+    /// <summary>
+    /// Records metrics describing paging behaviour and candidate limits of an FTS grid query.
+    /// </summary>
+    /// <param name="requestedOffset">The requested offset.</param>
+    /// <param name="pageSize">The requested page size.</param>
+    /// <param name="candidateLimit">The effective candidate limit.</param>
+    /// <param name="maxCandidateResults">The configured maximum candidate results.</param>
+    /// <param name="returnedCount">The number of items returned on the current page.</param>
+    /// <param name="reportedTotalCount">The total count reported to callers (capped).</param>
+    /// <param name="actualTotalCount">The actual total count measured.</param>
+    /// <param name="hasMore">Indicates whether more pages are available.</param>
+    /// <param name="isTruncated">Indicates whether the result set was truncated by policy.</param>
+    void RecordFtsPagingMetrics(
+        int requestedOffset,
+        int pageSize,
+        int candidateLimit,
+        int maxCandidateResults,
+        int returnedCount,
+        int reportedTotalCount,
+        int actualTotalCount,
+        bool hasMore,
+        bool isTruncated);
 }

--- a/Veriado.Application/Search/FileGridSearchResult.cs
+++ b/Veriado.Application/Search/FileGridSearchResult.cs
@@ -9,10 +9,11 @@ namespace Veriado.Appl.Search;
 public sealed record FileGridSearchResult(
     IReadOnlyList<FileSummaryDto> Items,
     int TotalCount,
-    bool HasMore)
+    bool HasMore,
+    bool IsTruncated)
 {
     /// <summary>
     /// Gets an empty result instance.
     /// </summary>
-    public static FileGridSearchResult Empty { get; } = new(Array.Empty<FileSummaryDto>(), 0, false);
+    public static FileGridSearchResult Empty { get; } = new(Array.Empty<FileSummaryDto>(), 0, false, false);
 }

--- a/Veriado.Application/UseCases/Queries/FileGrid/FileGridQueryValidator.cs
+++ b/Veriado.Application/UseCases/Queries/FileGrid/FileGridQueryValidator.cs
@@ -41,6 +41,9 @@ public sealed class FileGridQueryValidator : AbstractValidator<FileGridQueryDto>
             .Must(extension => extension is null || extension.Length <= 16)
             .WithMessage("Extension must be at most 16 characters long.");
 
+        RuleFor(dto => dto.ExtensionMatchMode)
+            .IsInEnum();
+
         RuleFor(dto => dto.Mime)
             .Must(mime => mime is null || mime.Contains('/'))
             .WithMessage("Mime must contain a '/' separator.");

--- a/Veriado.Contracts/Common/Paging.cs
+++ b/Veriado.Contracts/Common/Paging.cs
@@ -29,7 +29,7 @@ public sealed record PageResult<T>
     /// <param name="page">The current one-based page number.</param>
     /// <param name="pageSize">The requested page size.</param>
     /// <param name="totalCount">The total number of items across all pages.</param>
-    public PageResult(IReadOnlyList<T> items, int page, int pageSize, int totalCount)
+    public PageResult(IReadOnlyList<T> items, int page, int pageSize, int totalCount, bool hasMore = false, bool isTruncated = false)
     {
         ArgumentNullException.ThrowIfNull(items);
         if (page <= 0)
@@ -51,6 +51,8 @@ public sealed record PageResult<T>
         Page = page;
         PageSize = pageSize;
         TotalCount = totalCount;
+        HasMore = hasMore;
+        IsTruncated = isTruncated;
     }
 
     /// <summary>
@@ -72,6 +74,16 @@ public sealed record PageResult<T>
     /// Gets the total number of items available.
     /// </summary>
     public int TotalCount { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether another page is available after the current one.
+    /// </summary>
+    public bool HasMore { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether the result set was truncated by policy.
+    /// </summary>
+    public bool IsTruncated { get; }
 
     /// <summary>
     /// Gets the total number of pages available.

--- a/Veriado.Contracts/Files/ExtensionMatchMode.cs
+++ b/Veriado.Contracts/Files/ExtensionMatchMode.cs
@@ -1,0 +1,17 @@
+namespace Veriado.Contracts.Files;
+
+/// <summary>
+/// Defines the matching strategy for file extension filters.
+/// </summary>
+public enum ExtensionMatchMode
+{
+    /// <summary>
+    /// Requires an exact case-insensitive match of the extension.
+    /// </summary>
+    Equals = 0,
+
+    /// <summary>
+    /// Applies a case-insensitive substring match to the extension.
+    /// </summary>
+    Contains = 1,
+}

--- a/Veriado.Contracts/Files/FileGridQueryDto.cs
+++ b/Veriado.Contracts/Files/FileGridQueryDto.cs
@@ -48,6 +48,12 @@ public sealed record FileGridQueryDto
         = null;
 
     /// <summary>
+    /// Gets or sets the matching strategy applied to the extension filter.
+    /// </summary>
+    public ExtensionMatchMode ExtensionMatchMode { get; init; }
+        = ExtensionMatchMode.Equals;
+
+    /// <summary>
     /// Gets or sets a filter applied to the MIME type.
     /// </summary>
     public string? Mime { get; init; }

--- a/Veriado.Infrastructure/Search/SearchTelemetry.cs
+++ b/Veriado.Infrastructure/Search/SearchTelemetry.cs
@@ -1,5 +1,6 @@
 namespace Veriado.Infrastructure.Search;
 
+using System;
 using System.Diagnostics.Metrics;
 
 /// <summary>
@@ -15,6 +16,14 @@ internal sealed class SearchTelemetry : ISearchTelemetry
     private readonly Histogram<double> _overallHistogram = Meter.CreateHistogram<double>("search_latency_ms");
     private readonly Histogram<double> _verifyDurationHistogram = Meter.CreateHistogram<double>("fts_verify_duration_ms");
     private readonly Counter<long> _verifyDriftCounter = Meter.CreateCounter<long>("fts_verify_drift_total");
+    private readonly Histogram<long> _ftsRequestedOffsetHistogram = Meter.CreateHistogram<long>("search_fts_requested_offset");
+    private readonly Histogram<long> _ftsPageSizeHistogram = Meter.CreateHistogram<long>("search_fts_page_size");
+    private readonly Histogram<long> _ftsCandidateLimitHistogram = Meter.CreateHistogram<long>("search_fts_candidate_limit");
+    private readonly Histogram<long> _ftsReturnedHistogram = Meter.CreateHistogram<long>("search_fts_returned_items");
+    private readonly Histogram<long> _ftsReportedTotalHistogram = Meter.CreateHistogram<long>("search_fts_reported_total");
+    private readonly Histogram<long> _ftsActualTotalHistogram = Meter.CreateHistogram<long>("search_fts_actual_total");
+    private readonly Counter<long> _ftsHasMoreCounter = Meter.CreateCounter<long>("search_fts_has_more_total");
+    private readonly Counter<long> _ftsTruncatedCounter = Meter.CreateCounter<long>("search_fts_truncated_total");
     private readonly ObservableGauge<long> _documentGauge;
     private readonly ObservableGauge<long> _indexSizeGauge;
     private readonly Histogram<int> _outboxAttemptsHistogram = Meter.CreateHistogram<int>("outbox_attempts_histogram");
@@ -64,6 +73,35 @@ internal sealed class SearchTelemetry : ISearchTelemetry
         }
 
         _verifyDriftCounter.Add(driftCount);
+    }
+
+    public void RecordFtsPagingMetrics(
+        int requestedOffset,
+        int pageSize,
+        int candidateLimit,
+        int maxCandidateResults,
+        int returnedCount,
+        int reportedTotalCount,
+        int actualTotalCount,
+        bool hasMore,
+        bool isTruncated)
+    {
+        _ftsRequestedOffsetHistogram.Record(Math.Max(requestedOffset, 0));
+        _ftsPageSizeHistogram.Record(Math.Max(pageSize, 0));
+        _ftsCandidateLimitHistogram.Record(Math.Max(candidateLimit, 0));
+        _ftsReturnedHistogram.Record(Math.Max(returnedCount, 0));
+        _ftsReportedTotalHistogram.Record(Math.Max(reportedTotalCount, 0));
+        _ftsActualTotalHistogram.Record(Math.Max(actualTotalCount, 0));
+
+        if (hasMore)
+        {
+            _ftsHasMoreCounter.Add(1);
+        }
+
+        if (isTruncated || actualTotalCount > Math.Max(maxCandidateResults, 0))
+        {
+            _ftsTruncatedCounter.Add(1);
+        }
     }
 
     private IEnumerable<Measurement<long>> ObserveDocuments()


### PR DESCRIPTION
## Summary
- ensure FTS candidate limits honour offsets, compute accurate totals, and emit paging telemetry
- align extension filtering behavior across EF/SQL with configurable match mode
- update fuzzy paging and WinUI files view to support cancellation, HasMore, and truncated indicators

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e018bbdd9c8326a2e31c36f9eb4e84