### PR TITLE
Remove redundant TrigramQueryBuilder constructor

### DIFF
--- a/Veriado.Application.Tests/Search/TrigramQueryBuilderTests.cs
+++ b/Veriado.Application.Tests/Search/TrigramQueryBuilderTests.cs
@@ -1,6 +1,7 @@
 using System.Threading.Tasks;
 using Microsoft.Data.Sqlite;
 using Veriado.Appl.Search;
+using Microsoft.Extensions.Options;
 using Xunit;
 
 namespace Veriado.Application.Tests.Search;
@@ -10,7 +11,7 @@ public static class TrigramQueryBuilderTests
     [Fact]
     public static void BuildTrigramMatch_QuotesReservedKeywords()
     {
-        var builder = new TrigramQueryBuilder(new SearchOptions());
+        var builder = new TrigramQueryBuilder(Options.Create(new SearchOptions()));
         var result = builder.BuildTrigramMatch("and or not", requireAllTerms: false);
 
         Assert.Equal("\"and\" OR \"not\" OR \"or\"", result);
@@ -19,7 +20,7 @@ public static class TrigramQueryBuilderTests
     [Fact]
     public static void TryBuild_ReturnsQuotedExpressionForReservedKeyword()
     {
-        var builder = new TrigramQueryBuilder(new SearchOptions());
+        var builder = new TrigramQueryBuilder(Options.Create(new SearchOptions()));
         var built = builder.TryBuild("AND", requireAllTerms: false, out var match);
 
         Assert.True(built);
@@ -29,7 +30,7 @@ public static class TrigramQueryBuilderTests
     [Fact]
     public static void BuildIndexEntry_DoesNotIncludeQuotes()
     {
-        var builder = new TrigramQueryBuilder(new SearchOptions());
+        var builder = new TrigramQueryBuilder(Options.Create(new SearchOptions()));
         var entry = builder.BuildIndexEntry("and", "or", "not");
 
         Assert.DoesNotContain('"', entry);
@@ -48,7 +49,7 @@ public static class TrigramQueryBuilderTests
             await create.ExecuteNonQueryAsync();
         }
 
-        var builder = new TrigramQueryBuilder(new SearchOptions());
+        var builder = new TrigramQueryBuilder(Options.Create(new SearchOptions()));
         var indexEntry = builder.BuildIndexEntry("andromeda");
         await using (var insert = connection.CreateCommand())
         {

--- a/Veriado.Application/Search/SearchQueryBuilder.cs
+++ b/Veriado.Application/Search/SearchQueryBuilder.cs
@@ -6,6 +6,7 @@ using System.Globalization;
 using System.Linq;
 using System.Text;
 using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Options;
 using Veriado.Appl.Search.Abstractions;
 
 /// <summary>
@@ -98,7 +99,8 @@ public sealed class SearchQueryBuilder : ISearchQueryBuilder
         _language = string.IsNullOrWhiteSpace(language)
             ? "en"
             : language!.Trim().ToLowerInvariant();
-        _trigramBuilder = trigramBuilder ?? new TrigramQueryBuilder(new SearchOptions());
+        _trigramBuilder = trigramBuilder
+            ?? new TrigramQueryBuilder(Options.Create(new SearchOptions()));
     }
 
     private void ApplyScoreOptions(SearchScoreOptions? options)

--- a/Veriado.Application/Search/TrigramQueryBuilder.cs
+++ b/Veriado.Application/Search/TrigramQueryBuilder.cs
@@ -28,16 +28,15 @@ public sealed class TrigramQueryBuilder : ITrigramQueryBuilder
 
     private readonly SearchOptions _options;
 
-    public TrigramQueryBuilder(SearchOptions options)
-    {
-        _options = options ?? throw new ArgumentNullException(nameof(options));
-    }
-
     [ActivatorUtilitiesConstructor]
     public TrigramQueryBuilder(IOptions<SearchOptions> options)
-        : this((options ?? throw new ArgumentNullException(nameof(options))).Value
-            ?? throw new ArgumentNullException(nameof(options)))
     {
+        if (options is null)
+        {
+            throw new ArgumentNullException(nameof(options));
+        }
+
+        _options = options.Value ?? throw new ArgumentNullException(nameof(options));
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- remove the SearchOptions-based overload from TrigramQueryBuilder so only the IOptions constructor is available for DI

## Testing
- not run (dotnet CLI unavailable)


------
https://chatgpt.com/codex/tasks/task_e_68ebdedee2b48326a3c19a9262d5552d