### PR TITLE
Fix metadata command initialization for file detail dialog

### DIFF
--- a/Veriado.WinUI/ViewModels/Files/FileDetailDialogViewModel.cs
+++ b/Veriado.WinUI/ViewModels/Files/FileDetailDialogViewModel.cs
@@ -42,6 +42,10 @@ public partial class FileDetailDialogViewModel : ViewModelBase
         _fileOperationsService = fileOperationsService ?? throw new ArgumentNullException(nameof(fileOperationsService));
         _fileId = summary.Id;
 
+        _saveMetadataCommand = new AsyncRelayCommand(SaveMetadataAsync, CanSaveMetadata);
+        _saveValidityCommand = new AsyncRelayCommand(SaveValidityAsync, CanSaveValidity);
+        _clearValidityCommand = new AsyncRelayCommand(ClearValidityAsync, CanClearValidity);
+
         DisplayName = BuildDisplayName(summary);
         Title = summary.Title;
         Mime = summary.Mime;
@@ -56,10 +60,6 @@ public partial class FileDetailDialogViewModel : ViewModelBase
         IndexedTitle = summary.IndexedTitle;
         IndexSchemaVersion = summary.IndexSchemaVersion;
         IndexedContentHash = summary.IndexedContentHash;
-
-        _saveMetadataCommand = new AsyncRelayCommand(SaveMetadataAsync, CanSaveMetadata);
-        _saveValidityCommand = new AsyncRelayCommand(SaveValidityAsync, CanSaveValidity);
-        _clearValidityCommand = new AsyncRelayCommand(ClearValidityAsync, CanClearValidity);
     }
 
     public event EventHandler? ChangesSaved;


### PR DESCRIPTION
## Summary
- instantiate metadata and validity commands before setting observable properties in the file detail dialog view model to avoid null command usage during initialization

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e56513a1f88326bac6fefe8118cb99