### PR TITLE
Remove legacy outbox tables from EF Core schema

### DIFF
--- a/Veriado.Infrastructure/Migrations/20251011194732_SyncModel.Designer.cs
+++ b/Veriado.Infrastructure/Migrations/20251011194732_SyncModel.Designer.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Veriado.Infrastructure.Persistence;
 
@@ -10,9 +11,11 @@ using Veriado.Infrastructure.Persistence;
 namespace Veriado.Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20251011194732_SyncModel")]
+    partial class SyncModel
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "9.0.9");

--- a/Veriado.Infrastructure/Migrations/20251011194732_SyncModel.cs
+++ b/Veriado.Infrastructure/Migrations/20251011194732_SyncModel.cs
@@ -1,0 +1,70 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Veriado.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class SyncModel : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "outbox_dlq");
+
+            migrationBuilder.DropTable(
+                name: "outbox_events");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "outbox_dlq",
+                columns: table => new
+                {
+                    id = table.Column<long>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    attempts = table.Column<int>(type: "INTEGER", nullable: false),
+                    created_utc = table.Column<string>(type: "TEXT", nullable: false),
+                    dead_lettered_utc = table.Column<string>(type: "TEXT", nullable: false),
+                    error = table.Column<string>(type: "TEXT", nullable: false),
+                    outbox_id = table.Column<long>(type: "INTEGER", nullable: false),
+                    payload = table.Column<string>(type: "TEXT", nullable: false),
+                    type = table.Column<string>(type: "TEXT", maxLength: 128, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_outbox_dlq", x => x.id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "outbox_events",
+                columns: table => new
+                {
+                    id = table.Column<long>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    attempts = table.Column<int>(type: "INTEGER", nullable: false, defaultValue: 0),
+                    created_utc = table.Column<string>(type: "TEXT", nullable: false),
+                    payload = table.Column<string>(type: "TEXT", nullable: false),
+                    processed_utc = table.Column<string>(type: "TEXT", nullable: true),
+                    type = table.Column<string>(type: "TEXT", maxLength: 128, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_outbox_events", x => x.id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "idx_outbox_dlq_dead_lettered",
+                table: "outbox_dlq",
+                column: "dead_lettered_utc");
+
+            migrationBuilder.CreateIndex(
+                name: "idx_outbox_processed",
+                table: "outbox_events",
+                column: "processed_utc");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a new EF Core migration that drops the unused outbox tables
- update the AppDbContext snapshot so the model no longer maps the legacy outbox entities

## Testing
- dotnet build Veriado.Infrastructure/Veriado.Infrastructure.csproj
- dotnet test Veriado.Application.Tests/Veriado.Application.Tests.csproj *(fails: package downgrade conflict for Microsoft.Data.Sqlite)*

------
https://chatgpt.com/codex/tasks/task_e_68eab3363eb0832688a8814da508d762