### PR TITLE
Ensure FileEntity content is loaded before computing search signature

### DIFF
--- a/Veriado.Infrastructure/Integrity/FulltextIntegrityService.cs
+++ b/Veriado.Infrastructure/Integrity/FulltextIntegrityService.cs
@@ -357,7 +357,11 @@ internal sealed class FulltextIntegrityService : IFulltextIntegrityService
         var document = file.ToSearchDocument();
         await _searchIndexer.IndexAsync(document, cancellationToken).ConfigureAwait(false);
 
-        var tracked = await writeContext.Files.FirstOrDefaultAsync(f => f.Id == fileId, cancellationToken).ConfigureAwait(false);
+        var tracked = await writeContext.Files
+            .Include(f => f.SearchIndex)
+            .Include(f => f.Content)
+            .FirstOrDefaultAsync(f => f.Id == fileId, cancellationToken)
+            .ConfigureAwait(false);
         if (tracked is not null)
         {
             var signature = _signatureCalculator.Compute(tracked);

--- a/Veriado.Infrastructure/Search/IndexQueue.cs
+++ b/Veriado.Infrastructure/Search/IndexQueue.cs
@@ -108,6 +108,7 @@ internal sealed class IndexQueue : IIndexQueue, IAsyncDisposable
         await using var writeContext = await _writeFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
         var tracked = await writeContext.Files
             .Include(f => f.SearchIndex)
+            .Include(f => f.Content)
             .FirstOrDefaultAsync(f => f.Id == fileId, cancellationToken)
             .ConfigureAwait(false);
         if (tracked is null)


### PR DESCRIPTION
## Summary
- ensure the index queue reloads FileEntity instances with Content when generating search signatures
- make FulltextIntegrityService include Content when rehydrating tracked entities prior to signature calculation

## Testing
- not run (dotnet CLI unavailable in execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68ecf3c3e35c832696b61da0c609e882