### PR TITLE
Refine trigram query builder construction

### DIFF
--- a/Veriado.Application.Tests/Search/TrigramQueryBuilderTests.cs
+++ b/Veriado.Application.Tests/Search/TrigramQueryBuilderTests.cs
@@ -10,7 +10,7 @@ public static class TrigramQueryBuilderTests
     [Fact]
     public static void BuildTrigramMatch_QuotesReservedKeywords()
     {
-        var builder = new TrigramQueryBuilder();
+        var builder = new TrigramQueryBuilder(new SearchOptions());
         var result = builder.BuildTrigramMatch("and or not", requireAllTerms: false);
 
         Assert.Equal("\"and\" OR \"not\" OR \"or\"", result);
@@ -19,7 +19,7 @@ public static class TrigramQueryBuilderTests
     [Fact]
     public static void TryBuild_ReturnsQuotedExpressionForReservedKeyword()
     {
-        var builder = new TrigramQueryBuilder();
+        var builder = new TrigramQueryBuilder(new SearchOptions());
         var built = builder.TryBuild("AND", requireAllTerms: false, out var match);
 
         Assert.True(built);
@@ -29,7 +29,7 @@ public static class TrigramQueryBuilderTests
     [Fact]
     public static void BuildIndexEntry_DoesNotIncludeQuotes()
     {
-        var builder = new TrigramQueryBuilder();
+        var builder = new TrigramQueryBuilder(new SearchOptions());
         var entry = builder.BuildIndexEntry("and", "or", "not");
 
         Assert.DoesNotContain('"', entry);
@@ -48,7 +48,7 @@ public static class TrigramQueryBuilderTests
             await create.ExecuteNonQueryAsync();
         }
 
-        var builder = new TrigramQueryBuilder();
+        var builder = new TrigramQueryBuilder(new SearchOptions());
         var indexEntry = builder.BuildIndexEntry("andromeda");
         await using (var insert = connection.CreateCommand())
         {

--- a/Veriado.Application/Search/SearchQueryBuilder.cs
+++ b/Veriado.Application/Search/SearchQueryBuilder.cs
@@ -98,7 +98,7 @@ public sealed class SearchQueryBuilder : ISearchQueryBuilder
         _language = string.IsNullOrWhiteSpace(language)
             ? "en"
             : language!.Trim().ToLowerInvariant();
-        _trigramBuilder = trigramBuilder ?? new TrigramQueryBuilder();
+        _trigramBuilder = trigramBuilder ?? new TrigramQueryBuilder(new SearchOptions());
     }
 
     private void ApplyScoreOptions(SearchScoreOptions? options)

--- a/Veriado.Application/Search/TrigramQueryBuilder.cs
+++ b/Veriado.Application/Search/TrigramQueryBuilder.cs
@@ -26,22 +26,18 @@ public sealed class TrigramQueryBuilder : ITrigramQueryBuilder
 {
     internal const int DefaultMaxIndexTokens = 2048;
 
-    private readonly SearchOptions? _options;
+    private readonly SearchOptions _options;
 
-    public TrigramQueryBuilder()
-    {
-    }
-
-    [ActivatorUtilitiesConstructor]
     public TrigramQueryBuilder(SearchOptions options)
     {
         _options = options ?? throw new ArgumentNullException(nameof(options));
     }
 
+    [ActivatorUtilitiesConstructor]
     public TrigramQueryBuilder(IOptions<SearchOptions> options)
+        : this((options ?? throw new ArgumentNullException(nameof(options))).Value
+            ?? throw new ArgumentNullException(nameof(options)))
     {
-        ArgumentNullException.ThrowIfNull(options);
-        _options = options.Value ?? throw new ArgumentNullException(nameof(options));
     }
 
     /// <summary>
@@ -271,7 +267,7 @@ public sealed class TrigramQueryBuilder : ITrigramQueryBuilder
 
     private int ResolveLimit(int? overrideLimit)
     {
-        var limit = overrideLimit ?? _options?.Trigram?.MaxTokens ?? DefaultMaxIndexTokens;
+        var limit = overrideLimit ?? _options.Trigram?.MaxTokens ?? DefaultMaxIndexTokens;
         if (limit <= 0)
         {
             return DefaultMaxIndexTokens;


### PR DESCRIPTION
## Summary
- collapse TrigramQueryBuilder to the SearchOptions and IOptions constructors and mark the latter for DI
- inject default SearchOptions when SearchQueryBuilder creates its own trigram builder
- update trigram query builder tests to provide SearchOptions explicitly

## Testing
- dotnet test Veriado.Application.Tests/Veriado.Application.Tests.csproj *(fails: dotnet not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ebd802a0288326b772dc42c646d90f