### PR TITLE
Follow-up: Harden SQLite FTS schema detection

### DIFF
--- a/Veriado.Infrastructure/Persistence/SqliteFulltextSupportDetector.cs
+++ b/Veriado.Infrastructure/Persistence/SqliteFulltextSupportDetector.cs
@@ -50,6 +50,11 @@ internal static class SqliteFulltextSupportDetector
                 command.CommandText = "DROP TABLE temp.__fts5_probe;";
                 command.ExecuteNonQuery();
 
+                if (!TableExists(connection, "DocumentContent"))
+                {
+                    return (true, null);
+                }
+
                 var inspection = SqliteFulltextSchemaInspector
                     .InspectAsync(connection, CancellationToken.None)
                     .GetAwaiter()
@@ -88,5 +93,14 @@ internal static class SqliteFulltextSupportDetector
         {
             return (false, ex.Message);
         }
+    }
+
+    private static bool TableExists(SqliteConnection connection, string tableName)
+    {
+        using var command = connection.CreateCommand();
+        command.CommandText =
+            "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = $name LIMIT 1;";
+        command.Parameters.AddWithValue("$name", tableName);
+        return command.ExecuteScalar() is not null;
     }
 }


### PR DESCRIPTION
## Summary
- add a reusable inspector that validates the file_search and DocumentContent schema
- disable SQLite FTS usage when required tables, columns, or triggers are missing
- log richer development diagnostics and extend the cached schema snapshot with DocumentContent information
- skip schema inspection when the DocumentContent table is absent so first-run detection doesn't disable FTS permanently

## Testing
- ⚠️ not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68f092ef5214832692e4301cb506e614