### PR TITLE
Compute token hash for search index signatures and fix wildcard normalization

### DIFF
--- a/Veriado.Application.Tests/Infrastructure/SearchIndexSignatureCalculatorTests.cs
+++ b/Veriado.Application.Tests/Infrastructure/SearchIndexSignatureCalculatorTests.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.Extensions.Options;
+using Veriado.Appl.Search;
+using Veriado.Domain.Files;
+using Veriado.Domain.ValueObjects;
+using Veriado.Infrastructure.Search;
+
+namespace Veriado.Application.Tests.Infrastructure;
+
+public sealed class SearchIndexSignatureCalculatorTests
+{
+    [Fact]
+    public void Compute_ReturnsNormalizedTitleAndTokenHash()
+    {
+        // Arrange
+        var analyzerOptions = new AnalyzerOptions
+        {
+            DefaultProfile = "cs",
+            Profiles = new Dictionary<string, AnalyzerProfile>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["cs"] = new()
+                {
+                    Name = "cs",
+                    EnableStemming = false,
+                    KeepNumbers = true,
+                    SplitFilenames = true,
+                    Stopwords = Array.Empty<string>(),
+                    CustomFilters = Array.Empty<string>()
+                }
+            }
+        };
+
+        var analyzerFactory = new AnalyzerFactory(Options.Create(analyzerOptions));
+        var searchOptions = new SearchOptions
+        {
+            Analyzer = analyzerOptions
+        };
+
+        var calculator = new SearchIndexSignatureCalculator(Options.Create(searchOptions), analyzerFactory);
+
+        var created = UtcTimestamp.From(new DateTimeOffset(2024, 1, 2, 3, 4, 5, TimeSpan.Zero));
+        var file = FileEntity.CreateNew(
+            FileName.From("Výkaz"),
+            FileExtension.From("pdf"),
+            MimeType.From("application/pdf"),
+            "Čeněk",
+            Encoding.UTF8.GetBytes("Hello metadata"),
+            created);
+
+        file.SetTitle("Přehled Dat", created);
+        file.SetAuthor("Čeněk", created);
+
+        var analyzer = analyzerFactory.Create();
+
+        // Act
+        var signature = calculator.Compute(file);
+        var document = file.ToSearchDocument();
+
+        // Assert
+        var expectedTitle = analyzer.Normalize(document.Title);
+        Assert.Equal(expectedTitle, signature.NormalizedTitle);
+
+        var tokens = new List<string>();
+        void Collect(string? source)
+        {
+            if (string.IsNullOrWhiteSpace(source))
+            {
+                return;
+            }
+
+            foreach (var token in analyzer.Tokenize(source))
+            {
+                if (!string.IsNullOrWhiteSpace(token))
+                {
+                    tokens.Add(token);
+                }
+            }
+        }
+
+        Collect(document.Title);
+        Collect(document.Author);
+        Collect(document.Mime);
+        Collect(document.MetadataText);
+
+        Assert.NotEmpty(tokens);
+        var payload = string.Join('\n', tokens);
+        var expectedHash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(payload)));
+        Assert.Equal(expectedHash, signature.TokenHash);
+    }
+}

--- a/Veriado.Application.Tests/Search/SearchFilesHandlerTests.cs
+++ b/Veriado.Application.Tests/Search/SearchFilesHandlerTests.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using AutoMapper;
+using Microsoft.Extensions.Options;
+using Veriado.Appl.Search;
+using Veriado.Appl.Search.Abstractions;
+using Veriado.Appl.UseCases.Search;
+using Veriado.Infrastructure.Search;
+using Veriado.Domain.Search;
+
+namespace Veriado.Application.Tests.Search;
+
+public sealed class SearchFilesHandlerTests
+{
+    [Fact]
+    public void NormalizeWildcardSegment_PreservesWhitespaceBetweenTokens()
+    {
+        // Arrange
+        var analyzerOptions = new AnalyzerOptions
+        {
+            DefaultProfile = "cs",
+            Profiles = new Dictionary<string, AnalyzerProfile>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["cs"] = new()
+                {
+                    Name = "cs"
+                }
+            }
+        };
+
+        var analyzerFactory = new AnalyzerFactory(Options.Create(analyzerOptions));
+        var searchOptions = new SearchOptions
+        {
+            Analyzer = analyzerOptions
+        };
+
+        var handler = new SearchFilesHandler(
+            new StubSearchQueryService(),
+            new MapperConfiguration(cfg => { }).CreateMapper(),
+            analyzerFactory,
+            searchOptions);
+
+        var method = typeof(SearchFilesHandler)
+            .GetMethod("NormalizeWildcardSegment", BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException("Could not locate NormalizeWildcardSegment method.");
+
+        // Act
+        var result = method.Invoke(handler, new object[] { "Data Science" }) as string;
+
+        // Assert
+        Assert.Equal("data science", result);
+    }
+
+    private sealed class StubSearchQueryService : ISearchQueryService
+    {
+        public Task<IReadOnlyList<(Guid Id, double Score)>> SearchWithScoresAsync(
+            SearchQueryPlan plan,
+            int skip,
+            int take,
+            CancellationToken cancellationToken)
+            => Task.FromResult<IReadOnlyList<(Guid, double)>>(Array.Empty<(Guid, double)>());
+
+        public Task<int> CountAsync(SearchQueryPlan plan, CancellationToken cancellationToken)
+            => Task.FromResult(0);
+
+        public Task<IReadOnlyList<SearchHit>> SearchAsync(SearchQueryPlan plan, int? limit, CancellationToken cancellationToken)
+            => Task.FromResult<IReadOnlyList<SearchHit>>(Array.Empty<SearchHit>());
+    }
+}

--- a/Veriado.Application/UseCases/Search/SearchFilesHandler.cs
+++ b/Veriado.Application/UseCases/Search/SearchFilesHandler.cs
@@ -600,7 +600,7 @@ public sealed class SearchFilesHandler : IRequestHandler<SearchFilesQuery, IRead
             return string.Empty;
         }
 
-        return string.Concat(tokens);
+        return tokens.Length == 1 ? tokens[0] : string.Join(' ', tokens);
     }
 
     private static bool TryExtractField(string rawToken, out string fieldName, out string remainder)


### PR DESCRIPTION
## Summary
- compute analyzer-driven token hashes when building `SearchIndexSignature` and persist the normalized title
- adjust wildcard segment normalisation so multi-token segments retain whitespace
- add unit tests covering the new signature calculator behaviour and wildcard normalisation helper

## Testing
- dotnet test *(fails: `dotnet` command is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ecedf79a6083268e315307a8897f9e