### PR TITLE
Fix WinUI color resource definitions

### DIFF
--- a/Veriado.WinUI/Resources/Theme.xaml
+++ b/Veriado.WinUI/Resources/Theme.xaml
@@ -7,32 +7,32 @@
 
         <!-- LIGHT -->
         <ResourceDictionary x:Key="Light">
-            <x:Color x:Key="AppAccentColor">#FF0063B1</x:Color>
-            <x:Color x:Key="AppBackgroundColor">#FFF7F8FC</x:Color>
-            <x:Color x:Key="AppSurfaceColor">#FFFFFFFF</x:Color>
-            <x:Color x:Key="AppNavigationBackgroundColor">#FFF0F2F7</x:Color>
-            <x:Color x:Key="AppNavigationForegroundColor">#FF101820</x:Color>
-            <x:Color x:Key="AppTextPrimaryColor">#FF1B1F23</x:Color>
+            <Color x:Key="AppAccentColor">#FF0063B1</Color>
+            <Color x:Key="AppBackgroundColor">#FFF7F8FC</Color>
+            <Color x:Key="AppSurfaceColor">#FFFFFFFF</Color>
+            <Color x:Key="AppNavigationBackgroundColor">#FFF0F2F7</Color>
+            <Color x:Key="AppNavigationForegroundColor">#FF101820</Color>
+            <Color x:Key="AppTextPrimaryColor">#FF1B1F23</Color>
         </ResourceDictionary>
 
         <!-- DARK -->
         <ResourceDictionary x:Key="Dark">
-            <x:Color x:Key="AppAccentColor">#FF4CC2FF</x:Color>
-            <x:Color x:Key="AppBackgroundColor">#FF1B1E23</x:Color>
-            <x:Color x:Key="AppSurfaceColor">#FF252932</x:Color>
-            <x:Color x:Key="AppNavigationBackgroundColor">#FF2C313C</x:Color>
-            <x:Color x:Key="AppNavigationForegroundColor">#FFE7ECF4</x:Color>
-            <x:Color x:Key="AppTextPrimaryColor">#FFE7ECF4</x:Color>
+            <Color x:Key="AppAccentColor">#FF4CC2FF</Color>
+            <Color x:Key="AppBackgroundColor">#FF1B1E23</Color>
+            <Color x:Key="AppSurfaceColor">#FF252932</Color>
+            <Color x:Key="AppNavigationBackgroundColor">#FF2C313C</Color>
+            <Color x:Key="AppNavigationForegroundColor">#FFE7ECF4</Color>
+            <Color x:Key="AppTextPrimaryColor">#FFE7ECF4</Color>
         </ResourceDictionary>
 
         <!-- DEFAULT (fallback) -->
         <ResourceDictionary x:Key="Default">
-            <x:Color x:Key="AppAccentColor">#FF0063B1</x:Color>
-            <x:Color x:Key="AppBackgroundColor">#FFF7F8FC</x:Color>
-            <x:Color x:Key="AppSurfaceColor">#FFFFFFFF</x:Color>
-            <x:Color x:Key="AppNavigationBackgroundColor">#FFF0F2F7</x:Color>
-            <x:Color x:Key="AppNavigationForegroundColor">#FF101820</x:Color>
-            <x:Color x:Key="AppTextPrimaryColor">#FF1B1F23</x:Color>
+            <Color x:Key="AppAccentColor">#FF0063B1</Color>
+            <Color x:Key="AppBackgroundColor">#FFF7F8FC</Color>
+            <Color x:Key="AppSurfaceColor">#FFFFFFFF</Color>
+            <Color x:Key="AppNavigationBackgroundColor">#FFF0F2F7</Color>
+            <Color x:Key="AppNavigationForegroundColor">#FF101820</Color>
+            <Color x:Key="AppTextPrimaryColor">#FF1B1F23</Color>
         </ResourceDictionary>
 
         <!-- (volitelné) HighContrast: můžeš doplnit vlastní barvy/štětce -->


### PR DESCRIPTION
## Summary
- replace the theme dictionary color resources to use the WinUI Color type so the XAML parser can resolve them

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e23cc3be0883268c2c7250482d64d4