### PR TITLE
Run SQLite PRAGMA health check every invocation

### DIFF
--- a/Veriado.Infrastructure/Persistence/SqlitePragmaHealthCheck.cs
+++ b/Veriado.Infrastructure/Persistence/SqlitePragmaHealthCheck.cs
@@ -7,20 +7,13 @@ namespace Veriado.Infrastructure.Persistence;
 /// </summary>
 internal sealed class SqlitePragmaHealthCheck : IHealthCheck
 {
-    private static readonly TimeSpan VerificationInterval = TimeSpan.FromDays(1);
-
     private readonly InfrastructureOptions _options;
-    private readonly IClock _clock;
     private readonly ILogger<SqlitePragmaHealthCheck> _logger;
     private readonly SemaphoreSlim _mutex = new(1, 1);
 
-    private DateTimeOffset _lastVerificationUtc = DateTimeOffset.MinValue;
-    private HealthCheckResult _lastResult = HealthCheckResult.Healthy("SQLite PRAGMA verification pending initial execution.");
-
-    public SqlitePragmaHealthCheck(InfrastructureOptions options, IClock clock, ILogger<SqlitePragmaHealthCheck> logger)
+    public SqlitePragmaHealthCheck(InfrastructureOptions options, ILogger<SqlitePragmaHealthCheck> logger)
     {
         _options = options ?? throw new ArgumentNullException(nameof(options));
-        _clock = clock ?? throw new ArgumentNullException(nameof(clock));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -35,53 +28,41 @@ internal sealed class SqlitePragmaHealthCheck : IHealthCheck
         await _mutex.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
-            var now = _clock.UtcNow;
-            if (_lastVerificationUtc != DateTimeOffset.MinValue && now - _lastVerificationUtc < VerificationInterval)
+            await using var connection = new SqliteConnection(_options.ConnectionString);
+            await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+            var current = await SqlitePragmaHelper.ReadStateAsync(connection, cancellationToken).ConfigureAwait(false);
+            if (SqlitePragmaHelper.IsCompliant(current))
             {
-                return _lastResult;
+                return HealthCheckResult.Healthy(
+                    "SQLite PRAGMA settings are configured as expected.",
+                    BuildData(current));
             }
 
-            var result = await VerifyAndRepairAsync(cancellationToken).ConfigureAwait(false);
-            _lastVerificationUtc = now;
-            _lastResult = result;
-            return result;
+            _logger.LogWarning(
+                "SQLite PRAGMA settings deviated from expected values (journal_mode={JournalMode}, synchronous={Synchronous}, busy_timeout={BusyTimeout}). Applying corrective action.",
+                current.JournalMode,
+                current.Synchronous,
+                current.BusyTimeout);
+
+            await SqlitePragmaHelper.ApplyAsync(connection, _logger, cancellationToken).ConfigureAwait(false);
+            var repaired = await SqlitePragmaHelper.ReadStateAsync(connection, cancellationToken).ConfigureAwait(false);
+
+            if (!SqlitePragmaHelper.IsCompliant(repaired))
+            {
+                return HealthCheckResult.Unhealthy(
+                    "SQLite PRAGMA settings remain non-compliant after automatic remediation attempts.",
+                    data: BuildData(repaired));
+            }
+
+            return HealthCheckResult.Degraded(
+                "SQLite PRAGMA settings required corrective action. Values were updated automatically.",
+                data: BuildData(repaired));
         }
         finally
         {
             _mutex.Release();
         }
-    }
-
-    private async Task<HealthCheckResult> VerifyAndRepairAsync(CancellationToken cancellationToken)
-    {
-        await using var connection = new SqliteConnection(_options.ConnectionString);
-        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
-
-        var current = await SqlitePragmaHelper.ReadStateAsync(connection, cancellationToken).ConfigureAwait(false);
-        if (SqlitePragmaHelper.IsCompliant(current))
-        {
-            return HealthCheckResult.Healthy("SQLite PRAGMA settings are configured as expected.", BuildData(current));
-        }
-
-        _logger.LogWarning(
-            "SQLite PRAGMA settings deviated from expected values (journal_mode={JournalMode}, synchronous={Synchronous}, busy_timeout={BusyTimeout}). Applying corrective action.",
-            current.JournalMode,
-            current.Synchronous,
-            current.BusyTimeout);
-
-        await SqlitePragmaHelper.ApplyAsync(connection, _logger, cancellationToken).ConfigureAwait(false);
-        var repaired = await SqlitePragmaHelper.ReadStateAsync(connection, cancellationToken).ConfigureAwait(false);
-
-        if (!SqlitePragmaHelper.IsCompliant(repaired))
-        {
-            return HealthCheckResult.Unhealthy(
-                "SQLite PRAGMA settings remain non-compliant after automatic remediation attempts.",
-                data: BuildData(repaired));
-        }
-
-        return HealthCheckResult.Degraded(
-            "SQLite PRAGMA settings required corrective action. Values were updated automatically.",
-            data: BuildData(repaired));
     }
 
     private static IReadOnlyDictionary<string, object?> BuildData(SqlitePragmaHelper.SqlitePragmaState state)


### PR DESCRIPTION
## Summary
- remove the cached 24-hour health check result so each probe validates current SQLite PRAGMA state
- simplify the health check to open a connection, repair deviations immediately, and drop the unused clock dependency

## Testing
- dotnet test *(fails: `dotnet` CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ecc64ef2108326912427a397fa8b7b