### PR TITLE
Fix extension filtering without EF Collate

### DIFF
--- a/Veriado.Application/UseCases/Queries/FileGrid/QueryableFilters.cs
+++ b/Veriado.Application/UseCases/Queries/FileGrid/QueryableFilters.cs
@@ -39,13 +39,13 @@ internal static class QueryableFilters
                 {
                     var pattern = $"%{EscapeLike(normalized)}%";
                     query = query.Where(file => EF.Functions.Like(
-                        EF.Functions.Collate(file.Extension.Value, "NOCASE"),
+                        file.Extension.Value,
                         pattern,
                         EscapeChar));
                 }
                 else
                 {
-                    query = query.Where(file => EF.Functions.Collate(file.Extension.Value, "NOCASE") == normalized);
+                    query = query.Where(file => file.Extension.Value == normalized);
                 }
             }
         }


### PR DESCRIPTION
## Summary
- replace unsupported EF.Functions.Collate calls with direct comparisons in file extension filters
- keep extension filtering case-insensitive by relying on normalized values

## Testing
- dotnet build *(fails: command not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e02a0e7b74832691399479bb54bcfa