### PR TITLE
Handle missing localization resources without COM exceptions

### DIFF
--- a/Veriado.WinUI/Services/LocalizationService.cs
+++ b/Veriado.WinUI/Services/LocalizationService.cs
@@ -178,11 +178,17 @@ public sealed class LocalizationService : ILocalizationService
 
         try
         {
-            var candidate = _resourceMap.GetValue(resourceKey, context);
-            if (candidate is not null)
+            if (_resourceMap.TryGetValue(resourceKey, context, out var candidate) && candidate is not null)
             {
                 var value = candidate.ValueAsString;
-                return string.IsNullOrEmpty(value) ? resourceKey : value;
+                if (!string.IsNullOrEmpty(value))
+                {
+                    return value;
+                }
+            }
+            else
+            {
+                _logger?.LogWarning("Resource key {ResourceKey} was not found for culture {Culture}.", resourceKey, culture);
             }
         }
         catch (Exception ex)


### PR DESCRIPTION
## Summary
- switch the localization lookup to TryGetValue to avoid throwing COM exceptions when a resource is missing
- return the resource key only after logging a warning so the app continues gracefully

## Testing
- dotnet test *(fails: command not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e158c499608326a848c05df9936327