### PR TITLE
Load search suggestions for files page

### DIFF
--- a/Veriado.WinUI/Views/Files/FilesPage.xaml.cs
+++ b/Veriado.WinUI/Views/Files/FilesPage.xaml.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.UI.Composition;
 using Microsoft.UI.Xaml;
@@ -41,7 +43,10 @@ public sealed partial class FilesPage : CultureAwarePage
         Loaded -= OnLoaded;
         ViewModel.PropertyChanged += OnViewModelPropertyChanged;
         ViewModel.StartHealthMonitoring();
-        await ExecuteInitialRefreshAsync().ConfigureAwait(true);
+
+        await Task.WhenAll(
+            ExecuteInitialRefreshAsync(),
+            ViewModel.LoadSearchSuggestionsAsync(CancellationToken.None)).ConfigureAwait(true);
     }
 
     private void OnUnloaded(object sender, RoutedEventArgs e)


### PR DESCRIPTION
## Summary
- add an observable search suggestion list to `FilesPageViewModel` backed by the suggestions provider
- load suggestions when the files page appears so the AutoSuggestBox binding resolves

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e0355628ec83269967e46bd3bc1ad5