### PR TITLE
Fix infrastructure options validation configuration issues

### DIFF
--- a/Veriado.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/Veriado.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
@@ -86,7 +86,7 @@ public static class ServiceCollectionExtensions
             {
                 using var connection = new SqliteConnection(options.ConnectionString);
                 connection.Open();
-                SqlitePragmaHelper.ApplyAsync(connection, CancellationToken.None).GetAwaiter().GetResult();
+                SqlitePragmaHelper.ApplyAsync(connection, cancellationToken: CancellationToken.None).GetAwaiter().GetResult();
             }
 
             SqliteFulltextSupportDetector.Detect(options);

--- a/Veriado.Infrastructure/Veriado.Infrastructure.csproj
+++ b/Veriado.Infrastructure/Veriado.Infrastructure.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="9.0.9" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.9" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="9.0.9" />
     <PackageReference Include="PdfPig" Version="0.1.11" />
     <PackageReference Include="System.Text.Json" Version="9.0.9" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.9" />


### PR DESCRIPTION
## Summary
- add the Microsoft.Extensions.Options.DataAnnotations dependency so InfrastructureOptions can use ValidateDataAnnotations
- fix the SqlitePragmaHelper.ApplyAsync invocation to pass the cancellation token via a named argument

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68ecff2040d88326997abda2845df1a4