### PR TITLE
Phase 0: annotate deferred indexing dependencies

### DIFF
--- a/Veriado.Application/Abstractions/ISearchIndexCoordinator.cs
+++ b/Veriado.Application/Abstractions/ISearchIndexCoordinator.cs
@@ -17,9 +17,11 @@ public interface ISearchIndexCoordinator
     /// <returns><see langword="true"/> when the document was indexed immediately; otherwise <see langword="false"/>.</returns>
     Task<bool> IndexAsync(FileEntity file, FilePersistenceOptions options, DbTransaction? transaction, CancellationToken cancellationToken);
 
+    #region TODO(SQLiteOnly): Remove deferred indexing refresh once outbox pipeline is removed
     /// <summary>
     /// Forces any deferred indexing work to be processed immediately.
     /// </summary>
     /// <param name="cancellationToken">The cancellation token.</param>
     Task SearchIndexRefreshAsync(CancellationToken cancellationToken);
+    #endregion
 }

--- a/Veriado.Infrastructure/Concurrency/WriteWorker.cs
+++ b/Veriado.Infrastructure/Concurrency/WriteWorker.cs
@@ -19,6 +19,7 @@ internal sealed class WriteWorker : BackgroundService
     private readonly IDbContextFactory<AppDbContext> _dbContextFactory;
     private readonly ILogger<WriteWorker> _logger;
     private readonly InfrastructureOptions _options;
+    #region TODO(SQLiteOnly): Streamline dependencies after removing deferred/outbox pipeline
     private readonly ISearchIndexCoordinator _searchCoordinator;
     private readonly ISearchIndexer _searchIndexer;
     private readonly IFulltextIntegrityService _integrityService;
@@ -29,6 +30,7 @@ internal sealed class WriteWorker : BackgroundService
     private readonly INeedsReindexEvaluator _needsReindexEvaluator;
     private readonly ISearchIndexSignatureCalculator _signatureCalculator;
     private readonly FtsWriteAheadService _writeAhead;
+    #endregion
 
     public WriteWorker(
         IWriteQueue writeQueue,

--- a/Veriado.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/Veriado.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
@@ -146,10 +146,13 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<ISearchIndexer>(sp => sp.GetRequiredService<SqliteFts5Indexer>());
         services.AddSingleton<ISearchIndexCoordinator, SqliteSearchIndexCoordinator>();
         services.AddSingleton<IDatabaseMaintenanceService, SqliteDatabaseMaintenanceService>();
+
+        #region TODO(SQLiteOnly): Collapse query pipeline to SQLite-only implementation (remove hybrid + trigram)
         services.AddSingleton<SqliteFts5QueryService>();
         services.AddSingleton<TrigramQueryService>();
         services.AddSingleton<HybridSearchQueryService>();
         services.AddSingleton<ISearchQueryService>(sp => sp.GetRequiredService<HybridSearchQueryService>());
+        #endregion
         services.AddSingleton<FtsWriteAheadService>();
         services.AddSingleton<ISearchHistoryService, SearchHistoryService>();
         services.AddSingleton<ISearchFavoritesService, SearchFavoritesService>();

--- a/Veriado.Infrastructure/Search/HybridSearchQueryService.cs
+++ b/Veriado.Infrastructure/Search/HybridSearchQueryService.cs
@@ -9,11 +9,13 @@ namespace Veriado.Infrastructure.Search;
 /// </summary>
 internal sealed class HybridSearchQueryService : ISearchQueryService
 {
+    #region TODO(SQLiteOnly): Replace dual-provider aggregation with SQLite FTS-only queries
     private readonly SqliteFts5QueryService _ftsService;
     private readonly TrigramQueryService _trigramService;
     private readonly ISearchTelemetry _telemetry;
     private readonly SearchScoreOptions _scoreOptions;
     private readonly SearchParseOptions _parseOptions;
+    #endregion
 
     public HybridSearchQueryService(
         SqliteFts5QueryService ftsService,

--- a/Veriado.Infrastructure/Search/Outbox/OutboxDeadLetterEvent.cs
+++ b/Veriado.Infrastructure/Search/Outbox/OutboxDeadLetterEvent.cs
@@ -5,6 +5,7 @@ namespace Veriado.Infrastructure.Search.Outbox;
 /// </summary>
 public sealed class OutboxDeadLetterEvent
 {
+    #region TODO(SQLiteOnly): Remove dead-letter persistence once deferred pipeline is retired
     public long Id { get; set; }
         = 0;
 
@@ -28,4 +29,5 @@ public sealed class OutboxDeadLetterEvent
 
     public string Error { get; set; }
         = string.Empty;
+    #endregion
 }

--- a/Veriado.Infrastructure/Search/Outbox/OutboxEvent.cs
+++ b/Veriado.Infrastructure/Search/Outbox/OutboxEvent.cs
@@ -7,6 +7,7 @@ namespace Veriado.Infrastructure.Search.Outbox;
 /// </summary>
 public sealed class OutboxEvent
 {
+    #region TODO(SQLiteOnly): Remove legacy outbox storage once direct SQLite indexing is synchronous
     public long Id { get; set; }
         = 0;
 
@@ -37,4 +38,5 @@ public sealed class OutboxEvent
             Attempts = 0,
         };
     }
+    #endregion
 }

--- a/Veriado.Infrastructure/Search/SqliteSearchIndexCoordinator.cs
+++ b/Veriado.Infrastructure/Search/SqliteSearchIndexCoordinator.cs
@@ -58,9 +58,11 @@ internal sealed class SqliteSearchIndexCoordinator : ISearchIndexCoordinator
         return true;
     }
 
+    #region TODO(SQLiteOnly): Remove no-op deferred indexing hook when outbox is deleted
     public Task SearchIndexRefreshAsync(CancellationToken cancellationToken)
     {
         _logger.LogDebug("SearchIndexRefreshAsync invoked with no deferred indexing to process.");
         return Task.CompletedTask;
     }
+    #endregion
 }


### PR DESCRIPTION
## Summary
- annotate deferred indexing and multi-provider hotspots with TODO-focused regions
- document SQLite-only migration targets without changing runtime behavior

## Phase 0 Report
- Veriado.Application/Abstractions/ISearchIndexCoordinator (ISearchIndexCoordinator) — remove deferred refresh hook tied to the outbox pipeline
- Veriado.Infrastructure/Search/SqliteSearchIndexCoordinator (SqliteSearchIndexCoordinator) — drop the no-op outbox refresh method
- Veriado.Infrastructure/DependencyInjection/ServiceCollectionExtensions (ServiceCollectionExtensions) — collapse hybrid/trigram DI registrations into a SQLite-only stack
- Veriado.Infrastructure/Search/HybridSearchQueryService (HybridSearchQueryService) — replace dual-provider aggregation with FTS-only logic
- Veriado.Infrastructure/Search/Outbox/OutboxEvent (OutboxEvent) — delete legacy outbox persistence once synchronous indexing lands
- Veriado.Infrastructure/Search/Outbox/OutboxDeadLetterEvent (OutboxDeadLetterEvent) — remove dead-letter tracking alongside the outbox retirement
- Veriado.Infrastructure/Concurrency/WriteWorker (WriteWorker) — streamline dependencies when deferred indexing is removed

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68ea8e49d9048326a167b1595eb31ff3