### PR TITLE
Fix FilesPage scroll hosting for items repeater

### DIFF
--- a/Veriado.WinUI/Views/Files/FilesPage.xaml
+++ b/Veriado.WinUI/Views/Files/FilesPage.xaml
@@ -256,14 +256,15 @@
             </controls:InfoBar>
         </StackPanel>
 
-        <controls:ItemsRepeaterScrollHost x:Name="ResultsHost" Grid.Row="1" Grid.Column="1" Opacity="1">
-            <controls:ScrollViewer
-        x:Name="FilesScrollViewer"
-        HorizontalScrollMode="Disabled"
-        HorizontalScrollBarVisibility="Hidden"
-        VerticalScrollMode="Auto"
-        VerticalScrollBarVisibility="Auto">
-
+        <ScrollViewer
+            x:Name="FilesScrollViewer"
+            Grid.Row="1"
+            Grid.Column="1"
+            HorizontalScrollMode="Disabled"
+            HorizontalScrollBarVisibility="Hidden"
+            VerticalScrollMode="Auto"
+            VerticalScrollBarVisibility="Auto">
+            <controls:ItemsRepeaterScrollHost x:Name="ResultsHost" Opacity="1">
                 <controls:ItemsRepeater
                     x:Name="FilesRepeater"
                     ItemsSource="{x:Bind ViewModel.Items}"
@@ -299,8 +300,7 @@
                         </DataTemplate>
                     </controls:ItemsRepeater.ItemTemplate>
                 </controls:ItemsRepeater>
-
-            </controls:ScrollViewer>
-        </controls:ItemsRepeaterScrollHost>
+            </controls:ItemsRepeaterScrollHost>
+        </ScrollViewer>
     </Grid>
 </Page>

--- a/Veriado.WinUI/Views/Files/FilesPage.xaml.cs
+++ b/Veriado.WinUI/Views/Files/FilesPage.xaml.cs
@@ -76,12 +76,14 @@ public sealed partial class FilesPage : Page
             LoadingRing.Opacity = isBusy ? 1d : 0d;
             ResultsHost.Opacity = isBusy ? 0d : 1d;
             ResultsHost.IsHitTestVisible = !isBusy;
+            FilesScrollViewer.IsHitTestVisible = !isBusy;
             return;
         }
 
         LoadingRing.Visibility = Visibility.Visible;
         ResultsHost.Visibility = Visibility.Visible;
         ResultsHost.IsHitTestVisible = !isBusy;
+        FilesScrollViewer.IsHitTestVisible = !isBusy;
 
         var resultsVisual = ElementCompositionPreview.GetElementVisual(ResultsHost);
         var loadingVisual = ElementCompositionPreview.GetElementVisual(LoadingRing);


### PR DESCRIPTION
## Summary
- host the files ItemsRepeater inside the ScrollViewer so the scroll host cooperates with platform expectations
- disable the files ScrollViewer when the page is busy to align with the updated visual tree

## Testing
- dotnet build Veriado.WinUI/Veriado.WinUI.csproj *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e22162e244832680cabaa5d0f55ee7