### PR TITLE
Implement configurable trigram builder and analyzer signatures

### DIFF
--- a/Veriado.Application.Tests/Search/TrigramQueryBuilderTests.cs
+++ b/Veriado.Application.Tests/Search/TrigramQueryBuilderTests.cs
@@ -10,7 +10,8 @@ public static class TrigramQueryBuilderTests
     [Fact]
     public static void BuildTrigramMatch_QuotesReservedKeywords()
     {
-        var result = TrigramQueryBuilder.BuildTrigramMatch("and or not", requireAllTerms: false);
+        var builder = new TrigramQueryBuilder();
+        var result = builder.BuildTrigramMatch("and or not", requireAllTerms: false);
 
         Assert.Equal("\"and\" OR \"not\" OR \"or\"", result);
     }
@@ -18,7 +19,8 @@ public static class TrigramQueryBuilderTests
     [Fact]
     public static void TryBuild_ReturnsQuotedExpressionForReservedKeyword()
     {
-        var built = TrigramQueryBuilder.TryBuild("AND", requireAllTerms: false, out var match);
+        var builder = new TrigramQueryBuilder();
+        var built = builder.TryBuild("AND", requireAllTerms: false, out var match);
 
         Assert.True(built);
         Assert.Equal("\"and\"", match);
@@ -27,7 +29,8 @@ public static class TrigramQueryBuilderTests
     [Fact]
     public static void BuildIndexEntry_DoesNotIncludeQuotes()
     {
-        var entry = TrigramQueryBuilder.BuildIndexEntry("and", "or", "not");
+        var builder = new TrigramQueryBuilder();
+        var entry = builder.BuildIndexEntry("and", "or", "not");
 
         Assert.DoesNotContain('"', entry);
         Assert.False(string.IsNullOrWhiteSpace(entry));
@@ -45,7 +48,8 @@ public static class TrigramQueryBuilderTests
             await create.ExecuteNonQueryAsync();
         }
 
-        var indexEntry = TrigramQueryBuilder.BuildIndexEntry("andromeda");
+        var builder = new TrigramQueryBuilder();
+        var indexEntry = builder.BuildIndexEntry("andromeda");
         await using (var insert = connection.CreateCommand())
         {
             insert.CommandText = "INSERT INTO trigram(token) VALUES ($value);";
@@ -61,7 +65,7 @@ public static class TrigramQueryBuilderTests
             await Assert.ThrowsAsync<SqliteException>(() => failing.ExecuteScalarAsync());
         }
 
-        var sanitizedQuery = TrigramQueryBuilder.BuildTrigramMatch("and", requireAllTerms: false);
+        var sanitizedQuery = builder.BuildTrigramMatch("and", requireAllTerms: false);
 
         await using (var passing = connection.CreateCommand())
         {

--- a/Veriado.Application/UseCases/Queries/FileGrid/FileGridQueryHandler.cs
+++ b/Veriado.Application/UseCases/Queries/FileGrid/FileGridQueryHandler.cs
@@ -22,6 +22,7 @@ public sealed class FileGridQueryHandler : IRequestHandler<FileGridQuery, PageRe
     private readonly FileGridQueryOptions _options;
     private readonly IMapper _mapper;
     private readonly IAnalyzerFactory _analyzerFactory;
+    private readonly ITrigramQueryBuilder _trigramBuilder;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="FileGridQueryHandler"/> class.
@@ -34,7 +35,8 @@ public sealed class FileGridQueryHandler : IRequestHandler<FileGridQuery, PageRe
         IClock clock,
         FileGridQueryOptions options,
         IMapper mapper,
-        IAnalyzerFactory analyzerFactory)
+        IAnalyzerFactory analyzerFactory,
+        ITrigramQueryBuilder trigramBuilder)
     {
         _contextFactory = contextFactory;
         _searchQueryService = searchQueryService;
@@ -44,6 +46,7 @@ public sealed class FileGridQueryHandler : IRequestHandler<FileGridQuery, PageRe
         _options = options;
         _mapper = mapper;
         _analyzerFactory = analyzerFactory ?? throw new ArgumentNullException(nameof(analyzerFactory));
+        _trigramBuilder = trigramBuilder ?? throw new ArgumentNullException(nameof(trigramBuilder));
     }
 
     /// <inheritdoc />
@@ -78,7 +81,7 @@ public sealed class FileGridQueryHandler : IRequestHandler<FileGridQuery, PageRe
         if (dto.Fuzzy && !string.IsNullOrWhiteSpace(dto.Text))
         {
             var normalizedFuzzy = NormalizeForTrigram(dto.Text!);
-            if (TrigramQueryBuilder.TryBuild(normalizedFuzzy, dto.TextAllTerms, out var builtFuzzy))
+            if (_trigramBuilder.TryBuild(normalizedFuzzy, dto.TextAllTerms, out var builtFuzzy))
             {
                 fuzzyMatchQuery = builtFuzzy;
                 fuzzyRequestedByDto = true;

--- a/Veriado.Application/UseCases/Search/SearchFilesHandler.cs
+++ b/Veriado.Application/UseCases/Search/SearchFilesHandler.cs
@@ -18,6 +18,7 @@ public sealed class SearchFilesHandler : IRequestHandler<SearchFilesQuery, IRead
     private readonly IAnalyzerFactory _analyzerFactory;
     private readonly SearchOptions _searchOptions;
     private readonly SearchParseOptions _parseOptions;
+    private readonly ITrigramQueryBuilder _trigramBuilder;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="SearchFilesHandler"/> class.
@@ -26,20 +27,22 @@ public sealed class SearchFilesHandler : IRequestHandler<SearchFilesQuery, IRead
         ISearchQueryService searchQueryService,
         IMapper mapper,
         IAnalyzerFactory analyzerFactory,
-        SearchOptions searchOptions)
+        SearchOptions searchOptions,
+        ITrigramQueryBuilder trigramBuilder)
     {
         _searchQueryService = searchQueryService;
         _mapper = mapper;
         _analyzerFactory = analyzerFactory ?? throw new ArgumentNullException(nameof(analyzerFactory));
         _searchOptions = searchOptions ?? throw new ArgumentNullException(nameof(searchOptions));
         _parseOptions = _searchOptions.Parse ?? new SearchParseOptions();
+        _trigramBuilder = trigramBuilder ?? throw new ArgumentNullException(nameof(trigramBuilder));
     }
 
     /// <inheritdoc />
     public async Task<IReadOnlyList<SearchHitDto>> Handle(SearchFilesQuery request, CancellationToken cancellationToken)
     {
         Guard.AgainstNullOrWhiteSpace(request.Text, nameof(request.Text));
-        var builder = new SearchQueryBuilder(_searchOptions.Score, null, _searchOptions.Analyzer.DefaultProfile);
+        var builder = new SearchQueryBuilder(_searchOptions.Score, null, _searchOptions.Analyzer.DefaultProfile, _trigramBuilder);
         var expression = BuildQueryExpression(request.Text, builder);
         if (expression is null)
         {

--- a/Veriado.Infrastructure/Concurrency/WriteWorker.cs
+++ b/Veriado.Infrastructure/Concurrency/WriteWorker.cs
@@ -34,6 +34,7 @@ internal sealed class WriteWorker : BackgroundService
     private readonly ISearchIndexSignatureCalculator _signatureCalculator;
     private readonly FtsWriteAheadService _writeAhead;
     private readonly ISearchTelemetry _telemetry;
+    private readonly ITrigramQueryBuilder _trigramBuilder;
 
     private static readonly FilePersistenceOptions SameTransactionOptions = FilePersistenceOptions.Default;
 
@@ -52,7 +53,8 @@ internal sealed class WriteWorker : BackgroundService
         INeedsReindexEvaluator needsReindexEvaluator,
         ISearchIndexSignatureCalculator signatureCalculator,
         FtsWriteAheadService writeAhead,
-        ISearchTelemetry telemetry)
+        ISearchTelemetry telemetry,
+        ITrigramQueryBuilder trigramBuilder)
     {
         _writeQueue = writeQueue;
         _dbContextFactory = dbContextFactory;
@@ -69,6 +71,7 @@ internal sealed class WriteWorker : BackgroundService
         _signatureCalculator = signatureCalculator ?? throw new ArgumentNullException(nameof(signatureCalculator));
         _writeAhead = writeAhead ?? throw new ArgumentNullException(nameof(writeAhead));
         _telemetry = telemetry ?? throw new ArgumentNullException(nameof(telemetry));
+        _trigramBuilder = trigramBuilder ?? throw new ArgumentNullException(nameof(trigramBuilder));
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -514,7 +517,7 @@ internal sealed class WriteWorker : BackgroundService
             return true;
         }
 
-        var helper = new SqliteFts5Transactional(_analyzerFactory, _trigramOptions, _writeAhead);
+        var helper = new SqliteFts5Transactional(_analyzerFactory, _trigramOptions, _writeAhead, _trigramBuilder);
         var handled = false;
 
         foreach (var id in filesToDelete)

--- a/Veriado.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/Veriado.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
@@ -119,6 +119,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IOptions<TrigramIndexOptions>>(sp => Options.Create(sp.GetRequiredService<SearchOptions>().Trigram));
 
         services.AddSingleton<IAnalyzerFactory, AnalyzerFactory>();
+        services.AddSingleton<ITrigramQueryBuilder, TrigramQueryBuilder>();
 
         services.AddDbContextPool<AppDbContext>((sp, builder) =>
         {

--- a/Veriado.Infrastructure/Search/ISearchIndexSignatureCalculator.cs
+++ b/Veriado.Infrastructure/Search/ISearchIndexSignatureCalculator.cs
@@ -3,4 +3,6 @@ namespace Veriado.Infrastructure.Search;
 public interface ISearchIndexSignatureCalculator
 {
     SearchIndexSignature Compute(FileEntity file);
+
+    string GetAnalyzerVersion();
 }

--- a/Veriado.Infrastructure/Search/NeedsReindexEvaluator.cs
+++ b/Veriado.Infrastructure/Search/NeedsReindexEvaluator.cs
@@ -17,7 +17,7 @@ public sealed class NeedsReindexEvaluator : INeedsReindexEvaluator
 
         var signature = _signatureCalculator.Compute(file);
         var normalizedTitle = signature.NormalizedTitle;
-        var analyzerVersion = signature.AnalyzerVersion;
+        var analyzerVersion = _signatureCalculator.GetAnalyzerVersion();
         var tokenHash = signature.TokenHash;
         var contentHash = file.Content.Hash.Value;
 

--- a/Veriado.Infrastructure/Search/SqliteFts5Indexer.cs
+++ b/Veriado.Infrastructure/Search/SqliteFts5Indexer.cs
@@ -17,6 +17,7 @@ internal sealed class SqliteFts5Indexer : ISearchIndexer
     private readonly ISqliteConnectionFactory _connectionFactory;
     private readonly TrigramIndexOptions _trigramOptions;
     private readonly FtsWriteAheadService _writeAhead;
+    private readonly ITrigramQueryBuilder _trigramBuilder;
 
     public SqliteFts5Indexer(
         InfrastructureOptions options,
@@ -25,6 +26,7 @@ internal sealed class SqliteFts5Indexer : ISearchIndexer
         ISqliteConnectionFactory connectionFactory,
         TrigramIndexOptions trigramOptions,
         FtsWriteAheadService writeAhead,
+        ITrigramQueryBuilder trigramBuilder,
         SuggestionMaintenanceService? suggestionMaintenance = null)
     {
         _options = options;
@@ -33,6 +35,7 @@ internal sealed class SqliteFts5Indexer : ISearchIndexer
         _connectionFactory = connectionFactory ?? throw new ArgumentNullException(nameof(connectionFactory));
         _trigramOptions = trigramOptions ?? throw new ArgumentNullException(nameof(trigramOptions));
         _writeAhead = writeAhead ?? throw new ArgumentNullException(nameof(writeAhead));
+        _trigramBuilder = trigramBuilder ?? throw new ArgumentNullException(nameof(trigramBuilder));
         _suggestionMaintenance = suggestionMaintenance;
     }
 
@@ -72,7 +75,7 @@ internal sealed class SqliteFts5Indexer : ISearchIndexer
         await using var sqliteTransaction = (SqliteTransaction)await connection
             .BeginTransactionAsync(cancellationToken)
             .ConfigureAwait(false);
-        var helper = new SqliteFts5Transactional(_analyzerFactory, _trigramOptions, _writeAhead);
+        var helper = new SqliteFts5Transactional(_analyzerFactory, _trigramOptions, _writeAhead, _trigramBuilder);
 
         try
         {
@@ -111,7 +114,7 @@ internal sealed class SqliteFts5Indexer : ISearchIndexer
         await using var sqliteTransaction = (SqliteTransaction)await connection
             .BeginTransactionAsync(cancellationToken)
             .ConfigureAwait(false);
-        var helper = new SqliteFts5Transactional(_analyzerFactory, _trigramOptions, _writeAhead);
+        var helper = new SqliteFts5Transactional(_analyzerFactory, _trigramOptions, _writeAhead, _trigramBuilder);
 
         try
         {


### PR DESCRIPTION
## Summary
- replace the static trigram utilities with a configurable `ITrigramQueryBuilder` that honours search options
- update trigram-based query, indexing, and spell suggestion services to share the same trigram generation logic
- derive analyzer signatures from the configured analyzer and trigram options to trigger automatic reindexing when settings change

## Testing
- dotnet build *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68eb85e775d483269c5dffc24d1def50