### PR TITLE
Fix pagination bounds and nullable number bindings

### DIFF
--- a/Veriado.WinUI/Converters/NullableIntToDoubleConverter.cs
+++ b/Veriado.WinUI/Converters/NullableIntToDoubleConverter.cs
@@ -12,10 +12,10 @@ public sealed class NullableIntToDoubleConverter : IValueConverter
         if (value is int?)
         {
             var nullable = (int?)value;
-            return nullable.HasValue ? (double)nullable.Value : 0d;
+            return nullable.HasValue ? (double)nullable.Value : double.NaN;
         }
 
-        return 0d;
+        return double.NaN;
     }
 
     public object ConvertBack(object value, Type targetType, object parameter, string language)

--- a/Veriado.WinUI/Converters/NullableLongToDoubleConverter.cs
+++ b/Veriado.WinUI/Converters/NullableLongToDoubleConverter.cs
@@ -16,10 +16,10 @@ public sealed class NullableLongToDoubleConverter : IValueConverter
         if (value is long?)
         {
             var nullable = (long?)value;
-            return nullable.HasValue ? (double)nullable.Value : 0d;
+            return nullable.HasValue ? (double)nullable.Value : double.NaN;
         }
 
-        return 0d;
+        return double.NaN;
     }
 
     public object ConvertBack(object value, Type targetType, object parameter, string language)

--- a/Veriado.WinUI/ViewModels/Files/FilesPageViewModel.cs
+++ b/Veriado.WinUI/ViewModels/Files/FilesPageViewModel.cs
@@ -163,18 +163,7 @@ public partial class FilesPageViewModel : ViewModelBase
     [ObservableProperty]
     private string? indexingWarningMessage;
 
-    public double TargetPageMaximum
-    {
-        get
-        {
-            if (TotalPages > 0)
-            {
-                return TotalPages;
-            }
-
-            return 1;
-        }
-    }
+    public double TargetPageMaximum => TotalPages > 0 ? TotalPages : 0;
 
     partial void OnTotalPagesChanged(int value)
     {

--- a/Veriado.WinUI/Views/Files/FilesPage.xaml
+++ b/Veriado.WinUI/Views/Files/FilesPage.xaml
@@ -203,7 +203,7 @@
                             x:Uid="FilesPage_PageNumberBox"
                             Width="80"
                             HorizontalAlignment="Left"
-                            Minimum="1"
+                            Minimum="0"
                             Maximum="{x:Bind ViewModel.TargetPageMaximum, Mode=OneWay}"
                             SmallChange="1"
                             Value="{x:Bind ViewModel.TargetPage, Mode=TwoWay}" />


### PR DESCRIPTION
## Summary
- ensure nullable numeric filters render as blank instead of zero by returning NaN from the WinUI converters
- align files page pagination limits with the absence of results by allowing a zero page number and fixing the reported maximum

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e0ec15615c832694a40a5d1ec8667c