### PR TITLE
Add auto export log option to import page

### DIFF
--- a/Veriado.WinUI/Services/Abstractions/IHotStateService.cs
+++ b/Veriado.WinUI/Services/Abstractions/IHotStateService.cs
@@ -22,5 +22,7 @@ public interface IHotStateService
 
     double? ImportMaxFileSizeMegabytes { get; set; }
 
+    bool ImportAutoExportLog { get; set; }
+
     Task InitializeAsync(CancellationToken cancellationToken = default);
 }

--- a/Veriado.WinUI/Services/Abstractions/ISettingsService.cs
+++ b/Veriado.WinUI/Services/Abstractions/ISettingsService.cs
@@ -48,4 +48,7 @@ public sealed class ImportPreferences
 
     public double? MaxFileSizeMegabytes { get; set; }
         = null;
+
+    public bool? AutoExportLog { get; set; }
+        = null;
 }

--- a/Veriado.WinUI/Services/HotStateService.cs
+++ b/Veriado.WinUI/Services/HotStateService.cs
@@ -40,6 +40,9 @@ public sealed partial class HotStateService : ObservableObject, IHotStateService
     [ObservableProperty]
     private double? importMaxFileSizeMegabytes;
 
+    [ObservableProperty]
+    private bool importAutoExportLog;
+
     public HotStateService(
         ISettingsService settingsService,
         IStatusService statusService,
@@ -72,6 +75,7 @@ public sealed partial class HotStateService : ObservableObject, IHotStateService
             importMaxFileSizeMegabytes = import.MaxFileSizeMegabytes.HasValue && import.MaxFileSizeMegabytes.Value > 0
                 ? import.MaxFileSizeMegabytes
                 : null;
+            importAutoExportLog = import.AutoExportLog ?? false;
 
             OnPropertyChanged(nameof(ImportRecursive));
             OnPropertyChanged(nameof(ImportKeepFsMetadata));
@@ -80,6 +84,7 @@ public sealed partial class HotStateService : ObservableObject, IHotStateService
             OnPropertyChanged(nameof(ImportMaxDegreeOfParallelism));
             OnPropertyChanged(nameof(ImportDefaultAuthor));
             OnPropertyChanged(nameof(ImportMaxFileSizeMegabytes));
+            OnPropertyChanged(nameof(ImportAutoExportLog));
             _initialized = true;
         }
         finally
@@ -110,6 +115,8 @@ public sealed partial class HotStateService : ObservableObject, IHotStateService
     partial void OnImportSetReadOnlyChanged(bool value) => PersistAsync();
 
     partial void OnImportUseParallelChanged(bool value) => PersistAsync();
+
+    partial void OnImportAutoExportLogChanged(bool value) => PersistAsync();
 
     partial void OnImportMaxDegreeOfParallelismChanged(int value)
     {
@@ -185,6 +192,7 @@ public sealed partial class HotStateService : ObservableObject, IHotStateService
                     settings.Import.MaxFileSizeMegabytes = ImportMaxFileSizeMegabytes.HasValue && ImportMaxFileSizeMegabytes.Value > 0
                         ? ImportMaxFileSizeMegabytes
                         : null;
+                    settings.Import.AutoExportLog = ImportAutoExportLog;
                 }).ConfigureAwait(false);
             }
             finally

--- a/Veriado.WinUI/Views/Import/ImportPage.xaml
+++ b/Veriado.WinUI/Views/Import/ImportPage.xaml
@@ -163,6 +163,9 @@
                 <StackPanel Orientation="Vertical" Spacing="8">
                     <CheckBox Content="Rekurzivně" IsChecked="{Binding Recursive, Mode=TwoWay}" />
                     <CheckBox Content="Zachovat FS metadata" IsChecked="{Binding KeepFsMetadata, Mode=TwoWay}" />
+                    <CheckBox
+                        Content="Automaticky exportovat protokol po dokončení"
+                        IsChecked="{Binding AutoExportLog, Mode=TwoWay}" />
                 </StackPanel>
                 <StackPanel Orientation="Vertical" Spacing="8">
                     <CheckBox Content="Nastavit jen pro čtení" IsChecked="{Binding SetReadOnly, Mode=TwoWay}" />


### PR DESCRIPTION
## Summary
- add an ImportPage checkbox that toggles automatic export of the import log
- persist the preference via the hot state service and settings storage
- reuse the export routine to automatically write the log after batch completion

## Testing
- `dotnet test` *(fails: dotnet: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e541c17e908326bd4b9f119e45b4e5