### PR TITLE
Disable FTS5 usage while keeping write-ahead journal

### DIFF
--- a/Veriado.Infrastructure/Persistence/SqliteFulltextSupportDetector.cs
+++ b/Veriado.Infrastructure/Persistence/SqliteFulltextSupportDetector.cs
@@ -17,65 +17,12 @@ internal static class SqliteFulltextSupportDetector
             return;
         }
 
-        var (available, reason) = Probe(options.ConnectionString);
-        options.IsFulltextAvailable = available;
+        // FTS5 support has been removed from the application runtime. Instead of probing for
+        // module availability, mark the capability as unavailable while keeping the write-ahead
+        // journal infrastructure intact.
+        const string reason = "SQLite FTS5 support disabled.";
+        options.IsFulltextAvailable = false;
         options.FulltextAvailabilityError = reason;
-        SqliteFulltextSupport.Update(available, reason);
-    }
-
-    private static (bool Available, string? Reason) Probe(string connectionString)
-    {
-        try
-        {
-            using var connection = new SqliteConnection(connectionString);
-            connection.Open();
-            SqlitePragmaHelper.ApplyAsync(connection, CancellationToken.None).GetAwaiter().GetResult();
-
-            using (var moduleCheck = connection.CreateCommand())
-            {
-                moduleCheck.CommandText = "SELECT 1 FROM pragma_module_list WHERE name = 'fts5' LIMIT 1;";
-                var result = moduleCheck.ExecuteScalar();
-                if (result is null)
-                {
-                    return (false, "SQLite build does not include the FTS5 module.");
-                }
-            }
-
-            using var command = connection.CreateCommand();
-            command.CommandText =
-                "CREATE VIRTUAL TABLE temp.__fts5_probe USING fts5(x, tokenize='unicode61 remove_diacritics 2');";
-            try
-            {
-                command.ExecuteNonQuery();
-                command.CommandText = "DROP TABLE temp.__fts5_probe;";
-                command.ExecuteNonQuery();
-                return (true, null);
-            }
-            catch (SqliteException ex)
-            {
-                try
-                {
-                    command.CommandText = "DROP TABLE IF EXISTS temp.__fts5_probe;";
-                    command.ExecuteNonQuery();
-                }
-                catch
-                {
-                    // Ignore cleanup failures.
-                }
-
-                var reason = ex.Message.Contains("remove_diacritics", StringComparison.OrdinalIgnoreCase)
-                    ? "SQLite FTS5 unicode61 tokenizer does not support remove_diacritics=2."
-                    : $"SQLite FTS5 tokenizer configuration is not supported: {ex.Message}";
-                return (false, reason);
-            }
-        }
-        catch (SqliteException ex)
-        {
-            return (false, ex.Message);
-        }
-        catch (Exception ex)
-        {
-            return (false, ex.Message);
-        }
+        SqliteFulltextSupport.Update(false, reason);
     }
 }

--- a/Veriado.Infrastructure/Search/Outbox/OutboxDrainService.cs
+++ b/Veriado.Infrastructure/Search/Outbox/OutboxDrainService.cs
@@ -140,18 +140,7 @@ internal sealed class OutboxDrainService
 
         if (!_options.IsFulltextAvailable)
         {
-            var tracked = await writeContext.Files.FirstOrDefaultAsync(f => f.Id == fileId, cancellationToken).ConfigureAwait(false);
-            if (tracked is not null)
-            {
-                var signature = _signatureCalculator.Compute(tracked);
-                tracked.ConfirmIndexed(
-                    tracked.SearchIndex.SchemaVersion,
-                    UtcTimestamp.From(_clock.UtcNow),
-                    signature.AnalyzerVersion,
-                    signature.TokenHash,
-                    signature.NormalizedTitle);
-            }
-
+            await ReindexFileAsync(writeContext, fileId, cancellationToken).ConfigureAwait(false);
             outbox.ProcessedUtc = _clock.UtcNow;
             return;
         }

--- a/Veriado.Infrastructure/Search/SqliteFts5Indexer.cs
+++ b/Veriado.Infrastructure/Search/SqliteFts5Indexer.cs
@@ -60,6 +60,18 @@ internal sealed class SqliteFts5Indexer : ISearchIndexer
         ArgumentNullException.ThrowIfNull(document);
         if (!_options.IsFulltextAvailable)
         {
+            if (beforeCommit is not null)
+            {
+                await beforeCommit(cancellationToken).ConfigureAwait(false);
+            }
+
+            await _luceneIndex.IndexAsync(document, cancellationToken).ConfigureAwait(false);
+
+            if (_suggestionMaintenance is not null)
+            {
+                await _suggestionMaintenance.UpsertAsync(document, cancellationToken).ConfigureAwait(false);
+            }
+
             return;
         }
 
@@ -109,6 +121,12 @@ internal sealed class SqliteFts5Indexer : ISearchIndexer
     {
         if (!_options.IsFulltextAvailable)
         {
+            if (beforeCommit is not null)
+            {
+                await beforeCommit(cancellationToken).ConfigureAwait(false);
+            }
+
+            await _luceneIndex.DeleteAsync(fileId, cancellationToken).ConfigureAwait(false);
             return;
         }
 


### PR DESCRIPTION
## Summary
- mark SQLite FTS5 support as disabled while keeping the write-ahead journal infrastructure intact
- route indexing paths (coordinator, indexer, outbox, write worker) to Lucene so search continues even without FTS

## Testing
- `dotnet test` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e2bd19c740832689e1f5b41f06f082