### PR TITLE
Fix import MIME fallback

### DIFF
--- a/Veriado.Services/Import/Internal/MimeMap.cs
+++ b/Veriado.Services/Import/Internal/MimeMap.cs
@@ -51,6 +51,6 @@ internal static class MimeMap
             return mime;
         }
 
-        return string.Concat("application/", normalized);
+        return "application/octet-stream";
     }
 }


### PR DESCRIPTION
## Summary
- ensure the import MIME map returns application/octet-stream for unknown extensions

## Testing
- not run (dotnet CLI unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68ef6c33cde48326a75829331c532d71