### PR TITLE
Fix DocumentContent migration for legacy metadata-less schema

### DIFF
--- a/Veriado.Infrastructure/Persistence/Migrations/20251026090000_UpdateDocumentContentSchema.cs
+++ b/Veriado.Infrastructure/Persistence/Migrations/20251026090000_UpdateDocumentContentSchema.cs
@@ -26,8 +26,9 @@ public partial class UpdateDocumentContentSchema : Migration
 );");
 
         migrationBuilder.Sql(
-            @"INSERT INTO DocumentContent
-SELECT * FROM DocumentContent_old;");
+            @"INSERT INTO DocumentContent (doc_id, file_id, title, author, mime, metadata_text, metadata)
+SELECT DocId, FileId, Title, Author, Mime, NULL, NULL
+FROM DocumentContent_old;");
 
         migrationBuilder.Sql("DROP TABLE DocumentContent_old;");
 


### PR DESCRIPTION
## Summary
- ensure the DocumentContent rebuild migration explicitly lists its target columns
- populate the new metadata fields with NULL so upgrades from databases without those columns no longer fail

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68ef681cacac832689ac310ec7003966