### PR TITLE
Ensure FTS write-ahead logging joins active transactions

### DIFF
--- a/Veriado.Infrastructure/Search/SqliteFts5Indexer.cs
+++ b/Veriado.Infrastructure/Search/SqliteFts5Indexer.cs
@@ -70,15 +70,10 @@ internal sealed class SqliteFts5Indexer : ISearchIndexer
 
         try
         {
-            var journalId = await helper
-                .IndexAsync(document, connection, transaction, beforeCommit, cancellationToken, enlistJournal: false)
+            await helper
+                .IndexAsync(document, connection, transaction, beforeCommit, cancellationToken)
                 .ConfigureAwait(false);
             await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
-            if (journalId.HasValue)
-            {
-                await _writeAhead.ClearAsync(connection, transaction: null, journalId.Value, cancellationToken)
-                    .ConfigureAwait(false);
-            }
         }
         catch
         {
@@ -112,15 +107,10 @@ internal sealed class SqliteFts5Indexer : ISearchIndexer
 
         try
         {
-            var journalId = await helper
-                .DeleteAsync(fileId, connection, transaction, beforeCommit, cancellationToken, enlistJournal: false)
+            await helper
+                .DeleteAsync(fileId, connection, transaction, beforeCommit, cancellationToken)
                 .ConfigureAwait(false);
             await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
-            if (journalId.HasValue)
-            {
-                await _writeAhead.ClearAsync(connection, transaction: null, journalId.Value, cancellationToken)
-                    .ConfigureAwait(false);
-            }
         }
         catch
         {


### PR DESCRIPTION
## Summary
- ensure the SQLite FTS indexer enlists write-ahead logging operations in the ambient transaction
- avoid executing write-ahead log commands without a transaction when the connection already has one

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e92943961c832683ee9f1d83b4f84f