### PR TITLE
Fix SqliteTransaction casts

### DIFF
--- a/Veriado.Infrastructure/Concurrency/WriteWorker.cs
+++ b/Veriado.Infrastructure/Concurrency/WriteWorker.cs
@@ -281,7 +281,7 @@ internal sealed class WriteWorker : BackgroundService
             await sqliteConnection.OpenAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        await using SqliteTransaction sqliteTransaction = await sqliteConnection
+        await using SqliteTransaction sqliteTransaction = (SqliteTransaction)await sqliteConnection
             .BeginTransactionAsync(cancellationToken)
             .ConfigureAwait(false);
 

--- a/Veriado.Infrastructure/Search/FtsWriteAheadService.cs
+++ b/Veriado.Infrastructure/Search/FtsWriteAheadService.cs
@@ -273,7 +273,7 @@ internal sealed class FtsWriteAheadService : IFtsDlqMonitor
             entry.FileId,
             error);
 
-        await using SqliteTransaction sqliteTransaction = await connection
+        await using SqliteTransaction sqliteTransaction = (SqliteTransaction)await connection
             .BeginTransactionAsync(cancellationToken)
             .ConfigureAwait(false);
 
@@ -334,7 +334,7 @@ internal sealed class FtsWriteAheadService : IFtsDlqMonitor
             entry.Id,
             entry.FileId);
 
-        await using SqliteTransaction sqliteTransaction = await connection
+        await using SqliteTransaction sqliteTransaction = (SqliteTransaction)await connection
             .BeginTransactionAsync(cancellationToken)
             .ConfigureAwait(false);
         try
@@ -380,7 +380,7 @@ internal sealed class FtsWriteAheadService : IFtsDlqMonitor
             entry.Id,
             entry.FileId);
 
-        await using SqliteTransaction sqliteTransaction = await connection
+        await using SqliteTransaction sqliteTransaction = (SqliteTransaction)await connection
             .BeginTransactionAsync(cancellationToken)
             .ConfigureAwait(false);
         try
@@ -445,7 +445,7 @@ internal sealed class FtsWriteAheadService : IFtsDlqMonitor
             entry.Id,
             entry.FileId);
 
-        await using SqliteTransaction sqliteTransaction = await connection
+        await using SqliteTransaction sqliteTransaction = (SqliteTransaction)await connection
             .BeginTransactionAsync(cancellationToken)
             .ConfigureAwait(false);
         try
@@ -493,7 +493,7 @@ internal sealed class FtsWriteAheadService : IFtsDlqMonitor
             entry.Id,
             entry.FileId);
 
-        await using SqliteTransaction sqliteTransaction = await connection
+        await using SqliteTransaction sqliteTransaction = (SqliteTransaction)await connection
             .BeginTransactionAsync(cancellationToken)
             .ConfigureAwait(false);
         try

--- a/Veriado.Infrastructure/Search/SearchFavoritesService.cs
+++ b/Veriado.Infrastructure/Search/SearchFavoritesService.cs
@@ -51,7 +51,7 @@ internal sealed class SearchFavoritesService : ISearchFavoritesService
         await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
         await SqlitePragmaHelper.ApplyAsync(connection, cancellationToken: cancellationToken).ConfigureAwait(false);
 
-        await using SqliteTransaction sqliteTransaction = await connection
+        await using SqliteTransaction sqliteTransaction = (SqliteTransaction)await connection
             .BeginTransactionAsync(cancellationToken)
             .ConfigureAwait(false);
 
@@ -129,7 +129,7 @@ internal sealed class SearchFavoritesService : ISearchFavoritesService
 
         providedOrder.AddRange(existing);
 
-        await using SqliteTransaction sqliteTransaction = await connection
+        await using SqliteTransaction sqliteTransaction = (SqliteTransaction)await connection
             .BeginTransactionAsync(cancellationToken)
             .ConfigureAwait(false);
         for (var index = 0; index < providedOrder.Count; index++)

--- a/Veriado.Infrastructure/Search/SearchHistoryService.cs
+++ b/Veriado.Infrastructure/Search/SearchHistoryService.cs
@@ -21,7 +21,7 @@ internal sealed class SearchHistoryService : ISearchHistoryService
         var connection = lease.Connection;
         await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
         await SqlitePragmaHelper.ApplyAsync(connection, cancellationToken: cancellationToken).ConfigureAwait(false);
-        await using SqliteTransaction sqliteTransaction = await connection
+        await using SqliteTransaction sqliteTransaction = (SqliteTransaction)await connection
             .BeginTransactionAsync(cancellationToken)
             .ConfigureAwait(false);
         var now = _clock.UtcNow.ToString("O");

--- a/Veriado.Infrastructure/Search/SqliteFts5Indexer.cs
+++ b/Veriado.Infrastructure/Search/SqliteFts5Indexer.cs
@@ -66,7 +66,7 @@ internal sealed class SqliteFts5Indexer : ISearchIndexer
         var connection = lease.Connection;
         await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
         await SqlitePragmaHelper.ApplyAsync(connection, _logger, cancellationToken).ConfigureAwait(false);
-        await using SqliteTransaction sqliteTransaction = await connection
+        await using SqliteTransaction sqliteTransaction = (SqliteTransaction)await connection
             .BeginTransactionAsync(cancellationToken)
             .ConfigureAwait(false);
         var helper = new SqliteFts5Transactional(_analyzerFactory, _writeAhead);
@@ -105,7 +105,7 @@ internal sealed class SqliteFts5Indexer : ISearchIndexer
         var connection = lease.Connection;
         await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
         await SqlitePragmaHelper.ApplyAsync(connection, _logger, cancellationToken).ConfigureAwait(false);
-        await using SqliteTransaction sqliteTransaction = await connection
+        await using SqliteTransaction sqliteTransaction = (SqliteTransaction)await connection
             .BeginTransactionAsync(cancellationToken)
             .ConfigureAwait(false);
         var helper = new SqliteFts5Transactional(_analyzerFactory, _writeAhead);

--- a/Veriado.Infrastructure/Search/SuggestionMaintenanceService.cs
+++ b/Veriado.Infrastructure/Search/SuggestionMaintenanceService.cs
@@ -46,7 +46,7 @@ internal sealed class SuggestionMaintenanceService
             await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
             await SqlitePragmaHelper.ApplyAsync(connection, cancellationToken: cancellationToken).ConfigureAwait(false);
 
-            await using SqliteTransaction sqliteTransaction = await connection
+            await using SqliteTransaction sqliteTransaction = (SqliteTransaction)await connection
                 .BeginTransactionAsync(cancellationToken)
                 .ConfigureAwait(false);
             foreach (var entry in harvested)


### PR DESCRIPTION
## Summary
- cast SQLite transactions returned from `BeginTransactionAsync` to `SqliteTransaction` so they can be assigned to commands

## Testing
- dotnet build *(fails: `dotnet` is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68ecf4fe891c83268e449b85b2b69709