### PR TITLE
Fix outbox entity accessibility and update integrity collection methods

### DIFF
--- a/Veriado.Infrastructure/Persistence/Outbox/OutboxEventEntity.cs
+++ b/Veriado.Infrastructure/Persistence/Outbox/OutboxEventEntity.cs
@@ -5,7 +5,7 @@ namespace Veriado.Infrastructure.Persistence.Outbox;
 /// <summary>
 /// Represents a pending domain event stored for reliable delivery via the outbox pattern.
 /// </summary>
-internal sealed class OutboxEventEntity
+public sealed class OutboxEventEntity
 {
     public Guid Id { get; set; }
 


### PR DESCRIPTION
## Summary
- make the outbox entity public so it matches the DbContext surface
- update full-text integrity collection helpers to return tuples instead of using ref parameters

## Testing
- dotnet build Veriado.sln *(fails: dotnet is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ecf03f3a348326866ba69e78f57553