### PR TITLE
Add localization service and update view models

### DIFF
--- a/Veriado.WinUI/AppHost.cs
+++ b/Veriado.WinUI/AppHost.cs
@@ -51,6 +51,7 @@ internal sealed class AppHost : IAsyncDisposable
                 services.AddSingleton<IPreviewService, PreviewService>();
                 services.AddSingleton<ICacheService, MemoryCacheService>();
                 services.AddSingleton<IHotStateService, HotStateService>();
+                services.AddSingleton<ILocalizationService, LocalizationService>();
                 services.AddSingleton<INavigationService, NavigationService>();
                 services.AddSingleton<IDialogService, DialogService>();
                 services.AddSingleton<IPickerService, PickerService>();

--- a/Veriado.WinUI/Localization/CultureHelper.cs
+++ b/Veriado.WinUI/Localization/CultureHelper.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using Microsoft.Windows.ApplicationModel.Resources;
+
+namespace Veriado.WinUI.Localization;
+
+/// <summary>
+/// Provides helper methods for working with cultures and the WinAppSDK resource system.
+/// </summary>
+internal static class CultureHelper
+{
+    private static readonly CultureInfoComparer _cultureComparer = new();
+
+    public static IEqualityComparer<CultureInfo> CultureComparer => _cultureComparer;
+
+    public static IReadOnlyList<CultureInfo> GetSupportedCultures(ResourceMap resourceMap)
+    {
+        if (resourceMap is null)
+        {
+            throw new ArgumentNullException(nameof(resourceMap));
+        }
+
+        // WinAppSDK does not expose the list of available languages directly. We opt-in to a curated
+        // list that reflects the languages shipped with the application resources. If no explicit
+        // qualifiers exist we fall back to English and Czech which are the primary languages of the
+        // application.
+        var knownCultures = new[]
+        {
+            new CultureInfo("cs-CZ"),
+            new CultureInfo("en-US"),
+        };
+
+        return Array.AsReadOnly(knownCultures);
+    }
+
+    public static CultureInfo DetermineInitialCulture(IReadOnlyList<CultureInfo> supportedCultures)
+    {
+        if (supportedCultures is null || supportedCultures.Count == 0)
+        {
+            return CultureInfo.CurrentUICulture;
+        }
+
+        var current = CultureInfo.CurrentUICulture;
+        var match = supportedCultures.FirstOrDefault(c => _cultureComparer.Equals(c, current));
+        return match ?? supportedCultures[0];
+    }
+
+    public static void ApplyCulture(CultureInfo culture)
+    {
+        if (culture is null)
+        {
+            throw new ArgumentNullException(nameof(culture));
+        }
+
+        CultureInfo.DefaultThreadCurrentCulture = culture;
+        CultureInfo.DefaultThreadCurrentUICulture = culture;
+        CultureInfo.CurrentCulture = culture;
+        CultureInfo.CurrentUICulture = culture;
+
+        var viewIndependentContext = ResourceContext.GetForViewIndependentUse();
+        ApplyCulture(viewIndependentContext, culture);
+    }
+
+    public static void ApplyCulture(ResourceContext context, CultureInfo culture)
+    {
+        if (context is null)
+        {
+            throw new ArgumentNullException(nameof(context));
+        }
+
+        if (culture is null)
+        {
+            throw new ArgumentNullException(nameof(culture));
+        }
+
+        context.QualifierValues["Language"] = culture.Name;
+    }
+
+    private sealed class CultureInfoComparer : IEqualityComparer<CultureInfo>, IComparer<CultureInfo>
+    {
+        public int Compare(CultureInfo? x, CultureInfo? y)
+        {
+            return string.Compare(x?.Name, y?.Name, StringComparison.OrdinalIgnoreCase);
+        }
+
+        public bool Equals(CultureInfo? x, CultureInfo? y)
+        {
+            return string.Equals(x?.Name, y?.Name, StringComparison.OrdinalIgnoreCase);
+        }
+
+        public int GetHashCode(CultureInfo obj)
+        {
+            return StringComparer.OrdinalIgnoreCase.GetHashCode(obj.Name);
+        }
+    }
+}

--- a/Veriado.WinUI/Services/Abstractions/ILocalizationService.cs
+++ b/Veriado.WinUI/Services/Abstractions/ILocalizationService.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Globalization;
+
+namespace Veriado.WinUI.Services.Abstractions;
+
+/// <summary>
+/// Provides access to localized resources and exposes the current application culture.
+/// </summary>
+public interface ILocalizationService
+{
+    /// <summary>
+    /// Occurs when the current culture changes.
+    /// </summary>
+    event EventHandler<CultureInfo>? CultureChanged;
+
+    /// <summary>
+    /// Gets the culture currently used by the application.
+    /// </summary>
+    CultureInfo CurrentCulture { get; }
+
+    /// <summary>
+    /// Gets the cultures supported by the application.
+    /// </summary>
+    IReadOnlyList<CultureInfo> SupportedCultures { get; }
+
+    /// <summary>
+    /// Attempts to change the current application culture.
+    /// </summary>
+    /// <param name="culture">The culture to apply.</param>
+    /// <returns><see langword="true"/> if the culture was changed; otherwise <see langword="false"/>.</returns>
+    bool TrySetCulture(CultureInfo culture);
+
+    /// <summary>
+    /// Gets a localized string for the specified resource key using the current culture.
+    /// </summary>
+    /// <param name="resourceKey">The resource key.</param>
+    /// <returns>The localized string if found; otherwise, the key itself.</returns>
+    string GetString(string resourceKey);
+
+    /// <summary>
+    /// Gets a localized string formatted with the supplied arguments using the current culture.
+    /// </summary>
+    /// <param name="resourceKey">The resource key.</param>
+    /// <param name="arguments">Arguments used to format the resource string.</param>
+    /// <returns>The formatted localized string.</returns>
+    string GetString(string resourceKey, params object?[] arguments);
+}

--- a/Veriado.WinUI/Services/LocalizationService.cs
+++ b/Veriado.WinUI/Services/LocalizationService.cs
@@ -1,0 +1,119 @@
+using System;
+using System.Globalization;
+using System.Linq;
+using Microsoft.Extensions.Logging;
+using Microsoft.Windows.ApplicationModel.Resources;
+using Veriado.WinUI.Localization;
+using Veriado.WinUI.Services.Abstractions;
+
+namespace Veriado.WinUI.Services;
+
+/// <summary>
+/// Provides access to localized resources backed by the WinAppSDK resource manager.
+/// </summary>
+public sealed class LocalizationService : ILocalizationService
+{
+    private readonly ILogger<LocalizationService>? _logger;
+    private readonly ResourceManager _resourceManager;
+    private readonly ResourceMap _resourceMap;
+    private readonly IReadOnlyList<CultureInfo> _supportedCultures;
+    private CultureInfo _currentCulture;
+    private readonly object _gate = new();
+
+    public LocalizationService(ILogger<LocalizationService>? logger = null)
+    {
+        _logger = logger;
+        _resourceManager = new ResourceManager();
+        _resourceMap = _resourceManager.MainResourceMap;
+        _supportedCultures = CultureHelper.GetSupportedCultures(_resourceMap);
+        _currentCulture = CultureHelper.DetermineInitialCulture(_supportedCultures);
+        CultureHelper.ApplyCulture(_currentCulture);
+    }
+
+    public event EventHandler<CultureInfo>? CultureChanged;
+
+    public CultureInfo CurrentCulture
+    {
+        get
+        {
+            lock (_gate)
+            {
+                return _currentCulture;
+            }
+        }
+    }
+
+    public IReadOnlyList<CultureInfo> SupportedCultures => _supportedCultures;
+
+    public bool TrySetCulture(CultureInfo culture)
+    {
+        if (culture is null)
+        {
+            throw new ArgumentNullException(nameof(culture));
+        }
+
+        if (!_supportedCultures.Contains(culture, CultureHelper.CultureComparer))
+        {
+            _logger?.LogWarning("Requested culture {Culture} is not part of the supported culture list.", culture);
+            return false;
+        }
+
+        CultureInfo previous;
+        lock (_gate)
+        {
+            if (CultureHelper.CultureComparer.Equals(_currentCulture, culture))
+            {
+                return false;
+            }
+
+            previous = _currentCulture;
+            _currentCulture = culture;
+        }
+
+        CultureHelper.ApplyCulture(culture);
+        _logger?.LogInformation("Application culture changed from {PreviousCulture} to {CurrentCulture}.", previous, culture);
+        CultureChanged?.Invoke(this, culture);
+        return true;
+    }
+
+    public string GetString(string resourceKey) => GetStringCore(resourceKey, CurrentCulture);
+
+    public string GetString(string resourceKey, params object?[] arguments)
+    {
+        var raw = GetStringCore(resourceKey, CurrentCulture);
+
+        if (arguments is null || arguments.Length == 0)
+        {
+            return raw;
+        }
+
+        return string.Format(CurrentCulture, raw, arguments);
+    }
+
+    private string GetStringCore(string resourceKey, CultureInfo culture)
+    {
+        if (string.IsNullOrWhiteSpace(resourceKey))
+        {
+            throw new ArgumentException("Resource key cannot be null or whitespace.", nameof(resourceKey));
+        }
+
+        var context = _resourceManager.CreateResourceContext();
+        CultureHelper.ApplyCulture(context, culture);
+
+        try
+        {
+            var candidate = _resourceMap.GetValue(resourceKey, context);
+            if (candidate is not null)
+            {
+                var value = candidate.ValueAsString;
+                return string.IsNullOrEmpty(value) ? resourceKey : value;
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(ex, "Failed to resolve resource {ResourceKey} for culture {Culture}.", resourceKey, culture);
+        }
+
+        return resourceKey;
+    }
+}

--- a/Veriado.WinUI/ViewModels/Files/FilesPageViewModel.cs
+++ b/Veriado.WinUI/ViewModels/Files/FilesPageViewModel.cs
@@ -41,8 +41,9 @@ public partial class FilesPageViewModel : ViewModelBase
         IMessenger messenger,
         IStatusService statusService,
         IDispatcherService dispatcher,
-        IExceptionHandler exceptionHandler)
-        : base(messenger, statusService, dispatcher, exceptionHandler)
+        IExceptionHandler exceptionHandler,
+        ILocalizationService localizationService)
+        : base(messenger, statusService, dispatcher, exceptionHandler, localizationService)
     {
         _fileQueryService = fileQueryService ?? throw new ArgumentNullException(nameof(fileQueryService));
         _hotStateService = hotStateService ?? throw new ArgumentNullException(nameof(hotStateService));

--- a/Veriado.WinUI/ViewModels/Import/ImportPageViewModel.cs
+++ b/Veriado.WinUI/ViewModels/Import/ImportPageViewModel.cs
@@ -41,10 +41,11 @@ public partial class ImportPageViewModel : ViewModelBase
         IStatusService statusService,
         IDispatcherService dispatcher,
         IExceptionHandler exceptionHandler,
+        ILocalizationService localizationService,
         IDialogService dialogService,
         IHotStateService? hotStateService = null,
         IPickerService? pickerService = null)
-        : base(messenger, statusService, dispatcher, exceptionHandler)
+        : base(messenger, statusService, dispatcher, exceptionHandler, localizationService)
     {
         _importService = importService ?? throw new ArgumentNullException(nameof(importService));
         _dialogService = dialogService ?? throw new ArgumentNullException(nameof(dialogService));

--- a/Veriado.WinUI/ViewModels/Settings/SettingsPageViewModel.cs
+++ b/Veriado.WinUI/ViewModels/Settings/SettingsPageViewModel.cs
@@ -14,8 +14,9 @@ public partial class SettingsPageViewModel : ViewModelBase
         IMessenger messenger,
         IStatusService statusService,
         IDispatcherService dispatcher,
-        IExceptionHandler exceptionHandler)
-        : base(messenger, statusService, dispatcher, exceptionHandler)
+        IExceptionHandler exceptionHandler,
+        ILocalizationService localizationService)
+        : base(messenger, statusService, dispatcher, exceptionHandler, localizationService)
     {
         _hotStateService = hotStateService ?? throw new ArgumentNullException(nameof(hotStateService));
         _themeService = themeService ?? throw new ArgumentNullException(nameof(themeService));


### PR DESCRIPTION
## Summary
- add a localization abstraction and WinAppSDK-backed implementation
- register the localization service and update the base view model to consume it
- require localization dependencies in page view models so status messaging can be localized

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e02ea2731883269d32c393bb66dc15