### PR TITLE
Rename FTS query builder for Lucene transition

### DIFF
--- a/Veriado.Application.Tests/Search/LuceneQueryBuilderTests.cs
+++ b/Veriado.Application.Tests/Search/LuceneQueryBuilderTests.cs
@@ -6,14 +6,14 @@ using Xunit;
 
 namespace Veriado.Application.Tests.Search;
 
-public static class FtsQueryBuilderTests
+public static class LuceneQueryBuilderTests
 {
     [Fact]
     public static void BuildMatch_DropsReservedTokensFromRawInput()
     {
         var factory = new FakeAnalyzerFactory(text => text.Split(' ', StringSplitOptions.RemoveEmptyEntries));
 
-        var result = FtsQueryBuilder.BuildMatch("alpha and beta", prefix: false, allTerms: false, factory);
+        var result = LuceneQueryBuilder.BuildMatch("alpha and beta", prefix: false, allTerms: false, factory);
 
         Assert.Equal("alpha OR beta", result);
     }
@@ -23,7 +23,7 @@ public static class FtsQueryBuilderTests
     {
         var factory = new FakeAnalyzerFactory(text => text.Split(' ', StringSplitOptions.RemoveEmptyEntries));
 
-        var result = FtsQueryBuilder.BuildMatch("and or not", prefix: false, allTerms: false, factory);
+        var result = LuceneQueryBuilder.BuildMatch("and or not", prefix: false, allTerms: false, factory);
 
         Assert.Equal(string.Empty, result);
     }
@@ -33,7 +33,7 @@ public static class FtsQueryBuilderTests
     {
         var factory = new FakeAnalyzerFactory(_ => new[] { "alpha", "and" });
 
-        var result = FtsQueryBuilder.BuildMatch("alpha", prefix: false, allTerms: false, factory);
+        var result = LuceneQueryBuilder.BuildMatch("alpha", prefix: false, allTerms: false, factory);
 
         Assert.Equal("alpha OR \"and\"", result);
     }

--- a/Veriado.Application/README.md
+++ b/Veriado.Application/README.md
@@ -17,4 +17,4 @@ Aplikační projekt vystavuje veřejné API výhradně prostřednictvím MediatR
 
 Každý command má odpovídající validátor v `UseCases.Files.Validation`, který dědí z `FluentValidation.AbstractValidator` a zároveň implementuje `IRequestValidator<T>`, takže se automaticky zapojuje do pipeline. Spotřebitelé by měli pracovat výhradně s `IMediator.Send` a těmito UseCases.
 
-Dotazovací část je sjednocena v `UseCases.Queries` – například `FileGridQueryHandler` využívá `QueryableFilters`, `FtsQueryBuilder` a `TrigramQueryBuilder` pro pokročilé filtrování, řazení a fulltextové vyhledávání.
+Dotazovací část je sjednocena v `UseCases.Queries` – například `FileGridQueryHandler` využívá `QueryableFilters`, `LuceneQueryBuilder` a `TrigramQueryBuilder` pro pokročilé filtrování, řazení a fulltextové vyhledávání.

--- a/Veriado.Application/Search/LuceneQueryBuilder.cs
+++ b/Veriado.Application/Search/LuceneQueryBuilder.cs
@@ -7,7 +7,7 @@ namespace Veriado.Appl.Search;
 /// <summary>
 /// Provides helpers to construct safe Lucene query expressions from raw user input.
 /// </summary>
-public static class FtsQueryBuilder
+public static class LuceneQueryBuilder
 {
     /// <summary>
     /// Builds a Lucene query expression from the provided text.

--- a/Veriado.Application/UseCases/Queries/FileGrid/FileGridQueryHandler.cs
+++ b/Veriado.Application/UseCases/Queries/FileGrid/FileGridQueryHandler.cs
@@ -90,7 +90,7 @@ public sealed class FileGridQueryHandler : IRequestHandler<FileGridQuery, PageRe
 
         if (!string.IsNullOrWhiteSpace(dto.Text) && string.IsNullOrWhiteSpace(matchQuery) && !(favorite?.IsFuzzy ?? false))
         {
-            if (FtsQueryBuilder.TryBuild(dto.Text!, dto.TextPrefix, dto.TextAllTerms, _analyzerFactory, out var built))
+            if (LuceneQueryBuilder.TryBuild(dto.Text!, dto.TextPrefix, dto.TextAllTerms, _analyzerFactory, out var built))
             {
                 matchQuery = built;
             }

--- a/Veriado.Services/Search/SearchFacade.cs
+++ b/Veriado.Services/Search/SearchFacade.cs
@@ -36,7 +36,7 @@ public sealed class SearchFacade : ISearchFacade
             return Array.Empty<SearchHitDto>();
         }
 
-        var match = FtsQueryBuilder.BuildMatch(query, prefix: false, allTerms: false, _analyzerFactory);
+        var match = LuceneQueryBuilder.BuildMatch(query, prefix: false, allTerms: false, _analyzerFactory);
         if (string.IsNullOrWhiteSpace(match))
         {
             return Array.Empty<SearchHitDto>();
@@ -84,7 +84,7 @@ public sealed class SearchFacade : ISearchFacade
     public async Task AddToHistoryAsync(string query, CancellationToken ct)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(query);
-        if (!FtsQueryBuilder.TryBuild(query, prefix: true, allTerms: false, _analyzerFactory, out var matchQuery))
+        if (!LuceneQueryBuilder.TryBuild(query, prefix: true, allTerms: false, _analyzerFactory, out var matchQuery))
         {
             return;
         }

--- a/docs/completion-assessment.md
+++ b/docs/completion-assessment.md
@@ -14,7 +14,7 @@
 - **Data indexing health must cover binary ingestion.** Once text extraction exists, extend health diagnostics so `GetHealthStatusHandler` reports extractor/backlog issues, and surface warnings in the Files dashboard alongside current indexing alerts.【F:Veriado.Application/UseCases/Diagnostics/GetHealthStatusHandler.cs†L1-L200】【F:Veriado.WinUI/ViewModels/Files/FilesPageViewModel.cs†L19-L129】
 
 ## Quality & automation
-- **Test coverage focuses solely on query builders.** Testy pokrývají pouze Lucene/trigram buildery; chybí unit/integration testy pro importy, mutace souborů, UI view-modely nebo infrastrukturu. Rozšiřte sadu o doménové invariance, streamované importy a end-to-end smoke testy.【F:Veriado.Application.Tests/Search/FtsQueryBuilderTests.cs†L1-L64】【F:Veriado.Application.Tests/Search/TrigramQueryBuilderTests.cs†L1-L160】
+- **Test coverage focuses solely on query builders.** Testy pokrývají pouze Lucene/trigram buildery; chybí unit/integration testy pro importy, mutace souborů, UI view-modely nebo infrastrukturu. Rozšiřte sadu o doménové invariance, streamované importy a end-to-end smoke testy.【F:Veriado.Application.Tests/Search/LuceneQueryBuilderTests.cs†L1-L64】【F:Veriado.Application.Tests/Search/TrigramQueryBuilderTests.cs†L1-L160】
 - **Continuous integration is missing.** Add pipelines that build all projects, run tests, lint XAML, and produce signed MSIX artifacts. Include SQLite migration validation and full-text index smoke checks to catch regressions automatically.【F:README.md†L1-L68】
 
 ## Configuration & operations


### PR DESCRIPTION
## Summary
- rename the application-layer FTS query builder to `LuceneQueryBuilder` and update all call sites to reflect the Lucene engine
- align the associated unit test and documentation references with the new builder name

## Testing
- `dotnet test Veriado.Application.Tests/Veriado.Application.Tests.csproj` *(fails: `dotnet` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e2d702c7688326b31d8410d057f43b