### PR TITLE
Fix import deduplication and restore audit domain events

### DIFF
--- a/Veriado.Infrastructure/Import/FileImportService.cs
+++ b/Veriado.Infrastructure/Import/FileImportService.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
@@ -8,8 +10,12 @@ using Veriado.Appl.Abstractions;
 using Veriado.Application.Import;
 using Veriado.Domain.FileSystem;
 using Veriado.Domain.Files;
+using Veriado.Domain.Primitives;
+using Veriado.Domain.Search.Events;
 using Veriado.Domain.ValueObjects;
+using Veriado.Infrastructure.Events;
 using Veriado.Infrastructure.Persistence;
+using Veriado.Infrastructure.Persistence.EventLog;
 
 namespace Veriado.Infrastructure.Import;
 
@@ -21,21 +27,26 @@ public sealed class FileImportService : IFileImportWriter
     private const int MinimumBatchSize = 500;
     private const int MaximumBatchSize = 2000;
 
+    private static readonly JsonSerializerOptions EventSerializerOptions = new(JsonSerializerDefaults.Web);
+
     private readonly AppDbContext _dbContext;
     private readonly IFileSearchProjection _searchProjection;
     private readonly ISearchIndexSignatureCalculator _signatureCalculator;
     private readonly IClock _clock;
+    private readonly AuditEventProjector _auditProjector;
 
     public FileImportService(
         AppDbContext dbContext,
         IFileSearchProjection searchProjection,
         ISearchIndexSignatureCalculator signatureCalculator,
-        IClock clock)
+        IClock clock,
+        AuditEventProjector auditProjector)
     {
         _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
         _searchProjection = searchProjection ?? throw new ArgumentNullException(nameof(searchProjection));
         _signatureCalculator = signatureCalculator ?? throw new ArgumentNullException(nameof(signatureCalculator));
         _clock = clock ?? throw new ArgumentNullException(nameof(clock));
+        _auditProjector = auditProjector ?? throw new ArgumentNullException(nameof(auditProjector));
     }
 
     public async Task<ImportResult> ImportAsync(
@@ -120,7 +131,7 @@ public sealed class FileImportService : IFileImportWriter
         {
             ct.ThrowIfCancellationRequested();
             var existing = existingFiles.FirstOrDefault(file => file.Id == item.FileId);
-            var mapped = ImportMapping.MapToAggregate(item, existing?.FileSystemId);
+            var mapped = ImportMapping.MapToAggregate(item, existing is null, existing?.FileSystemId);
 
             if (existing is not null)
             {
@@ -158,6 +169,7 @@ public sealed class FileImportService : IFileImportWriter
         }
 
         await _dbContext.SaveChangesAsync(ct).ConfigureAwait(false);
+        await PersistDomainEventsAsync(persisted, ct).ConfigureAwait(false);
 
         if (options.UpsertFts)
         {
@@ -181,6 +193,91 @@ public sealed class FileImportService : IFileImportWriter
 
         await transaction.CommitAsync(ct).ConfigureAwait(false);
         return new ImportResult(imported, skipped, updated);
+    }
+
+    private async Task PersistDomainEventsAsync(IReadOnlyList<MappedImport> persisted, CancellationToken ct)
+    {
+        if (persisted.Count == 0)
+        {
+            return;
+        }
+
+        var domainEvents = new List<(Guid AggregateId, IDomainEvent DomainEvent)>();
+
+        foreach (var mapped in persisted)
+        {
+            CollectDomainEvents(mapped.File, domainEvents);
+            CollectDomainEvents(mapped.FileSystem, domainEvents);
+        }
+
+        if (domainEvents.Count == 0)
+        {
+            ClearDomainEvents(persisted);
+            return;
+        }
+
+        await StoreDomainEventsAsync(_dbContext, _auditProjector, domainEvents, ct).ConfigureAwait(false);
+        ClearDomainEvents(persisted);
+    }
+
+    private static void CollectDomainEvents(EntityBase entity, List<(Guid AggregateId, IDomainEvent DomainEvent)> domainEvents)
+    {
+        foreach (var domainEvent in entity.DomainEvents)
+        {
+            domainEvents.Add((entity.Id, domainEvent));
+        }
+    }
+
+    private static void ClearDomainEvents(IReadOnlyList<MappedImport> persisted)
+    {
+        foreach (var mapped in persisted)
+        {
+            mapped.File.ClearDomainEvents();
+            mapped.FileSystem.ClearDomainEvents();
+        }
+    }
+
+    private static async Task StoreDomainEventsAsync(
+        AppDbContext context,
+        AuditEventProjector auditProjector,
+        IReadOnlyList<(Guid AggregateId, IDomainEvent DomainEvent)> domainEvents,
+        CancellationToken cancellationToken)
+    {
+        if (domainEvents.Count == 0)
+        {
+            return;
+        }
+
+        var logs = new List<DomainEventLogEntry>(domainEvents.Count);
+
+        foreach (var (aggregateId, domainEvent) in domainEvents)
+        {
+            var eventType = domainEvent.GetType();
+            logs.Add(new DomainEventLogEntry
+            {
+                EventType = eventType.FullName ?? eventType.Name,
+                EventJson = JsonSerializer.Serialize(domainEvent, eventType, EventSerializerOptions),
+                AggregateId = aggregateId.ToString("D", CultureInfo.InvariantCulture),
+                OccurredUtc = domainEvent.OccurredOnUtc,
+            });
+
+            if (domainEvent is SearchReindexRequested)
+            {
+                // TODO(FTS Sync): Handle SearchReindexRequested synchronously once FTS updates run inside the transaction.
+            }
+        }
+
+        var hasAuditChanges = auditProjector.Project(context, domainEvents);
+
+        if (logs.Count > 0)
+        {
+            await context.DomainEventLog.AddRangeAsync(logs, cancellationToken).ConfigureAwait(false);
+        }
+
+        if (logs.Count > 0 || hasAuditChanges)
+        {
+            await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        }
     }
 
     private static IReadOnlyList<ImportItem> Deduplicate(IReadOnlyList<ImportItem> items)

--- a/Veriado.Infrastructure/Import/ImportMapping.cs
+++ b/Veriado.Infrastructure/Import/ImportMapping.cs
@@ -10,7 +10,7 @@ namespace Veriado.Infrastructure.Import;
 
 internal static class ImportMapping
 {
-    public static MappedImport MapToAggregate(ImportItem item, Guid? existingFileSystemId = null)
+    public static MappedImport MapToAggregate(ImportItem item, bool isNewFile, Guid? existingFileSystemId = null)
     {
         ArgumentNullException.ThrowIfNull(item);
 
@@ -58,7 +58,8 @@ internal static class ImportMapping
             contentVersion,
             isMissing: false,
             missingSinceUtc: null,
-            lastLinkedUtc: modifiedUtc);
+            lastLinkedUtc: modifiedUtc,
+            emitContentEvents: true);
 
         var file = FileEntity.CreateForImport(
             fileId,
@@ -78,7 +79,8 @@ internal static class ImportMapping
             validity,
             searchIndex,
             ftsPolicy,
-            metadata.Title);
+            metadata.Title,
+            emitCreationEvents: isNewFile);
 
         return new MappedImport(file, fileSystem, metadata.Version, metadata.Search);
     }

--- a/Veriado.Services/Import/ImportService.cs
+++ b/Veriado.Services/Import/ImportService.cs
@@ -916,6 +916,16 @@ public sealed class ImportService : IImportService
 
         using var scope = BeginScope();
 
+        if (await FileAlreadyExistsAsync(import.ContentHash, cancellationToken).ConfigureAwait(false))
+        {
+            var duplicateError = new ApiError(
+                "duplicate_content",
+                "File was skipped because identical content already exists.",
+                descriptor);
+            LogApiError(descriptor, duplicateError);
+            return ApiResponse<Guid>.Failure(duplicateError);
+        }
+
         await using var contentStream = new MemoryStream(command.Content, writable: false);
         var storageResult = await _fileStorage.SaveAsync(contentStream, cancellationToken).ConfigureAwait(false);
 


### PR DESCRIPTION
## Summary
- reintroduce the hash-based duplicate guard in ImportService before persisting file content
- emit FileCreated/FileContentLinked and file system events during import mapping
- persist collected domain events within FileImportService so audit projections are recorded

## Testing
- not run (dotnet CLI unavailable in environment)


------
https://chatgpt.com/codex/tasks/task_e_68f3bb1938a08326b8255c7d918a2091