### PR TITLE
Fix FTS version query for diagnostics

### DIFF
--- a/Veriado.Infrastructure/Repositories/DiagnosticsRepository.cs
+++ b/Veriado.Infrastructure/Repositories/DiagnosticsRepository.cs
@@ -58,7 +58,7 @@ internal sealed class DiagnosticsRepository : IDiagnosticsRepository
         string? version;
         if (_options.IsFulltextAvailable)
         {
-            var rawVersion = await GetScalarAsync(connection, "SELECT fts5();", cancellationToken).ConfigureAwait(false);
+            var rawVersion = await GetScalarAsync(connection, "SELECT fts5_source_id();", cancellationToken).ConfigureAwait(false);
             version = string.IsNullOrWhiteSpace(rawVersion) ? null : rawVersion;
         }
         else


### PR DESCRIPTION
## Summary
- replace the invalid FTS5 version query with the supported fts5_source_id() call to avoid runtime errors

## Testing
- dotnet test *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e26c8582d88326b8bc8915620db126