### PR TITLE
Fix Sqlite transaction casts for async operations

### DIFF
--- a/Veriado.Infrastructure/Concurrency/WriteWorker.cs
+++ b/Veriado.Infrastructure/Concurrency/WriteWorker.cs
@@ -233,7 +233,7 @@ internal sealed class WriteWorker : BackgroundService
             await sqliteConnection.OpenAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        await using var sqliteTransaction = await sqliteConnection
+        await using var sqliteTransaction = (SqliteTransaction)await sqliteConnection
             .BeginTransactionAsync(cancellationToken)
             .ConfigureAwait(false);
 

--- a/Veriado.Infrastructure/Search/FtsWriteAheadService.cs
+++ b/Veriado.Infrastructure/Search/FtsWriteAheadService.cs
@@ -276,7 +276,8 @@ internal sealed class FtsWriteAheadService : IFtsDlqMonitor
             entry.FileId,
             error);
 
-        await using var sqliteTransaction = await connection.BeginTransactionAsync(cancellationToken)
+        await using var sqliteTransaction = (SqliteTransaction)await connection
+            .BeginTransactionAsync(cancellationToken)
             .ConfigureAwait(false);
 
         try
@@ -336,7 +337,8 @@ internal sealed class FtsWriteAheadService : IFtsDlqMonitor
             entry.Id,
             entry.FileId);
 
-        await using var sqliteTransaction = await connection.BeginTransactionAsync(cancellationToken)
+        await using var sqliteTransaction = (SqliteTransaction)await connection
+            .BeginTransactionAsync(cancellationToken)
             .ConfigureAwait(false);
         try
         {
@@ -381,7 +383,8 @@ internal sealed class FtsWriteAheadService : IFtsDlqMonitor
             entry.Id,
             entry.FileId);
 
-        await using var sqliteTransaction = await connection.BeginTransactionAsync(cancellationToken)
+        await using var sqliteTransaction = (SqliteTransaction)await connection
+            .BeginTransactionAsync(cancellationToken)
             .ConfigureAwait(false);
         try
         {
@@ -445,7 +448,8 @@ internal sealed class FtsWriteAheadService : IFtsDlqMonitor
             entry.Id,
             entry.FileId);
 
-        await using var sqliteTransaction = await connection.BeginTransactionAsync(cancellationToken)
+        await using var sqliteTransaction = (SqliteTransaction)await connection
+            .BeginTransactionAsync(cancellationToken)
             .ConfigureAwait(false);
         try
         {
@@ -492,7 +496,8 @@ internal sealed class FtsWriteAheadService : IFtsDlqMonitor
             entry.Id,
             entry.FileId);
 
-        await using var sqliteTransaction = await connection.BeginTransactionAsync(cancellationToken)
+        await using var sqliteTransaction = (SqliteTransaction)await connection
+            .BeginTransactionAsync(cancellationToken)
             .ConfigureAwait(false);
         try
         {

--- a/Veriado.Infrastructure/Search/SearchFavoritesService.cs
+++ b/Veriado.Infrastructure/Search/SearchFavoritesService.cs
@@ -111,7 +111,9 @@ internal sealed class SearchFavoritesService : ISearchFavoritesService
 
         providedOrder.AddRange(existing);
 
-        await using var sqliteTransaction = await connection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
+        await using var sqliteTransaction = (SqliteTransaction)await connection
+            .BeginTransactionAsync(cancellationToken)
+            .ConfigureAwait(false);
         for (var index = 0; index < providedOrder.Count; index++)
         {
             await using var update = connection.CreateCommand();

--- a/Veriado.Infrastructure/Search/SearchHistoryService.cs
+++ b/Veriado.Infrastructure/Search/SearchHistoryService.cs
@@ -20,7 +20,9 @@ internal sealed class SearchHistoryService : ISearchHistoryService
         await using var connection = CreateConnection();
         await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
         await SqlitePragmaHelper.ApplyAsync(connection, cancellationToken: cancellationToken).ConfigureAwait(false);
-        await using var sqliteTransaction = await connection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
+        await using var sqliteTransaction = (SqliteTransaction)await connection
+            .BeginTransactionAsync(cancellationToken)
+            .ConfigureAwait(false);
         var now = _clock.UtcNow.ToString("O");
 
         await using (var update = connection.CreateCommand())

--- a/Veriado.Infrastructure/Search/SqliteFts5Indexer.cs
+++ b/Veriado.Infrastructure/Search/SqliteFts5Indexer.cs
@@ -69,7 +69,9 @@ internal sealed class SqliteFts5Indexer : ISearchIndexer
         var connection = lease.Connection;
         await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
         await SqlitePragmaHelper.ApplyAsync(connection, _logger, cancellationToken).ConfigureAwait(false);
-        await using var sqliteTransaction = await connection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
+        await using var sqliteTransaction = (SqliteTransaction)await connection
+            .BeginTransactionAsync(cancellationToken)
+            .ConfigureAwait(false);
         var helper = new SqliteFts5Transactional(_analyzerFactory, _trigramOptions, _writeAhead);
 
         try
@@ -106,7 +108,9 @@ internal sealed class SqliteFts5Indexer : ISearchIndexer
         var connection = lease.Connection;
         await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
         await SqlitePragmaHelper.ApplyAsync(connection, _logger, cancellationToken).ConfigureAwait(false);
-        await using var sqliteTransaction = await connection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
+        await using var sqliteTransaction = (SqliteTransaction)await connection
+            .BeginTransactionAsync(cancellationToken)
+            .ConfigureAwait(false);
         var helper = new SqliteFts5Transactional(_analyzerFactory, _trigramOptions, _writeAhead);
 
         try

--- a/Veriado.Infrastructure/Search/SuggestionMaintenanceService.cs
+++ b/Veriado.Infrastructure/Search/SuggestionMaintenanceService.cs
@@ -50,7 +50,9 @@ internal sealed class SuggestionMaintenanceService
             await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
             await SqlitePragmaHelper.ApplyAsync(connection, cancellationToken: cancellationToken).ConfigureAwait(false);
 
-            await using var sqliteTransaction = await connection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
+            await using var sqliteTransaction = (SqliteTransaction)await connection
+                .BeginTransactionAsync(cancellationToken)
+                .ConfigureAwait(false);
             foreach (var entry in harvested)
             {
                 await using var command = connection.CreateCommand();


### PR DESCRIPTION
## Summary
- add explicit casts to `SqliteTransaction` wherever `BeginTransactionAsync` now returns `DbTransaction`
- keep SQLite-based indexing and history services working with strongly typed transactions

## Testing
- `dotnet build` *(fails: command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68eac739f240832680e73ee386a968ca