### PR TITLE
Fix Sqlite health check result data argument usage

### DIFF
--- a/Veriado.Infrastructure/Persistence/SqlitePragmaHealthCheck.cs
+++ b/Veriado.Infrastructure/Persistence/SqlitePragmaHealthCheck.cs
@@ -76,12 +76,12 @@ internal sealed class SqlitePragmaHealthCheck : IHealthCheck
         {
             return HealthCheckResult.Unhealthy(
                 "SQLite PRAGMA settings remain non-compliant after automatic remediation attempts.",
-                BuildData(repaired));
+                data: BuildData(repaired));
         }
 
         return HealthCheckResult.Degraded(
             "SQLite PRAGMA settings required corrective action. Values were updated automatically.",
-            BuildData(repaired));
+            data: BuildData(repaired));
     }
 
     private static IReadOnlyDictionary<string, object?> BuildData(SqlitePragmaHelper.SqlitePragmaState state)


### PR DESCRIPTION
## Summary
- pass the PRAGMA state dictionary to health check results using the data parameter

## Testing
- dotnet build *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68eaaf362e6c8326a4494b2376d9528d