### PR TITLE
fix(winui): resolve FilesPage command binding errors

### DIFF
--- a/Veriado.WinUI/Views/Files/FilesPage.xaml
+++ b/Veriado.WinUI/Views/Files/FilesPage.xaml
@@ -13,6 +13,7 @@
     <Page.Resources>
         <converters:NullableIntToDoubleConverter x:Key="NullableIntToDoubleConverter" />
         <converters:NullableLongToDoubleConverter x:Key="NullableLongToDoubleConverter" />
+        <converters:SizeToHumanConverter x:Key="SizeToHumanConverter" />
     </Page.Resources>
 
     <Grid Padding="24" RowSpacing="16" ColumnSpacing="24">
@@ -250,8 +251,7 @@
                                 BorderThickness="1"
                                 Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
                                 HorizontalContentAlignment="Stretch"
-                                Command="{x:Bind Path=ViewModel.OpenDetailCommand, RelativeSource={RelativeSource AncestorType=views:FilesPage}}"
-                                CommandParameter="{x:Bind}">
+                                Click="OnOpenDetailClick">
                                 <StackPanel Spacing="4">
                                     <TextBlock
                                         Text="{x:Bind Name}"

--- a/Veriado.WinUI/Views/Files/FilesPage.xaml.cs
+++ b/Veriado.WinUI/Views/Files/FilesPage.xaml.cs
@@ -1,5 +1,6 @@
 using System;
 using Microsoft.UI.Xaml;
+using Veriado.Contracts.Files;
 using Veriado.WinUI.ViewModels.Files;
 
 namespace Veriado.WinUI.Views.Files;
@@ -32,5 +33,13 @@ public sealed partial class FilesPage : Page
     private Task ExecuteInitialRefreshAsync()
     {
         return ViewModel.RefreshCommand.ExecuteAsync(null);
+    }
+
+    private async void OnOpenDetailClick(object sender, RoutedEventArgs e)
+    {
+        if (sender is FrameworkElement fe && fe.DataContext is FileSummaryDto dto)
+        {
+            await ViewModel.OpenDetailCommand.ExecuteAsync(dto);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- replace the FilesPage item template command x:Bind usage with a click handler to eliminate XLS0413/XLS0432
- forward item clicks to ViewModel.OpenDetailCommand from the code-behind
- register SizeToHumanConverter in the page resources for the item template

## Testing
- not run (dotnet CLI is unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68e6b4fb33c08326a350a9c56e799c4d