### PR TITLE
Handle cancellation in write queue

### DIFF
--- a/Veriado.Infrastructure/Concurrency/WriteQueue.cs
+++ b/Veriado.Infrastructure/Concurrency/WriteQueue.cs
@@ -49,8 +49,9 @@ internal sealed class WriteQueue : IWriteQueue
                 }
             }
         }
-        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        catch (OperationCanceledException)
         {
+            // Propagate cancellation as a graceful shutdown signal for the background worker.
             return null;
         }
 


### PR DESCRIPTION
## Summary
- catch OperationCanceledException in the write queue without filtering on the caller token
- ensure cancellation is treated as a graceful shutdown of the background worker

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e275de74ac8326bce559bdafe0d7db