### PR TITLE
Make LuceneIndexManager publicly accessible

### DIFF
--- a/Veriado.Infrastructure/Search/LuceneIndexManager.cs
+++ b/Veriado.Infrastructure/Search/LuceneIndexManager.cs
@@ -19,7 +19,7 @@ namespace Veriado.Infrastructure.Search;
 /// <summary>
 /// Provides shared Lucene.NET primitives for indexing and querying search documents.
 /// </summary>
-internal sealed class LuceneIndexManager : IDisposable
+public sealed class LuceneIndexManager : IDisposable
 {
     private readonly InfrastructureOptions _options;
     private readonly ILogger<LuceneIndexManager> _logger;


### PR DESCRIPTION
## Summary
- expose `LuceneIndexManager` as a public type so it can be injected into `IndexAuditor`

## Testing
- `dotnet build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e2d851fd7c8326af0f6188ecbafc42