### PR TITLE
Restore single backslash normalization in LocalFileStorage

### DIFF
--- a/Veriado.Infrastructure/Storage/LocalFileStorage.cs
+++ b/Veriado.Infrastructure/Storage/LocalFileStorage.cs
@@ -168,19 +168,21 @@ internal sealed class LocalFileStorage : IFileStorage
         return Path.Combine(identifier[..2], identifier[2..]);
     }
 
+    private const string Backslash = "\u005C";
+
     private string ResolvePath(string relativePath)
     {
         var trimmed = relativePath.TrimStart(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
         var directorySeparator = Path.DirectorySeparatorChar.ToString();
         var localPath = trimmed
             .Replace(Path.AltDirectorySeparatorChar.ToString(), directorySeparator, StringComparison.Ordinal)
-            .Replace("\\", directorySeparator, StringComparison.Ordinal);
+            .Replace(Backslash, directorySeparator, StringComparison.Ordinal);
         return Path.Combine(_rootPath, localPath);
     }
 
     private static string NormalizePath(string relativePath)
     {
-        return relativePath.Replace("\\", "/", StringComparison.Ordinal);
+        return relativePath.Replace(Backslash, "/", StringComparison.Ordinal);
     }
 
     private static FileAttributesFlags MapAttributes(FileAttributes attributes)


### PR DESCRIPTION
## Summary
- add a Unicode-escaped backslash constant for normalization
- reuse the constant when converting Windows-style separators in path handling

## Testing
- not run (dotnet CLI not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68f3e20e80888326a6f10dfd06b652f3