### PR TITLE
Handle cancellation in write queue

### DIFF
--- a/Veriado.Infrastructure/Concurrency/WriteQueue.cs
+++ b/Veriado.Infrastructure/Concurrency/WriteQueue.cs
@@ -32,8 +32,9 @@ internal sealed class WriteQueue : IWriteQueue
             var value = await work(context, ct).ConfigureAwait(false);
             return (object?)value;
         }, completion, trackedFiles, cancellationToken);
+        using var registration = cancellationToken.Register(() => request.TrySetCanceled(cancellationToken));
         await _channel.Writer.WriteAsync(request, cancellationToken).ConfigureAwait(false);
-        var result = await completion.Task.ConfigureAwait(false);
+        var result = await completion.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
         return result is T typed ? typed : default!;
     }
 

--- a/Veriado.Infrastructure/Concurrency/WriteRequest.cs
+++ b/Veriado.Infrastructure/Concurrency/WriteRequest.cs
@@ -25,6 +25,10 @@ internal sealed class WriteRequest
 
     public IReadOnlyList<QueuedFileWrite>? TrackedFiles { get; }
 
+    public CancellationToken RequestCancellation => _requestCancellation;
+
+    public bool IsCancellationRequested => _requestCancellation.IsCancellationRequested;
+
     public async Task<object?> ExecuteAsync(AppDbContext context, CancellationToken workerCancellation)
     {
         using var linked = CancellationTokenSource.CreateLinkedTokenSource(workerCancellation, _requestCancellation);


### PR DESCRIPTION
## Summary
- expose the request cancellation token and status from write requests
- register enqueue cancellations and await results with cancellation awareness
- skip canceled write requests before batch processing in the worker

## Testing
- Not run (dotnet CLI unavailable in environment)


------
https://chatgpt.com/codex/tasks/task_e_68e27d74ea608326921a0878d3717381