### PR TITLE
Replace FTS terminology with Lucene equivalents

### DIFF
--- a/Veriado.Application.Tests/Search/LuceneQueryBuilderTests.cs
+++ b/Veriado.Application.Tests/Search/LuceneQueryBuilderTests.cs
@@ -6,14 +6,14 @@ using Xunit;
 
 namespace Veriado.Application.Tests.Search;
 
-public static class FtsQueryBuilderTests
+public static class LuceneQueryBuilderTests
 {
     [Fact]
     public static void BuildMatch_DropsReservedTokensFromRawInput()
     {
         var factory = new FakeAnalyzerFactory(text => text.Split(' ', StringSplitOptions.RemoveEmptyEntries));
 
-        var result = FtsQueryBuilder.BuildMatch("alpha and beta", prefix: false, allTerms: false, factory);
+        var result = LuceneQueryBuilder.BuildMatch("alpha and beta", prefix: false, allTerms: false, factory);
 
         Assert.Equal("alpha OR beta", result);
     }
@@ -23,7 +23,7 @@ public static class FtsQueryBuilderTests
     {
         var factory = new FakeAnalyzerFactory(text => text.Split(' ', StringSplitOptions.RemoveEmptyEntries));
 
-        var result = FtsQueryBuilder.BuildMatch("and or not", prefix: false, allTerms: false, factory);
+        var result = LuceneQueryBuilder.BuildMatch("and or not", prefix: false, allTerms: false, factory);
 
         Assert.Equal(string.Empty, result);
     }
@@ -33,7 +33,7 @@ public static class FtsQueryBuilderTests
     {
         var factory = new FakeAnalyzerFactory(_ => new[] { "alpha", "and" });
 
-        var result = FtsQueryBuilder.BuildMatch("alpha", prefix: false, allTerms: false, factory);
+        var result = LuceneQueryBuilder.BuildMatch("alpha", prefix: false, allTerms: false, factory);
 
         Assert.Equal("alpha OR \"and\"", result);
     }

--- a/Veriado.Application/Abstractions/IDiagnosticsRepository.cs
+++ b/Veriado.Application/Abstractions/IDiagnosticsRepository.cs
@@ -36,8 +36,8 @@ public sealed record DatabaseHealthSnapshot(
 /// </summary>
 /// <param name="TotalDocuments">Total number of indexed documents.</param>
 /// <param name="StaleDocuments">Number of documents marked as stale.</param>
-/// <param name="FtsVersion">The Lucene.NET version string.</param>
+/// <param name="LuceneVersion">The Lucene.NET version string.</param>
 public sealed record SearchIndexSnapshot(
     int TotalDocuments,
     int StaleDocuments,
-    string? FtsVersion);
+    string? LuceneVersion);

--- a/Veriado.Application/DependencyInjection/ApplicationServicesExtensions.cs
+++ b/Veriado.Application/DependencyInjection/ApplicationServicesExtensions.cs
@@ -86,7 +86,7 @@ public sealed class ApplicationOptions
     public int MaxGridPageSize { get; set; } = 200;
 
     /// <summary>
-    /// Gets or sets the maximum number of FTS candidates retrieved before applying filters.
+    /// Gets or sets the maximum number of Lucene candidates retrieved before applying filters.
     /// </summary>
     public int MaxFulltextCandidates { get; set; } = 2_000;
 }

--- a/Veriado.Application/README.md
+++ b/Veriado.Application/README.md
@@ -17,4 +17,4 @@ Aplikační projekt vystavuje veřejné API výhradně prostřednictvím MediatR
 
 Každý command má odpovídající validátor v `UseCases.Files.Validation`, který dědí z `FluentValidation.AbstractValidator` a zároveň implementuje `IRequestValidator<T>`, takže se automaticky zapojuje do pipeline. Spotřebitelé by měli pracovat výhradně s `IMediator.Send` a těmito UseCases.
 
-Dotazovací část je sjednocena v `UseCases.Queries` – například `FileGridQueryHandler` využívá `QueryableFilters`, `FtsQueryBuilder` a `TrigramQueryBuilder` pro pokročilé filtrování, řazení a fulltextové vyhledávání.
+Dotazovací část je sjednocena v `UseCases.Queries` – například `FileGridQueryHandler` využívá `QueryableFilters`, `LuceneQueryBuilder` a `TrigramQueryBuilder` pro pokročilé filtrování, řazení a fulltextové vyhledávání.

--- a/Veriado.Application/Search/Abstractions/SearchServices.cs
+++ b/Veriado.Application/Search/Abstractions/SearchServices.cs
@@ -220,7 +220,7 @@ public interface IFacetService
 }
 
 /// <summary>
-/// Provides synonym expansion for FTS queries.
+/// Provides synonym expansion for Lucene queries.
 /// </summary>
 public interface ISynonymProvider
 {
@@ -310,7 +310,7 @@ public interface ISearchTelemetry
     /// Updates gauges describing the current index size and document counts.
     /// </summary>
     /// <param name="documentCount">The total number of indexed documents.</param>
-    /// <param name="indexSizeBytes">The combined size of FTS and trigram indices, when known.</param>
+    /// <param name="indexSizeBytes">The combined size of Lucene and trigram indices, when known.</param>
     void UpdateIndexMetrics(long documentCount, long indexSizeBytes);
 
     /// <summary>

--- a/Veriado.Application/Search/ISearchQueryBuilder.cs
+++ b/Veriado.Application/Search/ISearchQueryBuilder.cs
@@ -48,7 +48,7 @@ public interface ISearchQueryBuilder
     /// <param name="field">The optional column restriction used for diagnostics.</param>
     /// <param name="term">The fuzzy term.</param>
     /// <param name="requireAllTerms">Indicates whether all trigram terms should match.</param>
-    /// <returns>An optional FTS node to combine with other clauses.</returns>
+    /// <returns>An optional search node to combine with other clauses.</returns>
     QueryNode? Fuzzy(string? field, string term, bool requireAllTerms = false);
 
     /// <summary>

--- a/Veriado.Application/Search/LuceneQueryBuilder.cs
+++ b/Veriado.Application/Search/LuceneQueryBuilder.cs
@@ -7,7 +7,7 @@ namespace Veriado.Appl.Search;
 /// <summary>
 /// Provides helpers to construct safe Lucene query expressions from raw user input.
 /// </summary>
-public static class FtsQueryBuilder
+public static class LuceneQueryBuilder
 {
     /// <summary>
     /// Builds a Lucene query expression from the provided text.

--- a/Veriado.Application/Search/QueryNode.cs
+++ b/Veriado.Application/Search/QueryNode.cs
@@ -3,7 +3,7 @@ namespace Veriado.Appl.Search;
 using System.Collections.Generic;
 
 /// <summary>
-/// Represents a node in the FTS query expression tree.
+/// Represents a node in the Lucene query expression tree.
 /// </summary>
 public abstract record QueryNode;
 

--- a/Veriado.Application/Search/SearchOptions.cs
+++ b/Veriado.Application/Search/SearchOptions.cs
@@ -7,7 +7,7 @@ namespace Veriado.Appl.Search;
 public sealed class SearchOptions
 {
     /// <summary>
-    /// Gets or sets the scoring configuration applied to FTS and hybrid queries.
+    /// Gets or sets the scoring configuration applied to Lucene and hybrid queries.
     /// </summary>
     public SearchScoreOptions Score { get; set; } = new();
 
@@ -67,7 +67,7 @@ public sealed class SearchScoreOptions
     public double DefaultTrigramScale { get; set; } = 0.45d;
     public double TrigramFloor { get; set; } = 0.30d;
     public string MergeMode { get; set; } = "max";
-    public double WeightedFts { get; set; } = 0.7d;
+    public double LuceneWeight { get; set; } = 0.7d;
 }
 
 /// <summary>

--- a/Veriado.Application/Search/SearchParseOptions.cs
+++ b/Veriado.Application/Search/SearchParseOptions.cs
@@ -11,12 +11,12 @@ public sealed class SearchParseOptions
     public bool EnableHeuristicFuzzy { get; set; } = true;
 
     /// <summary>
-    /// Gets or sets the minimum number of FTS hits required for prefix queries to avoid trigram fallback.
+    /// Gets or sets the minimum number of Lucene hits required for prefix queries to avoid trigram fallback.
     /// </summary>
     public int PrefixMinResults { get; set; } = 3;
 
     /// <summary>
-    /// Gets or sets the minimum number of FTS hits required for fuzzy queries to avoid trigram fallback.
+    /// Gets or sets the minimum number of Lucene hits required for fuzzy queries to avoid trigram fallback.
     /// </summary>
     public int FuzzyMinResults { get; set; } = 5;
 

--- a/Veriado.Application/Search/SearchQueryPlan.cs
+++ b/Veriado.Application/Search/SearchQueryPlan.cs
@@ -81,7 +81,7 @@ public static class SearchQueryPlanFactory
 }
 
 /// <summary>
-/// Describes a scoring configuration preserved for compatibility with legacy FTS queries.
+/// Describes a scoring configuration preserved for compatibility with legacy search queries.
 /// </summary>
 public sealed record SearchScorePlan
 {

--- a/Veriado.Application/Search/TrigramQueryBuilder.cs
+++ b/Veriado.Application/Search/TrigramQueryBuilder.cs
@@ -7,7 +7,7 @@ public static class TrigramQueryBuilder
 {
     /// <summary>
     /// Defines the maximum number of tokens that will be emitted when building a trigram index entry.
-    /// Keeping the limit reasonably low prevents pathological documents from bloating the FTS index
+    /// Keeping the limit reasonably low prevents pathological documents from bloating the Lucene-backed index
     /// while still capturing enough context for fuzzy matching.
     /// </summary>
     private const int MaxIndexTokens = 2048;

--- a/Veriado.Application/UseCases/Diagnostics/GetIndexStatisticsHandler.cs
+++ b/Veriado.Application/UseCases/Diagnostics/GetIndexStatisticsHandler.cs
@@ -17,7 +17,7 @@ public sealed class GetIndexStatisticsHandler : IRequestHandler<GetIndexStatisti
         try
         {
             var snapshot = await _diagnosticsRepository.GetIndexStatisticsAsync(cancellationToken).ConfigureAwait(false);
-            var dto = new IndexStatisticsDto(snapshot.TotalDocuments, snapshot.StaleDocuments, snapshot.FtsVersion);
+            var dto = new IndexStatisticsDto(snapshot.TotalDocuments, snapshot.StaleDocuments, snapshot.LuceneVersion);
             return AppResult<IndexStatisticsDto>.Success(dto);
         }
         catch (Exception ex)

--- a/Veriado.Application/UseCases/Queries/FileGrid/FileGridQueryHandler.cs
+++ b/Veriado.Application/UseCases/Queries/FileGrid/FileGridQueryHandler.cs
@@ -90,7 +90,7 @@ public sealed class FileGridQueryHandler : IRequestHandler<FileGridQuery, PageRe
 
         if (!string.IsNullOrWhiteSpace(dto.Text) && string.IsNullOrWhiteSpace(matchQuery) && !(favorite?.IsFuzzy ?? false))
         {
-            if (FtsQueryBuilder.TryBuild(dto.Text!, dto.TextPrefix, dto.TextAllTerms, _analyzerFactory, out var built))
+            if (LuceneQueryBuilder.TryBuild(dto.Text!, dto.TextPrefix, dto.TextAllTerms, _analyzerFactory, out var built))
             {
                 matchQuery = built;
             }

--- a/Veriado.Application/UseCases/Queries/FileGrid/FileGridQueryOptions.cs
+++ b/Veriado.Application/UseCases/Queries/FileGrid/FileGridQueryOptions.cs
@@ -11,7 +11,7 @@ public sealed class FileGridQueryOptions
     public int MaxPageSize { get; set; } = 200;
 
     /// <summary>
-    /// Gets or sets the maximum number of FTS candidates evaluated before filtering.
+    /// Gets or sets the maximum number of Lucene candidates evaluated before filtering.
     /// </summary>
     public int MaxCandidateResults { get; set; } = 2_000;
 }

--- a/Veriado.Contracts/Diagnostics/IndexStatisticsDto.cs
+++ b/Veriado.Contracts/Diagnostics/IndexStatisticsDto.cs
@@ -5,8 +5,8 @@ namespace Veriado.Contracts.Diagnostics;
 /// </summary>
 /// <param name="TotalDocuments">Total number of indexed documents.</param>
 /// <param name="StaleDocuments">Documents pending reindexing.</param>
-/// <param name="FtsVersion">The Lucene.NET version string.</param>
+/// <param name="LuceneVersion">The Lucene.NET version string.</param>
 public sealed record IndexStatisticsDto(
     int TotalDocuments,
     int StaleDocuments,
-    string? FtsVersion);
+    string? LuceneVersion);

--- a/Veriado.Contracts/Search/SearchFavoriteItem.cs
+++ b/Veriado.Contracts/Search/SearchFavoriteItem.cs
@@ -6,7 +6,7 @@ namespace Veriado.Contracts.Search;
 /// <param name="Id">The favourite identifier.</param>
 /// <param name="Name">The unique favourite name.</param>
 /// <param name="QueryText">The optional original query text.</param>
-/// <param name="MatchQuery">The generated FTS match query.</param>
+/// <param name="MatchQuery">The generated Lucene match query.</param>
 /// <param name="Position">The ordering position.</param>
 /// <param name="CreatedUtc">The creation timestamp.</param>
 /// <param name="IsFuzzy">Indicates whether the favourite uses fuzzy search.</param>

--- a/Veriado.Contracts/Search/SearchHistoryEntry.cs
+++ b/Veriado.Contracts/Search/SearchHistoryEntry.cs
@@ -5,7 +5,7 @@ namespace Veriado.Contracts.Search;
 /// </summary>
 /// <param name="Id">The entry identifier.</param>
 /// <param name="QueryText">The optional user supplied query text.</param>
-/// <param name="MatchQuery">The generated FTS match clause.</param>
+/// <param name="MatchQuery">The generated Lucene match clause.</param>
 /// <param name="LastQueriedUtc">The timestamp of the most recent execution.</param>
 /// <param name="Executions">The number of times the query was executed.</param>
 /// <param name="LastTotalHits">The last observed hit count.</param>

--- a/Veriado.Contracts/Search/SearchHitDto.cs
+++ b/Veriado.Contracts/Search/SearchHitDto.cs
@@ -16,7 +16,7 @@ public sealed record HighlightSpanDto(string Field, int Start, int Length, strin
 /// </summary>
 /// <param name="Id">The identifier of the matching file.</param>
 /// <param name="Score">The relevance score.</param>
-/// <param name="Source">The origin of the hit (FTS or TRIGRAM).</param>
+/// <param name="Source">The origin of the hit (Lucene or TRIGRAM).</param>
 /// <param name="PrimaryField">The field from which the snippet was generated.</param>
 /// <param name="SnippetText">The plain-text snippet.</param>
 /// <param name="Highlights">The highlight spans located within the snippet.</param>

--- a/Veriado.Domain/Search/SearchHit.cs
+++ b/Veriado.Domain/Search/SearchHit.cs
@@ -16,7 +16,7 @@ public sealed record HighlightSpan(string Field, int Start, int Length, string? 
 /// </summary>
 /// <param name="Id">The unique identifier of the matching document.</param>
 /// <param name="Score">The relevance score for the hit.</param>
-/// <param name="Source">The origin of the hit (e.g. FTS or TRIGRAM).</param>
+/// <param name="Source">The origin of the hit (e.g. LUCENE or TRIGRAM).</param>
 /// <param name="PrimaryField">The primary field used to generate the snippet.</param>
 /// <param name="SnippetText">The snippet presented to the caller.</param>
 /// <param name="Highlights">The highlight spans contained within the snippet.</param>

--- a/Veriado.Services/Search/SearchFacade.cs
+++ b/Veriado.Services/Search/SearchFacade.cs
@@ -36,7 +36,7 @@ public sealed class SearchFacade : ISearchFacade
             return Array.Empty<SearchHitDto>();
         }
 
-        var match = FtsQueryBuilder.BuildMatch(query, prefix: false, allTerms: false, _analyzerFactory);
+        var match = LuceneQueryBuilder.BuildMatch(query, prefix: false, allTerms: false, _analyzerFactory);
         if (string.IsNullOrWhiteSpace(match))
         {
             return Array.Empty<SearchHitDto>();
@@ -84,7 +84,7 @@ public sealed class SearchFacade : ISearchFacade
     public async Task AddToHistoryAsync(string query, CancellationToken ct)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(query);
-        if (!FtsQueryBuilder.TryBuild(query, prefix: true, allTerms: false, _analyzerFactory, out var matchQuery))
+        if (!LuceneQueryBuilder.TryBuild(query, prefix: true, allTerms: false, _analyzerFactory, out var matchQuery))
         {
             return;
         }

--- a/docs/completion-assessment.md
+++ b/docs/completion-assessment.md
@@ -14,7 +14,7 @@
 - **Data indexing health must cover binary ingestion.** Once text extraction exists, extend health diagnostics so `GetHealthStatusHandler` reports extractor/backlog issues, and surface warnings in the Files dashboard alongside current indexing alerts.【F:Veriado.Application/UseCases/Diagnostics/GetHealthStatusHandler.cs†L1-L200】【F:Veriado.WinUI/ViewModels/Files/FilesPageViewModel.cs†L19-L129】
 
 ## Quality & automation
-- **Test coverage focuses solely on query builders.** Testy pokrývají pouze Lucene/trigram buildery; chybí unit/integration testy pro importy, mutace souborů, UI view-modely nebo infrastrukturu. Rozšiřte sadu o doménové invariance, streamované importy a end-to-end smoke testy.【F:Veriado.Application.Tests/Search/FtsQueryBuilderTests.cs†L1-L64】【F:Veriado.Application.Tests/Search/TrigramQueryBuilderTests.cs†L1-L160】
+- **Test coverage focuses solely on query builders.** Testy pokrývají pouze Lucene/trigram buildery; chybí unit/integration testy pro importy, mutace souborů, UI view-modely nebo infrastrukturu. Rozšiřte sadu o doménové invariance, streamované importy a end-to-end smoke testy.【F:Veriado.Application.Tests/Search/LuceneQueryBuilderTests.cs†L1-L64】【F:Veriado.Application.Tests/Search/TrigramQueryBuilderTests.cs†L1-L160】
 - **Continuous integration is missing.** Add pipelines that build all projects, run tests, lint XAML, and produce signed MSIX artifacts. Include SQLite migration validation and full-text index smoke checks to catch regressions automatically.【F:README.md†L1-L68】
 
 ## Configuration & operations


### PR DESCRIPTION
## Summary
- rename the FTS query builder to `LuceneQueryBuilder` and update handlers, services, and tests to use it
- adjust search options, parser settings, and telemetry comments to reference Lucene rather than FTS
- expose the Lucene version in diagnostics DTOs and handlers instead of the legacy `FtsVersion` name

## Testing
- dotnet test *(fails: dotnet not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e2d4c3cf948326816f6d09c73a722c