### PR TITLE
Normalize MIME values during migration data copy

### DIFF
--- a/Veriado.Infrastructure/Persistence/Migrations/20251026090000_UpdateDocumentContentSchema.cs
+++ b/Veriado.Infrastructure/Persistence/Migrations/20251026090000_UpdateDocumentContentSchema.cs
@@ -26,8 +26,9 @@ public partial class UpdateDocumentContentSchema : Migration
 );");
 
         migrationBuilder.Sql(
-            @"INSERT INTO DocumentContent
-SELECT * FROM DocumentContent_old;");
+            @"INSERT INTO DocumentContent (doc_id, file_id, title, author, mime, metadata_text, metadata)
+SELECT doc_id, file_id, title, author, COALESCE(mime, ''), metadata_text, metadata
+FROM DocumentContent_old;");
 
         migrationBuilder.Sql("DROP TABLE DocumentContent_old;");
 


### PR DESCRIPTION
## Summary
- coerce legacy DocumentContent rows with null MIME values when copying into the new NOT NULL schema

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ef84c451dc8326b19af314669278ee