### PR TITLE
Ensure SQLite transaction is available to the write worker

### DIFF
--- a/Veriado.Infrastructure/Concurrency/WriteWorker.cs
+++ b/Veriado.Infrastructure/Concurrency/WriteWorker.cs
@@ -238,12 +238,17 @@ internal sealed class WriteWorker : BackgroundService
             await sqliteConnection.OpenAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        await using var sqliteTransaction = await sqliteConnection
+        await using var dbTransaction = await sqliteConnection
             .BeginTransactionAsync(cancellationToken)
             .ConfigureAwait(false);
 
+        if (dbTransaction is not SqliteTransaction sqliteTransaction)
+        {
+            throw new InvalidOperationException("SQLite transaction is required for write operations.");
+        }
+
         await using var transaction = await context.Database
-            .UseTransactionAsync(sqliteTransaction, cancellationToken)
+            .UseTransactionAsync(dbTransaction, cancellationToken)
             .ConfigureAwait(false);
 
         var transactionId = Guid.NewGuid();


### PR DESCRIPTION
## Summary
- ensure the write worker opens a SQLite transaction and validates the concrete type
- reuse the validated transaction when enlisting the EF context so full-text updates receive a SqliteTransaction instance

## Testing
- dotnet build Veriado.sln *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68eab0322acc8326b23ca1bb2823a8ee