### PR TITLE
Harden SQLite retry and corruption handling

### DIFF
--- a/Veriado.Infrastructure/Search/SqliteFts5Transactional.cs
+++ b/Veriado.Infrastructure/Search/SqliteFts5Transactional.cs
@@ -114,9 +114,9 @@ internal sealed class SqliteFts5Transactional
 
             return enlistJournal ? null : journalId;
         }
-        catch (SqliteException ex) when (ex.IndicatesDatabaseCorruption() || ex.IndicatesFulltextSchemaMissing())
+        catch (SqliteException ex) when (ex.IndicatesFatalFulltextFailure())
         {
-            throw new SearchIndexCorruptedException("SQLite full-text index is corrupted and needs to be repaired.", ex);
+            throw new SearchIndexCorruptedException("SQLite full-text index became unavailable and needs to be repaired.", ex);
         }
     }
 
@@ -198,9 +198,9 @@ internal sealed class SqliteFts5Transactional
 
             return enlistJournal ? null : journalId;
         }
-        catch (SqliteException ex) when (ex.IndicatesDatabaseCorruption() || ex.IndicatesFulltextSchemaMissing())
+        catch (SqliteException ex) when (ex.IndicatesFatalFulltextFailure())
         {
-            throw new SearchIndexCorruptedException("SQLite full-text index is corrupted and needs to be repaired.", ex);
+            throw new SearchIndexCorruptedException("SQLite full-text index became unavailable and needs to be repaired.", ex);
         }
     }
 


### PR DESCRIPTION
## Summary
- extend ExecuteWithRetryAsync with busy/IO-specific backoffs, retry metrics logging, and fatal error detection
- expose helpers to classify SQLite exceptions and mark fatal full-text failures
- propagate fatal SQLite failures from SqliteFts5Transactional so corruption triggers automatic repair

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68eaaae267b483269274a11dd653a4f0