### PR TITLE
Fix handling of AppError details during full-text repair logging

### DIFF
--- a/Veriado.Services/Import/ImportService.cs
+++ b/Veriado.Services/Import/ImportService.cs
@@ -1165,9 +1165,9 @@ public sealed class ImportService : IImportService
 
             var error = repairResult.Error;
             string? details = null;
-            if (error.Details is { Count: > 0 })
+            if (error.Details is { Count: > 0 } detailsCollection)
             {
-                var flattened = error.Details.SelectMany(static pair => pair.Value)
+                var flattened = detailsCollection
                     .Where(static value => !string.IsNullOrWhiteSpace(value))
                     .ToArray();
                 if (flattened.Length > 0)


### PR DESCRIPTION
## Summary
- fix the handling of AppError.Details when logging a failed full-text repair attempt
- ensure the details collection is flattened safely before building the log message

## Testing
- dotnet build *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68ebbe7f5d708326821b4b07e1bfded2