### PR TITLE
Enforce MIME requirement in DocumentContent schema

### DIFF
--- a/Veriado.Infrastructure/Persistence/Migrations/20251015071721_Init.cs
+++ b/Veriado.Infrastructure/Persistence/Migrations/20251015071721_Init.cs
@@ -341,7 +341,7 @@ namespace Veriado.Infrastructure.Persistence.Migrations
     file_id BLOB NOT NULL UNIQUE,
     title TEXT NULL,
     author TEXT NULL,
-    mime TEXT NULL,
+    mime TEXT NOT NULL,
     metadata_text TEXT NULL,
     metadata TEXT NULL
 );");

--- a/Veriado.Infrastructure/Persistence/Migrations/20251026090000_UpdateDocumentContentSchema.cs
+++ b/Veriado.Infrastructure/Persistence/Migrations/20251026090000_UpdateDocumentContentSchema.cs
@@ -20,7 +20,7 @@ public partial class UpdateDocumentContentSchema : Migration
     file_id BLOB NOT NULL UNIQUE,
     title TEXT NULL,
     author TEXT NULL,
-    mime TEXT NULL,
+    mime TEXT NOT NULL,
     metadata_text TEXT NULL,
     metadata TEXT NULL
 );");

--- a/Veriado.Infrastructure/Persistence/Schema/Fts5.sql
+++ b/Veriado.Infrastructure/Persistence/Schema/Fts5.sql
@@ -5,7 +5,7 @@ CREATE TABLE IF NOT EXISTS DocumentContent (
     file_id BLOB NOT NULL UNIQUE,
     title TEXT NULL,
     author TEXT NULL,
-    mime TEXT NULL,
+    mime TEXT NOT NULL,
     metadata_text TEXT NULL,
     metadata TEXT NULL
 );

--- a/Veriado.Infrastructure/Search/SqliteFts5Transactional.cs
+++ b/Veriado.Infrastructure/Search/SqliteFts5Transactional.cs
@@ -242,7 +242,7 @@ VALUES ($file_id, $title, $author, $mime, $metadata_text, $metadata);";
         Guid fileId,
         string? normalizedTitle,
         string? normalizedAuthor,
-        string? mime,
+        string mime,
         string? normalizedMetadataText,
         string? metadataJson)
     {
@@ -260,13 +260,17 @@ VALUES ($file_id, $title, $author, $mime, $metadata_text, $metadata);";
         SqliteCommand command,
         string? normalizedTitle,
         string? normalizedAuthor,
-        string? mime,
+        string mime,
         string? normalizedMetadataText,
         string? metadataJson)
     {
+        if (string.IsNullOrEmpty(mime))
+        {
+            throw new ArgumentException("MIME type is required for DocumentContent writes.", nameof(mime));
+        }
         command.Parameters.Add("$title", SqliteType.Text).Value = (object?)normalizedTitle ?? DBNull.Value;
         command.Parameters.Add("$author", SqliteType.Text).Value = (object?)normalizedAuthor ?? DBNull.Value;
-        command.Parameters.Add("$mime", SqliteType.Text).Value = (object?)mime ?? DBNull.Value;
+        command.Parameters.Add("$mime", SqliteType.Text).Value = mime;
         command.Parameters.Add("$metadata_text", SqliteType.Text).Value = (object?)normalizedMetadataText ?? DBNull.Value;
         command.Parameters.Add("$metadata", SqliteType.Text).Value = (object?)metadataJson ?? DBNull.Value;
     }


### PR DESCRIPTION
## Summary
- ensure the DocumentContent schema enforces non-null MIME values across the bootstrap SQL and migrations
- harden the FTS5 transactional helper to reject attempts to persist rows without a MIME type

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68ef7f0d40a88326a4322b17774109d2