### PR TITLE
Ensure file list items stretch full width

### DIFF
--- a/Veriado.WinUI/Views/Files/FilesPage.xaml
+++ b/Veriado.WinUI/Views/Files/FilesPage.xaml
@@ -250,6 +250,7 @@
                                 BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}"
                                 BorderThickness="1"
                                 Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                                HorizontalAlignment="Stretch"
                                 HorizontalContentAlignment="Stretch"
                                 Click="OnOpenDetailClick">
                                 <StackPanel Spacing="4">


### PR DESCRIPTION
## Summary
- stretch file items so they use the full width of the repeater

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e6b7e989bc8326995b8e290d48c61f