### PR TITLE
Fix resource packaging so localization works at runtime

### DIFF
--- a/Veriado.WinUI/Services/LocalizationService.cs
+++ b/Veriado.WinUI/Services/LocalizationService.cs
@@ -195,6 +195,6 @@ public sealed class LocalizationService : ILocalizationService
 
     public string GetString(string resourceKey)
     {
-        throw new NotImplementedException();
+        return GetString(resourceKey, null, Array.Empty<object?>());
     }
 }

--- a/Veriado.WinUI/Veriado.csproj
+++ b/Veriado.WinUI/Veriado.csproj
@@ -32,6 +32,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PRIResource Include="Strings\**\*.resw" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
     <PackageReference Include="CommunityToolkit.WinUI.Controls.HeaderedControls" Version="8.2.250402" />
     <PackageReference Include="CommunityToolkit.WinUI.Controls.Primitives" Version="8.2.250402" />


### PR DESCRIPTION
## Summary
- include the WinUI string resources in the PRI so x:Uid lookups resolve at runtime
- implement the single-parameter GetString overload so service callers don't hit a NotImplementedException

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e0ca458834832699412587be208a0e