### PR TITLE
Enforce SQLite provider guard and synchronous indexing

### DIFF
--- a/Veriado.Infrastructure/Search/SqliteSearchIndexCoordinator.cs
+++ b/Veriado.Infrastructure/Search/SqliteSearchIndexCoordinator.cs
@@ -10,6 +10,8 @@ namespace Veriado.Infrastructure.Search;
 /// </summary>
 internal sealed class SqliteSearchIndexCoordinator : ISearchIndexCoordinator
 {
+    private const string IndexingMode = "SameTransaction";
+
     private readonly InfrastructureOptions _options;
     private readonly ILogger<SqliteSearchIndexCoordinator> _logger;
     private readonly IAnalyzerFactory _analyzerFactory;
@@ -38,6 +40,14 @@ internal sealed class SqliteSearchIndexCoordinator : ISearchIndexCoordinator
         {
             _logger.LogDebug("Skipping full-text indexing for file {FileId} because FTS5 support is unavailable.", file.Id);
             return false;
+        }
+
+        if (options.AllowDeferredIndexing)
+        {
+            _logger.LogWarning(
+                "Deferred indexing requested for file {FileId}, but FtsIndexingMode '{IndexingMode}' enforces synchronous processing.",
+                file.Id,
+                IndexingMode);
         }
 
         if (transaction is not SqliteTransaction sqliteTransaction)


### PR DESCRIPTION
## Summary
- fail fast during infrastructure initialization when the configured EF Core provider is not Microsoft.Data.Sqlite
- normalize persistence options in the write worker to force same-transaction indexing and log ignored deferred requests
- warn on deferred requests inside the SQLite search coordinator and gate the outbox DI registrations behind `#if NEVER`

## Testing
- `dotnet build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68eaa0a302308326a5283245841db015