### PR TITLE
Handle missing DocumentContent errors as fulltext schema issues

### DIFF
--- a/Veriado.Infrastructure/Search/SqliteExceptionExtensions.cs
+++ b/Veriado.Infrastructure/Search/SqliteExceptionExtensions.cs
@@ -62,16 +62,28 @@ internal static class SqliteExceptionExtensions
 
         if (exception.Message.Contains("no such table", StringComparison.OrdinalIgnoreCase))
         {
-            return exception.Message.Contains("file_search", StringComparison.OrdinalIgnoreCase);
+            return ContainsFulltextIdentifier(exception.Message);
         }
 
         if (exception.Message.Contains("no such column", StringComparison.OrdinalIgnoreCase))
         {
-            return exception.Message.Contains("fts", StringComparison.OrdinalIgnoreCase)
-                || exception.Message.Contains("file_search", StringComparison.OrdinalIgnoreCase);
+            if (exception.Message.Contains("fts", StringComparison.OrdinalIgnoreCase)
+                || exception.Message.Contains("file_search", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            return ContainsFulltextIdentifier(exception.Message);
         }
 
         return false;
+    }
+
+    private static bool ContainsFulltextIdentifier(string message)
+    {
+        return message.Contains("file_search", StringComparison.OrdinalIgnoreCase)
+            || message.Contains("documentcontent", StringComparison.OrdinalIgnoreCase)
+            || message.Contains("document_content", StringComparison.OrdinalIgnoreCase);
     }
 
     public static bool IndicatesMissingColumn(this SqliteException exception)


### PR DESCRIPTION
## Summary
- treat missing DocumentContent tables or columns as full-text schema failures when interpreting SQLite exceptions
- centralize schema identifier detection so DocumentContent errors trigger the automatic repair path

## Testing
- not run (dotnet CLI unavailable in execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68ef397a8018832684449eddd55e8d44