### PR TITLE
Add link-only primitives and events to support upcoming refactor

### DIFF
--- a/Veriado.Domain/Files/Events/FileContentLinked.cs
+++ b/Veriado.Domain/Files/Events/FileContentLinked.cs
@@ -1,0 +1,54 @@
+// VERIADO REFACTOR
+using Veriado.Domain.ValueObjects;
+
+namespace Veriado.Domain.Files.Events;
+
+/// <summary>
+/// Domain event emitted when file content is linked to external storage.
+/// </summary>
+public sealed class FileContentLinked : IDomainEvent
+{
+    // VERIADO REFACTOR
+    public FileContentLinked(
+        Guid fileId,
+        Guid fileSystemId,
+        StorageProvider provider,
+        StoragePath path,
+        FileHash hash,
+        ContentVersion version,
+        UtcTimestamp occurredUtc)
+    {
+        FileId = fileId;
+        FileSystemId = fileSystemId;
+        Provider = provider;
+        Path = path;
+        Hash = hash;
+        Version = version;
+        EventId = Guid.NewGuid();
+        OccurredOnUtc = occurredUtc.ToDateTimeOffset();
+    }
+
+    // VERIADO REFACTOR
+    public Guid FileId { get; }
+
+    // VERIADO REFACTOR
+    public Guid FileSystemId { get; }
+
+    // VERIADO REFACTOR
+    public StorageProvider Provider { get; }
+
+    // VERIADO REFACTOR
+    public StoragePath Path { get; }
+
+    // VERIADO REFACTOR
+    public FileHash Hash { get; }
+
+    // VERIADO REFACTOR
+    public ContentVersion Version { get; }
+
+    // VERIADO REFACTOR
+    public Guid EventId { get; }
+
+    // VERIADO REFACTOR
+    public DateTimeOffset OccurredOnUtc { get; }
+}

--- a/Veriado.Domain/Files/Events/FileContentRelinked.cs
+++ b/Veriado.Domain/Files/Events/FileContentRelinked.cs
@@ -1,0 +1,54 @@
+// VERIADO REFACTOR
+using Veriado.Domain.ValueObjects;
+
+namespace Veriado.Domain.Files.Events;
+
+/// <summary>
+/// Domain event emitted when file content is re-linked to new storage metadata.
+/// </summary>
+public sealed class FileContentRelinked : IDomainEvent
+{
+    // VERIADO REFACTOR
+    public FileContentRelinked(
+        Guid fileId,
+        Guid fileSystemId,
+        StorageProvider provider,
+        StoragePath path,
+        FileHash hash,
+        ContentVersion version,
+        UtcTimestamp occurredUtc)
+    {
+        FileId = fileId;
+        FileSystemId = fileSystemId;
+        Provider = provider;
+        Path = path;
+        Hash = hash;
+        Version = version;
+        EventId = Guid.NewGuid();
+        OccurredOnUtc = occurredUtc.ToDateTimeOffset();
+    }
+
+    // VERIADO REFACTOR
+    public Guid FileId { get; }
+
+    // VERIADO REFACTOR
+    public Guid FileSystemId { get; }
+
+    // VERIADO REFACTOR
+    public StorageProvider Provider { get; }
+
+    // VERIADO REFACTOR
+    public StoragePath Path { get; }
+
+    // VERIADO REFACTOR
+    public FileHash Hash { get; }
+
+    // VERIADO REFACTOR
+    public ContentVersion Version { get; }
+
+    // VERIADO REFACTOR
+    public Guid EventId { get; }
+
+    // VERIADO REFACTOR
+    public DateTimeOffset OccurredOnUtc { get; }
+}

--- a/Veriado.Domain/Files/Events/FileContentUnlinked.cs
+++ b/Veriado.Domain/Files/Events/FileContentUnlinked.cs
@@ -1,0 +1,25 @@
+// VERIADO REFACTOR
+namespace Veriado.Domain.Files.Events;
+
+/// <summary>
+/// Domain event emitted when file content is disassociated from a file.
+/// </summary>
+public sealed class FileContentUnlinked : IDomainEvent
+{
+    // VERIADO REFACTOR
+    public FileContentUnlinked(Guid fileId, UtcTimestamp occurredUtc)
+    {
+        FileId = fileId;
+        EventId = Guid.NewGuid();
+        OccurredOnUtc = occurredUtc.ToDateTimeOffset();
+    }
+
+    // VERIADO REFACTOR
+    public Guid FileId { get; }
+
+    // VERIADO REFACTOR
+    public Guid EventId { get; }
+
+    // VERIADO REFACTOR
+    public DateTimeOffset OccurredOnUtc { get; }
+}

--- a/Veriado.Domain/Files/FileContentLinkEntity.cs
+++ b/Veriado.Domain/Files/FileContentLinkEntity.cs
@@ -1,0 +1,126 @@
+// VERIADO REFACTOR
+using Veriado.Domain.Metadata;
+using Veriado.Domain.ValueObjects;
+
+namespace Veriado.Domain.Files;
+
+/// <summary>
+/// Represents an immutable link to external file content stored outside of the domain aggregate.
+/// </summary>
+public sealed class FileContentLinkEntity
+{
+    // VERIADO REFACTOR
+    private FileContentLinkEntity(
+        Guid id,
+        Guid fileSystemId,
+        StorageProvider provider,
+        StoragePath path,
+        FileHash hash,
+        ByteSize size,
+        MimeType mime,
+        bool isEncrypted,
+        FileAttributesFlags attributes,
+        ContentVersion version,
+        UtcTimestamp linkedUtc)
+    {
+        Id = id;
+        FileSystemId = fileSystemId;
+        Provider = provider;
+        Path = path;
+        Hash = hash;
+        Size = size;
+        Mime = mime;
+        IsEncrypted = isEncrypted;
+        Attributes = attributes;
+        Version = version;
+        LinkedUtc = linkedUtc;
+    }
+
+    // VERIADO REFACTOR
+    public Guid Id { get; }
+
+    // VERIADO REFACTOR
+    public Guid FileSystemId { get; }
+
+    // VERIADO REFACTOR
+    public StorageProvider Provider { get; }
+
+    // VERIADO REFACTOR
+    public StoragePath Path { get; }
+
+    // VERIADO REFACTOR
+    public FileHash Hash { get; }
+
+    // VERIADO REFACTOR
+    public ByteSize Size { get; }
+
+    // VERIADO REFACTOR
+    public MimeType Mime { get; }
+
+    // VERIADO REFACTOR
+    public bool IsEncrypted { get; }
+
+    // VERIADO REFACTOR
+    public FileAttributesFlags Attributes { get; }
+
+    // VERIADO REFACTOR
+    public ContentVersion Version { get; }
+
+    // VERIADO REFACTOR
+    public UtcTimestamp LinkedUtc { get; }
+
+    // VERIADO REFACTOR
+    public static FileContentLinkEntity CreateNew(
+        Guid fileSystemId,
+        StorageProvider provider,
+        StoragePath path,
+        FileHash hash,
+        ByteSize size,
+        MimeType mime,
+        bool isEncrypted,
+        FileAttributesFlags attributes,
+        UtcTimestamp linkedUtc)
+    {
+        ArgumentNullException.ThrowIfNull(path);
+        return new FileContentLinkEntity(
+            Guid.NewGuid(),
+            fileSystemId,
+            provider,
+            path,
+            hash,
+            size,
+            mime,
+            isEncrypted,
+            attributes,
+            ContentVersion.Initial(),
+            linkedUtc);
+    }
+
+    // VERIADO REFACTOR
+    public FileContentLinkEntity Relink(
+        Guid fileSystemId,
+        StorageProvider provider,
+        StoragePath path,
+        FileHash hash,
+        ByteSize size,
+        MimeType mime,
+        bool isEncrypted,
+        FileAttributesFlags attributes,
+        UtcTimestamp linkedUtc)
+    {
+        ArgumentNullException.ThrowIfNull(path);
+        var nextVersion = hash == Hash ? Version : Version.Next();
+        return new FileContentLinkEntity(
+            Guid.NewGuid(),
+            fileSystemId,
+            provider,
+            path,
+            hash,
+            size,
+            mime,
+            isEncrypted,
+            attributes,
+            nextVersion,
+            linkedUtc);
+    }
+}

--- a/Veriado.Domain/ValueObjects/ContentVersion.cs
+++ b/Veriado.Domain/ValueObjects/ContentVersion.cs
@@ -1,0 +1,42 @@
+// VERIADO REFACTOR
+namespace Veriado.Domain.ValueObjects;
+
+/// <summary>
+/// Represents a positive, monotonically increasing content version.
+/// </summary>
+public readonly record struct ContentVersion
+{
+    // VERIADO REFACTOR
+    private ContentVersion(int value)
+    {
+        if (value <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(value), value, "Content version must be positive.");
+        }
+
+        Value = value;
+    }
+
+    // VERIADO REFACTOR
+    public int Value { get; }
+
+    // VERIADO REFACTOR
+    public static ContentVersion Initial() => new(1);
+
+    // VERIADO REFACTOR
+    public ContentVersion Next()
+    {
+        if (Value == int.MaxValue)
+        {
+            throw new InvalidOperationException("Content version overflow.");
+        }
+
+        return new ContentVersion(Value + 1);
+    }
+
+    // VERIADO REFACTOR
+    public static ContentVersion From(int value) => new(value);
+
+    // VERIADO REFACTOR
+    public override string ToString() => Value.ToString();
+}

--- a/Veriado.Domain/ValueObjects/StoragePath.cs
+++ b/Veriado.Domain/ValueObjects/StoragePath.cs
@@ -1,0 +1,37 @@
+// VERIADO REFACTOR
+namespace Veriado.Domain.ValueObjects;
+
+/// <summary>
+/// Represents a normalized pointer to externally stored file content.
+/// </summary>
+public sealed class StoragePath
+{
+    // VERIADO REFACTOR
+    private StoragePath(string value)
+    {
+        Value = value;
+    }
+
+    // VERIADO REFACTOR
+    public string Value { get; }
+
+    // VERIADO REFACTOR
+    public static StoragePath From(string value, int maxLength = 2048)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            throw new ArgumentException("Storage path cannot be null or whitespace.", nameof(value));
+        }
+
+        var normalized = value.Trim();
+        if (normalized.Length > maxLength)
+        {
+            throw new ArgumentOutOfRangeException(nameof(value), normalized.Length, "Storage path exceeds the configured limit.");
+        }
+
+        return new StoragePath(normalized);
+    }
+
+    // VERIADO REFACTOR
+    public override string ToString() => Value;
+}

--- a/Veriado.Domain/ValueObjects/StorageProvider.cs
+++ b/Veriado.Domain/ValueObjects/StorageProvider.cs
@@ -1,0 +1,23 @@
+// VERIADO REFACTOR
+namespace Veriado.Domain.ValueObjects;
+
+/// <summary>
+/// Enumerates storage providers that can host external file content.
+/// </summary>
+public enum StorageProvider
+{
+    // VERIADO REFACTOR
+    Local = 0,
+
+    // VERIADO REFACTOR
+    NetworkShare = 1,
+
+    // VERIADO REFACTOR
+    S3 = 2,
+
+    // VERIADO REFACTOR
+    AzureBlob = 3,
+
+    // VERIADO REFACTOR
+    Other = 99,
+}


### PR DESCRIPTION
## Summary
- add storage provider and path primitives to model externalized file content
- introduce a content version value object and companion link entity for files
- define domain events for linking, relinking, and unlinking content as groundwork for the link-only refactor

## Testing
- not run (dotnet CLI unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68f1ffe7a7b08326947a86f79e3045cb