### PR TITLE
Add file storage abstraction and transactional upload handlers

### DIFF
--- a/Veriado.Application/Abstractions/IFileRepository.cs
+++ b/Veriado.Application/Abstractions/IFileRepository.cs
@@ -14,6 +14,14 @@ public interface IFileRepository
     Task<FileEntity?> GetAsync(Guid id, CancellationToken cancellationToken);
 
     /// <summary>
+    /// Loads a file system aggregate by its identifier.
+    /// </summary>
+    /// <param name="id">The identifier of the file system entity.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The loaded aggregate or <see langword="null"/> when it does not exist.</returns>
+    Task<FileSystemEntity?> GetFileSystemAsync(Guid id, CancellationToken cancellationToken);
+
+    /// <summary>
     /// Loads multiple file aggregates by their identifiers in a single call.
     /// </summary>
     /// <param name="ids">The identifiers of the files to retrieve.</param>
@@ -44,9 +52,27 @@ public interface IFileRepository
     Task AddAsync(FileEntity file, FilePersistenceOptions options, CancellationToken cancellationToken);
 
     /// <summary>
+    /// Adds a file aggregate together with its backing file system entity.
+    /// </summary>
+    /// <param name="file">The file aggregate.</param>
+    /// <param name="fileSystem">The file system aggregate describing the stored content.</param>
+    /// <param name="options">The persistence options.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    Task AddAsync(FileEntity file, FileSystemEntity fileSystem, FilePersistenceOptions options, CancellationToken cancellationToken);
+
+    /// <summary>
     /// Persists the provided file aggregate updates.
     /// </summary>
     /// <param name="file">The aggregate to persist.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     Task UpdateAsync(FileEntity file, FilePersistenceOptions options, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Persists updates to a file aggregate and its associated file system entity.
+    /// </summary>
+    /// <param name="file">The file aggregate.</param>
+    /// <param name="fileSystem">The associated file system aggregate.</param>
+    /// <param name="options">The persistence options.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    Task UpdateAsync(FileEntity file, FileSystemEntity fileSystem, FilePersistenceOptions options, CancellationToken cancellationToken);
 }

--- a/Veriado.Application/Abstractions/IFileStorage.cs
+++ b/Veriado.Application/Abstractions/IFileStorage.cs
@@ -1,0 +1,126 @@
+using System.IO;
+
+namespace Veriado.Appl.Abstractions;
+
+/// <summary>
+/// Provides access to the underlying storage provider that hosts binary file content.
+/// </summary>
+public interface IFileStorage
+{
+    /// <summary>
+    /// Persists the provided content stream and returns the resulting metadata snapshot.
+    /// </summary>
+    /// <param name="content">The content stream to persist.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The storage metadata describing the saved content.</returns>
+    Task<StorageResult> SaveAsync(Stream content, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Moves existing stored content to a different logical path.
+    /// </summary>
+    /// <param name="from">The original storage path.</param>
+    /// <param name="to">The desired target path.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The normalized path pointing to the moved content.</returns>
+    Task<StoragePath> MoveAsync(StoragePath from, StoragePath to, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Retrieves the latest metadata snapshot for the specified storage path.
+    /// </summary>
+    /// <param name="path">The storage path.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The metadata describing the stored content.</returns>
+    Task<FileStat> StatAsync(StoragePath path, CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// Represents the outcome of a storage write operation.
+/// </summary>
+/// <param name="Provider">The storage provider that hosts the content.</param>
+/// <param name="Path">The normalized storage path.</param>
+/// <param name="Hash">The SHA-256 content hash.</param>
+/// <param name="Size">The size of the stored content.</param>
+/// <param name="Mime">The MIME type detected for the content.</param>
+/// <param name="Attributes">The observed file attributes.</param>
+/// <param name="OwnerSid">The optional owner security identifier.</param>
+/// <param name="IsEncrypted">Indicates whether the content is encrypted at rest.</param>
+/// <param name="CreatedUtc">The creation timestamp.</param>
+/// <param name="LastWriteUtc">The last write timestamp.</param>
+/// <param name="LastAccessUtc">The last access timestamp.</param>
+public readonly record struct StorageResult(
+    StorageProvider Provider,
+    StoragePath Path,
+    FileHash Hash,
+    ByteSize Size,
+    MimeType Mime,
+    FileAttributesFlags Attributes,
+    string? OwnerSid,
+    bool IsEncrypted,
+    UtcTimestamp CreatedUtc,
+    UtcTimestamp LastWriteUtc,
+    UtcTimestamp LastAccessUtc)
+{
+    /// <summary>
+    /// Converts the storage result to a <see cref="FileStat"/> snapshot.
+    /// </summary>
+    /// <returns>The corresponding file stat.</returns>
+    public FileStat ToFileStat()
+        => new(
+            Provider,
+            Path,
+            Hash,
+            Size,
+            Mime,
+            Attributes,
+            OwnerSid,
+            IsEncrypted,
+            CreatedUtc,
+            LastWriteUtc,
+            LastAccessUtc);
+}
+
+/// <summary>
+/// Represents metadata describing stored content.
+/// </summary>
+/// <param name="Provider">The storage provider that hosts the content.</param>
+/// <param name="Path">The normalized storage path.</param>
+/// <param name="Hash">The SHA-256 content hash.</param>
+/// <param name="Size">The size of the stored content.</param>
+/// <param name="Mime">The MIME type detected for the content.</param>
+/// <param name="Attributes">The observed file attributes.</param>
+/// <param name="OwnerSid">The optional owner security identifier.</param>
+/// <param name="IsEncrypted">Indicates whether the content is encrypted at rest.</param>
+/// <param name="CreatedUtc">The creation timestamp.</param>
+/// <param name="LastWriteUtc">The last write timestamp.</param>
+/// <param name="LastAccessUtc">The last access timestamp.</param>
+public readonly record struct FileStat(
+    StorageProvider Provider,
+    StoragePath Path,
+    FileHash Hash,
+    ByteSize Size,
+    MimeType Mime,
+    FileAttributesFlags Attributes,
+    string? OwnerSid,
+    bool IsEncrypted,
+    UtcTimestamp CreatedUtc,
+    UtcTimestamp LastWriteUtc,
+    UtcTimestamp LastAccessUtc)
+{
+    /// <summary>
+    /// Converts the stat snapshot to a <see cref="StorageResult"/> for convenience.
+    /// </summary>
+    /// <returns>The corresponding storage result.</returns>
+    public StorageResult ToStorageResult()
+        => new(
+            Provider,
+            Path,
+            Hash,
+            Size,
+            Mime,
+            Attributes,
+            OwnerSid,
+            IsEncrypted,
+            CreatedUtc,
+            LastWriteUtc,
+            LastAccessUtc);
+}

--- a/Veriado.Application/GlobalUsings.cs
+++ b/Veriado.Application/GlobalUsings.cs
@@ -1,6 +1,7 @@
 global using System;
 global using System.Collections.Generic;
 global using System.Globalization;
+global using System.IO;
 global using System.Linq;
 global using System.Text;
 global using System.Threading;
@@ -15,6 +16,7 @@ global using Veriado.Appl.UseCases.Files.Common;
 global using Veriado.Contracts.Diagnostics;
 global using Veriado.Contracts.Files;
 global using Veriado.Contracts.Search;
+global using Veriado.Domain.FileSystem;
 global using Veriado.Domain.Files;
 global using Veriado.Domain.Metadata;
 global using Veriado.Domain.ValueObjects;

--- a/Veriado.Application/UseCases/Files/CreateFileWithUpload/CreateFileWithUploadCommand.cs
+++ b/Veriado.Application/UseCases/Files/CreateFileWithUpload/CreateFileWithUploadCommand.cs
@@ -1,0 +1,16 @@
+namespace Veriado.Appl.UseCases.Files.CreateFileWithUpload;
+
+/// <summary>
+/// Command used to create a new file aggregate backed by an uploaded blob stored in the external file system.
+/// </summary>
+/// <param name="Name">The file name without extension.</param>
+/// <param name="Extension">The file extension.</param>
+/// <param name="Mime">The MIME type reported by the caller.</param>
+/// <param name="Author">The document author.</param>
+/// <param name="Content">The binary content of the file.</param>
+public sealed record CreateFileWithUploadCommand(
+    string Name,
+    string Extension,
+    string Mime,
+    string Author,
+    byte[] Content) : IRequest<AppResult<Guid>>;

--- a/Veriado.Application/UseCases/Files/CreateFileWithUpload/CreateFileWithUploadHandler.cs
+++ b/Veriado.Application/UseCases/Files/CreateFileWithUpload/CreateFileWithUploadHandler.cs
@@ -1,0 +1,101 @@
+namespace Veriado.Appl.UseCases.Files.CreateFileWithUpload;
+
+/// <summary>
+/// Handles creation of new file aggregates together with their backing file system content.
+/// </summary>
+public sealed class CreateFileWithUploadHandler : FileWriteHandlerBase, IRequestHandler<CreateFileWithUploadCommand, AppResult<Guid>>
+{
+    private readonly ImportPolicy _importPolicy;
+    private readonly IFileStorage _fileStorage;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CreateFileWithUploadHandler"/> class.
+    /// </summary>
+    public CreateFileWithUploadHandler(
+        IFileRepository repository,
+        IClock clock,
+        ImportPolicy importPolicy,
+        IMapper mapper,
+        IFileStorage fileStorage)
+        : base(repository, clock, mapper)
+    {
+        _importPolicy = importPolicy ?? throw new ArgumentNullException(nameof(importPolicy));
+        _fileStorage = fileStorage ?? throw new ArgumentNullException(nameof(fileStorage));
+    }
+
+    /// <inheritdoc />
+    public async Task<AppResult<Guid>> Handle(CreateFileWithUploadCommand request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            Guard.AgainstNull(request.Content, nameof(request.Content));
+            _importPolicy.EnsureWithinLimit(request.Content.LongLength);
+
+            var name = FileName.From(request.Name);
+            var extension = FileExtension.From(request.Extension);
+            var mime = MimeType.From(request.Mime);
+            var size = ByteSize.From(request.Content.LongLength);
+            var hash = FileHash.Compute(request.Content);
+
+            if (await Repository.ExistsByHashAsync(hash, cancellationToken).ConfigureAwait(false))
+            {
+                return AppResult<Guid>.Conflict("A file with identical content already exists.");
+            }
+
+            await using var contentStream = new MemoryStream(request.Content, writable: false);
+            var storageResult = await _fileStorage.SaveAsync(contentStream, cancellationToken).ConfigureAwait(false);
+            storageResult = storageResult with { Mime = mime };
+
+            if (storageResult.Hash != hash)
+            {
+                throw new InvalidOperationException("Stored content hash does not match the computed hash.");
+            }
+
+            if (storageResult.Size != size)
+            {
+                throw new InvalidOperationException("Stored content size does not match the provided payload.");
+            }
+
+            var createdAt = CurrentTimestamp();
+            var fileSystem = FileSystemEntity.CreateNew(
+                storageResult.Provider,
+                storageResult.Path,
+                storageResult.Hash,
+                storageResult.Size,
+                storageResult.Mime,
+                storageResult.Attributes,
+                storageResult.OwnerSid,
+                storageResult.IsEncrypted,
+                storageResult.CreatedUtc,
+                storageResult.LastWriteUtc,
+                storageResult.LastAccessUtc,
+                createdAt);
+
+            var file = FileEntity.CreateNew(
+                name,
+                extension,
+                mime,
+                request.Author,
+                fileSystem.Id,
+                storageResult.Hash,
+                storageResult.Size,
+                ContentVersion.Initial,
+                createdAt);
+
+            await Repository.AddAsync(file, fileSystem, FilePersistenceOptions.Default, cancellationToken).ConfigureAwait(false);
+            return AppResult<Guid>.Success(file.Id);
+        }
+        catch (Exception ex) when (ex is ArgumentException or ArgumentOutOfRangeException)
+        {
+            return AppResult<Guid>.FromException(ex);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return AppResult<Guid>.FromException(ex);
+        }
+        catch (Exception ex)
+        {
+            return AppResult<Guid>.FromException(ex, "Failed to create the file.");
+        }
+    }
+}

--- a/Veriado.Application/UseCases/Files/RelinkFileContent/RelinkFileContentCommand.cs
+++ b/Veriado.Application/UseCases/Files/RelinkFileContent/RelinkFileContentCommand.cs
@@ -1,0 +1,12 @@
+namespace Veriado.Appl.UseCases.Files.RelinkFileContent;
+
+/// <summary>
+/// Command used to relink an existing file to freshly uploaded content stored in the external file system.
+/// </summary>
+/// <param name="FileId">The identifier of the logical file.</param>
+/// <param name="Mime">The MIME type reported by the caller.</param>
+/// <param name="Content">The new binary content.</param>
+public sealed record RelinkFileContentCommand(
+    Guid FileId,
+    string Mime,
+    byte[] Content) : IRequest<AppResult<FileSummaryDto>>;

--- a/Veriado.Application/UseCases/Files/RelinkFileContent/RelinkFileContentHandler.cs
+++ b/Veriado.Application/UseCases/Files/RelinkFileContent/RelinkFileContentHandler.cs
@@ -1,0 +1,109 @@
+namespace Veriado.Appl.UseCases.Files.RelinkFileContent;
+
+/// <summary>
+/// Handles relinking logical files to freshly uploaded file system content.
+/// </summary>
+public sealed class RelinkFileContentHandler : FileWriteHandlerBase, IRequestHandler<RelinkFileContentCommand, AppResult<FileSummaryDto>>
+{
+    private readonly ImportPolicy _importPolicy;
+    private readonly IFileStorage _fileStorage;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RelinkFileContentHandler"/> class.
+    /// </summary>
+    public RelinkFileContentHandler(
+        IFileRepository repository,
+        IClock clock,
+        ImportPolicy importPolicy,
+        IMapper mapper,
+        IFileStorage fileStorage)
+        : base(repository, clock, mapper)
+    {
+        _importPolicy = importPolicy ?? throw new ArgumentNullException(nameof(importPolicy));
+        _fileStorage = fileStorage ?? throw new ArgumentNullException(nameof(fileStorage));
+    }
+
+    /// <inheritdoc />
+    public async Task<AppResult<FileSummaryDto>> Handle(RelinkFileContentCommand request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            Guard.AgainstNull(request.Content, nameof(request.Content));
+            _importPolicy.EnsureWithinLimit(request.Content.LongLength);
+
+            var file = await Repository.GetAsync(request.FileId, cancellationToken).ConfigureAwait(false);
+            if (file is null)
+            {
+                return AppResult<FileSummaryDto>.NotFound($"File '{request.FileId}' was not found.");
+            }
+
+            var newHash = FileHash.Compute(request.Content);
+            if (newHash == file.ContentHash)
+            {
+                return AppResult<FileSummaryDto>.Success(Mapper.Map<FileSummaryDto>(file));
+            }
+
+            var newMime = MimeType.From(request.Mime);
+            var newSize = ByteSize.From(request.Content.LongLength);
+
+            await using var contentStream = new MemoryStream(request.Content, writable: false);
+            var storageResult = await _fileStorage.SaveAsync(contentStream, cancellationToken).ConfigureAwait(false);
+            storageResult = storageResult with { Mime = newMime };
+
+            if (storageResult.Hash != newHash)
+            {
+                throw new InvalidOperationException("Stored content hash does not match the computed hash.");
+            }
+
+            if (storageResult.Size != newSize)
+            {
+                throw new InvalidOperationException("Stored content size does not match the provided payload.");
+            }
+
+            var fileSystem = await Repository.GetFileSystemAsync(file.FileSystemId, cancellationToken).ConfigureAwait(false);
+            if (fileSystem is null)
+            {
+                throw new InvalidOperationException($"File system entity '{file.FileSystemId}' was not found.");
+            }
+
+            var timestamp = CurrentTimestamp();
+            fileSystem.ReplaceContent(
+                storageResult.Path,
+                storageResult.Hash,
+                storageResult.Size,
+                storageResult.Mime,
+                storageResult.IsEncrypted,
+                timestamp);
+            fileSystem.UpdateAttributes(storageResult.Attributes, timestamp);
+            fileSystem.UpdateOwner(storageResult.OwnerSid, timestamp);
+            fileSystem.UpdateTimestamps(
+                storageResult.CreatedUtc,
+                storageResult.LastWriteUtc,
+                storageResult.LastAccessUtc,
+                timestamp);
+
+            file.LinkTo(
+                fileSystem.Id,
+                storageResult.Hash,
+                storageResult.Size,
+                fileSystem.ContentVersion,
+                storageResult.Mime,
+                timestamp);
+
+            await Repository.UpdateAsync(file, fileSystem, FilePersistenceOptions.Default, cancellationToken).ConfigureAwait(false);
+            return AppResult<FileSummaryDto>.Success(Mapper.Map<FileSummaryDto>(file));
+        }
+        catch (Exception ex) when (ex is ArgumentException or ArgumentOutOfRangeException)
+        {
+            return AppResult<FileSummaryDto>.FromException(ex);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return AppResult<FileSummaryDto>.FromException(ex);
+        }
+        catch (Exception ex)
+        {
+            return AppResult<FileSummaryDto>.FromException(ex, "Failed to relink file content.");
+        }
+    }
+}

--- a/Veriado.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/Veriado.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
@@ -21,6 +21,7 @@ using Veriado.Infrastructure.Persistence.Interceptors;
 using Veriado.Infrastructure.Repositories;
 using Veriado.Infrastructure.Search;
 using Veriado.Infrastructure.Time;
+using Veriado.Infrastructure.Storage;
 using Veriado.Domain.Primitives;
 using Veriado.Appl.Pipeline.Idempotency;
 using Veriado.Appl.Search;
@@ -195,6 +196,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<ISearchIndexCoordinator, SqliteSearchIndexCoordinator>();
         services.AddSingleton<IIndexQueue, IndexQueue>();
         services.AddSingleton<IDatabaseMaintenanceService, SqliteDatabaseMaintenanceService>();
+        services.AddSingleton<IFileStorage, LocalFileStorage>();
 
         services.AddSingleton<ISearchQueryService, SqliteFts5QueryService>();
         services.AddSingleton<FtsWriteAheadService>();

--- a/Veriado.Infrastructure/Storage/LocalFileStorage.cs
+++ b/Veriado.Infrastructure/Storage/LocalFileStorage.cs
@@ -1,0 +1,265 @@
+using System.Buffers;
+using System.Globalization;
+using System.Security.Cryptography;
+
+namespace Veriado.Infrastructure.Storage;
+
+/// <summary>
+/// Provides a simple file-system based implementation of <see cref="IFileStorage"/> for local development scenarios.
+/// </summary>
+internal sealed class LocalFileStorage : IFileStorage
+{
+    private const string DefaultMimeType = "application/octet-stream";
+    private readonly string _rootPath;
+    private readonly StorageProvider _provider = StorageProvider.Local;
+
+    public LocalFileStorage(InfrastructureOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        if (string.IsNullOrWhiteSpace(options.DbPath))
+        {
+            throw new ArgumentException("Infrastructure options must configure a database path to derive storage location.", nameof(options));
+        }
+
+        var baseDirectory = Path.GetDirectoryName(options.DbPath);
+        if (string.IsNullOrWhiteSpace(baseDirectory))
+        {
+            baseDirectory = AppContext.BaseDirectory;
+        }
+
+        _rootPath = Path.Combine(baseDirectory!, "storage");
+        Directory.CreateDirectory(_rootPath);
+    }
+
+    public async Task<StorageResult> SaveAsync(Stream content, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(content);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var relativePath = BuildRelativePath();
+        var physicalPath = ResolvePath(relativePath);
+        Directory.CreateDirectory(Path.GetDirectoryName(physicalPath)!);
+
+        await using var destination = new FileStream(physicalPath, FileMode.Create, FileAccess.Write, FileShare.None, 81920, useAsync: true);
+        using var incrementalHash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+        var buffer = ArrayPool<byte>.Shared.Rent(81920);
+        long totalBytes = 0;
+
+        try
+        {
+            while (true)
+            {
+                var read = await content.ReadAsync(buffer.AsMemory(0, buffer.Length), cancellationToken).ConfigureAwait(false);
+                if (read == 0)
+                {
+                    break;
+                }
+
+                await destination.WriteAsync(buffer.AsMemory(0, read), cancellationToken).ConfigureAwait(false);
+                incrementalHash.AppendData(buffer, 0, read);
+                totalBytes += read;
+            }
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+
+        await destination.FlushAsync(cancellationToken).ConfigureAwait(false);
+
+        var hashBytes = incrementalHash.GetHashAndReset();
+        var hash = FileHash.From(Convert.ToHexString(hashBytes));
+        return CreateSnapshot(relativePath, hash, totalBytes);
+    }
+
+    public Task<StoragePath> MoveAsync(StoragePath from, StoragePath to, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(from);
+        ArgumentNullException.ThrowIfNull(to);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var sourcePath = ResolvePath(from.Value);
+        var destinationPath = ResolvePath(to.Value);
+        Directory.CreateDirectory(Path.GetDirectoryName(destinationPath)!);
+
+        File.Move(sourcePath, destinationPath, overwrite: false);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        return Task.FromResult(StoragePath.From(NormalizePath(to.Value)));
+    }
+
+    public async Task<FileStat> StatAsync(StoragePath path, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(path);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var physicalPath = ResolvePath(path.Value);
+        if (!File.Exists(physicalPath))
+        {
+            throw new FileNotFoundException($"File '{path.Value}' was not found in storage.", physicalPath);
+        }
+
+        await using var source = new FileStream(physicalPath, FileMode.Open, FileAccess.Read, FileShare.Read, 81920, useAsync: true);
+        using var incrementalHash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+        var buffer = ArrayPool<byte>.Shared.Rent(81920);
+        long totalBytes = 0;
+
+        try
+        {
+            while (true)
+            {
+                var read = await source.ReadAsync(buffer.AsMemory(0, buffer.Length), cancellationToken).ConfigureAwait(false);
+                if (read == 0)
+                {
+                    break;
+                }
+
+                incrementalHash.AppendData(buffer, 0, read);
+                totalBytes += read;
+            }
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+
+        var hashBytes = incrementalHash.GetHashAndReset();
+        var hash = FileHash.From(Convert.ToHexString(hashBytes));
+        var snapshot = CreateSnapshot(path.Value, hash, totalBytes);
+        return snapshot.ToFileStat();
+    }
+
+    private StorageResult CreateSnapshot(string relativePath, FileHash hash, long length)
+    {
+        var physicalPath = ResolvePath(relativePath);
+        var info = new FileInfo(physicalPath);
+
+        if (!info.Exists)
+        {
+            throw new FileNotFoundException($"File '{relativePath}' was not found in storage.", physicalPath);
+        }
+
+        var attributes = MapAttributes(info.Attributes);
+        var normalizedPath = NormalizePath(relativePath);
+        var mime = MimeType.From(DefaultMimeType);
+
+        return new StorageResult(
+            _provider,
+            StoragePath.From(normalizedPath),
+            hash,
+            ByteSize.From(length),
+            mime,
+            attributes,
+            ownerSid: null,
+            isEncrypted: attributes.HasFlag(FileAttributesFlags.Encrypted),
+            UtcTimestamp.From(info.CreationTimeUtc),
+            UtcTimestamp.From(info.LastWriteTimeUtc),
+            UtcTimestamp.From(info.LastAccessTimeUtc));
+    }
+
+    private static string BuildRelativePath()
+    {
+        var identifier = Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture);
+        return Path.Combine(identifier[..2], identifier[2..]);
+    }
+
+    private string ResolvePath(string relativePath)
+    {
+        var trimmed = relativePath.TrimStart(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        var localPath = trimmed.Replace('/', Path.DirectorySeparatorChar).Replace('\', Path.DirectorySeparatorChar);
+        return Path.Combine(_rootPath, localPath);
+    }
+
+    private static string NormalizePath(string relativePath)
+    {
+        return relativePath.Replace('\', '/');
+    }
+
+    private static FileAttributesFlags MapAttributes(FileAttributes attributes)
+    {
+        FileAttributesFlags flags = FileAttributesFlags.None;
+
+        if (attributes.HasFlag(FileAttributes.ReadOnly))
+        {
+            flags |= FileAttributesFlags.ReadOnly;
+        }
+
+        if (attributes.HasFlag(FileAttributes.Hidden))
+        {
+            flags |= FileAttributesFlags.Hidden;
+        }
+
+        if (attributes.HasFlag(FileAttributes.System))
+        {
+            flags |= FileAttributesFlags.System;
+        }
+
+        if (attributes.HasFlag(FileAttributes.Directory))
+        {
+            flags |= FileAttributesFlags.Directory;
+        }
+
+        if (attributes.HasFlag(FileAttributes.Archive))
+        {
+            flags |= FileAttributesFlags.Archive;
+        }
+
+        if (attributes.HasFlag(FileAttributes.Device))
+        {
+            flags |= FileAttributesFlags.Device;
+        }
+
+        if (attributes.HasFlag(FileAttributes.Temporary))
+        {
+            flags |= FileAttributesFlags.Temporary;
+        }
+
+        if (attributes.HasFlag(FileAttributes.SparseFile))
+        {
+            flags |= FileAttributesFlags.SparseFile;
+        }
+
+        if (attributes.HasFlag(FileAttributes.ReparsePoint))
+        {
+            flags |= FileAttributesFlags.ReparsePoint;
+        }
+
+        if (attributes.HasFlag(FileAttributes.Compressed))
+        {
+            flags |= FileAttributesFlags.Compressed;
+        }
+
+        if (attributes.HasFlag(FileAttributes.Offline))
+        {
+            flags |= FileAttributesFlags.Offline;
+        }
+
+        if (attributes.HasFlag(FileAttributes.NotContentIndexed))
+        {
+            flags |= FileAttributesFlags.NotContentIndexed;
+        }
+
+        if (attributes.HasFlag(FileAttributes.Encrypted))
+        {
+            flags |= FileAttributesFlags.Encrypted;
+        }
+
+        if (attributes.HasFlag(FileAttributes.IntegrityStream))
+        {
+            flags |= FileAttributesFlags.IntegrityStream;
+        }
+
+        if (attributes.HasFlag(FileAttributes.NoScrubData))
+        {
+            flags |= FileAttributesFlags.NoScrubData;
+        }
+
+        if (flags == FileAttributesFlags.None)
+        {
+            flags = FileAttributesFlags.Normal;
+        }
+
+        return flags;
+    }
+}


### PR DESCRIPTION
## Summary
- introduce an IFileStorage abstraction with accompanying metadata snapshots and a local file system implementation wired into DI
- extend the file repository and write worker to handle filesystem entities and persist combined domain events
- add CreateFileWithUpload and RelinkFileContent handlers that upload binaries, create FileSystemEntity records, and commit within the queued transaction

## Testing
- dotnet build *(fails: `dotnet` command is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68f23e5185c88326bd6319d938dcb6e0