### PR TITLE
Add file detail dialog to FilesPage items

### DIFF
--- a/Veriado.WinUI/ViewModels/Files/FileDetailViewModel.cs
+++ b/Veriado.WinUI/ViewModels/Files/FileDetailViewModel.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Globalization;
+using Veriado.Contracts.Files;
+using Veriado.WinUI.Converters;
+
+namespace Veriado.WinUI.ViewModels.Files;
+
+public sealed class FileDetailViewModel
+{
+    private static readonly SizeToHumanConverter SizeConverter = new();
+    private static readonly CultureInfo Culture = CultureInfo.GetCultureInfo("cs-CZ");
+
+    public FileDetailViewModel(FileSummaryDto file)
+    {
+        File = file ?? throw new ArgumentNullException(nameof(file));
+    }
+
+    public FileSummaryDto File { get; }
+
+    public Guid Id => File.Id;
+
+    public string Name => File.Name;
+
+    public string? Title => string.IsNullOrWhiteSpace(File.Title) ? null : File.Title;
+
+    public bool HasTitle => !string.IsNullOrWhiteSpace(Title);
+
+    public string Extension => File.Extension;
+
+    public string Mime => File.Mime;
+
+    public string Author => File.Author;
+
+    public string SizeText => (string)SizeConverter.Convert(File.Size, typeof(string), null, string.Empty);
+
+    public int Version => File.Version;
+
+    public string ReadOnlyText => File.IsReadOnly ? "Ano" : "Ne";
+
+    public string CreatedText => FormatDateTime(File.CreatedUtc);
+
+    public string LastModifiedText => FormatDateTime(File.LastModifiedUtc);
+
+    public bool HasValidity => File.Validity is not null;
+
+    public string IssuedAtText => File.Validity is { } validity ? FormatDateTime(validity.IssuedAt) : string.Empty;
+
+    public string ValidUntilText => File.Validity is { } validity ? FormatDateTime(validity.ValidUntil) : string.Empty;
+
+    public string PhysicalCopyText => File.Validity?.HasPhysicalCopy == true ? "Ano" : "Ne";
+
+    public string ElectronicCopyText => File.Validity?.HasElectronicCopy == true ? "Ano" : "Ne";
+
+    public string DialogTitle => string.IsNullOrWhiteSpace(Name)
+        ? "Detail souboru"
+        : $"Detail souboru – {Name}";
+
+    private static string FormatDateTime(DateTimeOffset value)
+    {
+        return value.ToLocalTime().ToString("dd.MM.yyyy HH:mm", Culture);
+    }
+}

--- a/Veriado.WinUI/Views/Files/FileDetailView.xaml
+++ b/Veriado.WinUI/Views/Files/FileDetailView.xaml
@@ -1,0 +1,108 @@
+<UserControl
+    x:Class="Veriado.WinUI.Views.Files.FileDetailView"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    x:DefaultBindMode="OneWay">
+    <ScrollViewer VerticalScrollBarVisibility="Auto">
+        <StackPanel Padding="12" Spacing="16">
+            <StackPanel Spacing="4">
+                <TextBlock
+                    FontSize="20"
+                    FontWeight="SemiBold"
+                    Text="{x:Bind ViewModel.Name}" />
+                <TextBlock
+                    FontStyle="Italic"
+                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                    Text="{x:Bind ViewModel.Title}"
+                    Visibility="{x:Bind ViewModel.HasTitle, Converter={StaticResource BooleanToVisibilityConverter}}" />
+            </StackPanel>
+
+            <StackPanel Spacing="8">
+                <TextBlock FontWeight="SemiBold" Text="Základní údaje" />
+                <Grid RowSpacing="4" ColumnSpacing="16">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="160" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+
+                    <TextBlock Grid.Row="0" Grid.Column="0" FontWeight="SemiBold" Text="ID" />
+                    <TextBlock
+                        Grid.Row="0"
+                        Grid.Column="1"
+                        FontFamily="Consolas"
+                        Text="{x:Bind ViewModel.Id}" />
+
+                    <TextBlock Grid.Row="1" Grid.Column="0" FontWeight="SemiBold" Text="Název" />
+                    <TextBlock Grid.Row="1" Grid.Column="1" Text="{x:Bind ViewModel.Name}" TextWrapping="Wrap" />
+
+                    <TextBlock Grid.Row="2" Grid.Column="0" FontWeight="SemiBold" Text="Přípona" />
+                    <TextBlock Grid.Row="2" Grid.Column="1" Text="{x:Bind ViewModel.Extension}" />
+
+                    <TextBlock Grid.Row="3" Grid.Column="0" FontWeight="SemiBold" Text="MIME" />
+                    <TextBlock Grid.Row="3" Grid.Column="1" Text="{x:Bind ViewModel.Mime}" TextWrapping="Wrap" />
+
+                    <TextBlock Grid.Row="4" Grid.Column="0" FontWeight="SemiBold" Text="Autor" />
+                    <TextBlock Grid.Row="4" Grid.Column="1" Text="{x:Bind ViewModel.Author}" TextWrapping="Wrap" />
+
+                    <TextBlock Grid.Row="5" Grid.Column="0" FontWeight="SemiBold" Text="Velikost" />
+                    <TextBlock Grid.Row="5" Grid.Column="1" Text="{x:Bind ViewModel.SizeText}" />
+
+                    <TextBlock Grid.Row="6" Grid.Column="0" FontWeight="SemiBold" Text="Verze" />
+                    <TextBlock Grid.Row="6" Grid.Column="1" Text="{x:Bind ViewModel.Version}" />
+
+                    <TextBlock Grid.Row="7" Grid.Column="0" FontWeight="SemiBold" Text="Jen pro čtení" />
+                    <TextBlock Grid.Row="7" Grid.Column="1" Text="{x:Bind ViewModel.ReadOnlyText}" />
+
+                    <TextBlock Grid.Row="8" Grid.Column="0" FontWeight="SemiBold" Text="Vytvořeno" />
+                    <TextBlock Grid.Row="8" Grid.Column="1" Text="{x:Bind ViewModel.CreatedText}" />
+
+                    <TextBlock Grid.Row="9" Grid.Column="0" FontWeight="SemiBold" Text="Poslední změna" />
+                    <TextBlock Grid.Row="9" Grid.Column="1" Text="{x:Bind ViewModel.LastModifiedText}" />
+                </Grid>
+            </StackPanel>
+
+            <StackPanel Spacing="8">
+                <TextBlock FontWeight="SemiBold" Text="Platnost" />
+                <StackPanel
+                    Spacing="4"
+                    Visibility="{x:Bind ViewModel.HasValidity, Converter={StaticResource BooleanToVisibilityConverter}}">
+                    <StackPanel Orientation="Horizontal" Spacing="4">
+                        <TextBlock FontWeight="SemiBold" Text="Platí od:" />
+                        <TextBlock Text="{x:Bind ViewModel.IssuedAtText}" />
+                    </StackPanel>
+                    <StackPanel Orientation="Horizontal" Spacing="4">
+                        <TextBlock FontWeight="SemiBold" Text="Platí do:" />
+                        <TextBlock Text="{x:Bind ViewModel.ValidUntilText}" />
+                    </StackPanel>
+                    <StackPanel Orientation="Horizontal" Spacing="4">
+                        <TextBlock FontWeight="SemiBold" Text="Fyzická kopie:" />
+                        <TextBlock Text="{x:Bind ViewModel.PhysicalCopyText}" />
+                    </StackPanel>
+                    <StackPanel Orientation="Horizontal" Spacing="4">
+                        <TextBlock FontWeight="SemiBold" Text="Elektronická kopie:" />
+                        <TextBlock Text="{x:Bind ViewModel.ElectronicCopyText}" />
+                    </StackPanel>
+                </StackPanel>
+                <TextBlock
+                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                    Text="Dokument nemá nastavenou platnost."
+                    Visibility="{x:Bind !ViewModel.HasValidity, Converter={StaticResource BooleanToVisibilityConverter}}" />
+            </StackPanel>
+        </StackPanel>
+    </ScrollViewer>
+</UserControl>

--- a/Veriado.WinUI/Views/Files/FileDetailView.xaml.cs
+++ b/Veriado.WinUI/Views/Files/FileDetailView.xaml.cs
@@ -1,0 +1,21 @@
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Veriado.WinUI.ViewModels.Files;
+
+namespace Veriado.WinUI.Views.Files;
+
+public sealed partial class FileDetailView : UserControl
+{
+    public FileDetailView()
+    {
+        InitializeComponent();
+        DataContextChanged += OnDataContextChanged;
+    }
+
+    public FileDetailViewModel? ViewModel => DataContext as FileDetailViewModel;
+
+    private void OnDataContextChanged(FrameworkElement sender, DataContextChangedEventArgs args)
+    {
+        Bindings.Update();
+    }
+}

--- a/Veriado.WinUI/Views/Files/FilesPage.xaml
+++ b/Veriado.WinUI/Views/Files/FilesPage.xaml
@@ -240,28 +240,39 @@
 
                     <controls:ItemsRepeater.ItemTemplate>
                         <DataTemplate x:DataType="contracts:FileSummaryDto">
-                            <Border
+                            <Button
                                 Margin="8"
-                                Padding="12"
-                                CornerRadius="6"
-                                BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}"
-                                BorderThickness="1"
-                                HorizontalAlignment="Stretch">
-                                <StackPanel Spacing="4">
-                                    <TextBlock
-                                        Text="{x:Bind Name}"
-                                        FontWeight="SemiBold"
-                                        TextWrapping="Wrap" />
-                                    <TextBlock
-                                        Text="{x:Bind Mime}"
-                                        FontSize="12"
-                                        Opacity="0.7"
-                                        TextTrimming="CharacterEllipsis" />
-                                    <TextBlock
-                                        Text="{x:Bind Size, Converter={StaticResource SizeToHumanConverter}}"
-                                        FontSize="12" />
-                                </StackPanel>
-                            </Border>
+                                Padding="0"
+                                Background="Transparent"
+                                BorderBrush="Transparent"
+                                BorderThickness="0"
+                                HorizontalAlignment="Stretch"
+                                Command="{x:Bind ViewModel.OpenDetailsCommand}"
+                                CommandParameter="{x:Bind}">
+                                <Button.Content>
+                                    <Border
+                                        Padding="12"
+                                        CornerRadius="6"
+                                        BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}"
+                                        BorderThickness="1"
+                                        HorizontalAlignment="Stretch">
+                                        <StackPanel Spacing="4">
+                                            <TextBlock
+                                                Text="{x:Bind Name}"
+                                                FontWeight="SemiBold"
+                                                TextWrapping="Wrap" />
+                                            <TextBlock
+                                                Text="{x:Bind Mime}"
+                                                FontSize="12"
+                                                Opacity="0.7"
+                                                TextTrimming="CharacterEllipsis" />
+                                            <TextBlock
+                                                Text="{x:Bind Size, Converter={StaticResource SizeToHumanConverter}}"
+                                                FontSize="12" />
+                                        </StackPanel>
+                                    </Border>
+                                </Button.Content>
+                            </Button>
                         </DataTemplate>
                     </controls:ItemsRepeater.ItemTemplate>
                 </controls:ItemsRepeater>


### PR DESCRIPTION
## Summary
- make file entries on the Files page clickable and trigger a details dialog
- introduce a dialog view and view model that present core file metadata and validity information
- hook the new dialog into the existing page view model via a dedicated command

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e55b8aa8ac8326a5d59546fad7bae4