### PR TITLE
Add write pipeline telemetry interface and options

### DIFF
--- a/Veriado.Application/Search/Abstractions/SearchServices.cs
+++ b/Veriado.Application/Search/Abstractions/SearchServices.cs
@@ -290,3 +290,46 @@ public interface ISearchTelemetry
     /// <param name="retryCount">The number of retries to add to the counter.</param>
     void RecordSqliteBusyRetry(int retryCount);
 }
+
+/// <summary>
+/// Provides telemetry hooks specific to the write pipeline.
+/// </summary>
+public interface ISearchWriteTelemetry
+{
+    /// <summary>
+    /// Updates the current depth of the write queue for a partition.
+    /// </summary>
+    /// <param name="partitionId">The partition identifier.</param>
+    /// <param name="depth">The depth to report.</param>
+    void UpdateQueueDepth(int partitionId, int depth);
+
+    /// <summary>
+    /// Records the wait duration for a request before it entered execution.
+    /// </summary>
+    /// <param name="elapsed">The elapsed wait duration.</param>
+    void RecordQueueWait(TimeSpan elapsed);
+
+    /// <summary>
+    /// Records the execution duration of a processed batch.
+    /// </summary>
+    /// <param name="elapsed">The elapsed duration.</param>
+    /// <param name="itemCount">The number of items processed.</param>
+    void RecordBatchDuration(TimeSpan elapsed, int itemCount);
+
+    /// <summary>
+    /// Records the number of SQLite retry attempts performed.
+    /// </summary>
+    /// <param name="count">The number of retries.</param>
+    void RecordSqliteRetry(int count);
+
+    /// <summary>
+    /// Publishes the current availability state of the FTS subsystem.
+    /// </summary>
+    /// <param name="isAvailable">True when FTS is available.</param>
+    void UpdateFtsAvailability(bool isAvailable);
+
+    /// <summary>
+    /// Records a repair trigger emitted by the pipeline.
+    /// </summary>
+    void RecordFtsRepairTriggered();
+}

--- a/Veriado.Infrastructure/Concurrency/SearchWriteOptions.cs
+++ b/Veriado.Infrastructure/Concurrency/SearchWriteOptions.cs
@@ -1,0 +1,32 @@
+using System;
+
+namespace Veriado.Infrastructure.Concurrency;
+
+/// <summary>
+/// Represents configurable settings for the search write pipeline.
+/// </summary>
+public sealed class SearchWriteOptions
+{
+    public int MaxBatchSize { get; set; } = 128;
+
+    public int MaxBatchDurationMs { get; set; } = 5_000;
+
+    public int MaxQueueDepthWarning { get; set; } = 5_000;
+
+    public bool EnableMultiWorker { get; set; }
+        = false;
+
+    public int Workers { get; set; } = 1;
+
+    public string ShardKey { get; set; } = "DocumentId";
+
+    public TimeSpan FtsRedetectInterval { get; set; } = TimeSpan.FromMinutes(5);
+
+    public int SqliteBusyTimeoutMs { get; set; } = 250;
+
+    public int RetryMaxAttempts { get; set; } = 3;
+
+    public int RetryBaseDelayMs { get; set; } = 100;
+
+    public int BatchWindowMs { get; set; } = 250;
+}

--- a/Veriado.Infrastructure/Search/SearchWriteTelemetry.cs
+++ b/Veriado.Infrastructure/Search/SearchWriteTelemetry.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Collections.Concurrent;
+using System.Diagnostics.Metrics;
+using System.Threading;
+using Veriado.Appl.Search.Abstractions;
+
+namespace Veriado.Infrastructure.Search;
+
+/// <summary>
+/// Provides <see cref="ISearchWriteTelemetry"/> backed by <see cref="Meter"/> instruments.
+/// </summary>
+internal sealed class SearchWriteTelemetry : ISearchWriteTelemetry
+{
+    private static readonly Meter Meter = new("Veriado.Search.Write", "1.0.0");
+
+    private readonly ObservableGauge<long> _queueDepth;
+    private readonly Histogram<double> _queueWait;
+    private readonly Histogram<double> _batchDuration;
+    private readonly Counter<long> _sqliteRetry;
+    private readonly ObservableGauge<int> _ftsAvailable;
+    private readonly Counter<long> _ftsRepair;
+    private readonly ConcurrentDictionary<int, int> _partitionDepth = new();
+    private int _ftsAvailabilityValue = 0;
+
+    public SearchWriteTelemetry()
+    {
+        _queueDepth = Meter.CreateObservableGauge("write_queue_depth", ObserveQueueDepth);
+        _queueWait = Meter.CreateHistogram<double>("write_queue_wait_ms");
+        _batchDuration = Meter.CreateHistogram<double>("batch_duration_ms");
+        _sqliteRetry = Meter.CreateCounter<long>("sqlite_retry_count");
+        _ftsAvailable = Meter.CreateObservableGauge("fts_available", ObserveFtsAvailability);
+        _ftsRepair = Meter.CreateCounter<long>("fts_repair_triggered_total");
+    }
+
+    public void UpdateQueueDepth(int partitionId, int depth)
+    {
+        _partitionDepth[partitionId] = depth;
+    }
+
+    public void RecordQueueWait(TimeSpan elapsed)
+    {
+        _queueWait.Record(elapsed.TotalMilliseconds);
+    }
+
+    public void RecordBatchDuration(TimeSpan elapsed, int itemCount)
+    {
+        _batchDuration.Record(elapsed.TotalMilliseconds, new KeyValuePair<string, object?>("items", itemCount));
+    }
+
+    public void RecordSqliteRetry(int count)
+    {
+        if (count <= 0)
+        {
+            return;
+        }
+
+        _sqliteRetry.Add(count);
+    }
+
+    public void UpdateFtsAvailability(bool isAvailable)
+    {
+        Interlocked.Exchange(ref _ftsAvailabilityValue, isAvailable ? 1 : 0);
+    }
+
+    public void RecordFtsRepairTriggered()
+    {
+        _ftsRepair.Add(1);
+    }
+
+    private IEnumerable<Measurement<long>> ObserveQueueDepth()
+    {
+        foreach (var (partitionId, depth) in _partitionDepth)
+        {
+            yield return new Measurement<long>(depth, new KeyValuePair<string, object?>("partition", partitionId));
+        }
+    }
+
+    private IEnumerable<Measurement<int>> ObserveFtsAvailability()
+    {
+        yield return new Measurement<int>(Interlocked.CompareExchange(ref _ftsAvailabilityValue, 0, 0));
+    }
+}


### PR DESCRIPTION
## Summary
- introduce a dedicated ISearchWriteTelemetry abstraction and register it with DI
- add SearchWriteTelemetry for queue, batch, retry, and FTS health metrics
- surface SearchWriteOptions for configuring write pipeline behaviour

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ecd64999d08326b1aa96f984989cca