### PR TITLE
Add Lucene range filtering support and shared search field names

### DIFF
--- a/Veriado.Application.Tests/Search/SearchQueryBuilderTests.cs
+++ b/Veriado.Application.Tests/Search/SearchQueryBuilderTests.cs
@@ -1,0 +1,45 @@
+using System;
+using Veriado.Appl.Search;
+using Veriado.Domain.Search;
+using Xunit;
+
+namespace Veriado.Application.Tests.Search;
+
+public static class SearchQueryBuilderTests
+{
+    [Fact]
+    public static void Range_ModifiedDate_AddsNumericRangeFilter()
+    {
+        var builder = new SearchQueryBuilder();
+        var root = builder.Term(null, "report");
+        var from = new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+        builder.Range("modified", from, null);
+        var plan = builder.Build(root, "report");
+
+        var filter = Assert.Single(plan.RangeFilters);
+        Assert.Equal(SearchFieldNames.ModifiedTicks, filter.Field);
+        Assert.Equal(SearchRangeValueKind.Numeric, filter.ValueKind);
+        Assert.Equal(from.UtcTicks, filter.LowerValue);
+        Assert.True(filter.IncludeLower);
+        Assert.Null(filter.UpperValue);
+        Assert.False(filter.IncludeUpper);
+    }
+
+    [Fact]
+    public static void Range_SizeBytes_PopulatesBothBounds()
+    {
+        var builder = new SearchQueryBuilder();
+        var root = builder.Term(null, "log");
+
+        builder.Range("size", 1024, 4096);
+        var plan = builder.Build(root, "log");
+
+        var filter = Assert.Single(plan.RangeFilters);
+        Assert.Equal(SearchFieldNames.SizeBytes, filter.Field);
+        Assert.Equal(1024L, filter.LowerValue);
+        Assert.Equal(4096L, filter.UpperValue);
+        Assert.True(filter.IncludeLower);
+        Assert.True(filter.IncludeUpper);
+    }
+}

--- a/Veriado.Domain/Files/FileEntity.cs
+++ b/Veriado.Domain/Files/FileEntity.cs
@@ -389,6 +389,7 @@ public sealed class FileEntity : AggregateRoot
             Mime.Value,
             authorText,
             Name.Value,
+            Size.Value,
             CreatedUtc.Value,
             LastModifiedUtc.Value,
             metadataJson,

--- a/Veriado.Domain/Search/SearchDocument.cs
+++ b/Veriado.Domain/Search/SearchDocument.cs
@@ -14,6 +14,7 @@ public sealed record SearchDocument(
     string Mime,
     string? Author,
     string FileName,
+    long SizeBytes,
     DateTimeOffset CreatedUtc,
     DateTimeOffset ModifiedUtc,
     string? MetadataJson,

--- a/Veriado.Domain/Search/SearchFieldNames.cs
+++ b/Veriado.Domain/Search/SearchFieldNames.cs
@@ -1,0 +1,27 @@
+namespace Veriado.Domain.Search;
+
+/// <summary>
+/// Provides canonical field names exposed by the Lucene search index.
+/// </summary>
+public static class SearchFieldNames
+{
+    public const string Id = "id";
+    public const string Title = "title";
+    public const string Author = "author";
+    public const string MetadataText = "metadata_text";
+    public const string MetadataTextStored = "metadata_text_store";
+    public const string Metadata = "metadata";
+    public const string Mime = "mime";
+    public const string MimeSearch = "mime_search";
+    public const string FileName = "filename";
+    public const string FileNameSearch = "filename_search";
+    public const string ContentHash = "content_hash";
+    public const string CreatedUtc = "created_utc";
+    public const string ModifiedUtc = "modified_utc";
+    public const string CreatedTicks = "created_ticks";
+    public const string ModifiedTicks = "modified_ticks";
+    public const string ModifiedTicksSort = "modified_ticks_sort";
+    public const string SizeBytes = "size_bytes";
+    public const string SizeBytesSort = "size_bytes_sort";
+    public const string CatchAll = "catch_all";
+}

--- a/Veriado.Infrastructure/Integrity/FulltextIntegrityService.cs
+++ b/Veriado.Infrastructure/Integrity/FulltextIntegrityService.cs
@@ -58,7 +58,7 @@ internal sealed class FulltextIntegrityService : IFulltextIntegrityService
         for (var i = 0; i < reader.NumDocs; i++)
         {
             var doc = reader.Document(i);
-            if (Guid.TryParse(doc.Get(LuceneIndexManager.FieldNames.Id), out var parsed))
+            if (Guid.TryParse(doc.Get(SearchFieldNames.Id), out var parsed))
             {
                 indexIds.Add(parsed);
             }

--- a/Veriado.Infrastructure/Integrity/IndexAuditor.cs
+++ b/Veriado.Infrastructure/Integrity/IndexAuditor.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using Veriado.Domain.Search;
 using Veriado.Infrastructure.Persistence;
 using Veriado.Infrastructure.Search;
 
@@ -128,7 +129,7 @@ public sealed class IndexAuditor : IIndexAuditor
             {
                 ct.ThrowIfCancellationRequested();
                 var document = reader.Document(i);
-                if (Guid.TryParse(document.Get(LuceneIndexManager.FieldNames.Id), out var parsed))
+                if (Guid.TryParse(document.Get(SearchFieldNames.Id), out var parsed))
                 {
                     ids.Add(parsed);
                 }

--- a/Veriado.Infrastructure/Search/LuceneIndexManager.cs
+++ b/Veriado.Infrastructure/Search/LuceneIndexManager.cs
@@ -104,7 +104,7 @@ internal sealed class LuceneIndexManager : IDisposable
         try
         {
             var luceneDocument = CreateDocument(document);
-            var term = new Term(FieldNames.Id, document.FileId.ToString("D", CultureInfo.InvariantCulture));
+            var term = new Term(SearchFieldNames.Id, document.FileId.ToString("D", CultureInfo.InvariantCulture));
             _writer!.UpdateDocument(term, luceneDocument);
             _writer.Commit();
         }
@@ -121,7 +121,7 @@ internal sealed class LuceneIndexManager : IDisposable
         await _operationLock.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
-            var term = new Term(FieldNames.Id, fileId.ToString("D", CultureInfo.InvariantCulture));
+            var term = new Term(SearchFieldNames.Id, fileId.ToString("D", CultureInfo.InvariantCulture));
             _writer!.DeleteDocuments(term);
             _writer.Commit();
         }
@@ -162,25 +162,27 @@ internal sealed class LuceneIndexManager : IDisposable
 
         var doc = new Document
         {
-            new StringField(FieldNames.Id, document.FileId.ToString("D", CultureInfo.InvariantCulture), Field.Store.YES),
-            new StringField(FieldNames.Mime, mime, Field.Store.YES),
-            new StringField(FieldNames.FileName, fileName, Field.Store.YES),
-            new StoredField(FieldNames.Metadata, metadataJson),
-            new StoredField(FieldNames.ContentHash, document.ContentHash ?? string.Empty),
-            new StoredField(FieldNames.CreatedUtc, document.CreatedUtc.ToString("O", CultureInfo.InvariantCulture)),
-            new StoredField(FieldNames.ModifiedUtc, document.ModifiedUtc.ToString("O", CultureInfo.InvariantCulture)),
-            new StoredField(FieldNames.MetadataTextStored, metadataText),
-            new TextField(FieldNames.CatchAll, catchAll, Field.Store.NO),
-            new TextField(FieldNames.MetadataText, metadataText, Field.Store.YES),
-            new TextField(FieldNames.Title, title, Field.Store.YES),
-            new TextField(FieldNames.Author, author, Field.Store.YES),
+            new StringField(SearchFieldNames.Id, document.FileId.ToString("D", CultureInfo.InvariantCulture), Field.Store.YES),
+            new StringField(SearchFieldNames.Mime, mime, Field.Store.YES),
+            new StringField(SearchFieldNames.FileName, fileName, Field.Store.YES),
+            new StoredField(SearchFieldNames.Metadata, metadataJson),
+            new StoredField(SearchFieldNames.ContentHash, document.ContentHash ?? string.Empty),
+            new StoredField(SearchFieldNames.CreatedUtc, document.CreatedUtc.ToString("O", CultureInfo.InvariantCulture)),
+            new StoredField(SearchFieldNames.ModifiedUtc, document.ModifiedUtc.ToString("O", CultureInfo.InvariantCulture)),
+            new StoredField(SearchFieldNames.MetadataTextStored, metadataText),
+            new TextField(SearchFieldNames.CatchAll, catchAll, Field.Store.NO),
+            new TextField(SearchFieldNames.MetadataText, metadataText, Field.Store.YES),
+            new TextField(SearchFieldNames.Title, title, Field.Store.YES),
+            new TextField(SearchFieldNames.Author, author, Field.Store.YES),
         };
 
-        doc.Add(new TextField(FieldNames.FileNameSearch, fileName, Field.Store.NO));
-        doc.Add(new TextField(FieldNames.MimeSearch, mime, Field.Store.NO));
-        doc.Add(new Int64Field(FieldNames.ModifiedTicks, document.ModifiedUtc.UtcTicks, Field.Store.YES));
-        doc.Add(new Int64Field(FieldNames.CreatedTicks, document.CreatedUtc.UtcTicks, Field.Store.YES));
-        doc.Add(new NumericDocValuesField(FieldNames.ModifiedTicksSort, document.ModifiedUtc.UtcTicks));
+        doc.Add(new TextField(SearchFieldNames.FileNameSearch, fileName, Field.Store.NO));
+        doc.Add(new TextField(SearchFieldNames.MimeSearch, mime, Field.Store.NO));
+        doc.Add(new Int64Field(SearchFieldNames.ModifiedTicks, document.ModifiedUtc.UtcTicks, Field.Store.YES));
+        doc.Add(new Int64Field(SearchFieldNames.CreatedTicks, document.CreatedUtc.UtcTicks, Field.Store.YES));
+        doc.Add(new Int64Field(SearchFieldNames.SizeBytes, document.SizeBytes, Field.Store.YES));
+        doc.Add(new NumericDocValuesField(SearchFieldNames.ModifiedTicksSort, document.ModifiedUtc.UtcTicks));
+        doc.Add(new NumericDocValuesField(SearchFieldNames.SizeBytesSort, document.SizeBytes));
 
         return doc;
     }
@@ -223,24 +225,4 @@ internal sealed class LuceneIndexManager : IDisposable
         _operationLock.Dispose();
     }
 
-    internal static class FieldNames
-    {
-        public const string Id = "id";
-        public const string Title = "title";
-        public const string Author = "author";
-        public const string MetadataText = "metadata_text";
-        public const string MetadataTextStored = "metadata_text_store";
-        public const string Metadata = "metadata";
-        public const string Mime = "mime";
-        public const string MimeSearch = "mime_search";
-        public const string FileName = "filename";
-        public const string FileNameSearch = "filename_search";
-        public const string ContentHash = "content_hash";
-        public const string CreatedUtc = "created_utc";
-        public const string ModifiedUtc = "modified_utc";
-        public const string ModifiedTicks = "modified_ticks";
-        public const string CreatedTicks = "created_ticks";
-        public const string ModifiedTicksSort = "modified_ticks_sort";
-        public const string CatchAll = "catch_all";
-    }
 }


### PR DESCRIPTION
## Summary
- extend the search query plan and builder to capture Lucene range filters and propagate them to the query service
- index additional metadata such as file size with shared field-name constants and update integrity helpers
- add unit tests that verify the new range filter projections for modified timestamps and size limits

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e2ceb8ab1c832695d5dd68d5d086b1