### PR TITLE
Disable trigram indexing in SQLite search

### DIFF
--- a/Veriado.Application/Search/SearchOptions.cs
+++ b/Veriado.Application/Search/SearchOptions.cs
@@ -77,13 +77,7 @@ public sealed class TrigramIndexOptions
 {
     public int MaxTokens { get; set; } = 2048;
 
-    public string[] Fields { get; set; } =
-    {
-        "title",
-        "author",
-        "filename",
-        "metadata_text",
-    };
+    public string[] Fields { get; set; } = Array.Empty<string>();
 }
 
 /// <summary>

--- a/Veriado.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/Veriado.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
@@ -152,12 +152,9 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<ISearchIndexCoordinator, SqliteSearchIndexCoordinator>();
         services.AddSingleton<IDatabaseMaintenanceService, SqliteDatabaseMaintenanceService>();
 
-        #region TODO(SQLiteOnly): Collapse query pipeline to SQLite-only implementation (remove hybrid + trigram)
         services.AddSingleton<SqliteFts5QueryService>();
-        services.AddSingleton<TrigramQueryService>();
         services.AddSingleton<HybridSearchQueryService>();
         services.AddSingleton<ISearchQueryService>(sp => sp.GetRequiredService<HybridSearchQueryService>());
-        #endregion
         services.AddSingleton<FtsWriteAheadService>();
         services.AddSingleton<IFtsDlqMonitor>(sp => sp.GetRequiredService<FtsWriteAheadService>());
         services.AddSingleton<ISearchHistoryService, SearchHistoryService>();


### PR DESCRIPTION
## Summary
- stop populating trigram fields by default and guard index maintenance logic when trigram indexing is disabled
- simplify the hybrid search service to execute only FTS queries and drop the trigram query service registration
- keep telemetry while skipping trigram-specific database operations during indexing and deletes

## Testing
- dotnet build *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ec1061a588832684c57c60ea301e37