### PR TITLE
Fix DocumentContent schema migration for snake_case columns

### DIFF
--- a/Veriado.Infrastructure/Persistence/Migrations/20251026090000_UpdateDocumentContentSchema.cs
+++ b/Veriado.Infrastructure/Persistence/Migrations/20251026090000_UpdateDocumentContentSchema.cs
@@ -27,7 +27,7 @@ public partial class UpdateDocumentContentSchema : Migration
 
         migrationBuilder.Sql(
             @"INSERT INTO DocumentContent (doc_id, file_id, title, author, mime, metadata_text, metadata)
-SELECT DocId, FileId, Title, Author, Mime, NULL, NULL
+SELECT doc_id, file_id, title, author, mime, NULL, NULL
 FROM DocumentContent_old;");
 
         migrationBuilder.Sql("DROP TABLE DocumentContent_old;");


### PR DESCRIPTION
## Summary
- correct the DocumentContent schema migration to copy data from snake_case columns
- prevent the migration from failing with `SQL logic error` when the legacy table already used the new column names

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68f08b76ad1883268e4256da318278d1