### PR TITLE
Add hosted service to auto-initialize infrastructure

### DIFF
--- a/Veriado.Services/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/Veriado.Services/DependencyInjection/ServiceCollectionExtensions.cs
@@ -1,9 +1,12 @@
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
 using Veriado.Appl.DependencyInjection;
 using Veriado.Contracts.Search.Abstractions;
 using Veriado.Services.Diagnostics;
 using Veriado.Services.Files;
 using Veriado.Services.Import;
+using Veriado.Services.Infrastructure;
 using Veriado.Services.Maintenance;
 using Veriado.Services.Search;
 
@@ -19,9 +22,6 @@ public static class ServiceCollectionExtensions
     /// </summary>
     /// <param name="services">The service collection.</param>
     /// <returns>The same service collection for chaining.</returns>
-    /// <remarks>
-    /// Hosts must invoke <c>InitializeInfrastructureAsync()</c> during startup to ensure the database is ready.
-    /// </remarks>
     public static IServiceCollection AddVeriadoServices(this IServiceCollection services)
     {
         ArgumentNullException.ThrowIfNull(services);
@@ -35,6 +35,8 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IMaintenanceService, MaintenanceService>();
         services.AddScoped<IHealthService, HealthService>();
         services.AddSingleton<ISearchFacade, SearchFacade>();
+
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IHostedService, InfrastructureInitializationHostedService>());
 
         return services;
     }

--- a/Veriado.Services/Infrastructure/InfrastructureInitializationHostedService.cs
+++ b/Veriado.Services/Infrastructure/InfrastructureInitializationHostedService.cs
@@ -1,0 +1,43 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Veriado.Infrastructure.DependencyInjection;
+
+namespace Veriado.Services.Infrastructure;
+
+/// <summary>
+/// Ensures the SQLite infrastructure is initialised when the host starts.
+/// </summary>
+internal sealed class InfrastructureInitializationHostedService : IHostedService
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly ILogger<InfrastructureInitializationHostedService> _logger;
+
+    public InfrastructureInitializationHostedService(
+        IServiceProvider serviceProvider,
+        ILogger<InfrastructureInitializationHostedService> logger)
+    {
+        _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            await _serviceProvider
+                .InitializeInfrastructureAsync(cancellationToken, nameof(InfrastructureInitializationHostedService))
+                .ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to initialize infrastructure during startup.");
+            throw;
+        }
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}


### PR DESCRIPTION
## Summary
- add a hosted service that calls InitializeInfrastructureAsync during startup so the database schema exists before imports run
- register the hosted service when AddVeriadoServices is used to ensure initialization happens automatically

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68ee96f792448326a329c5c1fd89148d