### PR TITLE
Ensure DI selects SearchOptions constructor

### DIFF
--- a/Veriado.Application/Search/TrigramQueryBuilder.cs
+++ b/Veriado.Application/Search/TrigramQueryBuilder.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Text;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
 namespace Veriado.Appl.Search;
@@ -31,6 +32,7 @@ public sealed class TrigramQueryBuilder : ITrigramQueryBuilder
     {
     }
 
+    [ActivatorUtilitiesConstructor]
     public TrigramQueryBuilder(SearchOptions options)
     {
         _options = options ?? throw new ArgumentNullException(nameof(options));


### PR DESCRIPTION
## Summary
- import the dependency injection namespace for TrigramQueryBuilder
- mark the SearchOptions constructor with ActivatorUtilitiesConstructor to make DI choose the correct overload

## Testing
- dotnet build Veriado.sln *(fails: dotnet not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ebc2b2d020832694d11f1cdc3967a2