### PR TITLE
Add missing localization resources for files page

### DIFF
--- a/Veriado.WinUI/Strings/Resources.resw
+++ b/Veriado.WinUI/Strings/Resources.resw
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <root>
   <resheader name="resmimetype">
     <value>text/microsoft-resx</value>
@@ -66,184 +66,229 @@
   <data name="ImportPage_TitleTextBlock.Text" xml:space="preserve">
     <value>Import files</value>
   </data>
-
   <data name="ImportPage_RunImportButton.Content" xml:space="preserve">
     <value>Start import</value>
   </data>
-
   <data name="ImportPage_StopButton.Content" xml:space="preserve">
     <value>Stop</value>
   </data>
-
   <data name="ImportPage_ClearResultsButton.Content" xml:space="preserve">
     <value>Clear results</value>
   </data>
-
   <data name="ImportPage_ExportLogButton.Content" xml:space="preserve">
     <value>Export log</value>
   </data>
-
   <data name="ImportPage_CurrentFileNameTextBlock.[using:Microsoft.UI.Xaml.Data.Binding].TargetNullValue" xml:space="preserve">
     <value>(No file)</value>
   </data>
-
   <data name="ImportPage_ProcessedLabelRun.Text" xml:space="preserve">
     <value>Processed: </value>
   </data>
-
   <data name="ImportPage_ProcessedSeparatorRun.Text" xml:space="preserve">
     <value> / </value>
   </data>
-
   <data name="ImportPage_SummaryTitleTextBlock.Text" xml:space="preserve">
     <value>Import summary</value>
   </data>
-
   <data name="ImportPage_SummaryOkLabelRun.Text" xml:space="preserve">
     <value>OK: </value>
   </data>
-
   <data name="ImportPage_SummaryErrorLabelRun.Text" xml:space="preserve">
     <value>Errors: </value>
   </data>
-
   <data name="ImportPage_SummarySkippedLabelRun.Text" xml:space="preserve">
     <value>Skipped: </value>
   </data>
-
   <data name="ImportPage_SummaryDataLabelRun.Text" xml:space="preserve">
     <value>Processed data: </value>
   </data>
-
   <data name="ImportPage_SourceTitleTextBlock.Text" xml:space="preserve">
     <value>Import source</value>
   </data>
-
   <data name="ImportPage_PickFolderButton.Content" xml:space="preserve">
     <value>Choose folder</value>
   </data>
-
   <data name="ImportPage_OptionsTitleTextBlock.Text" xml:space="preserve">
     <value>Import options</value>
   </data>
-
   <data name="ImportPage_RecursiveCheckBox.Content" xml:space="preserve">
     <value>Recursive</value>
   </data>
-
   <data name="ImportPage_PreserveMetadataCheckBox.Content" xml:space="preserve">
     <value>Preserve file system metadata</value>
   </data>
-
   <data name="ImportPage_ReadOnlyCheckBox.Content" xml:space="preserve">
     <value>Set read-only</value>
   </data>
-
   <data name="ImportPage_ParallelCheckBox.Content" xml:space="preserve">
     <value>Parallel</value>
   </data>
-
   <data name="ImportPage_MaxThreadsNumberBox.Header" xml:space="preserve">
     <value>Max parallel threads</value>
   </data>
-
   <data name="ImportPage_MaxThreadsInfoBar.Title" xml:space="preserve">
     <value>Invalid thread count</value>
   </data>
-
   <data name="ImportPage_MaxThreadsInfoBar.Message" xml:space="preserve">
     <value>Enter a positive integer greater than zero.</value>
   </data>
-
   <data name="ImportPage_DefaultAuthorTextBox.Header" xml:space="preserve">
     <value>Default author</value>
   </data>
-
   <data name="ImportPage_DefaultAuthorTextBox.PlaceholderText" xml:space="preserve">
     <value>(not set)</value>
   </data>
-
   <data name="ImportPage_MaxFileSizeNumberBox.Header" xml:space="preserve">
     <value>Max file size (MB)</value>
   </data>
-
   <data name="ImportPage_MaxFileSizeInfoBar.Title" xml:space="preserve">
     <value>Invalid file size</value>
   </data>
-
   <data name="ImportPage_MaxFileSizeInfoBar.Message" xml:space="preserve">
     <value>Enter a non-negative value or leave 0 for no limit.</value>
   </data>
-
   <data name="ImportPage_MaxFileSizeHintTextBlock.Text" xml:space="preserve">
     <value>0 = no limit</value>
   </data>
-
   <data name="ImportPage_LogTitleTextBlock.Text" xml:space="preserve">
     <value>Import log</value>
   </data>
-
   <data name="ImportPage_QueueTitleTextBlock.Text" xml:space="preserve">
     <value>Import queue</value>
   </data>
-
   <data name="ImportPage_LogTimeColumn.Header" xml:space="preserve">
     <value>Time</value>
   </data>
-
   <data name="ImportPage_LogEventColumn.Header" xml:space="preserve">
     <value>Event</value>
   </data>
-
   <data name="ImportPage_LogMessageColumn.Header" xml:space="preserve">
     <value>Message</value>
   </data>
-
   <data name="ImportPage_LogStatusColumn.Header" xml:space="preserve">
     <value>Status</value>
   </data>
-
   <data name="ImportPage_LogDetailColumn.Header" xml:space="preserve">
     <value>Detail</value>
   </data>
-
   <data name="ImportPage_FilterLabelTextBlock.Text" xml:space="preserve">
     <value>Filter:</value>
   </data>
-
   <data name="ImportPage_ErrorTimeColumn.Header" xml:space="preserve">
     <value>Time</value>
   </data>
-
   <data name="ImportPage_ErrorFileColumn.Header" xml:space="preserve">
     <value>File</value>
   </data>
-
   <data name="ImportPage_ErrorCodeColumn.Header" xml:space="preserve">
     <value>Code</value>
   </data>
-
   <data name="ImportPage_ErrorSeverityColumn.Header" xml:space="preserve">
     <value>Severity</value>
   </data>
-
   <data name="ImportPage_ErrorMessageColumn.Header" xml:space="preserve">
     <value>Message</value>
   </data>
-
   <data name="ImportPage_OpenDetailButton.Content" xml:space="preserve">
     <value>Open detail</value>
   </data>
-
   <data name="ImportPage_NoErrorsTextBlock.Text" xml:space="preserve">
     <value>No errors match the selected filter.</value>
   </data>
-
   <data name="ImportPage_DropPromptTextBlock.Text" xml:space="preserve">
     <value>Drop a folder to import</value>
   </data>
-
   <data name="ImportPage_DropHintTextBlock.Text" xml:space="preserve">
     <value>You can also choose a folder using the button.</value>
+  </data>
+  <data name="FilesPage_SearchBox.PlaceholderText" xml:space="preserve">
+    <value>Search files</value>
+  </data>
+  <data name="FilesPage_FuzzyToggle.Header" xml:space="preserve">
+    <value>Fuzzy search</value>
+  </data>
+  <data name="FilesPage_AttributesExpander.Header" xml:space="preserve">
+    <value>Attributes</value>
+  </data>
+  <data name="FilesPage_ExtensionTextBox.PlaceholderText" xml:space="preserve">
+    <value>Extension</value>
+  </data>
+  <data name="FilesPage_MimeTextBox.PlaceholderText" xml:space="preserve">
+    <value>MIME type</value>
+  </data>
+  <data name="FilesPage_AuthorTextBox.PlaceholderText" xml:space="preserve">
+    <value>Author</value>
+  </data>
+  <data name="FilesPage_VersionTextBox.PlaceholderText" xml:space="preserve">
+    <value>Version</value>
+  </data>
+  <data name="FilesPage_ValidityExpander.Header" xml:space="preserve">
+    <value>Validity</value>
+  </data>
+  <data name="FilesPage_ReadOnlyCheckBox.Content" xml:space="preserve">
+    <value>Read-only</value>
+  </data>
+  <data name="FilesPage_IndexStaleCheckBox.Content" xml:space="preserve">
+    <value>Index is stale</value>
+  </data>
+  <data name="FilesPage_HasValidityCheckBox.Content" xml:space="preserve">
+    <value>Has validity period</value>
+  </data>
+  <data name="FilesPage_CurrentlyValidCheckBox.Content" xml:space="preserve">
+    <value>Currently valid</value>
+  </data>
+  <data name="FilesPage_ExpiringNumberBox.Header" xml:space="preserve">
+    <value>Expires in (days)</value>
+  </data>
+  <data name="FilesPage_DatesExpander.Header" xml:space="preserve">
+    <value>Dates</value>
+  </data>
+  <data name="FilesPage_CreatedFromPicker.PlaceholderText" xml:space="preserve">
+    <value>Created from</value>
+  </data>
+  <data name="FilesPage_CreatedToPicker.PlaceholderText" xml:space="preserve">
+    <value>Created to</value>
+  </data>
+  <data name="FilesPage_ModifiedFromPicker.PlaceholderText" xml:space="preserve">
+    <value>Modified from</value>
+  </data>
+  <data name="FilesPage_ModifiedToPicker.PlaceholderText" xml:space="preserve">
+    <value>Modified to</value>
+  </data>
+  <data name="FilesPage_SizeExpander.Header" xml:space="preserve">
+    <value>Size</value>
+  </data>
+  <data name="FilesPage_SizeMinNumberBox.Header" xml:space="preserve">
+    <value>Minimum size (bytes)</value>
+  </data>
+  <data name="FilesPage_SizeMaxNumberBox.Header" xml:space="preserve">
+    <value>Maximum size (bytes)</value>
+  </data>
+  <data name="FilesPage_ApplyButton.Content" xml:space="preserve">
+    <value>Apply</value>
+  </data>
+  <data name="FilesPage_ClearButton.Content" xml:space="preserve">
+    <value>Clear</value>
+  </data>
+  <data name="FilesPage_PreviousPageButton.Content" xml:space="preserve">
+    <value>Previous</value>
+  </data>
+  <data name="FilesPage_NextPageButton.Content" xml:space="preserve">
+    <value>Next</value>
+  </data>
+  <data name="FilesPage_PageSizeLabel.Text" xml:space="preserve">
+    <value>Per page</value>
+  </data>
+  <data name="FilesPage_IndexingInfoBar.Title" xml:space="preserve">
+    <value>Indexing in progress</value>
+  </data>
+  <data name="FilesPage_IndexingInfoBar.Message" xml:space="preserve">
+    <value>Results may be incomplete while indexing finishes.</value>
+  </data>
+  <data name="FilesPage_ErrorInfoBar.Title" xml:space="preserve">
+    <value>Loading error</value>
+  </data>
+  <data name="FilesPage_ErrorInfoBar.Message" xml:space="preserve">
+    <value>Unable to load the results.</value>
   </data>
 </root>

--- a/Veriado.WinUI/Strings/cs-CZ/Resources.resw
+++ b/Veriado.WinUI/Strings/cs-CZ/Resources.resw
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <root>
   <resheader name="resmimetype">
     <value>text/microsoft-resx</value>
@@ -64,186 +64,231 @@
     <value>Zkusit znovu</value>
   </data>
   <data name="ImportPage_TitleTextBlock.Text" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
-
   <data name="ImportPage_RunImportButton.Content" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
-
   <data name="ImportPage_StopButton.Content" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
-
   <data name="ImportPage_ClearResultsButton.Content" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
-
   <data name="ImportPage_ExportLogButton.Content" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
-
   <data name="ImportPage_CurrentFileNameTextBlock.[using:Microsoft.UI.Xaml.Data.Binding].TargetNullValue" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
-
   <data name="ImportPage_ProcessedLabelRun.Text" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
-
   <data name="ImportPage_ProcessedSeparatorRun.Text" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
-
   <data name="ImportPage_SummaryTitleTextBlock.Text" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
-
   <data name="ImportPage_SummaryOkLabelRun.Text" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
-
   <data name="ImportPage_SummaryErrorLabelRun.Text" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
-
   <data name="ImportPage_SummarySkippedLabelRun.Text" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
-
   <data name="ImportPage_SummaryDataLabelRun.Text" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
-
   <data name="ImportPage_SourceTitleTextBlock.Text" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
-
   <data name="ImportPage_PickFolderButton.Content" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
-
   <data name="ImportPage_OptionsTitleTextBlock.Text" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
-
   <data name="ImportPage_RecursiveCheckBox.Content" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
-
   <data name="ImportPage_PreserveMetadataCheckBox.Content" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
-
   <data name="ImportPage_ReadOnlyCheckBox.Content" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
-
   <data name="ImportPage_ParallelCheckBox.Content" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
-
   <data name="ImportPage_MaxThreadsNumberBox.Header" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
-
   <data name="ImportPage_MaxThreadsInfoBar.Title" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
-
   <data name="ImportPage_MaxThreadsInfoBar.Message" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
-
   <data name="ImportPage_DefaultAuthorTextBox.Header" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
-
   <data name="ImportPage_DefaultAuthorTextBox.PlaceholderText" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
-
   <data name="ImportPage_MaxFileSizeNumberBox.Header" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
-
   <data name="ImportPage_MaxFileSizeInfoBar.Title" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
-
   <data name="ImportPage_MaxFileSizeInfoBar.Message" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
-
   <data name="ImportPage_MaxFileSizeHintTextBlock.Text" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
-
   <data name="ImportPage_LogTitleTextBlock.Text" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
-
   <data name="ImportPage_QueueTitleTextBlock.Text" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
-
   <data name="ImportPage_LogTimeColumn.Header" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
-
   <data name="ImportPage_LogEventColumn.Header" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
-
   <data name="ImportPage_LogMessageColumn.Header" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
-
   <data name="ImportPage_LogStatusColumn.Header" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
-
   <data name="ImportPage_LogDetailColumn.Header" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
-
   <data name="ImportPage_FilterLabelTextBlock.Text" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
-
   <data name="ImportPage_ErrorTimeColumn.Header" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
-
   <data name="ImportPage_ErrorFileColumn.Header" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
-
   <data name="ImportPage_ErrorCodeColumn.Header" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
-
   <data name="ImportPage_ErrorSeverityColumn.Header" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
-
   <data name="ImportPage_ErrorMessageColumn.Header" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
-
   <data name="ImportPage_OpenDetailButton.Content" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
-
   <data name="ImportPage_NoErrorsTextBlock.Text" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
-
   <data name="ImportPage_DropPromptTextBlock.Text" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
-
   <data name="ImportPage_DropHintTextBlock.Text" xml:space="preserve">
-    <value></value>
+    <value />
+  </data>
+  <data name="FilesPage_SearchBox.PlaceholderText" xml:space="preserve">
+    <value>Hledat soubory</value>
+  </data>
+  <data name="FilesPage_FuzzyToggle.Header" xml:space="preserve">
+    <value>Fuzzy vyhledávání</value>
+  </data>
+  <data name="FilesPage_AttributesExpander.Header" xml:space="preserve">
+    <value>Atributy</value>
+  </data>
+  <data name="FilesPage_ExtensionTextBox.PlaceholderText" xml:space="preserve">
+    <value>Přípona</value>
+  </data>
+  <data name="FilesPage_MimeTextBox.PlaceholderText" xml:space="preserve">
+    <value>MIME</value>
+  </data>
+  <data name="FilesPage_AuthorTextBox.PlaceholderText" xml:space="preserve">
+    <value>Autor</value>
+  </data>
+  <data name="FilesPage_VersionTextBox.PlaceholderText" xml:space="preserve">
+    <value>Verze</value>
+  </data>
+  <data name="FilesPage_ValidityExpander.Header" xml:space="preserve">
+    <value>Platnost</value>
+  </data>
+  <data name="FilesPage_ReadOnlyCheckBox.Content" xml:space="preserve">
+    <value>Jen pro čtení</value>
+  </data>
+  <data name="FilesPage_IndexStaleCheckBox.Content" xml:space="preserve">
+    <value>Neaktuální index</value>
+  </data>
+  <data name="FilesPage_HasValidityCheckBox.Content" xml:space="preserve">
+    <value>Má platnost</value>
+  </data>
+  <data name="FilesPage_CurrentlyValidCheckBox.Content" xml:space="preserve">
+    <value>Aktuálně platné</value>
+  </data>
+  <data name="FilesPage_ExpiringNumberBox.Header" xml:space="preserve">
+    <value>Vyprší za (dní)</value>
+  </data>
+  <data name="FilesPage_DatesExpander.Header" xml:space="preserve">
+    <value>Data</value>
+  </data>
+  <data name="FilesPage_CreatedFromPicker.PlaceholderText" xml:space="preserve">
+    <value>Vytvořeno od</value>
+  </data>
+  <data name="FilesPage_CreatedToPicker.PlaceholderText" xml:space="preserve">
+    <value>Vytvořeno do</value>
+  </data>
+  <data name="FilesPage_ModifiedFromPicker.PlaceholderText" xml:space="preserve">
+    <value>Upraveno od</value>
+  </data>
+  <data name="FilesPage_ModifiedToPicker.PlaceholderText" xml:space="preserve">
+    <value>Upraveno do</value>
+  </data>
+  <data name="FilesPage_SizeExpander.Header" xml:space="preserve">
+    <value>Velikost</value>
+  </data>
+  <data name="FilesPage_SizeMinNumberBox.Header" xml:space="preserve">
+    <value>Minimální velikost (B)</value>
+  </data>
+  <data name="FilesPage_SizeMaxNumberBox.Header" xml:space="preserve">
+    <value>Maximální velikost (B)</value>
+  </data>
+  <data name="FilesPage_ApplyButton.Content" xml:space="preserve">
+    <value>Použít</value>
+  </data>
+  <data name="FilesPage_ClearButton.Content" xml:space="preserve">
+    <value>Vyčistit</value>
+  </data>
+  <data name="FilesPage_PreviousPageButton.Content" xml:space="preserve">
+    <value>Předchozí</value>
+  </data>
+  <data name="FilesPage_NextPageButton.Content" xml:space="preserve">
+    <value>Další</value>
+  </data>
+  <data name="FilesPage_PageSizeLabel.Text" xml:space="preserve">
+    <value>Na stránce</value>
+  </data>
+  <data name="FilesPage_IndexingInfoBar.Title" xml:space="preserve">
+    <value>Probíhá indexace</value>
+  </data>
+  <data name="FilesPage_IndexingInfoBar.Message" xml:space="preserve">
+    <value>Výsledky mohou být neúplné, dokud nebude dokončena indexace.</value>
+  </data>
+  <data name="FilesPage_ErrorInfoBar.Title" xml:space="preserve">
+    <value>Chyba načítání</value>
+  </data>
+  <data name="FilesPage_ErrorInfoBar.Message" xml:space="preserve">
+    <value>Nepodařilo se načíst výsledky.</value>
   </data>
 </root>

--- a/Veriado.WinUI/Views/Files/FilesPage.xaml
+++ b/Veriado.WinUI/Views/Files/FilesPage.xaml
@@ -40,7 +40,6 @@
                 <AutoSuggestBox
                     x:Uid="FilesPage_SearchBox"
                     Grid.Column="0"
-                    PlaceholderText="Hledat soubory"
                     ItemsSource="{x:Bind ViewModel.SearchSuggestions}"
                     Text="{x:Bind ViewModel.SearchText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                     UpdateTextOnSelect="True" />
@@ -62,58 +61,47 @@
                 <StackPanel Spacing="12">
                     <controls:Expander
                         x:Uid="FilesPage_AttributesExpander"
-                        Header="Atributy"
                         IsExpanded="True"
                         Style="{StaticResource AnimatedExpander}">
                         <StackPanel Spacing="8">
                             <TextBox
                                 x:Uid="FilesPage_ExtensionTextBox"
-                                PlaceholderText="Přípona"
                                 Text="{x:Bind ViewModel.ExtensionFilter, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                             <TextBox
                                 x:Uid="FilesPage_MimeTextBox"
-                                PlaceholderText="MIME"
                                 Text="{x:Bind ViewModel.MimeFilter, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                             <TextBox
                                 x:Uid="FilesPage_AuthorTextBox"
-                                PlaceholderText="Autor"
                                 Text="{x:Bind ViewModel.AuthorFilter, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                             <TextBox
                                 x:Uid="FilesPage_VersionTextBox"
-                                PlaceholderText="Verze"
                                 Text="{x:Bind ViewModel.VersionFilter, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                         </StackPanel>
                     </controls:Expander>
 
                     <controls:Expander
                         x:Uid="FilesPage_ValidityExpander"
-                        Header="Platnost"
                         IsExpanded="True"
                         Style="{StaticResource AnimatedExpander}">
                         <StackPanel Spacing="8">
                             <CheckBox
                                 x:Uid="FilesPage_ReadOnlyCheckBox"
-                                Content="Jen pro čtení"
                                 IsThreeState="True"
                                 IsChecked="{x:Bind ViewModel.ReadOnlyFilter, Mode=TwoWay}" />
                             <CheckBox
                                 x:Uid="FilesPage_IndexStaleCheckBox"
-                                Content="Neaktuální index"
                                 IsThreeState="True"
                                 IsChecked="{x:Bind ViewModel.IsIndexStaleFilter, Mode=TwoWay}" />
                             <CheckBox
                                 x:Uid="FilesPage_HasValidityCheckBox"
-                                Content="Má platnost"
                                 IsThreeState="True"
                                 IsChecked="{x:Bind ViewModel.HasValidityFilter, Mode=TwoWay}" />
                             <CheckBox
                                 x:Uid="FilesPage_CurrentlyValidCheckBox"
-                                Content="Aktuálně platné"
                                 IsThreeState="True"
                                 IsChecked="{x:Bind ViewModel.CurrentlyValidFilter, Mode=TwoWay}" />
                             <controls:NumberBox
                                 x:Uid="FilesPage_ExpiringNumberBox"
-                                Header="Vyprší za (dní)"
                                 Minimum="0"
                                 SmallChange="1"
                                 SpinButtonPlacementMode="Compact"
@@ -123,44 +111,36 @@
 
                     <controls:Expander
                         x:Uid="FilesPage_DatesExpander"
-                        Header="Data"
                         IsExpanded="False"
                         Style="{StaticResource AnimatedExpander}">
                         <StackPanel Spacing="8">
                             <CalendarDatePicker
                                 x:Uid="FilesPage_CreatedFromPicker"
-                                PlaceholderText="Vytvořeno od"
                                 Date="{x:Bind ViewModel.CreatedFromFilter, Mode=TwoWay}" />
                             <CalendarDatePicker
                                 x:Uid="FilesPage_CreatedToPicker"
-                                PlaceholderText="Vytvořeno do"
                                 Date="{x:Bind ViewModel.CreatedToFilter, Mode=TwoWay}" />
                             <CalendarDatePicker
                                 x:Uid="FilesPage_ModifiedFromPicker"
-                                PlaceholderText="Upraveno od"
                                 Date="{x:Bind ViewModel.ModifiedFromFilter, Mode=TwoWay}" />
                             <CalendarDatePicker
                                 x:Uid="FilesPage_ModifiedToPicker"
-                                PlaceholderText="Upraveno do"
                                 Date="{x:Bind ViewModel.ModifiedToFilter, Mode=TwoWay}" />
                         </StackPanel>
                     </controls:Expander>
 
                     <controls:Expander
                         x:Uid="FilesPage_SizeExpander"
-                        Header="Velikost"
                         IsExpanded="False"
                         Style="{StaticResource AnimatedExpander}">
                         <StackPanel Spacing="8">
                             <controls:NumberBox
                                 x:Uid="FilesPage_SizeMinNumberBox"
-                                Header="Minimální velikost (B)"
                                 Minimum="0"
                                 SpinButtonPlacementMode="Compact"
                                 Value="{x:Bind ViewModel.SizeMinFilter, Mode=TwoWay, Converter={StaticResource NullableLongToDoubleConverter}}" />
                             <controls:NumberBox
                                 x:Uid="FilesPage_SizeMaxNumberBox"
-                                Header="Maximální velikost (B)"
                                 Minimum="0"
                                 SpinButtonPlacementMode="Compact"
                                 Value="{x:Bind ViewModel.SizeMaxFilter, Mode=TwoWay, Converter={StaticResource NullableLongToDoubleConverter}}" />
@@ -177,13 +157,11 @@
                 <Button
                     x:Uid="FilesPage_ApplyButton"
                     Grid.Column="0"
-                    Content="Použít"
                     Command="{x:Bind ViewModel.RefreshCommand}"
                     Style="{StaticResource PulseButton}" />
                 <Button
                     x:Uid="FilesPage_ClearButton"
                     Grid.Column="1"
-                    Content="Vyčistit"
                     Command="{x:Bind ViewModel.ClearFiltersCommand}"
                     Style="{StaticResource PulseButton}" />
             </Grid>
@@ -204,7 +182,6 @@
                 <StackPanel Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
                     <Button
                         x:Uid="FilesPage_PreviousPageButton"
-                        Content="Předchozí"
                         Command="{x:Bind ViewModel.PreviousPageCommand}" />
                     <StackPanel Orientation="Horizontal" Spacing="4" VerticalAlignment="Center">
                         <controls:NumberBox
@@ -220,11 +197,10 @@
                     </StackPanel>
                     <Button
                         x:Uid="FilesPage_NextPageButton"
-                        Content="Další"
                         Command="{x:Bind ViewModel.NextPageCommand}" />
                 </StackPanel>
                 <StackPanel Orientation="Horizontal" Spacing="4" VerticalAlignment="Center">
-                    <TextBlock x:Uid="FilesPage_PageSizeLabel" VerticalAlignment="Center" Text="Na stránce" />
+                    <TextBlock x:Uid="FilesPage_PageSizeLabel" VerticalAlignment="Center" />
                     <ComboBox
                         x:Uid="FilesPage_PageSizeComboBox"
                         Width="90"
@@ -238,7 +214,6 @@
                 IsClosable="False"
                 IsOpen="{x:Bind ViewModel.IsIndexingPending, Mode=OneWay}"
                 Severity="Warning"
-                Title="Probíhá indexace"
                 Message="{x:Bind ViewModel.IndexingWarningMessage, Mode=OneWay}"
                 Loaded="OnInfoBarLoaded"
                 Closing="OnInfoBarClosing">
@@ -253,8 +228,6 @@
                 IsClosable="False"
                 IsOpen="{x:Bind ViewModel.HasError, Mode=OneWay}"
                 Severity="Error"
-                Title="Chyba načítání"
-                Message="Nepodařilo se načíst výsledky."
                 Loaded="OnInfoBarLoaded"
                 Closing="OnInfoBarClosing">
                 <controls:InfoBar.Transitions>


### PR DESCRIPTION
## Summary
- add English resource entries for the Files page to prevent runtime lookup failures
- provide matching Czech translations for the new Files page resources
- remove inline literals from FilesPage.xaml so text is supplied through the resource system

## Testing
- not run (dotnet CLI is unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68e03b7a092c8326a657f447940bcb8f