### PR TITLE
Remove fuzzy flags from search persistence

### DIFF
--- a/Veriado.Infrastructure/Migrations/20250927214141_InitContext.Designer.cs
+++ b/Veriado.Infrastructure/Migrations/20250927214141_InitContext.Designer.cs
@@ -214,12 +214,6 @@ namespace Veriado.Infrastructure.Migrations
                         .HasColumnType("TEXT")
                         .HasColumnName("created_utc");
 
-                    b.Property<bool>("IsFuzzy")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
-                        .HasDefaultValue(false)
-                        .HasColumnName("is_fuzzy");
-
                     b.Property<string>("Match")
                         .IsRequired()
                         .HasColumnType("TEXT")
@@ -266,12 +260,6 @@ namespace Veriado.Infrastructure.Migrations
                         .HasColumnType("INTEGER")
                         .HasDefaultValue(1)
                         .HasColumnName("executions");
-
-                    b.Property<bool>("IsFuzzy")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
-                        .HasDefaultValue(false)
-                        .HasColumnName("is_fuzzy");
 
                     b.Property<int?>("LastTotalHits")
                         .HasColumnType("INTEGER")

--- a/Veriado.Infrastructure/Migrations/20250927214141_InitContext.cs
+++ b/Veriado.Infrastructure/Migrations/20250927214141_InitContext.cs
@@ -108,8 +108,7 @@ namespace Veriado.Infrastructure.Migrations
                     query_text = table.Column<string>(type: "TEXT", nullable: true),
                     match = table.Column<string>(type: "TEXT", nullable: false),
                     position = table.Column<int>(type: "INTEGER", nullable: false),
-                    created_utc = table.Column<string>(type: "TEXT", nullable: false),
-                    is_fuzzy = table.Column<bool>(type: "INTEGER", nullable: false, defaultValue: false)
+                    created_utc = table.Column<string>(type: "TEXT", nullable: false)
                 },
                 constraints: table =>
                 {
@@ -125,8 +124,7 @@ namespace Veriado.Infrastructure.Migrations
                     match = table.Column<string>(type: "TEXT", nullable: false),
                     created_utc = table.Column<string>(type: "TEXT", nullable: false),
                     executions = table.Column<int>(type: "INTEGER", nullable: false, defaultValue: 1),
-                    last_total_hits = table.Column<int>(type: "INTEGER", nullable: true),
-                    is_fuzzy = table.Column<bool>(type: "INTEGER", nullable: false, defaultValue: false)
+                    last_total_hits = table.Column<int>(type: "INTEGER", nullable: true)
                 },
                 constraints: table =>
                 {

--- a/Veriado.Infrastructure/Migrations/20251001045018_Add_SearchIndexState_AnalyzerSignature.Designer.cs
+++ b/Veriado.Infrastructure/Migrations/20251001045018_Add_SearchIndexState_AnalyzerSignature.Designer.cs
@@ -240,12 +240,6 @@ namespace Veriado.Infrastructure.Migrations
                         .HasColumnType("TEXT")
                         .HasColumnName("created_utc");
 
-                    b.Property<bool>("IsFuzzy")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
-                        .HasDefaultValue(false)
-                        .HasColumnName("is_fuzzy");
-
                     b.Property<string>("Match")
                         .IsRequired()
                         .HasColumnType("TEXT")
@@ -292,12 +286,6 @@ namespace Veriado.Infrastructure.Migrations
                         .HasColumnType("INTEGER")
                         .HasDefaultValue(1)
                         .HasColumnName("executions");
-
-                    b.Property<bool>("IsFuzzy")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
-                        .HasDefaultValue(false)
-                        .HasColumnName("is_fuzzy");
 
                     b.Property<int?>("LastTotalHits")
                         .HasColumnType("INTEGER")

--- a/Veriado.Infrastructure/Migrations/AppDbContextModelSnapshot.cs
+++ b/Veriado.Infrastructure/Migrations/AppDbContextModelSnapshot.cs
@@ -237,12 +237,6 @@ namespace Veriado.Infrastructure.Migrations
                         .HasColumnType("TEXT")
                         .HasColumnName("created_utc");
 
-                    b.Property<bool>("IsFuzzy")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
-                        .HasDefaultValue(false)
-                        .HasColumnName("is_fuzzy");
-
                     b.Property<string>("Match")
                         .IsRequired()
                         .HasColumnType("TEXT")
@@ -289,12 +283,6 @@ namespace Veriado.Infrastructure.Migrations
                         .HasColumnType("INTEGER")
                         .HasDefaultValue(1)
                         .HasColumnName("executions");
-
-                    b.Property<bool>("IsFuzzy")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
-                        .HasDefaultValue(false)
-                        .HasColumnName("is_fuzzy");
 
                     b.Property<int?>("LastTotalHits")
                         .HasColumnType("INTEGER")

--- a/Veriado.Infrastructure/Persistence/Configurations/SearchFavoriteConfiguration.cs
+++ b/Veriado.Infrastructure/Persistence/Configurations/SearchFavoriteConfiguration.cs
@@ -38,10 +38,7 @@ internal sealed class SearchFavoriteConfiguration : IEntityTypeConfiguration<Sea
             .HasConversion(Converters.DateTimeOffsetToString)
             .IsRequired();
 
-        builder.Property(favorite => favorite.IsFuzzy)
-            .HasColumnName("is_fuzzy")
-            .HasColumnType("INTEGER")
-            .HasDefaultValue(false);
+        builder.Ignore(favorite => favorite.IsFuzzy);
 
         builder.HasIndex(favorite => favorite.Position)
             .HasDatabaseName("idx_search_favorites_position");

--- a/Veriado.Infrastructure/Persistence/Configurations/SearchHistoryConfiguration.cs
+++ b/Veriado.Infrastructure/Persistence/Configurations/SearchHistoryConfiguration.cs
@@ -39,10 +39,7 @@ internal sealed class SearchHistoryConfiguration : IEntityTypeConfiguration<Sear
             .HasColumnName("last_total_hits")
             .HasColumnType("INTEGER");
 
-        builder.Property(entry => entry.IsFuzzy)
-            .HasColumnName("is_fuzzy")
-            .HasColumnType("INTEGER")
-            .HasDefaultValue(false);
+        builder.Ignore(entry => entry.IsFuzzy);
 
         builder.HasIndex(entry => entry.CreatedUtc)
             .HasDatabaseName("idx_search_history_created")


### PR DESCRIPTION
## Summary
- stop persisting the `is_fuzzy` flag in search history and favourites tables
- update EF Core snapshots and model configuration to reflect the removed columns

## Testing
- dotnet test *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ebfbdef31c8326afe79211d37882da