### PR TITLE
Fix SQLite transaction detection

### DIFF
--- a/Veriado.Infrastructure/Search/FtsWriteAheadService.cs
+++ b/Veriado.Infrastructure/Search/FtsWriteAheadService.cs
@@ -69,7 +69,7 @@ internal sealed class FtsWriteAheadService
 
         var titleHash = ComputeTitleHash(normalizedTitle);
 
-        if (transaction is null && !connection.AutoCommit)
+        if (transaction is null && connection.Transaction is not null)
         {
             await using var lease = await _connectionFactory.CreateConnectionAsync(cancellationToken).ConfigureAwait(false);
             var isolatedConnection = lease.Connection;


### PR DESCRIPTION
## Summary
- replace use of the non-existent AutoCommit property with a transaction presence check when determining whether to log through an isolated connection

## Testing
- (not run)

------
https://chatgpt.com/codex/tasks/task_e_68e28ff38b4083269a35a8b26cb0aaea