### PR TITLE
Fix localization culture selection build issues

### DIFF
--- a/Veriado.WinUI/Localization/CultureHelper.cs
+++ b/Veriado.WinUI/Localization/CultureHelper.cs
@@ -58,9 +58,6 @@ internal static class CultureHelper
         CultureInfo.DefaultThreadCurrentUICulture = culture;
         CultureInfo.CurrentCulture = culture;
         CultureInfo.CurrentUICulture = culture;
-
-        var viewIndependentContext = ResourceContext.GetForViewIndependentUse();
-        ApplyCulture(viewIndependentContext, culture);
     }
 
     public static void ApplyCulture(ResourceContext context, CultureInfo culture)

--- a/Veriado.WinUI/ViewModels/Settings/SettingsPageViewModel.cs
+++ b/Veriado.WinUI/ViewModels/Settings/SettingsPageViewModel.cs
@@ -76,10 +76,18 @@ public partial class SettingsPageViewModel : ViewModelBase, IDisposable
             return Task.CompletedTask;
         }
 
-        return SafeExecuteAsync(async cancellationToken =>
+        return SafeExecuteAsync(cancellationToken =>
         {
-            await _localizationService.SetCultureAsync(SelectedLanguage, cancellationToken).ConfigureAwait(false);
-            StatusService.Info(GetString("Settings.LanguageApplied", null, SelectedLanguage.NativeName));
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var applied = _localizationService.TrySetCulture(SelectedLanguage);
+
+            if (applied)
+            {
+                StatusService.Info(GetString("Settings.LanguageApplied", null, SelectedLanguage.NativeName));
+            }
+
+            return Task.CompletedTask;
         });
     }
 


### PR DESCRIPTION
## Summary
- replace the settings language change workflow with the synchronous localization service API
- stop calling ResourceContext.GetForViewIndependentUse so the WinUI project builds with available SDK APIs

## Testing
- not run (environment does not have dotnet CLI)


------
https://chatgpt.com/codex/tasks/task_e_68e0320bdecc8326b2fcfc4d59ef35e7