### PR TITLE
Fix localization resource lookup overload

### DIFF
--- a/Veriado.WinUI/Services/LocalizationService.cs
+++ b/Veriado.WinUI/Services/LocalizationService.cs
@@ -178,7 +178,9 @@ public sealed class LocalizationService : ILocalizationService
 
         try
         {
-            if (_resourceMap.TryGetValue(resourceKey, context, out var candidate) && candidate is not null)
+            var candidate = _resourceMap.TryGetValue(resourceKey, context);
+
+            if (candidate is not null)
             {
                 var value = candidate.ValueAsString;
                 if (!string.IsNullOrEmpty(value))


### PR DESCRIPTION
## Summary
- adjust localization service to use the correct ResourceMap.TryGetValue overload
- maintain existing null handling and logging around resource lookups

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e15e9ed9688326bf710b815ce6c41c