### PR TITLE
Fix LocalFileStorage namespace and constructor usage

### DIFF
--- a/Veriado.Infrastructure/Storage/LocalFileStorage.cs
+++ b/Veriado.Infrastructure/Storage/LocalFileStorage.cs
@@ -1,7 +1,7 @@
 using System.Buffers;
 using System.Globalization;
 using System.Security.Cryptography;
-using Veriado.Application.Abstractions;
+using Veriado.Appl.Abstractions;
 using Veriado.Domain.Metadata;
 using Veriado.Domain.ValueObjects;
 
@@ -154,8 +154,8 @@ internal sealed class LocalFileStorage : IFileStorage
             ByteSize.From(length),
             mime,
             attributes,
-            ownerSid: null,
-            isEncrypted: attributes.HasFlag(FileAttributesFlags.Encrypted),
+            OwnerSid: null,
+            IsEncrypted: attributes.HasFlag(FileAttributesFlags.Encrypted),
             UtcTimestamp.From(info.CreationTimeUtc),
             UtcTimestamp.From(info.LastWriteTimeUtc),
             UtcTimestamp.From(info.LastAccessTimeUtc));


### PR DESCRIPTION
## Summary
- reference the correct Veriado.Appl.Abstractions namespace in LocalFileStorage
- align StorageResult named arguments with the record parameter names

## Testing
- dotnet build Veriado.sln *(fails: `dotnet` is not available in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f3c0efe7548326ba4f7a21ca22d332