### PR TITLE
Fix FilesPage OpenDetailCommand binding

### DIFF
--- a/Veriado.WinUI/Views/Files/FilesPage.xaml
+++ b/Veriado.WinUI/Views/Files/FilesPage.xaml
@@ -6,6 +6,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:controls="using:Microsoft.UI.Xaml.Controls"
+    xmlns:views="using:Veriado.WinUI.Views.Files"
     xmlns:converters="using:Veriado.WinUI.Converters"
     xmlns:contracts="using:Veriado.Contracts.Files"
     mc:Ignorable="d">
@@ -249,7 +250,7 @@
                                 BorderThickness="1"
                                 Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
                                 HorizontalContentAlignment="Stretch"
-                                Command="{x:Bind ElementName=PageRoot, Path=ViewModel.OpenDetailCommand}"
+                                Command="{x:Bind Path=ViewModel.OpenDetailCommand, RelativeSource={RelativeSource AncestorType=views:FilesPage}}"
                                 CommandParameter="{x:Bind}">
                                 <StackPanel Spacing="4">
                                     <TextBlock


### PR DESCRIPTION
## Summary
- update the files page item template binding to access the page view model via RelativeSource
- add the namespace declaration required for the new RelativeSource binding

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e56d062e4c832696d91a810cff89fe