### PR TITLE
Fix file details command binding

### DIFF
--- a/Veriado.WinUI/Views/Files/FilesPage.xaml
+++ b/Veriado.WinUI/Views/Files/FilesPage.xaml
@@ -247,8 +247,8 @@
                                 BorderBrush="Transparent"
                                 BorderThickness="0"
                                 HorizontalAlignment="Stretch"
-                                Command="{x:Bind RelativeSource={RelativeSource AncestorType=Page}, Path=ViewModel.OpenDetailsCommand}"
-                                CommandParameter="{x:Bind}">
+                                Command="{Binding DataContext.OpenDetailsCommand, RelativeSource={RelativeSource AncestorType=Page}}"
+                                CommandParameter="{Binding}">
                                 <Button.Content>
                                     <Border
                                         Padding="12"


### PR DESCRIPTION
## Summary
- replace the `x:Bind` command binding in `FilesPage.xaml` with a standard binding that resolves the page DataContext to the view model

## Testing
- dotnet build Veriado.sln *(fails: `dotnet` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e5689041c48326b80aafb847d4694e