### PR TITLE
Add FileSystemEntity aggregate and related domain events

### DIFF
--- a/Veriado.Domain/Files/Events/FileSystemEvents.cs
+++ b/Veriado.Domain/Files/Events/FileSystemEvents.cs
@@ -1,0 +1,366 @@
+using Veriado.Domain.Files;
+using Veriado.Domain.Metadata;
+using Veriado.Domain.Primitives;
+using Veriado.Domain.ValueObjects;
+
+namespace Veriado.Domain.Files.Events;
+
+/// <summary>
+/// Domain event emitted when file system content is created or replaced.
+/// </summary>
+public sealed class FileSystemContentChanged : IDomainEvent
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FileSystemContentChanged"/> class.
+    /// </summary>
+    /// <param name="fileSystemId">The identifier of the file system entity.</param>
+    /// <param name="provider">The storage provider hosting the content.</param>
+    /// <param name="storagePath">The storage path referencing the binary content.</param>
+    /// <param name="hash">The SHA-256 hash of the content.</param>
+    /// <param name="size">The size of the content in bytes.</param>
+    /// <param name="mime">The MIME type of the content.</param>
+    /// <param name="contentVersion">The version number assigned to the content.</param>
+    /// <param name="isEncrypted">Indicates whether the content is encrypted.</param>
+    /// <param name="occurredUtc">The timestamp when the change was observed.</param>
+    public FileSystemContentChanged(
+        Guid fileSystemId,
+        StorageProvider provider,
+        string storagePath,
+        FileHash hash,
+        ByteSize size,
+        MimeType mime,
+        int contentVersion,
+        bool isEncrypted,
+        UtcTimestamp occurredUtc)
+    {
+        FileSystemId = fileSystemId;
+        Provider = provider;
+        StoragePath = storagePath;
+        Hash = hash;
+        Size = size;
+        Mime = mime;
+        ContentVersion = contentVersion;
+        IsEncrypted = isEncrypted;
+        EventId = Guid.NewGuid();
+        OccurredOnUtc = occurredUtc.ToDateTimeOffset();
+    }
+
+    /// <summary>
+    /// Gets the identifier of the file system entity.
+    /// </summary>
+    public Guid FileSystemId { get; }
+
+    /// <summary>
+    /// Gets the storage provider hosting the content.
+    /// </summary>
+    public StorageProvider Provider { get; }
+
+    /// <summary>
+    /// Gets the storage path referencing the binary content.
+    /// </summary>
+    public string StoragePath { get; }
+
+    /// <summary>
+    /// Gets the SHA-256 hash of the content.
+    /// </summary>
+    public FileHash Hash { get; }
+
+    /// <summary>
+    /// Gets the size of the content in bytes.
+    /// </summary>
+    public ByteSize Size { get; }
+
+    /// <summary>
+    /// Gets the MIME type of the content.
+    /// </summary>
+    public MimeType Mime { get; }
+
+    /// <summary>
+    /// Gets the version number assigned to the content.
+    /// </summary>
+    public int ContentVersion { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether the content is encrypted.
+    /// </summary>
+    public bool IsEncrypted { get; }
+
+    /// <inheritdoc />
+    public Guid EventId { get; }
+
+    /// <inheritdoc />
+    public DateTimeOffset OccurredOnUtc { get; }
+}
+
+/// <summary>
+/// Domain event emitted when file system content is moved to a different storage path.
+/// </summary>
+public sealed class FileSystemMoved : IDomainEvent
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FileSystemMoved"/> class.
+    /// </summary>
+    /// <param name="fileSystemId">The identifier of the file system entity.</param>
+    /// <param name="provider">The storage provider hosting the content.</param>
+    /// <param name="previousPath">The previous storage path.</param>
+    /// <param name="newPath">The new storage path.</param>
+    /// <param name="occurredUtc">The timestamp when the change was observed.</param>
+    public FileSystemMoved(
+        Guid fileSystemId,
+        StorageProvider provider,
+        string previousPath,
+        string newPath,
+        UtcTimestamp occurredUtc)
+    {
+        FileSystemId = fileSystemId;
+        Provider = provider;
+        PreviousPath = previousPath;
+        NewPath = newPath;
+        EventId = Guid.NewGuid();
+        OccurredOnUtc = occurredUtc.ToDateTimeOffset();
+    }
+
+    /// <summary>
+    /// Gets the identifier of the file system entity.
+    /// </summary>
+    public Guid FileSystemId { get; }
+
+    /// <summary>
+    /// Gets the storage provider hosting the content.
+    /// </summary>
+    public StorageProvider Provider { get; }
+
+    /// <summary>
+    /// Gets the previous storage path.
+    /// </summary>
+    public string PreviousPath { get; }
+
+    /// <summary>
+    /// Gets the new storage path.
+    /// </summary>
+    public string NewPath { get; }
+
+    /// <inheritdoc />
+    public Guid EventId { get; }
+
+    /// <inheritdoc />
+    public DateTimeOffset OccurredOnUtc { get; }
+}
+
+/// <summary>
+/// Domain event emitted when file system attributes are updated.
+/// </summary>
+public sealed class FileSystemAttributesChanged : IDomainEvent
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FileSystemAttributesChanged"/> class.
+    /// </summary>
+    /// <param name="fileSystemId">The identifier of the file system entity.</param>
+    /// <param name="attributes">The updated file system attributes.</param>
+    /// <param name="occurredUtc">The timestamp when the change was observed.</param>
+    public FileSystemAttributesChanged(Guid fileSystemId, FileAttributesFlags attributes, UtcTimestamp occurredUtc)
+    {
+        FileSystemId = fileSystemId;
+        Attributes = attributes;
+        EventId = Guid.NewGuid();
+        OccurredOnUtc = occurredUtc.ToDateTimeOffset();
+    }
+
+    /// <summary>
+    /// Gets the identifier of the file system entity.
+    /// </summary>
+    public Guid FileSystemId { get; }
+
+    /// <summary>
+    /// Gets the updated file system attributes.
+    /// </summary>
+    public FileAttributesFlags Attributes { get; }
+
+    /// <inheritdoc />
+    public Guid EventId { get; }
+
+    /// <inheritdoc />
+    public DateTimeOffset OccurredOnUtc { get; }
+}
+
+/// <summary>
+/// Domain event emitted when the owner SID associated with a file is updated.
+/// </summary>
+public sealed class FileSystemOwnerChanged : IDomainEvent
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FileSystemOwnerChanged"/> class.
+    /// </summary>
+    /// <param name="fileSystemId">The identifier of the file system entity.</param>
+    /// <param name="ownerSid">The new owner SID.</param>
+    /// <param name="occurredUtc">The timestamp when the change was observed.</param>
+    public FileSystemOwnerChanged(Guid fileSystemId, string? ownerSid, UtcTimestamp occurredUtc)
+    {
+        FileSystemId = fileSystemId;
+        OwnerSid = ownerSid;
+        EventId = Guid.NewGuid();
+        OccurredOnUtc = occurredUtc.ToDateTimeOffset();
+    }
+
+    /// <summary>
+    /// Gets the identifier of the file system entity.
+    /// </summary>
+    public Guid FileSystemId { get; }
+
+    /// <summary>
+    /// Gets the owner SID associated with the file.
+    /// </summary>
+    public string? OwnerSid { get; }
+
+    /// <inheritdoc />
+    public Guid EventId { get; }
+
+    /// <inheritdoc />
+    public DateTimeOffset OccurredOnUtc { get; }
+}
+
+/// <summary>
+/// Domain event emitted when file system timestamps are updated.
+/// </summary>
+public sealed class FileSystemTimestampsUpdated : IDomainEvent
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FileSystemTimestampsUpdated"/> class.
+    /// </summary>
+    /// <param name="fileSystemId">The identifier of the file system entity.</param>
+    /// <param name="createdUtc">The updated creation timestamp.</param>
+    /// <param name="lastWriteUtc">The updated last write timestamp.</param>
+    /// <param name="lastAccessUtc">The updated last access timestamp.</param>
+    /// <param name="occurredUtc">The timestamp when the change was observed.</param>
+    public FileSystemTimestampsUpdated(
+        Guid fileSystemId,
+        UtcTimestamp createdUtc,
+        UtcTimestamp lastWriteUtc,
+        UtcTimestamp lastAccessUtc,
+        UtcTimestamp occurredUtc)
+    {
+        FileSystemId = fileSystemId;
+        CreatedUtc = createdUtc;
+        LastWriteUtc = lastWriteUtc;
+        LastAccessUtc = lastAccessUtc;
+        EventId = Guid.NewGuid();
+        OccurredOnUtc = occurredUtc.ToDateTimeOffset();
+    }
+
+    /// <summary>
+    /// Gets the identifier of the file system entity.
+    /// </summary>
+    public Guid FileSystemId { get; }
+
+    /// <summary>
+    /// Gets the updated creation timestamp.
+    /// </summary>
+    public UtcTimestamp CreatedUtc { get; }
+
+    /// <summary>
+    /// Gets the updated last write timestamp.
+    /// </summary>
+    public UtcTimestamp LastWriteUtc { get; }
+
+    /// <summary>
+    /// Gets the updated last access timestamp.
+    /// </summary>
+    public UtcTimestamp LastAccessUtc { get; }
+
+    /// <inheritdoc />
+    public Guid EventId { get; }
+
+    /// <inheritdoc />
+    public DateTimeOffset OccurredOnUtc { get; }
+}
+
+/// <summary>
+/// Domain event emitted when a file is detected as missing from storage.
+/// </summary>
+public sealed class FileSystemMissingDetected : IDomainEvent
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FileSystemMissingDetected"/> class.
+    /// </summary>
+    /// <param name="fileSystemId">The identifier of the file system entity.</param>
+    /// <param name="storagePath">The storage path that was probed.</param>
+    /// <param name="occurredUtc">The timestamp when the missing state was detected.</param>
+    public FileSystemMissingDetected(Guid fileSystemId, string storagePath, UtcTimestamp occurredUtc)
+    {
+        FileSystemId = fileSystemId;
+        StoragePath = storagePath;
+        EventId = Guid.NewGuid();
+        OccurredOnUtc = occurredUtc.ToDateTimeOffset();
+    }
+
+    /// <summary>
+    /// Gets the identifier of the file system entity.
+    /// </summary>
+    public Guid FileSystemId { get; }
+
+    /// <summary>
+    /// Gets the storage path that was probed.
+    /// </summary>
+    public string StoragePath { get; }
+
+    /// <inheritdoc />
+    public Guid EventId { get; }
+
+    /// <inheritdoc />
+    public DateTimeOffset OccurredOnUtc { get; }
+}
+
+/// <summary>
+/// Domain event emitted when a previously missing file is rehydrated in storage.
+/// </summary>
+public sealed class FileSystemRehydrated : IDomainEvent
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FileSystemRehydrated"/> class.
+    /// </summary>
+    /// <param name="fileSystemId">The identifier of the file system entity.</param>
+    /// <param name="provider">The storage provider hosting the content.</param>
+    /// <param name="storagePath">The storage path referencing the binary content.</param>
+    /// <param name="wasMissing">Indicates whether the file was previously marked as missing.</param>
+    /// <param name="occurredUtc">The timestamp when rehydration occurred.</param>
+    public FileSystemRehydrated(
+        Guid fileSystemId,
+        StorageProvider provider,
+        string storagePath,
+        bool wasMissing,
+        UtcTimestamp occurredUtc)
+    {
+        FileSystemId = fileSystemId;
+        Provider = provider;
+        StoragePath = storagePath;
+        WasMissing = wasMissing;
+        EventId = Guid.NewGuid();
+        OccurredOnUtc = occurredUtc.ToDateTimeOffset();
+    }
+
+    /// <summary>
+    /// Gets the identifier of the file system entity.
+    /// </summary>
+    public Guid FileSystemId { get; }
+
+    /// <summary>
+    /// Gets the storage provider hosting the content.
+    /// </summary>
+    public StorageProvider Provider { get; }
+
+    /// <summary>
+    /// Gets the storage path referencing the binary content.
+    /// </summary>
+    public string StoragePath { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether the file was previously missing from storage.
+    /// </summary>
+    public bool WasMissing { get; }
+
+    /// <inheritdoc />
+    public Guid EventId { get; }
+
+    /// <inheritdoc />
+    public DateTimeOffset OccurredOnUtc { get; }
+}

--- a/Veriado.Domain/Files/FileSystemEntity.cs
+++ b/Veriado.Domain/Files/FileSystemEntity.cs
@@ -1,0 +1,423 @@
+using Veriado.Domain.Files.Events;
+using Veriado.Domain.Metadata;
+using Veriado.Domain.Primitives;
+using Veriado.Domain.ValueObjects;
+
+namespace Veriado.Domain.Files;
+
+/// <summary>
+/// Represents the metadata for a physical file stored in an external storage system.
+/// </summary>
+public sealed class FileSystemEntity : AggregateRoot
+{
+    private const int InitialContentVersion = 1;
+
+    private FileSystemEntity(Guid id)
+        : base(id)
+    {
+    }
+
+    private FileSystemEntity(
+        Guid id,
+        StorageProvider provider,
+        string storagePath,
+        MimeType mime,
+        FileHash hash,
+        ByteSize size,
+        FileAttributesFlags attributes,
+        UtcTimestamp createdUtc,
+        UtcTimestamp lastWriteUtc,
+        UtcTimestamp lastAccessUtc,
+        string? ownerSid,
+        bool isEncrypted,
+        bool isMissing,
+        int contentVersion)
+        : base(id)
+    {
+        Provider = provider;
+        StoragePath = storagePath;
+        Mime = mime;
+        Hash = hash;
+        Size = size;
+        Attributes = attributes;
+        CreatedUtc = createdUtc;
+        LastWriteUtc = lastWriteUtc;
+        LastAccessUtc = lastAccessUtc;
+        OwnerSid = ownerSid;
+        IsEncrypted = isEncrypted;
+        IsMissing = isMissing;
+        ContentVersion = contentVersion;
+    }
+
+    /// <summary>
+    /// Gets the storage provider hosting the file content.
+    /// </summary>
+    public StorageProvider Provider { get; private set; }
+
+    /// <summary>
+    /// Gets the storage path referencing the file content.
+    /// </summary>
+    public string StoragePath { get; private set; } = null!;
+
+    /// <summary>
+    /// Gets the MIME type associated with the file.
+    /// </summary>
+    public MimeType Mime { get; private set; }
+
+    /// <summary>
+    /// Gets the SHA-256 hash of the stored content.
+    /// </summary>
+    public FileHash Hash { get; private set; }
+
+    /// <summary>
+    /// Gets the file size in bytes.
+    /// </summary>
+    public ByteSize Size { get; private set; }
+
+    /// <summary>
+    /// Gets the file system attributes snapshot.
+    /// </summary>
+    public FileAttributesFlags Attributes { get; private set; }
+
+    /// <summary>
+    /// Gets the timestamp when the file was created.
+    /// </summary>
+    public UtcTimestamp CreatedUtc { get; private set; }
+
+    /// <summary>
+    /// Gets the timestamp when the file content was last modified.
+    /// </summary>
+    public UtcTimestamp LastWriteUtc { get; private set; }
+
+    /// <summary>
+    /// Gets the timestamp when the file was last accessed.
+    /// </summary>
+    public UtcTimestamp LastAccessUtc { get; private set; }
+
+    /// <summary>
+    /// Gets the optional owner SID associated with the file.
+    /// </summary>
+    public string? OwnerSid { get; private set; }
+
+    /// <summary>
+    /// Gets a value indicating whether the file is encrypted at rest by the storage provider.
+    /// </summary>
+    public bool IsEncrypted { get; private set; }
+
+    /// <summary>
+    /// Gets a value indicating whether the file is currently missing from the storage provider.
+    /// </summary>
+    public bool IsMissing { get; private set; }
+
+    /// <summary>
+    /// Gets the version number of the physical content stored for this file.
+    /// </summary>
+    public int ContentVersion { get; private set; }
+
+    /// <summary>
+    /// Creates a new file system entity from the provided content bytes and metadata.
+    /// </summary>
+    /// <param name="provider">The storage provider containing the file.</param>
+    /// <param name="mime">The MIME type of the content.</param>
+    /// <param name="bytes">The binary content to persist externally.</param>
+    /// <param name="save">The delegate responsible for persisting the content and returning the storage path.</param>
+    /// <param name="attributes">The file system attributes.</param>
+    /// <param name="createdUtc">The creation timestamp.</param>
+    /// <param name="lastWriteUtc">The last write timestamp.</param>
+    /// <param name="lastAccessUtc">The last access timestamp.</param>
+    /// <param name="ownerSid">The optional owner SID.</param>
+    /// <param name="isEncrypted">Indicates whether the content is encrypted.</param>
+    /// <param name="maxContentSize">Optional maximum content size in bytes.</param>
+    /// <returns>The created aggregate root.</returns>
+    public static FileSystemEntity CreateNew(
+        StorageProvider provider,
+        MimeType mime,
+        ReadOnlySpan<byte> bytes,
+        Func<FileHash, ReadOnlySpan<byte>, string> save,
+        FileAttributesFlags attributes,
+        UtcTimestamp createdUtc,
+        UtcTimestamp lastWriteUtc,
+        UtcTimestamp lastAccessUtc,
+        string? ownerSid,
+        bool isEncrypted,
+        int? maxContentSize = null)
+    {
+        ArgumentNullException.ThrowIfNull(save);
+        if (maxContentSize.HasValue && bytes.Length > maxContentSize.Value)
+        {
+            throw new ArgumentOutOfRangeException(nameof(bytes), bytes.Length, "Content exceeds the maximum allowed size.");
+        }
+
+        var hash = FileHash.Compute(bytes);
+        var path = NormalizeStoragePath(save(hash, bytes));
+        var size = ByteSize.From(bytes.Length);
+        var normalizedOwner = NormalizeOwnerSid(ownerSid);
+
+        var entity = new FileSystemEntity(
+            Guid.NewGuid(),
+            provider,
+            path,
+            mime,
+            hash,
+            size,
+            attributes,
+            createdUtc,
+            lastWriteUtc,
+            lastAccessUtc,
+            normalizedOwner,
+            isEncrypted,
+            isMissing: false,
+            contentVersion: InitialContentVersion);
+
+        entity.RaiseDomainEvent(new FileSystemContentChanged(
+            entity.Id,
+            provider,
+            path,
+            hash,
+            size,
+            mime,
+            entity.ContentVersion,
+            isEncrypted,
+            createdUtc));
+
+        if (!string.IsNullOrEmpty(normalizedOwner))
+        {
+            entity.RaiseDomainEvent(new FileSystemOwnerChanged(entity.Id, normalizedOwner, createdUtc));
+        }
+
+        entity.RaiseDomainEvent(new FileSystemTimestampsUpdated(
+            entity.Id,
+            createdUtc,
+            lastWriteUtc,
+            lastAccessUtc,
+            createdUtc));
+
+        if (attributes != FileAttributesFlags.None)
+        {
+            entity.RaiseDomainEvent(new FileSystemAttributesChanged(entity.Id, attributes, createdUtc));
+        }
+
+        return entity;
+    }
+
+    /// <summary>
+    /// Replaces the stored content with new bytes and updates metadata.
+    /// </summary>
+    /// <param name="bytes">The new binary content.</param>
+    /// <param name="mime">The MIME type of the content.</param>
+    /// <param name="save">The delegate responsible for persisting the content and returning the storage path.</param>
+    /// <param name="whenUtc">The timestamp describing when the change occurred.</param>
+    /// <param name="maxContentSize">Optional maximum content size in bytes.</param>
+    public void ReplaceContent(
+        ReadOnlySpan<byte> bytes,
+        MimeType mime,
+        Func<FileHash, ReadOnlySpan<byte>, string> save,
+        UtcTimestamp whenUtc,
+        int? maxContentSize = null)
+    {
+        ArgumentNullException.ThrowIfNull(save);
+        if (maxContentSize.HasValue && bytes.Length > maxContentSize.Value)
+        {
+            throw new ArgumentOutOfRangeException(nameof(bytes), bytes.Length, "Content exceeds the maximum allowed size.");
+        }
+
+        var hash = FileHash.Compute(bytes);
+        if (hash == Hash && mime == Mime && bytes.Length == Size.Value)
+        {
+            return;
+        }
+
+        var path = NormalizeStoragePath(save(hash, bytes));
+
+        Hash = hash;
+        Mime = mime;
+        StoragePath = path;
+        Size = ByteSize.From(bytes.Length);
+        LastWriteUtc = whenUtc;
+        IsMissing = false;
+        ContentVersion += 1;
+
+        RaiseDomainEvent(new FileSystemContentChanged(Id, Provider, path, hash, Size, Mime, ContentVersion, IsEncrypted, whenUtc));
+    }
+
+    /// <summary>
+    /// Moves the file to a new storage path within the same provider.
+    /// </summary>
+    /// <param name="newPath">The new storage path.</param>
+    /// <param name="whenUtc">The timestamp describing when the change occurred.</param>
+    public void MoveTo(string newPath, UtcTimestamp whenUtc)
+    {
+        var normalized = NormalizeStoragePath(newPath);
+        if (string.Equals(StoragePath, normalized, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        var previous = StoragePath;
+        StoragePath = normalized;
+
+        RaiseDomainEvent(new FileSystemMoved(Id, Provider, previous, normalized, whenUtc));
+    }
+
+    /// <summary>
+    /// Updates the file attributes snapshot.
+    /// </summary>
+    /// <param name="attributes">The new attribute flags.</param>
+    /// <param name="whenUtc">The timestamp describing when the change occurred.</param>
+    public void UpdateAttributes(FileAttributesFlags attributes, UtcTimestamp whenUtc)
+    {
+        if (attributes == Attributes)
+        {
+            return;
+        }
+
+        Attributes = attributes;
+        RaiseDomainEvent(new FileSystemAttributesChanged(Id, attributes, whenUtc));
+    }
+
+    /// <summary>
+    /// Updates the stored owner SID reference.
+    /// </summary>
+    /// <param name="ownerSid">The new owner SID.</param>
+    /// <param name="whenUtc">The timestamp describing when the change occurred.</param>
+    public void UpdateOwner(string? ownerSid, UtcTimestamp whenUtc)
+    {
+        var normalized = NormalizeOwnerSid(ownerSid);
+        if (string.Equals(OwnerSid, normalized, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        OwnerSid = normalized;
+        RaiseDomainEvent(new FileSystemOwnerChanged(Id, normalized, whenUtc));
+    }
+
+    /// <summary>
+    /// Updates the file system timestamps.
+    /// </summary>
+    /// <param name="created">Optional creation timestamp.</param>
+    /// <param name="lastWrite">Optional last write timestamp.</param>
+    /// <param name="lastAccess">Optional last access timestamp.</param>
+    /// <param name="whenUtc">The timestamp describing when the change occurred.</param>
+    public void UpdateTimestamps(
+        UtcTimestamp? created,
+        UtcTimestamp? lastWrite,
+        UtcTimestamp? lastAccess,
+        UtcTimestamp whenUtc)
+    {
+        var changed = false;
+
+        if (created.HasValue && created.Value != CreatedUtc)
+        {
+            CreatedUtc = created.Value;
+            changed = true;
+        }
+
+        if (lastWrite.HasValue && lastWrite.Value != LastWriteUtc)
+        {
+            LastWriteUtc = lastWrite.Value;
+            changed = true;
+        }
+
+        if (lastAccess.HasValue && lastAccess.Value != LastAccessUtc)
+        {
+            LastAccessUtc = lastAccess.Value;
+            changed = true;
+        }
+
+        if (!changed)
+        {
+            return;
+        }
+
+        RaiseDomainEvent(new FileSystemTimestampsUpdated(Id, CreatedUtc, LastWriteUtc, LastAccessUtc, whenUtc));
+    }
+
+    /// <summary>
+    /// Marks the file as missing in storage.
+    /// </summary>
+    /// <param name="whenUtc">The timestamp describing when the missing state was detected.</param>
+    public void MarkMissing(UtcTimestamp whenUtc)
+    {
+        if (IsMissing)
+        {
+            return;
+        }
+
+        IsMissing = true;
+        RaiseDomainEvent(new FileSystemMissingDetected(Id, StoragePath, whenUtc));
+    }
+
+    /// <summary>
+    /// Rehydrates the file metadata when the content is restored in storage.
+    /// </summary>
+    /// <param name="newPath">An optional new storage path.</param>
+    /// <param name="whenUtc">The timestamp describing when rehydration occurred.</param>
+    public void Rehydrate(string? newPath, UtcTimestamp whenUtc)
+    {
+        var normalized = newPath is null ? StoragePath : NormalizeStoragePath(newPath);
+        var pathChanged = !string.Equals(StoragePath, normalized, StringComparison.Ordinal);
+        var wasMissing = IsMissing;
+
+        StoragePath = normalized;
+        IsMissing = false;
+
+        if (!wasMissing && !pathChanged)
+        {
+            return;
+        }
+
+        RaiseDomainEvent(new FileSystemRehydrated(Id, Provider, normalized, wasMissing, whenUtc));
+    }
+
+    private static string NormalizeStoragePath(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            throw new ArgumentException("Storage path cannot be null or whitespace.", nameof(value));
+        }
+
+        return value.Trim();
+    }
+
+    private static string? NormalizeOwnerSid(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        return value.Trim();
+    }
+}
+
+/// <summary>
+/// Defines the supported storage providers for physical file content.
+/// </summary>
+public enum StorageProvider
+{
+    /// <summary>
+    /// Local disk storage.
+    /// </summary>
+    Local = 0,
+
+    /// <summary>
+    /// Network share storage.
+    /// </summary>
+    NetworkShare = 1,
+
+    /// <summary>
+    /// Amazon S3 storage.
+    /// </summary>
+    S3 = 2,
+
+    /// <summary>
+    /// Azure Blob storage.
+    /// </summary>
+    AzureBlob = 3,
+
+    /// <summary>
+    /// Any other storage provider not explicitly listed.
+    /// </summary>
+    Other = 4,
+}


### PR DESCRIPTION
## Summary
- add a FileSystemEntity aggregate to represent physical storage metadata and operations
- introduce supporting domain events for file system changes such as content updates, moves, and missing detection

## Testing
- `dotnet build Veriado.Domain/Veriado.Domain.csproj` *(fails: command not found `dotnet`)*

------
https://chatgpt.com/codex/tasks/task_e_68f143c8ef98832692769742e244c80e