### PR TITLE
Add DLQ monitoring and health check for FTS write-ahead operations

### DIFF
--- a/Veriado.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/Veriado.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
@@ -81,7 +81,9 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<ISearchTelemetry, SearchTelemetry>();
         services.AddSingleton<SqlitePragmaInterceptor>();
         services.AddSingleton<ISqliteConnectionFactory, PooledSqliteConnectionFactory>();
-        services.AddHealthChecks().AddCheck<SqlitePragmaHealthCheck>("sqlite_pragmas");
+        services.AddHealthChecks()
+            .AddCheck<SqlitePragmaHealthCheck>("sqlite_pragmas")
+            .AddCheck<FtsDlqHealthCheck>("fts_write_ahead_dlq");
 
         var searchOptions = services.AddOptions<SearchOptions>();
         if (configuration is not null)
@@ -161,6 +163,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<ISearchQueryService>(sp => sp.GetRequiredService<HybridSearchQueryService>());
         #endregion
         services.AddSingleton<FtsWriteAheadService>();
+        services.AddSingleton<IFtsDlqMonitor>(sp => sp.GetRequiredService<FtsWriteAheadService>());
         services.AddSingleton<ISearchHistoryService, SearchHistoryService>();
         services.AddSingleton<ISearchFavoritesService, SearchFavoritesService>();
         services.AddSingleton<ISynonymProvider, SynonymService>();

--- a/Veriado.Infrastructure/Search/FtsDlqHealthCheck.cs
+++ b/Veriado.Infrastructure/Search/FtsDlqHealthCheck.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Logging;
+
+namespace Veriado.Infrastructure.Search;
+
+/// <summary>
+/// Reports the health of the FTS write-ahead dead-letter queue.
+/// </summary>
+internal sealed class FtsDlqHealthCheck : IHealthCheck
+{
+    private const int HealthyThreshold = 100;
+    private const int DegradedThreshold = 1000;
+
+    private readonly IFtsDlqMonitor _monitor;
+    private readonly ILogger<FtsDlqHealthCheck> _logger;
+
+    public FtsDlqHealthCheck(IFtsDlqMonitor monitor, ILogger<FtsDlqHealthCheck> logger)
+    {
+        _monitor = monitor ?? throw new ArgumentNullException(nameof(monitor));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var count = await _monitor.GetDlqCountAsync(cancellationToken).ConfigureAwait(false);
+            var data = new Dictionary<string, object?>
+            {
+                ["dlqCount"] = count,
+            };
+
+            if (count < HealthyThreshold)
+            {
+                return HealthCheckResult.Healthy(
+                    $"FTS write-ahead DLQ contains {count} entries.",
+                    data);
+            }
+
+            if (count < DegradedThreshold)
+            {
+                return HealthCheckResult.Degraded(
+                    $"FTS write-ahead DLQ backlog is {count} entries.",
+                    data: data);
+            }
+
+            return HealthCheckResult.Unhealthy(
+                $"FTS write-ahead DLQ backlog is {count} entries.",
+                data: data);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to evaluate FTS write-ahead DLQ health.");
+            return HealthCheckResult.Unhealthy(
+                "Failed to query FTS write-ahead DLQ backlog.",
+                ex);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- expose DLQ monitoring capabilities from the FTS write-ahead service, including a retry helper
- add a health check that reports the DLQ backlog using the new monitor interface
- register the monitor and health check in the infrastructure dependency injection setup

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68eaa7d9ac6c8326aa1bc56d64a73a67