### PR TITLE
Restrict storage providers to local and network

### DIFF
--- a/Veriado.Domain/Files/FileSystemEntity.cs
+++ b/Veriado.Domain/Files/FileSystemEntity.cs
@@ -402,22 +402,7 @@ public enum StorageProvider
     Local = 0,
 
     /// <summary>
-    /// Network share storage.
+    /// Network storage (e.g., SMB or NFS shares).
     /// </summary>
-    NetworkShare = 1,
-
-    /// <summary>
-    /// Amazon S3 storage.
-    /// </summary>
-    S3 = 2,
-
-    /// <summary>
-    /// Azure Blob storage.
-    /// </summary>
-    AzureBlob = 3,
-
-    /// <summary>
-    /// Any other storage provider not explicitly listed.
-    /// </summary>
-    Other = 4,
+    Network = 1,
 }


### PR DESCRIPTION
## Summary
- remove cloud and generic storage options from the FileSystemEntity storage provider enum
- keep only Local and Network providers, clarifying the network option description

## Testing
- dotnet test *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68f1456213f48326a74c17aec9850b84