### PR TITLE
Restore inline UI text on WinUI pages

### DIFF
--- a/Veriado.WinUI/Views/Files/FilesPage.xaml
+++ b/Veriado.WinUI/Views/Files/FilesPage.xaml
@@ -31,37 +31,40 @@
                 <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
 
-            <Grid x:Uid="FilesPage_SearchRow" Grid.Row="0" ColumnSpacing="12">
+            <Grid
+                Grid.Row="0"
+                ColumnSpacing="12"
+                AutomationProperties.Name="Search and fuzzy options">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*" />
                     <ColumnDefinition Width="Auto" />
                 </Grid.ColumnDefinitions>
 
                 <AutoSuggestBox
-                    x:Uid="FilesPage_SearchBox"
                     Grid.Column="0"
                     ItemsSource="{x:Bind ViewModel.SearchSuggestions}"
                     Text="{x:Bind ViewModel.SearchText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                    PlaceholderText="Search files"
                     UpdateTextOnSelect="True" />
                 <ToggleSwitch
-                    x:Uid="FilesPage_FuzzyToggle"
                     Grid.Column="1"
                     HorizontalAlignment="Right"
                     VerticalAlignment="Center"
+                    Header="Fuzzy search"
                     IsOn="{x:Bind ViewModel.Fuzzy, Mode=TwoWay}" />
             </Grid>
 
             <ScrollViewer
-                x:Uid="FilesPage_FilterScrollViewer"
                 Grid.Row="1"
                 HorizontalScrollMode="Disabled"
                 HorizontalScrollBarVisibility="Hidden"
                 VerticalScrollMode="Auto"
-                VerticalScrollBarVisibility="Auto">
+                VerticalScrollBarVisibility="Auto"
+                AutomationProperties.Name="Filter list">
                 <StackPanel Spacing="12">
                     <controls:Expander
-                        x:Uid="FilesPage_AttributesExpander"
-                        IsExpanded="True">
+                        IsExpanded="True"
+                        Header="Attributes">
                         <controls:Expander.ContentTransitions>
                             <TransitionCollection>
                                 <ContentThemeTransition />
@@ -69,23 +72,23 @@
                         </controls:Expander.ContentTransitions>
                         <StackPanel Spacing="8">
                             <TextBox
-                                x:Uid="FilesPage_ExtensionTextBox"
+                                PlaceholderText="Extension"
                                 Text="{x:Bind ViewModel.ExtensionFilter, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                             <TextBox
-                                x:Uid="FilesPage_MimeTextBox"
+                                PlaceholderText="MIME type"
                                 Text="{x:Bind ViewModel.MimeFilter, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                             <TextBox
-                                x:Uid="FilesPage_AuthorTextBox"
+                                PlaceholderText="Author"
                                 Text="{x:Bind ViewModel.AuthorFilter, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                             <TextBox
-                                x:Uid="FilesPage_VersionTextBox"
+                                PlaceholderText="Version"
                                 Text="{x:Bind ViewModel.VersionFilter, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                         </StackPanel>
                     </controls:Expander>
 
                     <controls:Expander
-                        x:Uid="FilesPage_ValidityExpander"
-                        IsExpanded="True">
+                        IsExpanded="True"
+                        Header="Validity">
                         <controls:Expander.ContentTransitions>
                             <TransitionCollection>
                                 <ContentThemeTransition />
@@ -93,33 +96,33 @@
                         </controls:Expander.ContentTransitions>
                         <StackPanel Spacing="8">
                             <CheckBox
-                                x:Uid="FilesPage_ReadOnlyCheckBox"
                                 IsThreeState="True"
+                                Content="Read-only"
                                 IsChecked="{x:Bind ViewModel.ReadOnlyFilter, Mode=TwoWay}" />
                             <CheckBox
-                                x:Uid="FilesPage_IndexStaleCheckBox"
                                 IsThreeState="True"
+                                Content="Index is stale"
                                 IsChecked="{x:Bind ViewModel.IsIndexStaleFilter, Mode=TwoWay}" />
                             <CheckBox
-                                x:Uid="FilesPage_HasValidityCheckBox"
                                 IsThreeState="True"
+                                Content="Has validity period"
                                 IsChecked="{x:Bind ViewModel.HasValidityFilter, Mode=TwoWay}" />
                             <CheckBox
-                                x:Uid="FilesPage_CurrentlyValidCheckBox"
                                 IsThreeState="True"
+                                Content="Currently valid"
                                 IsChecked="{x:Bind ViewModel.CurrentlyValidFilter, Mode=TwoWay}" />
                             <controls:NumberBox
-                                x:Uid="FilesPage_ExpiringNumberBox"
                                 Minimum="0"
                                 SmallChange="1"
+                                Header="Expires in (days)"
                                 SpinButtonPlacementMode="Compact"
                                 Value="{x:Bind ViewModel.ExpiringInDaysFilter, Mode=TwoWay, Converter={StaticResource NullableIntToDoubleConverter}}" />
                         </StackPanel>
                     </controls:Expander>
 
                     <controls:Expander
-                        x:Uid="FilesPage_DatesExpander"
-                        IsExpanded="False">
+                        IsExpanded="False"
+                        Header="Dates">
                         <controls:Expander.ContentTransitions>
                             <TransitionCollection>
                                 <ContentThemeTransition />
@@ -127,23 +130,23 @@
                         </controls:Expander.ContentTransitions>
                         <StackPanel Spacing="8">
                             <CalendarDatePicker
-                                x:Uid="FilesPage_CreatedFromPicker"
-                                Date="{x:Bind ViewModel.CreatedFromFilter, Mode=TwoWay}" />
+                                Date="{x:Bind ViewModel.CreatedFromFilter, Mode=TwoWay}"
+                                PlaceholderText="Created from" />
                             <CalendarDatePicker
-                                x:Uid="FilesPage_CreatedToPicker"
-                                Date="{x:Bind ViewModel.CreatedToFilter, Mode=TwoWay}" />
+                                Date="{x:Bind ViewModel.CreatedToFilter, Mode=TwoWay}"
+                                PlaceholderText="Created to" />
                             <CalendarDatePicker
-                                x:Uid="FilesPage_ModifiedFromPicker"
-                                Date="{x:Bind ViewModel.ModifiedFromFilter, Mode=TwoWay}" />
+                                Date="{x:Bind ViewModel.ModifiedFromFilter, Mode=TwoWay}"
+                                PlaceholderText="Modified from" />
                             <CalendarDatePicker
-                                x:Uid="FilesPage_ModifiedToPicker"
-                                Date="{x:Bind ViewModel.ModifiedToFilter, Mode=TwoWay}" />
+                                Date="{x:Bind ViewModel.ModifiedToFilter, Mode=TwoWay}"
+                                PlaceholderText="Modified to" />
                         </StackPanel>
                     </controls:Expander>
 
                     <controls:Expander
-                        x:Uid="FilesPage_SizeExpander"
-                        IsExpanded="False">
+                        IsExpanded="False"
+                        Header="Size">
                         <controls:Expander.ContentTransitions>
                             <TransitionCollection>
                                 <ContentThemeTransition />
@@ -151,13 +154,13 @@
                         </controls:Expander.ContentTransitions>
                         <StackPanel Spacing="8">
                             <controls:NumberBox
-                                x:Uid="FilesPage_SizeMinNumberBox"
                                 Minimum="0"
+                                Header="Minimum size (bytes)"
                                 SpinButtonPlacementMode="Compact"
                                 Value="{x:Bind ViewModel.SizeMinFilter, Mode=TwoWay, Converter={StaticResource NullableLongToDoubleConverter}}" />
                             <controls:NumberBox
-                                x:Uid="FilesPage_SizeMaxNumberBox"
                                 Minimum="0"
+                                Header="Maximum size (bytes)"
                                 SpinButtonPlacementMode="Compact"
                                 Value="{x:Bind ViewModel.SizeMaxFilter, Mode=TwoWay, Converter={StaticResource NullableLongToDoubleConverter}}" />
                         </StackPanel>
@@ -171,12 +174,12 @@
                     <ColumnDefinition Width="*" />
                 </Grid.ColumnDefinitions>
                 <Button
-                    x:Uid="FilesPage_ApplyButton"
                     Grid.Column="0"
+                    Content="Apply"
                     Command="{x:Bind ViewModel.RefreshCommand}" />
                 <Button
-                    x:Uid="FilesPage_ClearButton"
                     Grid.Column="1"
+                    Content="Clear"
                     Command="{x:Bind ViewModel.ClearFiltersCommand}" />
             </Grid>
         </Grid>
@@ -190,45 +193,45 @@
                     IsActive="{x:Bind ViewModel.IsBusy}"
                     Opacity="0" />
                 <TextBlock
-                    x:Uid="FilesPage_StatusText"
                     VerticalAlignment="Center"
+                    AutomationProperties.Name="Result status"
                     Text="{x:Bind ViewModel.StatusText, Mode=OneWay}" />
                 <StackPanel Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
                     <Button
-                        x:Uid="FilesPage_PreviousPageButton"
+                        Content="Previous"
                         Command="{x:Bind ViewModel.PreviousPageCommand}" />
                     <StackPanel Orientation="Horizontal" Spacing="4" VerticalAlignment="Center">
                         <controls:NumberBox
-                            x:Uid="FilesPage_PageNumberBox"
                             Width="80"
                             HorizontalAlignment="Left"
                             Minimum="0"
                             Maximum="{x:Bind ViewModel.TargetPageMaximum, Mode=OneWay}"
+                            Header="Target page"
                             SmallChange="1"
                             Value="{x:Bind ViewModel.TargetPage, Mode=TwoWay}" />
                         <TextBlock Text="/" VerticalAlignment="Center" />
                         <TextBlock Text="{x:Bind ViewModel.TotalPages, Mode=OneWay}" VerticalAlignment="Center" />
                     </StackPanel>
                     <Button
-                        x:Uid="FilesPage_NextPageButton"
+                        Content="Next"
                         Command="{x:Bind ViewModel.NextPageCommand}" />
                 </StackPanel>
                 <StackPanel Orientation="Horizontal" Spacing="4" VerticalAlignment="Center">
-                    <TextBlock x:Uid="FilesPage_PageSizeLabel" VerticalAlignment="Center" />
+                    <TextBlock Text="Per page" VerticalAlignment="Center" />
                     <ComboBox
-                        x:Uid="FilesPage_PageSizeComboBox"
                         Width="90"
                         HorizontalAlignment="Left"
                         ItemsSource="{x:Bind ViewModel.PageSizeOptions, Mode=OneWay}"
-                        SelectedItem="{x:Bind ViewModel.PageSize, Mode=TwoWay}" />
+                        SelectedItem="{x:Bind ViewModel.PageSize, Mode=TwoWay}"
+                        AutomationProperties.Name="Page size options" />
                 </StackPanel>
             </StackPanel>
             <controls:InfoBar
-                x:Uid="FilesPage_IndexingInfoBar"
                 IsClosable="False"
                 IsOpen="{x:Bind ViewModel.IsIndexingPending, Mode=OneWay}"
                 Severity="Warning"
-                Message="{x:Bind ViewModel.IndexingWarningMessage, Mode=OneWay}"
+                Title="Indexing in progress"
+                Message="{x:Bind ViewModel.IndexingWarningMessage, Mode=OneWay, FallbackValue='Results may be incomplete while indexing finishes.'}"
                 Loaded="OnInfoBarLoaded"
                 Closing="OnInfoBarClosing">
                 <controls:InfoBar.Transitions>
@@ -238,10 +241,11 @@
                 </controls:InfoBar.Transitions>
             </controls:InfoBar>
             <controls:InfoBar
-                x:Uid="FilesPage_ErrorInfoBar"
                 IsClosable="False"
                 IsOpen="{x:Bind ViewModel.HasError, Mode=OneWay}"
                 Severity="Error"
+                Title="Loading error"
+                Message="Unable to load the results."
                 Loaded="OnInfoBarLoaded"
                 Closing="OnInfoBarClosing">
                 <controls:InfoBar.Transitions>

--- a/Veriado.WinUI/Views/Import/ImportPage.xaml
+++ b/Veriado.WinUI/Views/Import/ImportPage.xaml
@@ -67,7 +67,7 @@
                     <animations:EntranceThemeTransition IsStaggeringEnabled="True" />
                 </TransitionCollection>
             </StackPanel.Transitions>
-            <TextBlock x:Uid="ImportPage_TitleTextBlock" FontSize="28" FontWeight="SemiBold" />
+            <TextBlock Text="Import files" FontSize="28" FontWeight="SemiBold" />
             <Grid ColumnSpacing="16">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="Auto" />
@@ -77,14 +77,14 @@
                 <StackPanel Orientation="Horizontal" Spacing="12">
                     <Button
                         x:Name="RunImportButton"
-                        x:Uid="ImportPage_RunImportButton"
+                        Content="Start import"
                         Command="{Binding RunImportCommand}" />
                     <Button
-                        x:Uid="ImportPage_StopButton"
+                        Content="Stop"
                         Command="{Binding StopImportCommand}"
                         IsEnabled="{Binding IsImporting}" />
-                    <Button x:Uid="ImportPage_ClearResultsButton" Command="{Binding ClearResultsCommand}" />
-                    <Button x:Uid="ImportPage_ExportLogButton" Command="{Binding ExportLogCommand}" />
+                    <Button Content="Clear results" Command="{Binding ClearResultsCommand}" />
+                    <Button Content="Export log" Command="{Binding ExportLogCommand}" />
                 </StackPanel>
 
                 <StackPanel Grid.Column="1" Orientation="Vertical" Spacing="4">
@@ -114,9 +114,9 @@
                                 <TextBlock FontWeight="SemiBold" Text="{Binding ProgressPercentDisplay, Mode=OneWay}" />
                                 <TextBlock Text="{Binding ProgressText}" />
                             </StackPanel>
-                            <TextBlock x:Uid="ImportPage_CurrentFileNameTextBlock" FontWeight="SemiBold">
+                            <TextBlock FontWeight="SemiBold">
                                 <TextBlock.Text>
-                                    <Binding Path="CurrentFileName" />
+                                    <Binding Path="CurrentFileName" TargetNullValue="(No file)" />
                                 </TextBlock.Text>
                             </TextBlock>
                             <TextBlock
@@ -125,9 +125,9 @@
                                 TextTrimming="CharacterEllipsis"
                                 MaxLines="2" />
                             <TextBlock>
-                                <Run x:Uid="ImportPage_ProcessedLabelRun" />
+                                <Run Text="Processed: " />
                                 <Run Text="{Binding ProcessedBytes, Converter={StaticResource SizeToHumanConverter}}" />
-                                <Run x:Uid="ImportPage_ProcessedSeparatorRun" />
+                                <Run Text=" / " />
                                 <Run Text="{Binding TotalBytes, Converter={StaticResource SizeToHumanConverter}}" />
                             </TextBlock>
                         </StackPanel>
@@ -140,26 +140,26 @@
                             Visibility="Collapsed"
                             IsHitTestVisible="False">
                             <StackPanel Spacing="4">
-                                <TextBlock x:Uid="ImportPage_SummaryTitleTextBlock" FontWeight="SemiBold" />
+                                <TextBlock Text="Import summary" FontWeight="SemiBold" />
                                 <TextBlock Text="{Binding ProgressText}" TextWrapping="Wrap" />
                                 <StackPanel Orientation="Horizontal" Spacing="12">
                                     <TextBlock>
-                                        <Run x:Uid="ImportPage_SummaryOkLabelRun" />
+                                        <Run Text="OK: " />
                                         <Run Text="{Binding OkCount}" />
                                     </TextBlock>
                                     <TextBlock>
-                                        <Run x:Uid="ImportPage_SummaryErrorLabelRun" />
+                                        <Run Text="Errors: " />
                                         <Run Text="{Binding ErrorCount}" />
                                     </TextBlock>
                                     <TextBlock>
-                                        <Run x:Uid="ImportPage_SummarySkippedLabelRun" />
+                                        <Run Text="Skipped: " />
                                         <Run Text="{Binding SkipCount}" />
                                     </TextBlock>
                                 </StackPanel>
                                 <TextBlock
                                     Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                     TextWrapping="Wrap">
-                                    <Run x:Uid="ImportPage_SummaryDataLabelRun" />
+                                    <Run Text="Processed data: " />
                                     <Run Text="{Binding ProcessedBytes, Converter={StaticResource SizeToHumanConverter}}" />
                                 </TextBlock>
                             </StackPanel>
@@ -212,7 +212,7 @@
                     <animations:EntranceThemeTransition IsStaggeringEnabled="True" />
                 </TransitionCollection>
             </StackPanel.Transitions>
-            <TextBlock x:Uid="ImportPage_SourceTitleTextBlock" FontSize="20" FontWeight="SemiBold" />
+            <TextBlock Text="Import source" FontSize="20" FontWeight="SemiBold" />
             <Grid ColumnSpacing="12">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="Auto" />
@@ -220,7 +220,7 @@
                 </Grid.ColumnDefinitions>
                 <Button
                     Grid.Column="0"
-                    x:Uid="ImportPage_PickFolderButton"
+                    Content="Choose folder"
                     Command="{Binding PickFolderCommand}" />
                 <TextBox
                     Grid.Column="1"
@@ -237,18 +237,18 @@
                     <animations:EntranceThemeTransition IsStaggeringEnabled="True" />
                 </TransitionCollection>
             </StackPanel.Transitions>
-            <TextBlock x:Uid="ImportPage_OptionsTitleTextBlock" FontSize="20" FontWeight="SemiBold" />
+            <TextBlock Text="Import options" FontSize="20" FontWeight="SemiBold" />
             <StackPanel Orientation="Horizontal" Spacing="16">
                 <StackPanel Orientation="Vertical" Spacing="8">
-                    <CheckBox x:Uid="ImportPage_RecursiveCheckBox" IsChecked="{Binding Recursive, Mode=TwoWay}" />
-                    <CheckBox x:Uid="ImportPage_PreserveMetadataCheckBox" IsChecked="{Binding KeepFsMetadata, Mode=TwoWay}" />
+                    <CheckBox Content="Recursive" IsChecked="{Binding Recursive, Mode=TwoWay}" />
+                    <CheckBox Content="Preserve file system metadata" IsChecked="{Binding KeepFsMetadata, Mode=TwoWay}" />
                 </StackPanel>
                 <StackPanel Orientation="Vertical" Spacing="8">
-                    <CheckBox x:Uid="ImportPage_ReadOnlyCheckBox" IsChecked="{Binding SetReadOnly, Mode=TwoWay}" />
-                    <CheckBox x:Uid="ImportPage_ParallelCheckBox" IsChecked="{Binding UseParallel, Mode=TwoWay}" />
+                    <CheckBox Content="Set read-only" IsChecked="{Binding SetReadOnly, Mode=TwoWay}" />
+                    <CheckBox Content="Parallel" IsChecked="{Binding UseParallel, Mode=TwoWay}" />
                     <NumberBox
-                        x:Uid="ImportPage_MaxThreadsNumberBox"
                         Minimum="1"
+                        Header="Max parallel threads"
                         SpinButtonPlacementMode="Compact"
                         IsEnabled="{Binding UseParallel}"
                         ValidationMode="InvalidInputOverwritten"
@@ -257,16 +257,18 @@
                         Margin="0,4,0,0"
                         IsOpen="{Binding HasParallelismError}"
                         Severity="Error"
-                        x:Uid="ImportPage_MaxThreadsInfoBar"
+                        Title="Invalid thread count"
+                        Message="Enter a positive integer greater than zero."
                         IsClosable="False" />
                 </StackPanel>
                 <StackPanel Orientation="Vertical" Spacing="8" Width="200">
                     <TextBox
-                        x:Uid="ImportPage_DefaultAuthorTextBox"
+                        Header="Default author"
+                        PlaceholderText="(not set)"
                         Text="{Binding DefaultAuthor, Mode=TwoWay}" />
                     <NumberBox
-                        x:Uid="ImportPage_MaxFileSizeNumberBox"
                         Minimum="0"
+                        Header="Max file size (MB)"
                         SpinButtonPlacementMode="Compact"
                         ValidationMode="InvalidInputOverwritten"
                         Value="{Binding MaxFileSizeMegabytes, Mode=TwoWay, TargetNullValue=0}" />
@@ -274,12 +276,13 @@
                         Margin="0,4,0,0"
                         IsOpen="{Binding HasMaxFileSizeError}"
                         Severity="Warning"
-                        x:Uid="ImportPage_MaxFileSizeInfoBar"
+                        Title="Invalid file size"
+                        Message="Enter a non-negative value or leave 0 for no limit."
                         IsClosable="False" />
                     <TextBlock
-                        x:Uid="ImportPage_MaxFileSizeHintTextBlock"
                         FontSize="12"
-                        Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                        Text="0 = no limit" />
                 </StackPanel>
             </StackPanel>
         </StackPanel>
@@ -291,9 +294,9 @@
                     <animations:EntranceThemeTransition IsStaggeringEnabled="True" />
                 </TransitionCollection>
             </StackPanel.Transitions>
-            <TextBlock x:Uid="ImportPage_LogTitleTextBlock" FontSize="20" FontWeight="SemiBold" />
+            <TextBlock Text="Import log" FontSize="20" FontWeight="SemiBold" />
             <StackPanel x:Name="QueueSection" Spacing="8" Visibility="Collapsed">
-                <TextBlock x:Uid="ImportPage_QueueTitleTextBlock" FontSize="16" FontWeight="SemiBold" />
+                <TextBlock Text="Import queue" FontSize="16" FontWeight="SemiBold" />
                 <ScrollViewer MaxHeight="240" VerticalScrollBarVisibility="Auto">
                     <muxc:ItemsRepeater
                         x:Name="ImportQueueRepeater"
@@ -384,19 +387,19 @@
                     ScrollViewer.VerticalScrollBarVisibility="Auto"
                     ScrollViewer.HorizontalScrollBarVisibility="Auto">
                     <datagrid:DataGrid.Columns>
-                        <datagrid:DataGridTextColumn x:Uid="ImportPage_LogTimeColumn" Binding="{Binding FormattedTimestamp}" Width="Auto" />
-                        <datagrid:DataGridTextColumn x:Uid="ImportPage_LogEventColumn" Binding="{Binding Title}" Width="2*">
+                        <datagrid:DataGridTextColumn Header="Time" Binding="{Binding FormattedTimestamp}" Width="Auto" />
+                        <datagrid:DataGridTextColumn Header="Event" Binding="{Binding Title}" Width="2*">
                             <datagrid:DataGridTextColumn.ElementStyle>
                                 <Style TargetType="TextBlock" BasedOn="{StaticResource WrapTextBlockStyle}" />
                             </datagrid:DataGridTextColumn.ElementStyle>
                         </datagrid:DataGridTextColumn>
-                        <datagrid:DataGridTextColumn x:Uid="ImportPage_LogMessageColumn" Binding="{Binding Message}" Width="3*">
+                        <datagrid:DataGridTextColumn Header="Message" Binding="{Binding Message}" Width="3*">
                             <datagrid:DataGridTextColumn.ElementStyle>
                                 <Style TargetType="TextBlock" BasedOn="{StaticResource WrapTextBlockStyle}" />
                             </datagrid:DataGridTextColumn.ElementStyle>
                         </datagrid:DataGridTextColumn>
-                        <datagrid:DataGridTextColumn x:Uid="ImportPage_LogStatusColumn" Binding="{Binding Status}" Width="Auto" />
-                        <datagrid:DataGridTextColumn x:Uid="ImportPage_LogDetailColumn" Binding="{Binding Detail}" Width="3*">
+                        <datagrid:DataGridTextColumn Header="Status" Binding="{Binding Status}" Width="Auto" />
+                        <datagrid:DataGridTextColumn Header="Detail" Binding="{Binding Detail}" Width="3*">
                             <datagrid:DataGridTextColumn.ElementStyle>
                                 <Style TargetType="TextBlock" BasedOn="{StaticResource WrapTextBlockStyle}" />
                             </datagrid:DataGridTextColumn.ElementStyle>
@@ -432,7 +435,7 @@
                         <StackPanel Orientation="Horizontal" Spacing="8">
                             <TextBlock
                                 VerticalAlignment="Center"
-                                x:Uid="ImportPage_FilterLabelTextBlock" />
+                                Text="Filter:" />
                             <ComboBox
                                 Width="180"
                                 ItemsSource="{Binding ErrorFilterOptions}"
@@ -465,17 +468,17 @@
                         ScrollViewer.VerticalScrollBarVisibility="Auto"
                         ScrollViewer.HorizontalScrollBarVisibility="Auto">
                         <datagrid:DataGrid.Columns>
-                            <datagrid:DataGridTextColumn x:Uid="ImportPage_ErrorTimeColumn" Binding="{Binding FormattedTimestamp}" Width="Auto" />
-                            <datagrid:DataGridTextColumn x:Uid="ImportPage_ErrorFileColumn" Binding="{Binding FileName}" Width="2*">
+                            <datagrid:DataGridTextColumn Header="Time" Binding="{Binding FormattedTimestamp}" Width="Auto" />
+                            <datagrid:DataGridTextColumn Header="File" Binding="{Binding FileName}" Width="2*">
                                 <datagrid:DataGridTextColumn.ElementStyle>
                                     <Style TargetType="TextBlock" BasedOn="{StaticResource WrapTextBlockStyle}">
                                         <Setter Property="ToolTipService.ToolTip" Value="{Binding FilePath}" />
                                     </Style>
                                 </datagrid:DataGridTextColumn.ElementStyle>
                             </datagrid:DataGridTextColumn>
-                            <datagrid:DataGridTextColumn x:Uid="ImportPage_ErrorCodeColumn" Binding="{Binding Code}" Width="Auto" />
-                            <datagrid:DataGridTextColumn x:Uid="ImportPage_ErrorSeverityColumn" Binding="{Binding Severity, Converter={StaticResource ErrorSeverityToStringConverter}}" Width="Auto" />
-                            <datagrid:DataGridTextColumn x:Uid="ImportPage_ErrorMessageColumn" Binding="{Binding ErrorMessage}" Width="3*">
+                            <datagrid:DataGridTextColumn Header="Code" Binding="{Binding Code}" Width="Auto" />
+                            <datagrid:DataGridTextColumn Header="Severity" Binding="{Binding Severity, Converter={StaticResource ErrorSeverityToStringConverter}}" Width="Auto" />
+                            <datagrid:DataGridTextColumn Header="Message" Binding="{Binding ErrorMessage}" Width="3*">
                                 <datagrid:DataGridTextColumn.ElementStyle>
                                     <Style TargetType="TextBlock" BasedOn="{StaticResource WrapTextBlockStyle}" />
                                 </datagrid:DataGridTextColumn.ElementStyle>
@@ -497,7 +500,7 @@
                                         TextWrapping="Wrap"
                                         Visibility="{Binding HasSuggestion, Converter={StaticResource BooleanToVisibilityConverter}}" />
                                     <Button
-                                        x:Uid="ImportPage_OpenDetailButton"
+                                        Content="Open detail"
                                         HorizontalAlignment="Left"
                                         Command="{Binding ElementName=ErrorsDataGrid, Path=DataContext.OpenErrorDetailCommand}"
                                         CommandParameter="{Binding Source}" />
@@ -510,7 +513,7 @@
                         Grid.Row="3"
                         Margin="0,8,0,0"
                         Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                        x:Uid="ImportPage_NoErrorsTextBlock"
+                        Text="No errors match the selected filter."
                         Visibility="{Binding HasNoFilteredErrors, Converter={StaticResource BooleanToVisibilityConverter}}" />
                 </Grid>
             </Grid>
@@ -529,8 +532,8 @@
                 HorizontalAlignment="Center"
                 VerticalAlignment="Center">
                 <StackPanel Spacing="8" HorizontalAlignment="Center">
-                    <TextBlock x:Uid="ImportPage_DropPromptTextBlock" FontSize="24" FontWeight="SemiBold" HorizontalAlignment="Center" />
-                    <TextBlock x:Uid="ImportPage_DropHintTextBlock" HorizontalAlignment="Center" />
+                    <TextBlock Text="Drop a folder to import" FontSize="24" FontWeight="SemiBold" HorizontalAlignment="Center" />
+                    <TextBlock Text="You can also choose a folder using the button." HorizontalAlignment="Center" />
                 </StackPanel>
             </Border>
         </Grid>

--- a/Veriado.WinUI/Views/Settings/SettingsPage.xaml
+++ b/Veriado.WinUI/Views/Settings/SettingsPage.xaml
@@ -7,25 +7,26 @@
     xmlns:controls="using:Microsoft.UI.Xaml.Controls"
     mc:Ignorable="d">
     <StackPanel Padding="24" Spacing="12">
-        <TextBlock x:Uid="SettingsPage_Title" FontSize="20" FontWeight="SemiBold" />
+        <TextBlock Text="Settings" FontSize="20" FontWeight="SemiBold" />
 
         <ComboBox
-            x:Uid="SettingsPage_ThemeCombo"
+            Header="Application theme"
             ItemsSource="{Binding ThemeOptions}"
             SelectedItem="{Binding ThemeMode, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
 
         <controls:NumberBox
-            x:Uid="SettingsPage_PageSizeBox"
             Minimum="1"
+            Header="Page size"
             SmallChange="1"
             Value="{Binding PageSize, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
 
         <TextBox
-            x:Uid="SettingsPage_FolderBox"
+            Header="Last folder"
+            PlaceholderText="Folder path"
             Text="{Binding LastFolder, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
 
         <StackPanel Orientation="Horizontal" Spacing="8">
-            <Button x:Uid="SettingsPage_ApplyThemeButton" Command="{Binding ApplyThemeCommand}" />
+            <Button Content="Apply theme" Command="{Binding ApplyThemeCommand}" />
         </StackPanel>
     </StackPanel>
 </Page>

--- a/Veriado.WinUI/Views/StartupWindow.xaml
+++ b/Veriado.WinUI/Views/StartupWindow.xaml
@@ -24,9 +24,9 @@
                 Foreground="{ThemeResource AppTextPrimaryBrush}"
                 Visibility="{Binding HasError, Converter={StaticResource BooleanToVisibilityConverter}}" />
             <Button
-                x:Uid="StartupWindow_RetryButton"
                 Width="160"
                 HorizontalAlignment="Center"
+                Content="Try again"
                 Command="{Binding RetryCommand}"
                 Visibility="{Binding HasError, Converter={StaticResource BooleanToVisibilityConverter}}" />
         </StackPanel>


### PR DESCRIPTION
## Summary
- replace localization UIDs on the Files, Import, Settings, and Startup WinUI pages with inline text
- restore headers, placeholders, and button content so the UI shows readable strings without resource files

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e17668ea908326a1ece1aab99c3d23