### PR TITLE
Rebuild write-ahead tables during full-text repair

### DIFF
--- a/Veriado.Infrastructure/Integrity/FulltextIntegrityService.cs
+++ b/Veriado.Infrastructure/Integrity/FulltextIntegrityService.cs
@@ -448,7 +448,9 @@ internal sealed class FulltextIntegrityService : IFulltextIntegrityService
             "DROP TABLE IF EXISTS file_trgm_docsize;",
             "DROP TABLE IF EXISTS file_trgm_config;",
             "DROP TABLE IF EXISTS file_search_map;",
-            "DROP TABLE IF EXISTS file_trgm_map;"
+            "DROP TABLE IF EXISTS file_trgm_map;",
+            "DROP TABLE IF EXISTS fts_write_ahead;",
+            "DROP TABLE IF EXISTS fts_write_ahead_dlq;"
         };
 
         foreach (var statement in dropStatements)

--- a/Veriado.Infrastructure/Persistence/Schema/Fts5.sql
+++ b/Veriado.Infrastructure/Persistence/Schema/Fts5.sql
@@ -28,3 +28,28 @@ CREATE TABLE IF NOT EXISTS file_trgm_map (
 );
 
 CREATE INDEX IF NOT EXISTS idx_file_trgm_map_file ON file_trgm_map(file_id);
+
+CREATE TABLE IF NOT EXISTS fts_write_ahead (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    file_id TEXT NOT NULL,
+    op TEXT NOT NULL,
+    content_hash TEXT NULL,
+    title_hash TEXT NULL,
+    enqueued_utc TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_fts_write_ahead_enqueued ON fts_write_ahead(enqueued_utc);
+
+CREATE TABLE IF NOT EXISTS fts_write_ahead_dlq (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    original_id INTEGER NOT NULL,
+    file_id TEXT NOT NULL,
+    op TEXT NOT NULL,
+    content_hash TEXT NULL,
+    title_hash TEXT NULL,
+    enqueued_utc TEXT NOT NULL,
+    dead_lettered_utc TEXT NOT NULL,
+    error TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_fts_write_ahead_dlq_dead_lettered ON fts_write_ahead_dlq(dead_lettered_utc);


### PR DESCRIPTION
## Summary
- drop and recreate the FTS write-ahead and DLQ tables when performing a full-text index rebuild
- extend the embedded FTS schema script so the repair routine can restore the write-ahead tables alongside the virtual FTS tables

## Testing
- `dotnet test` *(fails: dotnet SDK is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68eb7e2e6e3c8326ac4689094afaa6ca