### PR TITLE
Remove deferred indexing pipeline remnants

### DIFF
--- a/Veriado.Application/Abstractions/FilePersistenceOptions.cs
+++ b/Veriado.Application/Abstractions/FilePersistenceOptions.cs
@@ -13,11 +13,6 @@ public readonly struct FilePersistenceOptions
     }
 
     /// <summary>
-    /// Gets a value indicating whether the search coordinator may defer indexing to the outbox pipeline.
-    /// </summary>
-    public bool AllowDeferredIndexing { get; init; } = false;
-
-    /// <summary>
     /// Gets the default persistence options.
     /// </summary>
     public static FilePersistenceOptions Default => new();

--- a/Veriado.Application/Abstractions/ISearchIndexCoordinator.cs
+++ b/Veriado.Application/Abstractions/ISearchIndexCoordinator.cs
@@ -17,11 +17,4 @@ public interface ISearchIndexCoordinator
     /// <returns><see langword="true"/> when the document was indexed immediately; otherwise <see langword="false"/>.</returns>
     Task<bool> IndexAsync(FileEntity file, FilePersistenceOptions options, DbTransaction? transaction, CancellationToken cancellationToken);
 
-    #region TODO(SQLiteOnly): Remove deferred indexing refresh once outbox pipeline is removed
-    /// <summary>
-    /// Forces any deferred indexing work to be processed immediately.
-    /// </summary>
-    /// <param name="cancellationToken">The cancellation token.</param>
-    Task SearchIndexRefreshAsync(CancellationToken cancellationToken);
-    #endregion
 }

--- a/Veriado.Application/UseCases/Maintenance/ReindexCorpusAfterSchemaUpgradeCommand.cs
+++ b/Veriado.Application/UseCases/Maintenance/ReindexCorpusAfterSchemaUpgradeCommand.cs
@@ -4,5 +4,4 @@ namespace Veriado.Appl.UseCases.Maintenance;
 /// Requests a complete reindex of the corpus after a search schema upgrade.
 /// </summary>
 public sealed record ReindexCorpusAfterSchemaUpgradeCommand(
-    int TargetSchemaVersion,
-    bool AllowDeferredIndexing = false) : IRequest<AppResult<int>>;
+    int TargetSchemaVersion) : IRequest<AppResult<int>>;

--- a/Veriado.Application/UseCases/Maintenance/ReindexCorpusAfterSchemaUpgradeHandler.cs
+++ b/Veriado.Application/UseCases/Maintenance/ReindexCorpusAfterSchemaUpgradeHandler.cs
@@ -25,16 +25,13 @@ public sealed class ReindexCorpusAfterSchemaUpgradeHandler : IRequestHandler<Rei
 
         try
         {
-            var options = new FilePersistenceOptions
-            {
-                AllowDeferredIndexing = request.AllowDeferredIndexing,
-            };
-
             await foreach (var file in _repository.StreamAllAsync(cancellationToken))
             {
                 var timestamp = UtcTimestamp.From(_clock.UtcNow);
                 file.BumpSchemaVersion(request.TargetSchemaVersion, timestamp);
-                await _repository.UpdateAsync(file, options, cancellationToken).ConfigureAwait(false);
+                await _repository
+                    .UpdateAsync(file, FilePersistenceOptions.Default, cancellationToken)
+                    .ConfigureAwait(false);
                 reindexed++;
             }
 

--- a/Veriado.Infrastructure/Concurrency/WriteWorker.cs
+++ b/Veriado.Infrastructure/Concurrency/WriteWorker.cs
@@ -23,7 +23,6 @@ internal sealed class WriteWorker : BackgroundService
     private readonly IDbContextFactory<AppDbContext> _dbContextFactory;
     private readonly ILogger<WriteWorker> _logger;
     private readonly InfrastructureOptions _options;
-    #region TODO(SQLiteOnly): Streamline dependencies after removing deferred/outbox pipeline
     private readonly ISearchIndexCoordinator _searchCoordinator;
     private readonly ISearchIndexer _searchIndexer;
     private readonly IFulltextIntegrityService _integrityService;
@@ -35,12 +34,8 @@ internal sealed class WriteWorker : BackgroundService
     private readonly ISearchIndexSignatureCalculator _signatureCalculator;
     private readonly FtsWriteAheadService _writeAhead;
     private readonly ISearchTelemetry _telemetry;
-    #endregion
 
-    private static readonly FilePersistenceOptions SameTransactionOptions = new()
-    {
-        AllowDeferredIndexing = false,
-    };
+    private static readonly FilePersistenceOptions SameTransactionOptions = FilePersistenceOptions.Default;
 
     public WriteWorker(
         IWriteQueue writeQueue,
@@ -262,7 +257,7 @@ internal sealed class WriteWorker : BackgroundService
             {
                 foreach (var tracked in trackedFiles)
                 {
-                    trackedOptions[tracked.Entity] = NormalizePersistenceOptions(tracked.Entity, tracked.Options);
+                    trackedOptions[tracked.Entity] = NormalizePersistenceOptions(tracked.Options);
                 }
             }
         }
@@ -475,15 +470,9 @@ internal sealed class WriteWorker : BackgroundService
             transactionId);
     }
 
-    private FilePersistenceOptions NormalizePersistenceOptions(FileEntity file, FilePersistenceOptions requestedOptions)
+    private static FilePersistenceOptions NormalizePersistenceOptions(FilePersistenceOptions requestedOptions)
     {
-        if (requestedOptions.AllowDeferredIndexing)
-        {
-            _logger.LogWarning(
-                "Deferred indexing requested for file {FileId}, but SameTransaction mode is enforced. Processing inline instead.",
-                file.Id);
-        }
-
+        _ = requestedOptions;
         return SameTransactionOptions;
     }
 

--- a/Veriado.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/Veriado.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
@@ -149,11 +149,6 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<SqliteFts5Indexer>();
         services.AddSingleton<ISearchIndexer>(sp => sp.GetRequiredService<SqliteFts5Indexer>());
         services.AddSingleton<ISearchIndexCoordinator, SqliteSearchIndexCoordinator>();
-#if NEVER
-        // Outbox pipeline registrations are disabled for the SQLite-only phase but kept for future providers.
-        services.AddSingleton<ISearchIndexOutbox, SqliteSearchIndexOutbox>();
-        services.AddHostedService<SearchIndexOutboxWorker>();
-#endif
         services.AddSingleton<IDatabaseMaintenanceService, SqliteDatabaseMaintenanceService>();
 
         #region TODO(SQLiteOnly): Collapse query pipeline to SQLite-only implementation (remove hybrid + trigram)

--- a/Veriado.Infrastructure/Search/Outbox/OutboxDeadLetterEvent.cs
+++ b/Veriado.Infrastructure/Search/Outbox/OutboxDeadLetterEvent.cs
@@ -1,3 +1,4 @@
+#if NEVER
 namespace Veriado.Infrastructure.Search.Outbox;
 
 /// <summary>
@@ -31,3 +32,4 @@ public sealed class OutboxDeadLetterEvent
         = string.Empty;
     #endregion
 }
+#endif

--- a/Veriado.Infrastructure/Search/Outbox/OutboxEvent.cs
+++ b/Veriado.Infrastructure/Search/Outbox/OutboxEvent.cs
@@ -1,3 +1,4 @@
+#if NEVER
 using System.Text.Json;
 
 namespace Veriado.Infrastructure.Search.Outbox;
@@ -40,3 +41,4 @@ public sealed class OutboxEvent
     }
     #endregion
 }
+#endif

--- a/Veriado.Infrastructure/Search/SqliteSearchIndexCoordinator.cs
+++ b/Veriado.Infrastructure/Search/SqliteSearchIndexCoordinator.cs
@@ -42,14 +42,6 @@ internal sealed class SqliteSearchIndexCoordinator : ISearchIndexCoordinator
             return false;
         }
 
-        if (options.AllowDeferredIndexing)
-        {
-            _logger.LogWarning(
-                "Deferred indexing requested for file {FileId}, but FtsIndexingMode '{IndexingMode}' enforces synchronous processing.",
-                file.Id,
-                IndexingMode);
-        }
-
         if (transaction is not SqliteTransaction sqliteTransaction)
         {
             throw new InvalidOperationException("SQLite transaction is required for full-text indexing operations.");
@@ -68,11 +60,4 @@ internal sealed class SqliteSearchIndexCoordinator : ISearchIndexCoordinator
         return true;
     }
 
-    #region TODO(SQLiteOnly): Remove no-op deferred indexing hook when outbox is deleted
-    public Task SearchIndexRefreshAsync(CancellationToken cancellationToken)
-    {
-        _logger.LogDebug("SearchIndexRefreshAsync invoked with no deferred indexing to process.");
-        return Task.CompletedTask;
-    }
-    #endregion
 }

--- a/Veriado.Services/Maintenance/IMaintenanceService.cs
+++ b/Veriado.Services/Maintenance/IMaintenanceService.cs
@@ -11,5 +11,5 @@ public interface IMaintenanceService
 
     Task<AppResult<int>> RunVacuumAndOptimizeAsync(CancellationToken cancellationToken);
 
-    Task<AppResult<int>> ReindexAfterSchemaUpgradeAsync(int targetSchemaVersion, bool allowDeferredIndexing, CancellationToken cancellationToken);
+    Task<AppResult<int>> ReindexAfterSchemaUpgradeAsync(int targetSchemaVersion, CancellationToken cancellationToken);
 }

--- a/Veriado.Services/Maintenance/MaintenanceService.cs
+++ b/Veriado.Services/Maintenance/MaintenanceService.cs
@@ -32,9 +32,9 @@ public sealed class MaintenanceService : IMaintenanceService
         return _mediator.Send(new VacuumAndOptimizeDatabaseCommand(), cancellationToken);
     }
 
-    public Task<AppResult<int>> ReindexAfterSchemaUpgradeAsync(int targetSchemaVersion, bool allowDeferredIndexing, CancellationToken cancellationToken)
+    public Task<AppResult<int>> ReindexAfterSchemaUpgradeAsync(int targetSchemaVersion, CancellationToken cancellationToken)
     {
-        var command = new ReindexCorpusAfterSchemaUpgradeCommand(targetSchemaVersion, allowDeferredIndexing);
+        var command = new ReindexCorpusAfterSchemaUpgradeCommand(targetSchemaVersion);
         return _mediator.Send(command, cancellationToken);
     }
 }


### PR DESCRIPTION
## Summary
- remove deferred indexing options from the application surface now that indexing is always synchronous
- drop the unused search index outbox wiring and hide the legacy entities behind `#if NEVER`
- keep the SQLite write worker focused on same-transaction indexing by normalising persistence options to the default mode

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68eaafe3f18c83268fb974913926bdc8