### PR TITLE
Refactor file persistence to respect layering

### DIFF
--- a/Veriado.Application/Abstractions/IFilePersistenceUnitOfWork.cs
+++ b/Veriado.Application/Abstractions/IFilePersistenceUnitOfWork.cs
@@ -1,0 +1,36 @@
+namespace Veriado.Appl.Abstractions;
+
+/// <summary>
+/// Represents the write-side persistence unit of work for file aggregates.
+/// </summary>
+public interface IFilePersistenceUnitOfWork
+{
+    /// <summary>
+    /// Gets a value indicating whether the underlying persistence context is tracking changes.
+    /// </summary>
+    bool HasTrackedChanges { get; }
+
+    /// <summary>
+    /// Begins a new transactional scope for subsequent operations.
+    /// </summary>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    Task<IFilePersistenceTransaction> BeginTransactionAsync(CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Persists pending changes to the underlying store.
+    /// </summary>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    Task SaveChangesAsync(CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// Represents a transactional scope created by <see cref="IFilePersistenceUnitOfWork"/>.
+/// </summary>
+public interface IFilePersistenceTransaction : IAsyncDisposable
+{
+    /// <summary>
+    /// Commits the transaction.
+    /// </summary>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    Task CommitAsync(CancellationToken cancellationToken);
+}

--- a/Veriado.Application/Common/Exceptions/DuplicateFileContentException.cs
+++ b/Veriado.Application/Common/Exceptions/DuplicateFileContentException.cs
@@ -1,0 +1,21 @@
+namespace Veriado.Appl.Common.Exceptions;
+
+/// <summary>
+/// Represents a conflict caused by attempting to persist duplicate file content hashes.
+/// </summary>
+public sealed class DuplicateFileContentException : Exception
+{
+    public DuplicateFileContentException()
+    {
+    }
+
+    public DuplicateFileContentException(string message)
+        : base(message)
+    {
+    }
+
+    public DuplicateFileContentException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}

--- a/Veriado.Application/GlobalUsings.cs
+++ b/Veriado.Application/GlobalUsings.cs
@@ -9,7 +9,6 @@ global using System.Threading.Tasks;
 global using AutoMapper;
 global using FluentValidation;
 global using MediatR;
-global using Microsoft.EntityFrameworkCore;
 global using Veriado.Appl.Abstractions;
 global using Veriado.Appl.Common;
 global using Veriado.Appl.Common.Policies;

--- a/Veriado.Application/UseCases/Files/ApplySystemMetadata/ApplySystemMetadataHandler.cs
+++ b/Veriado.Application/UseCases/Files/ApplySystemMetadata/ApplySystemMetadataHandler.cs
@@ -12,10 +12,10 @@ public sealed class ApplySystemMetadataHandler : FileWriteHandlerBase, IRequestH
         IFileRepository repository,
         IClock clock,
         IMapper mapper,
-        DbContext dbContext,
+        IFilePersistenceUnitOfWork unitOfWork,
         IFileSearchProjection searchProjection,
         ISearchIndexSignatureCalculator signatureCalculator)
-        : base(repository, clock, mapper, dbContext, searchProjection, signatureCalculator)
+        : base(repository, clock, mapper, unitOfWork, searchProjection, signatureCalculator)
     {
     }
 

--- a/Veriado.Application/UseCases/Files/ClearFileValidity/ClearFileValidityHandler.cs
+++ b/Veriado.Application/UseCases/Files/ClearFileValidity/ClearFileValidityHandler.cs
@@ -12,10 +12,10 @@ public sealed class ClearFileValidityHandler : FileWriteHandlerBase, IRequestHan
         IFileRepository repository,
         IClock clock,
         IMapper mapper,
-        DbContext dbContext,
+        IFilePersistenceUnitOfWork unitOfWork,
         IFileSearchProjection searchProjection,
         ISearchIndexSignatureCalculator signatureCalculator)
-        : base(repository, clock, mapper, dbContext, searchProjection, signatureCalculator)
+        : base(repository, clock, mapper, unitOfWork, searchProjection, signatureCalculator)
     {
     }
 

--- a/Veriado.Application/UseCases/Files/CreateFileWithUpload/CreateFileWithUploadHandler.cs
+++ b/Veriado.Application/UseCases/Files/CreateFileWithUpload/CreateFileWithUploadHandler.cs
@@ -17,10 +17,10 @@ public sealed class CreateFileWithUploadHandler : FileWriteHandlerBase, IRequest
         ImportPolicy importPolicy,
         IMapper mapper,
         IFileStorage fileStorage,
-        DbContext dbContext,
+        IFilePersistenceUnitOfWork unitOfWork,
         IFileSearchProjection searchProjection,
         ISearchIndexSignatureCalculator signatureCalculator)
-        : base(repository, clock, mapper, dbContext, searchProjection, signatureCalculator)
+        : base(repository, clock, mapper, unitOfWork, searchProjection, signatureCalculator)
     {
         _importPolicy = importPolicy ?? throw new ArgumentNullException(nameof(importPolicy));
         _fileStorage = fileStorage ?? throw new ArgumentNullException(nameof(fileStorage));

--- a/Veriado.Application/UseCases/Files/RelinkFileContent/RelinkFileContentHandler.cs
+++ b/Veriado.Application/UseCases/Files/RelinkFileContent/RelinkFileContentHandler.cs
@@ -17,10 +17,10 @@ public sealed class RelinkFileContentHandler : FileWriteHandlerBase, IRequestHan
         ImportPolicy importPolicy,
         IMapper mapper,
         IFileStorage fileStorage,
-        DbContext dbContext,
+        IFilePersistenceUnitOfWork unitOfWork,
         IFileSearchProjection searchProjection,
         ISearchIndexSignatureCalculator signatureCalculator)
-        : base(repository, clock, mapper, dbContext, searchProjection, signatureCalculator)
+        : base(repository, clock, mapper, unitOfWork, searchProjection, signatureCalculator)
     {
         _importPolicy = importPolicy ?? throw new ArgumentNullException(nameof(importPolicy));
         _fileStorage = fileStorage ?? throw new ArgumentNullException(nameof(fileStorage));

--- a/Veriado.Application/UseCases/Files/RenameFile/RenameFileHandler.cs
+++ b/Veriado.Application/UseCases/Files/RenameFile/RenameFileHandler.cs
@@ -12,10 +12,10 @@ public sealed class RenameFileHandler : FileWriteHandlerBase, IRequestHandler<Re
         IFileRepository repository,
         IClock clock,
         IMapper mapper,
-        DbContext dbContext,
+        IFilePersistenceUnitOfWork unitOfWork,
         IFileSearchProjection searchProjection,
         ISearchIndexSignatureCalculator signatureCalculator)
-        : base(repository, clock, mapper, dbContext, searchProjection, signatureCalculator)
+        : base(repository, clock, mapper, unitOfWork, searchProjection, signatureCalculator)
     {
     }
 

--- a/Veriado.Application/UseCases/Files/ReplaceFileContent/ReplaceFileContentHandler.cs
+++ b/Veriado.Application/UseCases/Files/ReplaceFileContent/ReplaceFileContentHandler.cs
@@ -17,10 +17,10 @@ public sealed class ReplaceFileContentHandler : FileWriteHandlerBase, IRequestHa
         IClock clock,
         ImportPolicy importPolicy,
         IMapper mapper,
-        DbContext dbContext,
+        IFilePersistenceUnitOfWork unitOfWork,
         IFileSearchProjection searchProjection,
         ISearchIndexSignatureCalculator signatureCalculator)
-        : base(repository, clock, mapper, dbContext, searchProjection, signatureCalculator)
+        : base(repository, clock, mapper, unitOfWork, searchProjection, signatureCalculator)
     {
         _importPolicy = importPolicy;
     }

--- a/Veriado.Application/UseCases/Files/SetFileReadOnly/SetFileReadOnlyHandler.cs
+++ b/Veriado.Application/UseCases/Files/SetFileReadOnly/SetFileReadOnlyHandler.cs
@@ -12,10 +12,10 @@ public sealed class SetFileReadOnlyHandler : FileWriteHandlerBase, IRequestHandl
         IFileRepository repository,
         IClock clock,
         IMapper mapper,
-        DbContext dbContext,
+        IFilePersistenceUnitOfWork unitOfWork,
         IFileSearchProjection searchProjection,
         ISearchIndexSignatureCalculator signatureCalculator)
-        : base(repository, clock, mapper, dbContext, searchProjection, signatureCalculator)
+        : base(repository, clock, mapper, unitOfWork, searchProjection, signatureCalculator)
     {
     }
 

--- a/Veriado.Application/UseCases/Files/SetFileValidity/SetFileValidityHandler.cs
+++ b/Veriado.Application/UseCases/Files/SetFileValidity/SetFileValidityHandler.cs
@@ -12,10 +12,10 @@ public sealed class SetFileValidityHandler : FileWriteHandlerBase, IRequestHandl
         IFileRepository repository,
         IClock clock,
         IMapper mapper,
-        DbContext dbContext,
+        IFilePersistenceUnitOfWork unitOfWork,
         IFileSearchProjection searchProjection,
         ISearchIndexSignatureCalculator signatureCalculator)
-        : base(repository, clock, mapper, dbContext, searchProjection, signatureCalculator)
+        : base(repository, clock, mapper, unitOfWork, searchProjection, signatureCalculator)
     {
     }
 

--- a/Veriado.Application/UseCases/Files/UpdateFileMetadata/UpdateFileMetadataHandler.cs
+++ b/Veriado.Application/UseCases/Files/UpdateFileMetadata/UpdateFileMetadataHandler.cs
@@ -12,10 +12,10 @@ public sealed class UpdateFileMetadataHandler : FileWriteHandlerBase, IRequestHa
         IFileRepository repository,
         IClock clock,
         IMapper mapper,
-        DbContext dbContext,
+        IFilePersistenceUnitOfWork unitOfWork,
         IFileSearchProjection searchProjection,
         ISearchIndexSignatureCalculator signatureCalculator)
-        : base(repository, clock, mapper, dbContext, searchProjection, signatureCalculator)
+        : base(repository, clock, mapper, unitOfWork, searchProjection, signatureCalculator)
     {
     }
 

--- a/Veriado.Application/UseCases/Maintenance/BulkReindexHandler.cs
+++ b/Veriado.Application/UseCases/Maintenance/BulkReindexHandler.cs
@@ -12,10 +12,10 @@ public sealed class BulkReindexHandler : FileWriteHandlerBase, IRequestHandler<B
         IFileRepository repository,
         IClock clock,
         IMapper mapper,
-        DbContext dbContext,
+        IFilePersistenceUnitOfWork unitOfWork,
         IFileSearchProjection searchProjection,
         ISearchIndexSignatureCalculator signatureCalculator)
-        : base(repository, clock, mapper, dbContext, searchProjection, signatureCalculator)
+        : base(repository, clock, mapper, unitOfWork, searchProjection, signatureCalculator)
     {
     }
 

--- a/Veriado.Application/UseCases/Maintenance/ReindexCorpusAfterSchemaUpgradeHandler.cs
+++ b/Veriado.Application/UseCases/Maintenance/ReindexCorpusAfterSchemaUpgradeHandler.cs
@@ -9,10 +9,10 @@ public sealed class ReindexCorpusAfterSchemaUpgradeHandler : FileWriteHandlerBas
         IFileRepository repository,
         IClock clock,
         IMapper mapper,
-        DbContext dbContext,
+        IFilePersistenceUnitOfWork unitOfWork,
         IFileSearchProjection searchProjection,
         ISearchIndexSignatureCalculator signatureCalculator)
-        : base(repository, clock, mapper, dbContext, searchProjection, signatureCalculator)
+        : base(repository, clock, mapper, unitOfWork, searchProjection, signatureCalculator)
     {
     }
 

--- a/Veriado.Application/UseCases/Maintenance/ReindexFileHandler.cs
+++ b/Veriado.Application/UseCases/Maintenance/ReindexFileHandler.cs
@@ -12,10 +12,10 @@ public sealed class ReindexFileHandler : FileWriteHandlerBase, IRequestHandler<R
         IFileRepository repository,
         IClock clock,
         IMapper mapper,
-        DbContext dbContext,
+        IFilePersistenceUnitOfWork unitOfWork,
         IFileSearchProjection searchProjection,
         ISearchIndexSignatureCalculator signatureCalculator)
-        : base(repository, clock, mapper, dbContext, searchProjection, signatureCalculator)
+        : base(repository, clock, mapper, unitOfWork, searchProjection, signatureCalculator)
     {
     }
 

--- a/Veriado.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/Veriado.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
@@ -174,6 +174,7 @@ public static class ServiceCollectionExtensions
 
         services.AddScoped<IFileSearchProjection, SearchProjectionService>();
         services.AddScoped<IFileRepository, FileRepository>();
+        services.AddScoped<IFilePersistenceUnitOfWork, EfFilePersistenceUnitOfWork>();
         services.AddScoped<IReadOnlyFileContextFactory, ReadOnlyFileContextFactory>();
         services.AddScoped<IFileReadRepository, FileReadRepository>();
         services.AddSingleton<IDiagnosticsRepository, DiagnosticsRepository>();

--- a/Veriado.Infrastructure/Persistence/EfFilePersistenceUnitOfWork.cs
+++ b/Veriado.Infrastructure/Persistence/EfFilePersistenceUnitOfWork.cs
@@ -1,0 +1,84 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
+using Veriado.Appl.Abstractions;
+using Veriado.Appl.Common.Exceptions;
+
+namespace Veriado.Infrastructure.Persistence;
+
+/// <summary>
+/// Provides an EF Core-backed implementation of <see cref="IFilePersistenceUnitOfWork"/>.
+/// </summary>
+internal sealed class EfFilePersistenceUnitOfWork : IFilePersistenceUnitOfWork
+{
+    private readonly AppDbContext _dbContext;
+
+    public EfFilePersistenceUnitOfWork(AppDbContext dbContext)
+    {
+        _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+    }
+
+    public bool HasTrackedChanges => _dbContext.ChangeTracker.HasChanges();
+
+    public async Task<IFilePersistenceTransaction> BeginTransactionAsync(CancellationToken cancellationToken)
+    {
+        var transaction = await _dbContext.Database
+            .BeginTransactionAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return new EfFilePersistenceTransaction(transaction);
+    }
+
+    public async Task SaveChangesAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            await _dbContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (DbUpdateException ex) when (IsDuplicateContentHashViolation(ex))
+        {
+            throw new DuplicateFileContentException("A file with identical content already exists.", ex);
+        }
+    }
+
+    private static bool IsDuplicateContentHashViolation(DbUpdateException exception)
+    {
+        if (exception.InnerException is not SqliteException sqlite)
+        {
+            return false;
+        }
+
+        const int SqliteConstraint = 19; // SQLITE_CONSTRAINT
+        const int SqliteConstraintUnique = 2067; // SQLITE_CONSTRAINT_UNIQUE
+
+        if (sqlite.SqliteErrorCode != SqliteConstraint)
+        {
+            return false;
+        }
+
+        if (sqlite.SqliteExtendedErrorCode != 0 && sqlite.SqliteExtendedErrorCode != SqliteConstraintUnique)
+        {
+            return false;
+        }
+
+        return sqlite.Message.Contains("files.content_hash", StringComparison.OrdinalIgnoreCase)
+            || sqlite.Message.Contains("files_content.hash", StringComparison.OrdinalIgnoreCase)
+            || sqlite.Message.Contains("ux_files_content_hash", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private sealed class EfFilePersistenceTransaction : IFilePersistenceTransaction
+    {
+        private readonly IDbContextTransaction _transaction;
+
+        public EfFilePersistenceTransaction(IDbContextTransaction transaction)
+        {
+            _transaction = transaction ?? throw new ArgumentNullException(nameof(transaction));
+        }
+
+        public Task CommitAsync(CancellationToken cancellationToken)
+            => _transaction.CommitAsync(cancellationToken);
+
+        public ValueTask DisposeAsync()
+            => _transaction.DisposeAsync();
+    }
+}


### PR DESCRIPTION
## Summary
- introduce an application-level file persistence unit of work and duplicate content exception
- refactor file write handlers to rely on the new abstraction instead of Entity Framework types
- implement and register an EF Core-backed unit of work in the infrastructure layer

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68f2ad2a87008326b9a1d3517d9cd0dc