### PR TITLE
Add migration to sync FTS write-ahead indexes

### DIFF
--- a/Veriado.Infrastructure/Migrations/20251003210102_SyncSearchIndexState.Designer.cs
+++ b/Veriado.Infrastructure/Migrations/20251003210102_SyncSearchIndexState.Designer.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Veriado.Infrastructure.Persistence;
 
@@ -10,9 +11,11 @@ using Veriado.Infrastructure.Persistence;
 namespace Veriado.Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20251003210102_SyncSearchIndexState")]
+    partial class SyncSearchIndexState
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "9.0.9");

--- a/Veriado.Infrastructure/Migrations/20251003210102_SyncSearchIndexState.cs
+++ b/Veriado.Infrastructure/Migrations/20251003210102_SyncSearchIndexState.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Veriado.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class SyncSearchIndexState : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(
+                "CREATE INDEX IF NOT EXISTS idx_fts_write_ahead_dlq_dead_lettered ON fts_write_ahead_dlq (dead_lettered_utc);");
+
+            migrationBuilder.Sql(
+                "CREATE INDEX IF NOT EXISTS idx_fts_write_ahead_enqueued ON fts_write_ahead (enqueued_utc);");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql("DROP INDEX IF EXISTS idx_fts_write_ahead_dlq_dead_lettered;");
+
+            migrationBuilder.Sql("DROP INDEX IF EXISTS idx_fts_write_ahead_enqueued;");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a new EF Core migration to align the FTS write-ahead tables with configured indexes
- update the model snapshot to include the write-ahead enqueue/dead-letter indexes
- create the indexes idempotently during migration to avoid failures when they already exist

## Testing
- dotnet ef database update --context AppDbContext --project Veriado.Infrastructure/Veriado.Infrastructure.csproj --startup-project Veriado.Infrastructure/Veriado.Infrastructure.csproj

------
https://chatgpt.com/codex/tasks/task_e_68e038e7701483268459238f9051ca17