### PR TITLE
Align SQLite file schema mappings and add integration tests

### DIFF
--- a/Veriado.Application.Tests/Infrastructure/FileSchemaTests.cs
+++ b/Veriado.Application.Tests/Infrastructure/FileSchemaTests.cs
@@ -1,0 +1,253 @@
+using System.IO;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Veriado.Application.Tests.Domain.FileSystem;
+using Veriado.Domain.FileSystem;
+using Veriado.Domain.Files;
+using Veriado.Domain.Metadata;
+using Veriado.Domain.Primitives;
+using Veriado.Domain.ValueObjects;
+using Veriado.Infrastructure.DependencyInjection;
+using Veriado.Infrastructure.Persistence;
+using Veriado.Infrastructure.Persistence.Options;
+using Xunit;
+
+namespace Veriado.Application.Tests.Infrastructure;
+
+public sealed class FileSchemaTests
+{
+    [Fact]
+    [Trait("Category", "SQLiteOnly")]
+    public async Task InsertAndRetrieveFileSystemEntity_Succeeds()
+    {
+        var databasePath = CreateDatabasePath();
+        var provider = await BuildProviderAsync(databasePath).ConfigureAwait(false);
+
+        try
+        {
+            var entity = FileSystemEntityFactory.CreateSample();
+
+            await using (var scope = provider.CreateAsyncScope())
+            {
+                await using var context = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+                context.FileSystems.Add(entity);
+                await context.SaveChangesAsync().ConfigureAwait(false);
+            }
+
+            await using var verificationScope = provider.CreateAsyncScope();
+            await using var verificationContext = verificationScope.ServiceProvider.GetRequiredService<AppDbContext>();
+
+            var stored = await verificationContext.FileSystems.SingleAsync(f => f.Id == entity.Id).ConfigureAwait(false);
+
+            Assert.Equal(entity.Path, stored.Path);
+            Assert.Equal(entity.Hash, stored.Hash);
+            Assert.Equal(entity.ContentVersion, stored.ContentVersion);
+        }
+        finally
+        {
+            await CleanupDatabaseAsync(provider, databasePath).ConfigureAwait(false);
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "SQLiteOnly")]
+    public async Task InsertAndRetrieveFileEntity_Succeeds()
+    {
+        var databasePath = CreateDatabasePath();
+        var provider = await BuildProviderAsync(databasePath).ConfigureAwait(false);
+
+        try
+        {
+            var fileSystem = FileSystemEntityFactory.CreateSample();
+            var createdUtc = fileSystem.CreatedUtc;
+            var metadata = new FileSystemMetadata(
+                fileSystem.Attributes,
+                fileSystem.CreatedUtc,
+                fileSystem.LastWriteUtc,
+                fileSystem.LastAccessUtc,
+                fileSystem.OwnerSid,
+                hardLinkCount: null,
+                alternateDataStreamCount: null);
+
+            var file = FileEntity.CreateNew(
+                FileName.From("contract"),
+                FileExtension.From("pdf"),
+                MimeType.From("application/pdf"),
+                "author",
+                fileSystem.Id,
+                FileHash.From(new string('B', 64)),
+                ByteSize.From(2048),
+                ContentVersion.Initial,
+                createdUtc,
+                systemMetadata: metadata);
+
+            await using (var scope = provider.CreateAsyncScope())
+            {
+                await using var context = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+                context.FileSystems.Add(fileSystem);
+                context.Files.Add(file);
+                await context.SaveChangesAsync().ConfigureAwait(false);
+            }
+
+            await using var verificationScope = provider.CreateAsyncScope();
+            await using var verificationContext = verificationScope.ServiceProvider.GetRequiredService<AppDbContext>();
+
+            var stored = await verificationContext.Files.SingleAsync(f => f.Id == file.Id).ConfigureAwait(false);
+
+            Assert.Equal(fileSystem.Id, stored.FileSystemId);
+            Assert.Equal(file.ContentHash, stored.ContentHash);
+            Assert.Equal(file.Size, stored.Size);
+        }
+        finally
+        {
+            await CleanupDatabaseAsync(provider, databasePath).ConfigureAwait(false);
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "SQLiteOnly")]
+    public async Task ForeignKey_RequiresExistingFileSystemEntity()
+    {
+        var databasePath = CreateDatabasePath();
+        var provider = await BuildProviderAsync(databasePath).ConfigureAwait(false);
+
+        try
+        {
+            var createdUtc = UtcTimestamp.From(DateTimeOffset.UtcNow);
+            var metadata = new FileSystemMetadata(
+                FileAttributesFlags.Normal,
+                createdUtc,
+                createdUtc,
+                createdUtc,
+                ownerSid: null,
+                hardLinkCount: null,
+                alternateDataStreamCount: null);
+
+            var file = FileEntity.CreateNew(
+                FileName.From("missing"),
+                FileExtension.From("txt"),
+                MimeType.From("text/plain"),
+                "author",
+                Guid.NewGuid(),
+                FileHash.From(new string('C', 64)),
+                ByteSize.From(512),
+                ContentVersion.Initial,
+                createdUtc,
+                systemMetadata: metadata);
+
+            await using var scope = provider.CreateAsyncScope();
+            await using var context = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+
+            context.Files.Add(file);
+
+            var exception = await Assert.ThrowsAsync<DbUpdateException>(() => context.SaveChangesAsync()).ConfigureAwait(false);
+            var sqlite = Assert.IsType<SqliteException>(exception.InnerException);
+            Assert.Equal(19, sqlite.SqliteErrorCode); // SQLITE_CONSTRAINT
+            Assert.Contains("FOREIGN KEY", sqlite.Message, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            await CleanupDatabaseAsync(provider, databasePath).ConfigureAwait(false);
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "SQLiteOnly")]
+    public async Task UniqueConstraint_PreventsDuplicateFileSystemLinks()
+    {
+        var databasePath = CreateDatabasePath();
+        var provider = await BuildProviderAsync(databasePath).ConfigureAwait(false);
+
+        try
+        {
+            var fileSystem = FileSystemEntityFactory.CreateSample();
+            var createdUtc = fileSystem.CreatedUtc;
+            var metadata = new FileSystemMetadata(
+                fileSystem.Attributes,
+                fileSystem.CreatedUtc,
+                fileSystem.LastWriteUtc,
+                fileSystem.LastAccessUtc,
+                fileSystem.OwnerSid,
+                hardLinkCount: null,
+                alternateDataStreamCount: null);
+
+            var firstFile = FileEntity.CreateNew(
+                FileName.From("primary"),
+                FileExtension.From("txt"),
+                MimeType.From("text/plain"),
+                "author",
+                fileSystem.Id,
+                FileHash.From(new string('D', 64)),
+                ByteSize.From(1024),
+                ContentVersion.Initial,
+                createdUtc,
+                systemMetadata: metadata);
+
+            var duplicateFile = FileEntity.CreateNew(
+                FileName.From("secondary"),
+                FileExtension.From("txt"),
+                MimeType.From("text/plain"),
+                "author",
+                fileSystem.Id,
+                FileHash.From(new string('E', 64)),
+                ByteSize.From(2048),
+                ContentVersion.Initial,
+                createdUtc,
+                systemMetadata: metadata);
+
+            await using var scope = provider.CreateAsyncScope();
+            await using var context = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+
+            context.FileSystems.Add(fileSystem);
+            context.Files.Add(firstFile);
+            context.Files.Add(duplicateFile);
+
+            var exception = await Assert.ThrowsAsync<DbUpdateException>(() => context.SaveChangesAsync()).ConfigureAwait(false);
+            var sqlite = Assert.IsType<SqliteException>(exception.InnerException);
+            Assert.Equal(19, sqlite.SqliteErrorCode); // SQLITE_CONSTRAINT
+            Assert.Contains("files.filesystem_id", sqlite.Message, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            await CleanupDatabaseAsync(provider, databasePath).ConfigureAwait(false);
+        }
+    }
+
+    private static string CreateDatabasePath()
+    {
+        var directory = Path.Combine(Path.GetTempPath(), "veriado-tests");
+        Directory.CreateDirectory(directory);
+        return Path.Combine(directory, $"file-schema-{Guid.NewGuid():N}.db");
+    }
+
+    private static async Task<ServiceProvider> BuildProviderAsync(string databasePath)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging(builder => builder.SetMinimumLevel(LogLevel.None));
+        services.AddInfrastructure(options =>
+        {
+            options.DbPath = databasePath;
+            options.BatchMaxItems = 4;
+            options.BatchMaxWindowMs = 10;
+        });
+
+        var provider = services.BuildServiceProvider();
+        await provider.InitializeInfrastructureAsync().ConfigureAwait(false);
+        return provider;
+    }
+
+    private static async Task CleanupDatabaseAsync(ServiceProvider provider, string path)
+    {
+        if (provider is not null)
+        {
+            await provider.DisposeAsync().ConfigureAwait(false);
+        }
+
+        if (!string.IsNullOrEmpty(path) && File.Exists(path))
+        {
+            File.Delete(path);
+        }
+    }
+}

--- a/Veriado.Application/UseCases/Files/CreateFile/CreateFileHandler.cs
+++ b/Veriado.Application/UseCases/Files/CreateFile/CreateFileHandler.cs
@@ -95,7 +95,8 @@ public sealed class CreateFileHandler : FileWriteHandlerBase, IRequestHandler<Cr
             return false;
         }
 
-        return sqlite.Message.Contains("files_content.hash", StringComparison.OrdinalIgnoreCase)
+        return sqlite.Message.Contains("files.content_hash", StringComparison.OrdinalIgnoreCase)
+            || sqlite.Message.Contains("files_content.hash", StringComparison.OrdinalIgnoreCase)
             || sqlite.Message.Contains("ux_files_content_hash", StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/Veriado.Infrastructure/Persistence/Configurations/AuditEntityConfigurations.cs
+++ b/Veriado.Infrastructure/Persistence/Configurations/AuditEntityConfigurations.cs
@@ -2,9 +2,9 @@ using Veriado.Infrastructure.Persistence.Audit;
 
 namespace Veriado.Infrastructure.Persistence.Configurations;
 
-internal sealed class FileAuditEntityConfiguration : IEntityTypeConfiguration<FileAuditEntity>
+internal sealed class FileAuditRecordConfiguration : IEntityTypeConfiguration<FileAuditRecord>
 {
-    public void Configure(EntityTypeBuilder<FileAuditEntity> builder)
+    public void Configure(EntityTypeBuilder<FileAuditRecord> builder)
     {
         builder.ToTable("audit_file");
         builder.HasKey(audit => new { audit.FileId, audit.OccurredUtc });
@@ -46,9 +46,9 @@ internal sealed class FileAuditEntityConfiguration : IEntityTypeConfiguration<Fi
     }
 }
 
-internal sealed class FileLinkAuditEntityConfiguration : IEntityTypeConfiguration<FileLinkAuditEntity>
+internal sealed class FileLinkAuditRecordConfiguration : IEntityTypeConfiguration<FileLinkAuditRecord>
 {
-    public void Configure(EntityTypeBuilder<FileLinkAuditEntity> builder)
+    public void Configure(EntityTypeBuilder<FileLinkAuditRecord> builder)
     {
         builder.ToTable("audit_file_link");
         builder.HasKey(audit => new { audit.FileId, audit.OccurredUtc });
@@ -99,9 +99,9 @@ internal sealed class FileLinkAuditEntityConfiguration : IEntityTypeConfiguratio
     }
 }
 
-internal sealed class FileSystemAuditEntityConfiguration : IEntityTypeConfiguration<FileSystemAuditEntity>
+internal sealed class FileSystemAuditRecordConfiguration : IEntityTypeConfiguration<FileSystemAuditRecord>
 {
-    public void Configure(EntityTypeBuilder<FileSystemAuditEntity> builder)
+    public void Configure(EntityTypeBuilder<FileSystemAuditRecord> builder)
     {
         builder.ToTable("audit_filesystem");
         builder.HasKey(audit => new { audit.FileSystemId, audit.OccurredUtc });

--- a/Veriado.Infrastructure/Persistence/Configurations/FileEntityConfiguration.cs
+++ b/Veriado.Infrastructure/Persistence/Configurations/FileEntityConfiguration.cs
@@ -29,6 +29,7 @@ internal sealed class FileEntityConfiguration : IEntityTypeConfiguration<FileEnt
 
         builder.Property(file => file.Mime)
             .HasColumnName("mime")
+            .HasColumnType("TEXT")
             .HasMaxLength(255)
             .HasConversion(Converters.MimeTypeToString)
             .IsRequired();
@@ -46,12 +47,14 @@ internal sealed class FileEntityConfiguration : IEntityTypeConfiguration<FileEnt
 
         builder.Property(file => file.ContentHash)
             .HasColumnName("content_hash")
+            .HasColumnType("TEXT")
             .HasMaxLength(64)
             .HasConversion(Converters.FileHashToString)
             .IsRequired();
 
         builder.Property(file => file.LinkedContentVersion)
             .HasColumnName("content_version")
+            .HasColumnType("INTEGER")
             .HasConversion(Converters.ContentVersionToInt)
             .IsRequired();
 
@@ -61,6 +64,7 @@ internal sealed class FileEntityConfiguration : IEntityTypeConfiguration<FileEnt
 
         builder.Property(file => file.Size)
             .HasColumnName("size_bytes")
+            .HasColumnType("BIGINT")
             .HasConversion(Converters.ByteSizeToLong)
             .IsRequired();
 

--- a/Veriado.Infrastructure/Persistence/Configurations/FileSystemEntityConfiguration.cs
+++ b/Veriado.Infrastructure/Persistence/Configurations/FileSystemEntityConfiguration.cs
@@ -30,6 +30,7 @@ internal sealed class FileSystemEntityConfiguration : IEntityTypeConfiguration<F
 
         builder.Property(entity => entity.Hash)
             .HasColumnName("hash")
+            .HasColumnType("TEXT")
             .HasMaxLength(64)
             .HasConversion(Converters.FileHashToString)
             .IsRequired();
@@ -42,6 +43,7 @@ internal sealed class FileSystemEntityConfiguration : IEntityTypeConfiguration<F
 
         builder.Property(entity => entity.Mime)
             .HasColumnName("mime")
+            .HasColumnType("TEXT")
             .HasMaxLength(255)
             .HasConversion(Converters.MimeTypeToString)
             .IsRequired();

--- a/Veriado.Infrastructure/Persistence/Migrations/AppDbContextModelSnapshot.cs
+++ b/Veriado.Infrastructure/Persistence/Migrations/AppDbContextModelSnapshot.cs
@@ -307,7 +307,7 @@ namespace Veriado.Infrastructure.Persistence.Migrations
                         .HasColumnName("name");
 
                     b.Property<long>("Size")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("BIGINT")
                         .HasColumnName("size_bytes");
 
                     b.Property<string>("Title")


### PR DESCRIPTION
## Summary
- map audit tables to the new record types and align file/filesystem mappings with the updated SQLite schema
- update duplicate hash detection to look at the files.content_hash column after dropping files_content
- add SQLite integration tests covering file system inserts, file inserts, foreign key enforcement, and filesystem_id uniqueness

## Testing
- `dotnet test` *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f2320339d88326a83f4f518193aff2