### PR TITLE
Enable configuring import search pattern

### DIFF
--- a/Veriado.WinUI/Services/Abstractions/IHotStateService.cs
+++ b/Veriado.WinUI/Services/Abstractions/IHotStateService.cs
@@ -22,5 +22,7 @@ public interface IHotStateService
 
     double? ImportMaxFileSizeMegabytes { get; set; }
 
+    string ImportSearchPattern { get; set; }
+
     Task InitializeAsync(CancellationToken cancellationToken = default);
 }

--- a/Veriado.WinUI/Services/Abstractions/ISettingsService.cs
+++ b/Veriado.WinUI/Services/Abstractions/ISettingsService.cs
@@ -48,4 +48,7 @@ public sealed class ImportPreferences
 
     public double? MaxFileSizeMegabytes { get; set; }
         = null;
+
+    public string? SearchPattern { get; set; }
+        = null;
 }

--- a/Veriado.WinUI/Views/Import/ImportPage.xaml
+++ b/Veriado.WinUI/Views/Import/ImportPage.xaml
@@ -160,9 +160,24 @@
             </StackPanel.Transitions>
             <TextBlock Text="Volby importu" FontSize="20" FontWeight="SemiBold" />
             <StackPanel Orientation="Horizontal" Spacing="16">
-                <StackPanel Orientation="Vertical" Spacing="8">
+                <StackPanel Orientation="Vertical" Spacing="8" Width="200">
                     <CheckBox Content="Rekurzivně" IsChecked="{Binding Recursive, Mode=TwoWay}" />
                     <CheckBox Content="Zachovat FS metadata" IsChecked="{Binding KeepFsMetadata, Mode=TwoWay}" />
+                    <TextBox
+                        Header="Maska souborů"
+                        PlaceholderText="např. *.pdf"
+                        Text="{Binding SearchPattern, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                    <muxc:InfoBar
+                        Margin="0,4,0,0"
+                        IsOpen="{Binding HasSearchPatternError}"
+                        Severity="Error"
+                        Title="Neplatná maska"
+                        Message="{Binding SearchPatternErrorMessage}"
+                        IsClosable="False" />
+                    <TextBlock
+                        FontSize="12"
+                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                        Text="Použijte '*' nebo '?' jako zástupné znaky." />
                 </StackPanel>
                 <StackPanel Orientation="Vertical" Spacing="8">
                     <CheckBox Content="Nastavit jen pro čtení" IsChecked="{Binding SetReadOnly, Mode=TwoWay}" />


### PR DESCRIPTION
## Summary
- persist the import search pattern in hot state and settings storage
- add a configurable search pattern with validation to the WinUI import view-model
- expose a search pattern field with inline error messaging on the import options page

## Testing
- `dotnet build Veriado.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e2c2f348788326a8e242c68aa3a311