### PR TITLE
fix: guard FilesPage detail command invocation

### DIFF
--- a/Veriado.WinUI/Views/Files/FilesPage.xaml.cs
+++ b/Veriado.WinUI/Views/Files/FilesPage.xaml.cs
@@ -35,11 +35,14 @@ public sealed partial class FilesPage : Page
         return ViewModel.RefreshCommand.ExecuteAsync(null);
     }
 
-    private async void OnOpenDetailClick(object sender, RoutedEventArgs e)
+    private void OnOpenDetailClick(object sender, RoutedEventArgs e)
     {
         if (sender is FrameworkElement fe && fe.DataContext is FileSummaryDto dto)
         {
-            await ViewModel.OpenDetailCommand.ExecuteAsync(dto);
+            if (ViewModel.OpenDetailCommand.CanExecute(dto))
+            {
+                ViewModel.OpenDetailCommand.Execute(dto);
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- update FilesPage click handler to call the async command via Execute and CanExecute checks
- avoid awaiting the command in the async void handler to preserve exception containment behavior

## Testing
- not run (dotnet CLI is unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68e6be473078832689572c6f07636a50