### PR TITLE
Relax SQL fragment sanitizer for custom ranking expressions

### DIFF
--- a/Veriado.Application/Search/SearchQueryBuilder.cs
+++ b/Veriado.Application/Search/SearchQueryBuilder.cs
@@ -550,26 +550,14 @@ public sealed class SearchQueryBuilder : ISearchQueryBuilder
 
         foreach (var ch in trimmed)
         {
-            if (char.IsLetterOrDigit(ch) || char.IsWhiteSpace(ch))
+            if (char.IsWhiteSpace(ch))
             {
                 continue;
             }
 
-            switch (ch)
+            if (char.IsControl(ch))
             {
-                case '_':
-                case '(':
-                case ')':
-                case '+':
-                case '-':
-                case '*':
-                case '/':
-                case '.':
-                case ',':
-                case ':':
-                    continue;
-                default:
-                    throw new ArgumentException("SQL fragment contains unsupported characters.", parameterName);
+                throw new ArgumentException("SQL fragment contains control characters.", parameterName);
             }
         }
 


### PR DESCRIPTION
## Summary
- relax `EnsureSafeSqlFragment` so it only rejects control characters and SQL comment or statement separators

## Testing
- not run (environment lacks dotnet)


------
https://chatgpt.com/codex/tasks/task_e_68ece2fb473083269e82cef8bce40168