### PR TITLE
Handle cancellation while waiting for full-text repair semaphore

### DIFF
--- a/Veriado.Services/Import/ImportService.cs
+++ b/Veriado.Services/Import/ImportService.cs
@@ -1133,10 +1133,13 @@ public sealed class ImportService : IImportService
 
     private async Task<bool> TryRepairFulltextIndexAsync(CancellationToken cancellationToken)
     {
-        await _fulltextRepairSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+        var semaphoreAcquired = false;
 
         try
         {
+            await _fulltextRepairSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+            semaphoreAcquired = true;
+
             if (_fulltextRepairSucceeded)
             {
                 return false;
@@ -1203,7 +1206,10 @@ public sealed class ImportService : IImportService
         }
         finally
         {
-            _fulltextRepairSemaphore.Release();
+            if (semaphoreAcquired)
+            {
+                _fulltextRepairSemaphore.Release();
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- guard the full-text repair helper so the semaphore is only released after a successful wait, preventing SemaphoreFullException when cancellations occur mid-wait

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68ebbd31638483269e0ce7ee065620f2