### PR TITLE
Implement real SQLite FTS migrations and diagnostics

### DIFF
--- a/Veriado.Infrastructure/Concurrency/WriteWorker.cs
+++ b/Veriado.Infrastructure/Concurrency/WriteWorker.cs
@@ -37,6 +37,7 @@ internal sealed class WriteWorker : BackgroundService
     private readonly ISearchIndexSignatureCalculator _signatureCalculator;
     private readonly FtsWriteAheadService _writeAhead;
     private readonly ISearchTelemetry _telemetry;
+    private readonly ILogger<SqliteFts5Transactional> _ftsLogger;
 
     private static readonly FilePersistenceOptions SameTransactionOptions = FilePersistenceOptions.Default;
 
@@ -56,7 +57,8 @@ internal sealed class WriteWorker : BackgroundService
         INeedsReindexEvaluator needsReindexEvaluator,
         ISearchIndexSignatureCalculator signatureCalculator,
         FtsWriteAheadService writeAhead,
-        ISearchTelemetry telemetry)
+        ISearchTelemetry telemetry,
+        ILogger<SqliteFts5Transactional> ftsLogger)
     {
         if (options is null)
         {
@@ -96,6 +98,7 @@ internal sealed class WriteWorker : BackgroundService
         _signatureCalculator = signatureCalculator ?? throw new ArgumentNullException(nameof(signatureCalculator));
         _writeAhead = writeAhead ?? throw new ArgumentNullException(nameof(writeAhead));
         _telemetry = telemetry ?? throw new ArgumentNullException(nameof(telemetry));
+        _ftsLogger = ftsLogger ?? throw new ArgumentNullException(nameof(ftsLogger));
 
         _logger.LogDebug(
             "Write worker created for partition {PartitionId} of {WorkerCount} workers.",
@@ -602,7 +605,7 @@ internal sealed class WriteWorker : BackgroundService
             return true;
         }
 
-        var helper = new SqliteFts5Transactional(_analyzerFactory, _writeAhead);
+        var helper = new SqliteFts5Transactional(_analyzerFactory, _writeAhead, _ftsLogger);
         var handled = false;
 
         foreach (var id in filesToDelete)

--- a/Veriado.Infrastructure/Persistence/DesignTime/AppDbContextFactory.cs
+++ b/Veriado.Infrastructure/Persistence/DesignTime/AppDbContextFactory.cs
@@ -30,7 +30,13 @@ public sealed class AppDbContextFactory : IDesignTimeDbContextFactory<AppDbConte
 
         if (string.IsNullOrWhiteSpace(options.DbPath))
         {
-            options.DbPath = Path.Combine(AppContext.BaseDirectory, "veriado.db");
+            var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+            var dataDirectory = !string.IsNullOrWhiteSpace(localAppData)
+                ? Path.Combine(localAppData, "Veriado")
+                : Path.Combine(AppContext.BaseDirectory, "veriado-data");
+
+            // Eliminace duality DB (bin\Debug vs AppData)
+            options.DbPath = Path.Combine(dataDirectory, "veriado.db");
         }
 
         var directory = Path.GetDirectoryName(options.DbPath);

--- a/Veriado.Infrastructure/Persistence/Migrations/20251015071721_Init.Designer.cs
+++ b/Veriado.Infrastructure/Persistence/Migrations/20251015071721_Init.Designer.cs
@@ -2,17 +2,20 @@
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Veriado.Infrastructure.Persistence;
 
 #nullable disable
 
-namespace Veriado.Infrastructure.Migrations
+namespace Veriado.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20251015071721_Init")]
+    partial class Init
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "9.0.9");

--- a/Veriado.Infrastructure/Persistence/Migrations/AppDbContextModelSnapshot.cs
+++ b/Veriado.Infrastructure/Persistence/Migrations/AppDbContextModelSnapshot.cs
@@ -2,20 +2,17 @@
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Veriado.Infrastructure.Persistence;
 
 #nullable disable
 
-namespace Veriado.Infrastructure.Migrations
+namespace Veriado.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    [Migration("20251014175023_addInit")]
-    partial class addInit
+    partial class AppDbContextModelSnapshot : ModelSnapshot
     {
-        /// <inheritdoc />
-        protected override void BuildTargetModel(ModelBuilder modelBuilder)
+        protected override void BuildModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "9.0.9");

--- a/Veriado.Infrastructure/Persistence/SqliteFulltextSupport.cs
+++ b/Veriado.Infrastructure/Persistence/SqliteFulltextSupport.cs
@@ -8,6 +8,7 @@ internal static class SqliteFulltextSupport
     private static int _initialised;
     private static int _isAvailable;
     private static string? _failureReason;
+    private static FulltextSchemaSnapshot? _schemaSnapshot;
 
     /// <summary>
     /// Gets a value indicating whether the required FTS5 features are available.
@@ -20,6 +21,11 @@ internal static class SqliteFulltextSupport
     public static string? FailureReason => Volatile.Read(ref _failureReason);
 
     /// <summary>
+    /// Gets the last captured schema snapshot describing the FTS table configuration.
+    /// </summary>
+    public static FulltextSchemaSnapshot? SchemaSnapshot => Volatile.Read(ref _schemaSnapshot);
+
+    /// <summary>
     /// Updates the cached state describing FTS5 support for the current process.
     /// </summary>
     /// <param name="available">Indicates whether FTS5 support is available.</param>
@@ -30,4 +36,30 @@ internal static class SqliteFulltextSupport
         Volatile.Write(ref _failureReason, failureReason);
         Volatile.Write(ref _initialised, 1);
     }
+
+    /// <summary>
+    /// Updates the cached schema snapshot describing the FTS configuration.
+    /// </summary>
+    /// <param name="snapshot">The snapshot to cache.</param>
+    public static void UpdateSchemaSnapshot(FulltextSchemaSnapshot snapshot)
+    {
+        Volatile.Write(ref _schemaSnapshot, snapshot);
+    }
 }
+
+/// <summary>
+/// Represents a snapshot of the FTS schema metadata observed at runtime.
+/// </summary>
+/// <param name="TableSql">The raw CREATE VIRTUAL TABLE statement.</param>
+/// <param name="Columns">The column names reported by PRAGMA table_info.</param>
+/// <param name="Triggers">The triggers bound to DocumentContent.</param>
+/// <param name="IsContentless">Indicates whether the table uses the contentless FTS5 variant.</param>
+/// <param name="HasDocumentContentTriggers">Indicates whether the expected triggers are present.</param>
+/// <param name="CheckedAtUtc">The timestamp when the schema was inspected.</param>
+internal sealed record FulltextSchemaSnapshot(
+    string? TableSql,
+    IReadOnlyList<string> Columns,
+    IReadOnlyDictionary<string, string?> Triggers,
+    bool IsContentless,
+    bool HasDocumentContentTriggers,
+    DateTimeOffset CheckedAtUtc);

--- a/Veriado.Infrastructure/Search/SqliteFts5Indexer.cs
+++ b/Veriado.Infrastructure/Search/SqliteFts5Indexer.cs
@@ -16,6 +16,7 @@ internal sealed class SqliteFts5Indexer : ISearchIndexer
     private readonly IAnalyzerFactory _analyzerFactory;
     private readonly ISqliteConnectionFactory _connectionFactory;
     private readonly FtsWriteAheadService _writeAhead;
+    private readonly ILogger<SqliteFts5Transactional> _ftsLogger;
 
     public SqliteFts5Indexer(
         InfrastructureOptions options,
@@ -23,6 +24,7 @@ internal sealed class SqliteFts5Indexer : ISearchIndexer
         IAnalyzerFactory analyzerFactory,
         ISqliteConnectionFactory connectionFactory,
         FtsWriteAheadService writeAhead,
+        ILogger<SqliteFts5Transactional> ftsLogger,
         SuggestionMaintenanceService? suggestionMaintenance = null)
     {
         _options = options;
@@ -30,6 +32,7 @@ internal sealed class SqliteFts5Indexer : ISearchIndexer
         _analyzerFactory = analyzerFactory ?? throw new ArgumentNullException(nameof(analyzerFactory));
         _connectionFactory = connectionFactory ?? throw new ArgumentNullException(nameof(connectionFactory));
         _writeAhead = writeAhead ?? throw new ArgumentNullException(nameof(writeAhead));
+        _ftsLogger = ftsLogger ?? throw new ArgumentNullException(nameof(ftsLogger));
         _suggestionMaintenance = suggestionMaintenance;
     }
 
@@ -69,7 +72,7 @@ internal sealed class SqliteFts5Indexer : ISearchIndexer
         await using SqliteTransaction sqliteTransaction = (SqliteTransaction)await connection
             .BeginTransactionAsync(cancellationToken)
             .ConfigureAwait(false);
-        var helper = new SqliteFts5Transactional(_analyzerFactory, _writeAhead);
+        var helper = new SqliteFts5Transactional(_analyzerFactory, _writeAhead, _ftsLogger);
 
         try
         {
@@ -108,7 +111,7 @@ internal sealed class SqliteFts5Indexer : ISearchIndexer
         await using SqliteTransaction sqliteTransaction = (SqliteTransaction)await connection
             .BeginTransactionAsync(cancellationToken)
             .ConfigureAwait(false);
-        var helper = new SqliteFts5Transactional(_analyzerFactory, _writeAhead);
+        var helper = new SqliteFts5Transactional(_analyzerFactory, _writeAhead, _ftsLogger);
 
         try
         {

--- a/Veriado.Infrastructure/Search/SqliteSearchIndexCoordinator.cs
+++ b/Veriado.Infrastructure/Search/SqliteSearchIndexCoordinator.cs
@@ -16,17 +16,20 @@ internal sealed class SqliteSearchIndexCoordinator : ISearchIndexCoordinator
     private readonly ILogger<SqliteSearchIndexCoordinator> _logger;
     private readonly IAnalyzerFactory _analyzerFactory;
     private readonly FtsWriteAheadService _writeAhead;
+    private readonly ILogger<SqliteFts5Transactional> _ftsLogger;
 
     public SqliteSearchIndexCoordinator(
         InfrastructureOptions options,
         ILogger<SqliteSearchIndexCoordinator> logger,
         IAnalyzerFactory analyzerFactory,
-        FtsWriteAheadService writeAhead)
+        FtsWriteAheadService writeAhead,
+        ILogger<SqliteFts5Transactional> ftsLogger)
     {
         _options = options;
         _logger = logger;
         _analyzerFactory = analyzerFactory ?? throw new ArgumentNullException(nameof(analyzerFactory));
         _writeAhead = writeAhead ?? throw new ArgumentNullException(nameof(writeAhead));
+        _ftsLogger = ftsLogger ?? throw new ArgumentNullException(nameof(ftsLogger));
     }
 
     public async Task<bool> IndexAsync(FileEntity file, FilePersistenceOptions options, SqliteTransaction transaction, CancellationToken cancellationToken)
@@ -44,7 +47,7 @@ internal sealed class SqliteSearchIndexCoordinator : ISearchIndexCoordinator
             ?? throw new InvalidOperationException("SQLite connection is unavailable for the active transaction.");
 
         var document = file.ToSearchDocument();
-        var helper = new SqliteFts5Transactional(_analyzerFactory, _writeAhead);
+        var helper = new SqliteFts5Transactional(_analyzerFactory, _writeAhead, _ftsLogger);
         _logger.LogInformation(
             "Coordinating FTS upsert for file {FileId} within ambient transaction",
             file.Id);


### PR DESCRIPTION
## Summary
- align the design-time DbContext factory with the runtime LocalAppData SQLite database to avoid dual-database drift
- add a development guard that inspects the file_search FTS schema, caches a snapshot, and disables indexing when inconsistencies are detected
- capture the schema snapshot for later error logging and enhance SqliteFts5Transactional to use single statements with detailed diagnostics
- thread the shared FTS logger through all coordinator/indexer paths and generate an initial EF Core migration that creates DocumentContent, contentless file_search, and its triggers

## Testing
- not run (dotnet CLI unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68ef478a9dec8326ad8b9d4c74f2b31d