### PR TITLE
Fix FilesPage command binding for item template button

### DIFF
--- a/Veriado.WinUI/Views/Files/FilesPage.xaml
+++ b/Veriado.WinUI/Views/Files/FilesPage.xaml
@@ -247,7 +247,7 @@
                                 BorderBrush="Transparent"
                                 BorderThickness="0"
                                 HorizontalAlignment="Stretch"
-                                Command="{x:Bind ViewModel.OpenDetailsCommand}"
+                                Command="{x:Bind RelativeSource={RelativeSource AncestorType=Page}, Path=ViewModel.OpenDetailsCommand}"
                                 CommandParameter="{x:Bind}">
                                 <Button.Content>
                                     <Border


### PR DESCRIPTION
## Summary
- bind the file item button command via a page ancestor lookup so compiled bindings can resolve the page ViewModel

## Testing
- not run (dotnet CLI unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68e55f69c8a0832681bd69459a668c04