### PR TITLE
Fix XAML designer crash due to missing StartupWindow default constructor

### DIFF
--- a/Veriado.WinUI/Views/StartupWindow.xaml.cs
+++ b/Veriado.WinUI/Views/StartupWindow.xaml.cs
@@ -5,6 +5,11 @@ namespace Veriado.WinUI.Views;
 
 public sealed partial class StartupWindow : Window
 {
+    public StartupWindow()
+        : this(new StartupViewModel())
+    {
+    }
+
     public StartupWindow(StartupViewModel viewModel)
     {
         InitializeComponent();


### PR DESCRIPTION
## Summary
- add a parameterless StartupWindow constructor that forwards to the existing overload so the XAML designer can instantiate the window

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e226236b7c8326b9ba152f3ad8a132