### PR TITLE
Refactor storage metadata value objects

### DIFF
--- a/Veriado.Application.Tests/Infrastructure/ConvertersTests.cs
+++ b/Veriado.Application.Tests/Infrastructure/ConvertersTests.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Reflection;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using Veriado.Domain.ValueObjects;
+using Xunit;
+
+namespace Veriado.Application.Tests.Infrastructure;
+
+public sealed class ConvertersTests
+{
+    private static readonly Type ConvertersType = Type.GetType(
+        "Veriado.Infrastructure.Persistence.Configurations.Converters, Veriado.Infrastructure",
+        throwOnError: true)!;
+
+    [Fact]
+    public void StoragePathToString_RoundTrips()
+    {
+        var converter = (ValueConverter<StoragePath, string>)ConvertersType
+            .GetField("StoragePathToString", BindingFlags.Public | BindingFlags.Static)!
+            .GetValue(null)!;
+
+        var path = StoragePath.From("  /tmp/data.bin  ");
+        var stored = converter.ConvertToProvider(path);
+        Assert.Equal(path.Value, stored);
+
+        var restored = converter.ConvertFromProvider(stored);
+        Assert.Equal(path, restored);
+    }
+
+    [Fact]
+    public void ContentVersionToInt_RoundTrips()
+    {
+        var converter = (ValueConverter<ContentVersion, int>)ConvertersType
+            .GetField("ContentVersionToInt", BindingFlags.Public | BindingFlags.Static)!
+            .GetValue(null)!;
+
+        var version = ContentVersion.From(5);
+        var stored = converter.ConvertToProvider(version);
+        Assert.Equal(version.Value, stored);
+
+        var restored = converter.ConvertFromProvider(stored);
+        Assert.Equal(version, restored);
+    }
+}

--- a/Veriado.Domain/Files/Events/FileSystemEvents.cs
+++ b/Veriado.Domain/Files/Events/FileSystemEvents.cs
@@ -25,11 +25,11 @@ public sealed class FileSystemContentChanged : IDomainEvent
     public FileSystemContentChanged(
         Guid fileSystemId,
         StorageProvider provider,
-        string storagePath,
+        StoragePath storagePath,
         FileHash hash,
         ByteSize size,
         MimeType mime,
-        int contentVersion,
+        ContentVersion contentVersion,
         bool isEncrypted,
         UtcTimestamp occurredUtc)
     {
@@ -58,7 +58,7 @@ public sealed class FileSystemContentChanged : IDomainEvent
     /// <summary>
     /// Gets the storage path referencing the binary content.
     /// </summary>
-    public string StoragePath { get; }
+    public StoragePath StoragePath { get; }
 
     /// <summary>
     /// Gets the SHA-256 hash of the content.
@@ -78,7 +78,7 @@ public sealed class FileSystemContentChanged : IDomainEvent
     /// <summary>
     /// Gets the version number assigned to the content.
     /// </summary>
-    public int ContentVersion { get; }
+    public ContentVersion ContentVersion { get; }
 
     /// <summary>
     /// Gets a value indicating whether the content is encrypted.
@@ -108,8 +108,8 @@ public sealed class FileSystemMoved : IDomainEvent
     public FileSystemMoved(
         Guid fileSystemId,
         StorageProvider provider,
-        string previousPath,
-        string newPath,
+        StoragePath previousPath,
+        StoragePath newPath,
         UtcTimestamp occurredUtc)
     {
         FileSystemId = fileSystemId;
@@ -133,12 +133,12 @@ public sealed class FileSystemMoved : IDomainEvent
     /// <summary>
     /// Gets the previous storage path.
     /// </summary>
-    public string PreviousPath { get; }
+    public StoragePath PreviousPath { get; }
 
     /// <summary>
     /// Gets the new storage path.
     /// </summary>
-    public string NewPath { get; }
+    public StoragePath NewPath { get; }
 
     /// <inheritdoc />
     public Guid EventId { get; }
@@ -285,7 +285,7 @@ public sealed class FileSystemMissingDetected : IDomainEvent
     /// <param name="fileSystemId">The identifier of the file system entity.</param>
     /// <param name="storagePath">The storage path that was probed.</param>
     /// <param name="occurredUtc">The timestamp when the missing state was detected.</param>
-    public FileSystemMissingDetected(Guid fileSystemId, string storagePath, UtcTimestamp occurredUtc)
+    public FileSystemMissingDetected(Guid fileSystemId, StoragePath storagePath, UtcTimestamp occurredUtc)
     {
         FileSystemId = fileSystemId;
         StoragePath = storagePath;
@@ -301,7 +301,7 @@ public sealed class FileSystemMissingDetected : IDomainEvent
     /// <summary>
     /// Gets the storage path that was probed.
     /// </summary>
-    public string StoragePath { get; }
+    public StoragePath StoragePath { get; }
 
     /// <inheritdoc />
     public Guid EventId { get; }
@@ -326,7 +326,7 @@ public sealed class FileSystemRehydrated : IDomainEvent
     public FileSystemRehydrated(
         Guid fileSystemId,
         StorageProvider provider,
-        string storagePath,
+        StoragePath storagePath,
         bool wasMissing,
         UtcTimestamp occurredUtc)
     {
@@ -351,7 +351,7 @@ public sealed class FileSystemRehydrated : IDomainEvent
     /// <summary>
     /// Gets the storage path referencing the binary content.
     /// </summary>
-    public string StoragePath { get; }
+    public StoragePath StoragePath { get; }
 
     /// <summary>
     /// Gets a value indicating whether the file was previously missing from storage.

--- a/Veriado.Domain/Files/FileContentLinkEntity.cs
+++ b/Veriado.Domain/Files/FileContentLinkEntity.cs
@@ -92,7 +92,7 @@ public sealed class FileContentLinkEntity
             mime,
             isEncrypted,
             attributes,
-            ContentVersion.Initial(),
+            ContentVersion.Initial,
             linkedUtc);
     }
 

--- a/Veriado.Domain/ValueObjects/ContentVersion.cs
+++ b/Veriado.Domain/ValueObjects/ContentVersion.cs
@@ -1,4 +1,5 @@
-// VERIADO REFACTOR
+using System.Globalization;
+
 namespace Veriado.Domain.ValueObjects;
 
 /// <summary>
@@ -6,7 +7,6 @@ namespace Veriado.Domain.ValueObjects;
 /// </summary>
 public readonly record struct ContentVersion
 {
-    // VERIADO REFACTOR
     private ContentVersion(int value)
     {
         if (value <= 0)
@@ -17,13 +17,20 @@ public readonly record struct ContentVersion
         Value = value;
     }
 
-    // VERIADO REFACTOR
+    /// <summary>
+    /// Gets the numeric value of the version.
+    /// </summary>
     public int Value { get; }
 
-    // VERIADO REFACTOR
-    public static ContentVersion Initial() => new(1);
+    /// <summary>
+    /// Gets the initial content version.
+    /// </summary>
+    public static ContentVersion Initial => new(1);
 
-    // VERIADO REFACTOR
+    /// <summary>
+    /// Creates the next sequential version.
+    /// </summary>
+    /// <returns>The incremented version.</returns>
     public ContentVersion Next()
     {
         if (Value == int.MaxValue)
@@ -34,9 +41,13 @@ public readonly record struct ContentVersion
         return new ContentVersion(Value + 1);
     }
 
-    // VERIADO REFACTOR
+    /// <summary>
+    /// Creates a new <see cref="ContentVersion"/> from the provided value.
+    /// </summary>
+    /// <param name="value">The numeric version value.</param>
+    /// <returns>The created value object.</returns>
     public static ContentVersion From(int value) => new(value);
 
-    // VERIADO REFACTOR
-    public override string ToString() => Value.ToString();
+    /// <inheritdoc />
+    public override string ToString() => Value.ToString(CultureInfo.InvariantCulture);
 }

--- a/Veriado.Domain/ValueObjects/StoragePath.cs
+++ b/Veriado.Domain/ValueObjects/StoragePath.cs
@@ -1,22 +1,28 @@
-// VERIADO REFACTOR
 namespace Veriado.Domain.ValueObjects;
 
 /// <summary>
 /// Represents a normalized pointer to externally stored file content.
 /// </summary>
-public sealed class StoragePath
+public sealed class StoragePath : IEquatable<StoragePath>
 {
-    // VERIADO REFACTOR
+    private const int MaxLength = 2048;
+
     private StoragePath(string value)
     {
         Value = value;
     }
 
-    // VERIADO REFACTOR
+    /// <summary>
+    /// Gets the normalized storage path value.
+    /// </summary>
     public string Value { get; }
 
-    // VERIADO REFACTOR
-    public static StoragePath From(string value, int maxLength = 2048)
+    /// <summary>
+    /// Creates a new <see cref="StoragePath"/> from the provided string value.
+    /// </summary>
+    /// <param name="value">The raw storage path.</param>
+    /// <returns>The created value object.</returns>
+    public static StoragePath From(string value)
     {
         if (string.IsNullOrWhiteSpace(value))
         {
@@ -24,14 +30,28 @@ public sealed class StoragePath
         }
 
         var normalized = value.Trim();
-        if (normalized.Length > maxLength)
+        if (normalized.Length > MaxLength)
         {
-            throw new ArgumentOutOfRangeException(nameof(value), normalized.Length, "Storage path exceeds the configured limit.");
+            throw new ArgumentOutOfRangeException(
+                nameof(value),
+                normalized.Length,
+                $"Storage path exceeds the maximum allowed length of {MaxLength} characters.");
         }
 
         return new StoragePath(normalized);
     }
 
-    // VERIADO REFACTOR
+    /// <inheritdoc />
     public override string ToString() => Value;
+
+    /// <inheritdoc />
+    public bool Equals(StoragePath? other)
+        => other is not null && string.Equals(Value, other.Value, StringComparison.Ordinal);
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj)
+        => obj is StoragePath other && Equals(other);
+
+    /// <inheritdoc />
+    public override int GetHashCode() => StringComparer.Ordinal.GetHashCode(Value);
 }

--- a/Veriado.Domain/ValueObjects/StorageProvider.cs
+++ b/Veriado.Domain/ValueObjects/StorageProvider.cs
@@ -1,4 +1,3 @@
-// VERIADO REFACTOR
 namespace Veriado.Domain.ValueObjects;
 
 /// <summary>
@@ -6,18 +5,13 @@ namespace Veriado.Domain.ValueObjects;
 /// </summary>
 public enum StorageProvider
 {
-    // VERIADO REFACTOR
     Local = 0,
 
-    // VERIADO REFACTOR
     NetworkShare = 1,
 
-    // VERIADO REFACTOR
     S3 = 2,
 
-    // VERIADO REFACTOR
     AzureBlob = 3,
 
-    // VERIADO REFACTOR
     Other = 99,
 }

--- a/Veriado.Infrastructure/Persistence/Configurations/Converters.cs
+++ b/Veriado.Infrastructure/Persistence/Configurations/Converters.cs
@@ -32,6 +32,14 @@ internal static class Converters
         hash => hash.Value,
         value => FileHash.From(value));
 
+    public static readonly ValueConverter<StoragePath, string> StoragePathToString = new(
+        path => path.Value,
+        value => StoragePath.From(value));
+
+    public static readonly ValueConverter<ContentVersion, int> ContentVersionToInt = new(
+        version => version.Value,
+        value => ContentVersion.From(value));
+
     public static readonly ValueConverter<ByteSize, long> ByteSizeToLong = new(
         size => size.Value,
         value => ByteSize.From(value));


### PR DESCRIPTION
## Summary
- add strongly typed storage provider, storage path, and content version value objects
- refactor file system domain entities and events to consume the new value objects
- register EF Core converters and cover them with new unit tests

## Testing
- dotnet build *(fails: dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f20ed726c08326aa15ee641330b30f