### PR TITLE
Fix WinUI bindings and clean up unsupported properties

### DIFF
--- a/Veriado.WinUI/Views/Files/FileDetailDialog.xaml
+++ b/Veriado.WinUI/Views/Files/FileDetailDialog.xaml
@@ -81,8 +81,7 @@
                     <StackPanel Spacing="4">
                         <TextBlock Text="Platí od" />
                         <controls:DatePicker
-                            Date="{Binding ValidityIssuedDate, Mode=TwoWay}"
-                            PlaceholderText="Vyberte datum" />
+                            Date="{Binding ValidityIssuedDate, Mode=TwoWay}" />
                         <controls:TimePicker
                             Time="{Binding ValidityIssuedTime, Mode=TwoWay}"
                             ClockIdentifier="24HourClock" />
@@ -90,8 +89,7 @@
                     <StackPanel Spacing="4">
                         <TextBlock Text="Platí do" />
                         <controls:DatePicker
-                            Date="{Binding ValidityUntilDate, Mode=TwoWay}"
-                            PlaceholderText="Vyberte datum" />
+                            Date="{Binding ValidityUntilDate, Mode=TwoWay}" />
                         <controls:TimePicker
                             Time="{Binding ValidityUntilTime, Mode=TwoWay}"
                             ClockIdentifier="24HourClock" />

--- a/Veriado.WinUI/Views/Files/FilesPage.xaml
+++ b/Veriado.WinUI/Views/Files/FilesPage.xaml
@@ -1,5 +1,6 @@
 <Page
     x:Class="Veriado.WinUI.Views.Files.FilesPage"
+    x:Name="PageRoot"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -248,7 +249,7 @@
                                 BorderThickness="1"
                                 Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
                                 HorizontalContentAlignment="Stretch"
-                                Command="{x:Bind ViewModel.OpenDetailCommand}"
+                                Command="{x:Bind PageRoot.ViewModel.OpenDetailCommand}"
                                 CommandParameter="{x:Bind}">
                                 <StackPanel Spacing="4">
                                     <TextBlock


### PR DESCRIPTION
## Summary
- name the files page root so data templates can bind to the page view model
- point the file card command binding at the page view model
- remove unsupported placeholder text properties from date pickers in the file detail dialog

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e565ab6194832689fab7e39842fddf