### PR TITLE
Handle missing localization resources

### DIFF
--- a/Veriado.WinUI/Localization/CultureHelper.cs
+++ b/Veriado.WinUI/Localization/CultureHelper.cs
@@ -76,11 +76,14 @@ internal static class CultureHelper
 
         try
         {
-            var candidate = _resourceMap.GetValue(resourceKey, context);
+            var candidate = _resourceMap.TryGetValue(resourceKey, context);
             if (candidate is not null)
             {
                 var value = candidate.ValueAsString;
-                return string.IsNullOrEmpty(value) ? resourceKey : value;
+                if (!string.IsNullOrEmpty(value))
+                {
+                    return value;
+                }
             }
         }
         catch


### PR DESCRIPTION
## Summary
- avoid throwing when localized resources are missing by switching CultureHelper to TryGetValue
- fall back to the resource key when no resource candidate is present

## Testing
- not run (platform limitation in container)


------
https://chatgpt.com/codex/tasks/task_e_68e16282341c8326a091126b5f279bc9