### PR TITLE
Fix missing section title base style causing XAML parse error

### DIFF
--- a/Veriado.WinUI/Resources/Styles.xaml
+++ b/Veriado.WinUI/Resources/Styles.xaml
@@ -11,7 +11,7 @@
     <Setter Property="Foreground" Value="{ThemeResource AppNavigationForegroundBrush}" />
   </Style>
 
-  <Style TargetType="TextBlock" x:Key="SectionTitleTextBlockStyle" BasedOn="{StaticResource HeaderTextBlockStyle}">
+  <Style TargetType="TextBlock" x:Key="SectionTitleTextBlockStyle" BasedOn="{StaticResource TitleTextBlockStyle}">
     <Setter Property="Margin" Value="0,24,0,12" />
     <Setter Property="TextWrapping" Value="Wrap" />
     <Setter Property="Foreground" Value="{ThemeResource AppTextPrimaryBrush}" />


### PR DESCRIPTION
## Summary
- base the SectionTitleTextBlockStyle on TitleTextBlockStyle so it references an existing WinUI resource
- resolve the startup XAML parse error caused by the missing HeaderTextBlockStyle resource

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e22a56fcc48326bbe043f7d56aba7b