### PR TITLE
Refactor SQLite search schema to search_document

### DIFF
--- a/MIGRATION_NOTES.md
+++ b/MIGRATION_NOTES.md
@@ -2,6 +2,6 @@
 
 ## 2025-FTS rebuild hardening
 
-- Full-text rebuild now deploys the contentless `file_search` FTS5 variant with manual triggers keeping it in sync with `DocumentContent`.
+- Full-text rebuild now deploys the contentless `search_document_fts` FTS5 variant with manual triggers keeping it in sync with `search_document`.
 - The rebuild pipeline replaces checkpoint file deletion with `PRAGMA wal_checkpoint(TRUNCATE)` for safe WAL maintenance.
 - To experiment with the legacy `content='DocumentContent'` configuration, uncomment the reference block in `Veriado.Infrastructure/Persistence/Schema/Fts5.sql` and adjust the triggers to include the row payload.

--- a/Veriado.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/Veriado.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
@@ -312,10 +312,10 @@ public static class ServiceCollectionExtensions
             SqliteFulltextSupport.UpdateSchemaSnapshot(snapshot);
 
             logger.LogInformation(
-                "Development FTS guard inspected file_search (contentless={IsContentless}) with columns {Columns}, DocumentContent columns {DocumentColumns} and triggers {Triggers}.",
+                "Development FTS guard inspected search_document_fts (contentless={IsContentless}) with columns {Columns}, search_document columns {DocumentColumns} and triggers {Triggers}.",
                 snapshot.IsContentless,
                 string.Join(", ", snapshot.FtsColumns),
-                string.Join(", ", snapshot.DocumentColumns),
+                string.Join(", ", snapshot.SearchDocumentColumns),
                 string.Join(", ", snapshot.Triggers.Keys));
 
             if (!inspection.IsValid)

--- a/Veriado.Infrastructure/Integrity/IndexAuditor.cs
+++ b/Veriado.Infrastructure/Integrity/IndexAuditor.cs
@@ -170,7 +170,7 @@ public sealed class IndexAuditor : IIndexAuditor
     {
         var ids = new HashSet<Guid>();
         await using var command = connection.CreateCommand();
-        command.CommandText = "SELECT file_id FROM DocumentContent;";
+        command.CommandText = "SELECT file_id FROM search_document;";
         await using var reader = await command.ExecuteReaderAsync(ct).ConfigureAwait(false);
         while (await reader.ReadAsync(ct).ConfigureAwait(false))
         {

--- a/Veriado.Infrastructure/Persistence/Migrations/20251026090000_UpdateDocumentContentSchema.cs
+++ b/Veriado.Infrastructure/Persistence/Migrations/20251026090000_UpdateDocumentContentSchema.cs
@@ -8,11 +8,90 @@ public partial class UpdateDocumentContentSchema : Migration
     /// <inheritdoc />
     protected override void Up(MigrationBuilder migrationBuilder)
     {
+        migrationBuilder.Sql("DROP TRIGGER IF EXISTS sd_ai;");
+        migrationBuilder.Sql("DROP TRIGGER IF EXISTS sd_au;");
+        migrationBuilder.Sql("DROP TRIGGER IF EXISTS sd_ad;");
         migrationBuilder.Sql("DROP TRIGGER IF EXISTS dc_ai;");
         migrationBuilder.Sql("DROP TRIGGER IF EXISTS dc_au;");
         migrationBuilder.Sql("DROP TRIGGER IF EXISTS dc_ad;");
 
-        migrationBuilder.Sql("ALTER TABLE DocumentContent RENAME TO DocumentContent_old;");
+        migrationBuilder.Sql("DROP TABLE IF EXISTS search_document_fts;");
+        migrationBuilder.Sql("DROP TABLE IF EXISTS file_search;");
+        migrationBuilder.Sql("DROP TABLE IF EXISTS file_search_data;");
+        migrationBuilder.Sql("DROP TABLE IF EXISTS file_search_idx;");
+        migrationBuilder.Sql("DROP TABLE IF EXISTS file_search_content;");
+        migrationBuilder.Sql("DROP TABLE IF EXISTS file_search_docsize;");
+        migrationBuilder.Sql("DROP TABLE IF EXISTS file_search_config;");
+
+        migrationBuilder.Sql("ALTER TABLE DocumentContent RENAME TO search_document_old;");
+
+        migrationBuilder.Sql(
+            @"CREATE TABLE search_document (
+    file_id BLOB PRIMARY KEY,
+    title TEXT NULL,
+    author TEXT NULL,
+    mime TEXT NOT NULL,
+    metadata_text TEXT NULL,
+    metadata_json TEXT NULL,
+    created_utc TEXT NULL,
+    modified_utc TEXT NULL,
+    content_hash TEXT NULL
+);");
+
+        migrationBuilder.Sql(
+            @"INSERT INTO search_document (rowid, file_id, title, author, mime, metadata_text, metadata_json)
+SELECT doc_id, file_id, title, author, mime, metadata_text, metadata
+FROM search_document_old;");
+
+        migrationBuilder.Sql("DROP TABLE search_document_old;");
+
+        migrationBuilder.Sql(
+            @"CREATE VIRTUAL TABLE search_document_fts USING fts5(
+    title,
+    author,
+    mime,
+    metadata_text,
+    metadata,
+    content='',
+    tokenize='unicode61 remove_diacritics 2'
+);");
+
+        migrationBuilder.Sql(
+            @"INSERT INTO search_document_fts(rowid, title, author, mime, metadata_text, metadata)
+SELECT rowid, title, author, mime, metadata_text, metadata_json
+FROM search_document;");
+
+        migrationBuilder.Sql(
+            @"CREATE TRIGGER sd_ai AFTER INSERT ON search_document BEGIN
+  INSERT INTO search_document_fts(rowid, title, author, mime, metadata_text, metadata)
+  VALUES (new.rowid, new.title, new.author, new.mime, new.metadata_text, new.metadata_json);
+END;");
+
+        migrationBuilder.Sql(
+            @"CREATE TRIGGER sd_au AFTER UPDATE ON search_document BEGIN
+  INSERT INTO search_document_fts(search_document_fts, rowid, title, author, mime, metadata_text, metadata)
+  VALUES ('delete', old.rowid, old.title, old.author, old.mime, old.metadata_text, old.metadata_json);
+  INSERT INTO search_document_fts(rowid, title, author, mime, metadata_text, metadata)
+  VALUES (new.rowid, new.title, new.author, new.mime, new.metadata_text, new.metadata_json);
+END;");
+
+        migrationBuilder.Sql(
+            @"CREATE TRIGGER sd_ad AFTER DELETE ON search_document BEGIN
+  INSERT INTO search_document_fts(search_document_fts, rowid, title, author, mime, metadata_text, metadata)
+  VALUES ('delete', old.rowid, old.title, old.author, old.mime, old.metadata_text, old.metadata_json);
+END;");
+    }
+
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.Sql("DROP TRIGGER IF EXISTS sd_ai;");
+        migrationBuilder.Sql("DROP TRIGGER IF EXISTS sd_au;");
+        migrationBuilder.Sql("DROP TRIGGER IF EXISTS sd_ad;");
+
+        migrationBuilder.Sql("DROP TABLE IF EXISTS search_document_fts;");
+
+        migrationBuilder.Sql("ALTER TABLE search_document RENAME TO search_document_new;");
 
         migrationBuilder.Sql(
             @"CREATE TABLE DocumentContent (
@@ -27,10 +106,25 @@ public partial class UpdateDocumentContentSchema : Migration
 
         migrationBuilder.Sql(
             @"INSERT INTO DocumentContent (doc_id, file_id, title, author, mime, metadata_text, metadata)
-SELECT doc_id, file_id, title, author, mime, NULL, NULL
-FROM DocumentContent_old;");
+SELECT rowid, file_id, title, author, COALESCE(mime, ''), metadata_text, metadata_json
+FROM search_document_new;");
 
-        migrationBuilder.Sql("DROP TABLE DocumentContent_old;");
+        migrationBuilder.Sql("DROP TABLE search_document_new;");
+
+        migrationBuilder.Sql(
+            @"CREATE VIRTUAL TABLE file_search USING fts5(
+    title,
+    author,
+    mime,
+    metadata_text,
+    metadata,
+    tokenize='unicode61 remove_diacritics 2'
+);");
+
+        migrationBuilder.Sql(
+            @"INSERT INTO file_search(rowid, title, author, mime, metadata_text, metadata)
+SELECT doc_id, title, author, mime, metadata_text, metadata
+FROM DocumentContent;");
 
         migrationBuilder.Sql(
             @"CREATE TRIGGER dc_ai AFTER INSERT ON DocumentContent BEGIN
@@ -50,54 +144,6 @@ END;");
             @"CREATE TRIGGER dc_ad AFTER DELETE ON DocumentContent BEGIN
   INSERT INTO file_search(file_search, rowid)
   VALUES('delete', old.doc_id);
-END;");
-    }
-
-    /// <inheritdoc />
-    protected override void Down(MigrationBuilder migrationBuilder)
-    {
-        migrationBuilder.Sql("DROP TRIGGER IF EXISTS dc_ai;");
-        migrationBuilder.Sql("DROP TRIGGER IF EXISTS dc_au;");
-        migrationBuilder.Sql("DROP TRIGGER IF EXISTS dc_ad;");
-
-        migrationBuilder.Sql("ALTER TABLE DocumentContent RENAME TO DocumentContent_new;");
-
-        migrationBuilder.Sql(
-            @"CREATE TABLE DocumentContent (
-    DocId INTEGER PRIMARY KEY,
-    FileId BLOB NOT NULL UNIQUE,
-    Title TEXT NULL,
-    Author TEXT NULL,
-    Mime TEXT NOT NULL,
-    MetadataText TEXT NULL,
-    Metadata TEXT NULL
-);");
-
-        migrationBuilder.Sql(
-            @"INSERT INTO DocumentContent (DocId, FileId, Title, Author, Mime, MetadataText, Metadata)
-SELECT doc_id, file_id, title, author, COALESCE(mime, ''), metadata_text, metadata
-FROM DocumentContent_new;");
-
-        migrationBuilder.Sql("DROP TABLE DocumentContent_new;");
-
-        migrationBuilder.Sql(
-            @"CREATE TRIGGER dc_ai AFTER INSERT ON DocumentContent BEGIN
-  INSERT INTO file_search(rowid, title, author, mime, metadata_text, metadata)
-  VALUES (new.DocId, new.Title, new.Author, new.Mime, new.MetadataText, new.Metadata);
-END;");
-
-        migrationBuilder.Sql(
-            @"CREATE TRIGGER dc_au AFTER UPDATE ON DocumentContent BEGIN
-  INSERT INTO file_search(file_search, rowid)
-  VALUES('delete', old.DocId);
-  INSERT INTO file_search(rowid, title, author, mime, metadata_text, metadata)
-  VALUES(new.DocId, new.Title, new.Author, new.Mime, new.MetadataText, new.Metadata);
-END;");
-
-        migrationBuilder.Sql(
-            @"CREATE TRIGGER dc_ad AFTER DELETE ON DocumentContent BEGIN
-  INSERT INTO file_search(file_search, rowid)
-  VALUES('delete', old.DocId);
 END;");
     }
 }

--- a/Veriado.Infrastructure/Persistence/Schema/Fts5.sql
+++ b/Veriado.Infrastructure/Persistence/Schema/Fts5.sql
@@ -1,39 +1,42 @@
 DROP TABLE IF EXISTS file_trgm;
 
-CREATE TABLE IF NOT EXISTS DocumentContent (
-    doc_id INTEGER PRIMARY KEY,
-    file_id BLOB NOT NULL UNIQUE,
+CREATE TABLE IF NOT EXISTS search_document (
+    file_id BLOB PRIMARY KEY,
     title TEXT NULL,
     author TEXT NULL,
     mime TEXT NOT NULL,
     metadata_text TEXT NULL,
-    metadata TEXT NULL
+    metadata_json TEXT NULL,
+    created_utc TEXT NULL,
+    modified_utc TEXT NULL,
+    content_hash TEXT NULL
 );
 
-CREATE VIRTUAL TABLE IF NOT EXISTS file_search USING fts5(
+CREATE VIRTUAL TABLE IF NOT EXISTS search_document_fts USING fts5(
     title,
     author,
     mime,
     metadata_text,
     metadata,
+    content='',
     tokenize='unicode61 remove_diacritics 2'
 );
 
-CREATE TRIGGER IF NOT EXISTS dc_ai AFTER INSERT ON DocumentContent BEGIN
-  INSERT INTO file_search(rowid, title, author, mime, metadata_text, metadata)
-  VALUES (new.doc_id, new.title, new.author, new.mime, new.metadata_text, new.metadata);
+CREATE TRIGGER IF NOT EXISTS sd_ai AFTER INSERT ON search_document BEGIN
+  INSERT INTO search_document_fts(rowid, title, author, mime, metadata_text, metadata)
+  VALUES (new.rowid, new.title, new.author, new.mime, new.metadata_text, new.metadata_json);
 END;
 
-CREATE TRIGGER IF NOT EXISTS dc_au AFTER UPDATE ON DocumentContent BEGIN
-  INSERT INTO file_search(file_search, rowid)
-  VALUES('delete', old.doc_id);
-  INSERT INTO file_search(rowid, title, author, mime, metadata_text, metadata)
-  VALUES(new.doc_id, new.title, new.author, new.mime, new.metadata_text, new.metadata);
+CREATE TRIGGER IF NOT EXISTS sd_au AFTER UPDATE ON search_document BEGIN
+  INSERT INTO search_document_fts(search_document_fts, rowid, title, author, mime, metadata_text, metadata)
+  VALUES ('delete', old.rowid, old.title, old.author, old.mime, old.metadata_text, old.metadata_json);
+  INSERT INTO search_document_fts(rowid, title, author, mime, metadata_text, metadata)
+  VALUES (new.rowid, new.title, new.author, new.mime, new.metadata_text, new.metadata_json);
 END;
 
-CREATE TRIGGER IF NOT EXISTS dc_ad AFTER DELETE ON DocumentContent BEGIN
-  INSERT INTO file_search(file_search, rowid)
-  VALUES('delete', old.doc_id);
+CREATE TRIGGER IF NOT EXISTS sd_ad AFTER DELETE ON search_document BEGIN
+  INSERT INTO search_document_fts(search_document_fts, rowid, title, author, mime, metadata_text, metadata)
+  VALUES ('delete', old.rowid, old.title, old.author, old.mime, old.metadata_text, old.metadata_json);
 END;
 
 CREATE TABLE IF NOT EXISTS fts_write_ahead (

--- a/Veriado.Infrastructure/Persistence/SqliteFulltextSupport.cs
+++ b/Veriado.Infrastructure/Persistence/SqliteFulltextSupport.cs
@@ -52,15 +52,15 @@ internal static class SqliteFulltextSupport
 /// </summary>
 /// <param name="TableSql">The raw CREATE VIRTUAL TABLE statement.</param>
 /// <param name="Columns">The column names reported by PRAGMA table_info.</param>
-/// <param name="Triggers">The triggers bound to DocumentContent.</param>
+/// <param name="Triggers">The triggers bound to the search document table.</param>
 /// <param name="IsContentless">Indicates whether the table uses the contentless FTS5 variant.</param>
-/// <param name="HasDocumentContentTriggers">Indicates whether the expected triggers are present.</param>
+/// <param name="HasSearchDocumentTriggers">Indicates whether the expected triggers are present.</param>
 /// <param name="CheckedAtUtc">The timestamp when the schema was inspected.</param>
 internal sealed record FulltextSchemaSnapshot(
     string? TableSql,
     IReadOnlyList<string> FtsColumns,
-    IReadOnlyList<string> DocumentColumns,
+    IReadOnlyList<string> SearchDocumentColumns,
     IReadOnlyDictionary<string, string?> Triggers,
     bool IsContentless,
-    bool HasDocumentContentTriggers,
+    bool HasSearchDocumentTriggers,
     DateTimeOffset CheckedAtUtc);

--- a/Veriado.Infrastructure/Search/SqliteExceptionExtensions.cs
+++ b/Veriado.Infrastructure/Search/SqliteExceptionExtensions.cs
@@ -68,7 +68,7 @@ internal static class SqliteExceptionExtensions
         if (exception.Message.Contains("no such column", StringComparison.OrdinalIgnoreCase))
         {
             if (exception.Message.Contains("fts", StringComparison.OrdinalIgnoreCase)
-                || exception.Message.Contains("file_search", StringComparison.OrdinalIgnoreCase))
+                || exception.Message.Contains("search_document_fts", StringComparison.OrdinalIgnoreCase))
             {
                 return true;
             }
@@ -81,7 +81,8 @@ internal static class SqliteExceptionExtensions
 
     private static bool ContainsFulltextIdentifier(string message)
     {
-        return message.Contains("file_search", StringComparison.OrdinalIgnoreCase)
+        return message.Contains("search_document_fts", StringComparison.OrdinalIgnoreCase)
+            || message.Contains("search_document", StringComparison.OrdinalIgnoreCase)
             || message.Contains("documentcontent", StringComparison.OrdinalIgnoreCase)
             || message.Contains("document_content", StringComparison.OrdinalIgnoreCase);
     }

--- a/Veriado.Services/Import/ImportService.cs
+++ b/Veriado.Services/Import/ImportService.cs
@@ -1263,7 +1263,7 @@ public sealed class ImportService : IImportService
         }
 
         if (normalized.Contains("no such table", StringComparison.Ordinal)
-            && (normalized.Contains("file_search", StringComparison.Ordinal)
+            && (normalized.Contains("search_document_fts", StringComparison.Ordinal)
                 || normalized.Contains("fts", StringComparison.Ordinal)))
         {
             return true;


### PR DESCRIPTION
## Summary
- replace the DocumentContent table with the canonical search_document layout and rebuild triggers/FTS definitions
- update migrations, integrity tooling, and query paths to target search_document/search_document_fts
- refresh diagnostics and tooling to understand the new schema and metadata columns

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68f2351ecdcc832690b862b47d2f12e0