### PR TITLE
Add telemetry and structured logs for FTS and repair workflows

### DIFF
--- a/Veriado.Application/Search/Abstractions/SearchServices.cs
+++ b/Veriado.Application/Search/Abstractions/SearchServices.cs
@@ -326,6 +326,12 @@ public interface ISearchTelemetry
     void UpdateIndexMetrics(long documentCount, long indexSizeBytes);
 
     /// <summary>
+    /// Updates gauges describing the current FTS dead-letter queue depth.
+    /// </summary>
+    /// <param name="entryCount">The number of entries currently in the dead-letter queue.</param>
+    void UpdateDeadLetterQueueSize(long entryCount);
+
+    /// <summary>
     /// Records the elapsed time of a full-text index verification pass.
     /// </summary>
     /// <param name="elapsed">The elapsed duration.</param>
@@ -347,4 +353,10 @@ public interface ISearchTelemetry
     /// Records a repair failure.
     /// </summary>
     void RecordRepairFailure();
+
+    /// <summary>
+    /// Records the number of SQLITE_BUSY retries encountered during an operation.
+    /// </summary>
+    /// <param name="retryCount">The number of retries to add to the counter.</param>
+    void RecordSqliteBusyRetry(int retryCount);
 }


### PR DESCRIPTION
## Summary
- extend the search telemetry abstraction with dead-letter gauge updates and busy retry counters exposed via OpenTelemetry instruments
- add structured transaction and DLQ logging throughout the FTS write-ahead service while keeping the dead-letter gauge current
- surface audit and repair progress via logs and telemetry in the index auditor, repair service, and write worker retry loop

## Testing
- not run (dotnet not installed in container)


------
https://chatgpt.com/codex/tasks/task_e_68eaac94e84483268597e744c17e5d8d