### PR TITLE
Implement content hash guard for search projection upserts

### DIFF
--- a/Veriado.Application/Abstractions/IFileSearchProjection.cs
+++ b/Veriado.Application/Abstractions/IFileSearchProjection.cs
@@ -6,11 +6,21 @@ namespace Veriado.Appl.Abstractions;
 public interface IFileSearchProjection
 {
     /// <summary>
-    /// Upserts the specified file aggregate into the search projection store.
+    /// Upserts the specified file aggregate into the search projection store using optimistic concurrency guards.
     /// </summary>
     /// <param name="file">The aggregate to project.</param>
+    /// <param name="expectedContentHash">The content hash currently recorded in the index.</param>
+    /// <param name="newContentHash">The new content hash to persist.</param>
+    /// <param name="tokenHash">The analyzer token hash captured for the projection.</param>
+    /// <param name="guard">The projection transaction guard.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
-    Task UpsertAsync(FileEntity file, ISearchProjectionTransactionGuard guard, CancellationToken cancellationToken);
+    Task UpsertAsync(
+        FileEntity file,
+        string? expectedContentHash,
+        string? newContentHash,
+        string? tokenHash,
+        ISearchProjectionTransactionGuard guard,
+        CancellationToken cancellationToken);
 
     /// <summary>
     /// Deletes the search projection entry for the supplied identifier.

--- a/Veriado.Application/Common/Exceptions/StaleSearchProjectionUpdateException.cs
+++ b/Veriado.Application/Common/Exceptions/StaleSearchProjectionUpdateException.cs
@@ -1,0 +1,22 @@
+namespace Veriado.Appl.Common.Exceptions;
+
+/// <summary>
+/// Represents a conflict where a newer search projection already exists for the document.
+/// </summary>
+public sealed class StaleSearchProjectionUpdateException : Exception
+{
+    public StaleSearchProjectionUpdateException()
+        : base("Stale update – newer content already indexed.")
+    {
+    }
+
+    public StaleSearchProjectionUpdateException(string message)
+        : base(message)
+    {
+    }
+
+    public StaleSearchProjectionUpdateException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}

--- a/Veriado.Application/UseCases/Files/Common/FileWriteHandlerBase.cs
+++ b/Veriado.Application/UseCases/Files/Common/FileWriteHandlerBase.cs
@@ -124,8 +124,20 @@ public abstract class FileWriteHandlerBase
             }
             else
             {
-                await _searchProjection.UpsertAsync(file, _unitOfWork, cancellationToken).ConfigureAwait(false);
                 var signature = _signatureCalculator.Compute(file);
+                var expectedContentHash = file.SearchIndex?.IndexedContentHash;
+                var newContentHash = file.ContentHash.Value;
+
+                await _searchProjection
+                    .UpsertAsync(
+                        file,
+                        expectedContentHash,
+                        newContentHash,
+                        signature.TokenHash,
+                        _unitOfWork,
+                        cancellationToken)
+                    .ConfigureAwait(false);
+
                 file.ConfirmIndexed(
                     file.SearchIndex.SchemaVersion,
                     CurrentTimestamp(),

--- a/Veriado.Infrastructure/Persistence/Schema/SqliteFulltextSchemaSql.cs
+++ b/Veriado.Infrastructure/Persistence/Schema/SqliteFulltextSchemaSql.cs
@@ -47,16 +47,20 @@ internal static class SqliteFulltextSchemaSql
     public static IReadOnlyList<string> CreateStatements { get; } = new[]
     {
         @"CREATE TABLE IF NOT EXISTS search_document (
-    file_id        BLOB PRIMARY KEY,
-    title          TEXT,
-    author         TEXT,
-    mime           TEXT NOT NULL,
-    metadata_text  TEXT,
-    metadata_json  TEXT,
-    created_utc    TEXT,
-    modified_utc   TEXT,
-    content_hash   TEXT
+    file_id             BLOB PRIMARY KEY,
+    title               TEXT,
+    author              TEXT,
+    mime                TEXT NOT NULL,
+    metadata_text       TEXT,
+    metadata_json       TEXT,
+    created_utc         TEXT,
+    modified_utc        TEXT,
+    content_hash        TEXT,
+    stored_content_hash TEXT,
+    stored_token_hash   TEXT
 );",
+        "ALTER TABLE search_document ADD COLUMN IF NOT EXISTS stored_content_hash TEXT;",
+        "ALTER TABLE search_document ADD COLUMN IF NOT EXISTS stored_token_hash TEXT;",
         "CREATE INDEX IF NOT EXISTS idx_search_document_mime ON search_document(mime);",
         "CREATE INDEX IF NOT EXISTS idx_search_document_modified ON search_document(modified_utc DESC);",
         @"CREATE VIRTUAL TABLE IF NOT EXISTS search_document_fts USING fts5(

--- a/Veriado.Infrastructure/Persistence/SqliteFulltextSchemaInspector.cs
+++ b/Veriado.Infrastructure/Persistence/SqliteFulltextSchemaInspector.cs
@@ -29,6 +29,8 @@ internal static class SqliteFulltextSchemaInspector
         "created_utc",
         "modified_utc",
         "content_hash",
+        "stored_content_hash",
+        "stored_token_hash",
     };
 
     private static readonly string[] ExpectedTriggers = { "sd_ai", "sd_au", "sd_ad" };

--- a/Veriado.Infrastructure/Search/SearchProjectionService.cs
+++ b/Veriado.Infrastructure/Search/SearchProjectionService.cs
@@ -6,30 +6,43 @@ using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Veriado.Appl.Abstractions;
+using Veriado.Appl.Common.Exceptions;
 using Veriado.Appl.Search;
 using Veriado.Domain.Files;
+using Veriado.Domain.Search;
 using Veriado.Infrastructure.Persistence;
 
 namespace Veriado.Infrastructure.Search;
 
 public sealed class SearchProjectionService : IFileSearchProjection
 {
+    private const int SqliteBusyErrorCode = 5;
+    private const int MaxBusyRetries = 5;
+    private const double InitialBackoffMilliseconds = 25d;
+    private const double MaxBackoffMilliseconds = 400d;
+
     private readonly DbContext _dbContext;
     private readonly IAnalyzerFactory _analyzerFactory;
     private readonly ILogger<SearchProjectionService> _logger;
+    private readonly ISearchTelemetry? _telemetry;
 
     public SearchProjectionService(
         DbContext dbContext,
         IAnalyzerFactory analyzerFactory,
-        ILogger<SearchProjectionService>? logger = null)
+        ILogger<SearchProjectionService>? logger = null,
+        ISearchTelemetry? telemetry = null)
     {
         _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
         _analyzerFactory = analyzerFactory ?? throw new ArgumentNullException(nameof(analyzerFactory));
         _logger = logger ?? NullLogger<SearchProjectionService>.Instance;
+        _telemetry = telemetry;
     }
 
     public async Task UpsertAsync(
         FileEntity file,
+        string? expectedContentHash,
+        string? newContentHash,
+        string? tokenHash,
         ISearchProjectionTransactionGuard guard,
         CancellationToken cancellationToken)
     {
@@ -44,52 +57,92 @@ public sealed class SearchProjectionService : IFileSearchProjection
         }
 
         var document = file.ToSearchDocument();
+        var normalizedTitle = NormalizeOptional(document.Title);
+        var normalizedAuthor = NormalizeOptional(document.Author);
+        var normalizedMetadataText = NormalizeOptional(document.MetadataText);
+
+        var expectedHash = string.IsNullOrWhiteSpace(expectedContentHash)
+            ? null
+            : expectedContentHash;
+        var storedContentHash = string.IsNullOrWhiteSpace(newContentHash)
+            ? (string?)document.ContentHash
+            : newContentHash;
+        var storedTokenHash = string.IsNullOrWhiteSpace(tokenHash)
+            ? null
+            : tokenHash;
+
+        var attempt = 0;
+        var delay = TimeSpan.FromMilliseconds(InitialBackoffMilliseconds);
+
+        while (true)
+        {
+            attempt++;
+
+            try
+            {
+                var rowsAffected = await ExecuteUpsertCoreAsync(
+                        document,
+                        normalizedTitle,
+                        normalizedAuthor,
+                        normalizedMetadataText,
+                        expectedHash,
+                        storedContentHash,
+                        storedTokenHash,
+                        cancellationToken)
+                    .ConfigureAwait(false);
+
+                if (rowsAffected == 0)
+                {
+                    throw new StaleSearchProjectionUpdateException();
+                }
+
+                break;
+            }
+            catch (SqliteException ex) when (IsBusy(ex) && attempt < MaxBusyRetries)
+            {
+                _telemetry?.RecordSqliteBusyRetry(1);
+                _logger.LogWarning(
+                    ex,
+                    "SQLite busy while updating search document for {FileId}; retrying in {Delay} (attempt {Attempt}/{MaxAttempts})",
+                    document.FileId,
+                    delay,
+                    attempt,
+                    MaxBusyRetries);
+
+                await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
+                var nextDelay = Math.Min(delay.TotalMilliseconds * 2, MaxBackoffMilliseconds);
+                delay = TimeSpan.FromMilliseconds(nextDelay);
+            }
+            catch (SqliteException ex) when (IsBusy(ex))
+            {
+                _telemetry?.RecordSqliteBusyRetry(1);
+                _logger.LogError(
+                    ex,
+                    "SQLite busy while updating search document for {FileId} after {Attempts} attempts; aborting.",
+                    document.FileId,
+                    attempt);
+                throw;
+            }
+        }
+    }
+
+    private async Task<int> ExecuteUpsertCoreAsync(
+        SearchDocument document,
+        string? normalizedTitle,
+        string? normalizedAuthor,
+        string? normalizedMetadataText,
+        string? expectedContentHash,
+        string? storedContentHash,
+        string? storedTokenHash,
+        CancellationToken cancellationToken)
+    {
         var sqliteTransaction = GetAmbientTransaction();
         var connection = sqliteTransaction.Connection ?? throw new InvalidOperationException(
             "Active SQLite transaction has no associated connection.");
 
-        SqliteCommand? activeCommand = null;
-
-        try
-        {
-            var normalizedTitle = NormalizeOptional(document.Title);
-            var normalizedAuthor = NormalizeOptional(document.Author);
-            var normalizedMetadataText = NormalizeOptional(document.MetadataText);
-
-            await using var update = connection.CreateCommand();
-            update.Transaction = sqliteTransaction;
-            update.CommandText = @"UPDATE search_document
-SET title = $title,
-    author = $author,
-    mime = $mime,
-    metadata_text = $metadata_text,
-    metadata_json = $metadata_json,
-    created_utc = $created_utc,
-    modified_utc = $modified_utc,
-    content_hash = $content_hash
-WHERE file_id = $file_id;";
-
-            ConfigureSearchDocumentParameters(
-                update,
-                document.FileId,
-                normalizedTitle,
-                normalizedAuthor,
-                document.Mime,
-                normalizedMetadataText,
-                document.MetadataJson,
-                document.CreatedUtc,
-                document.ModifiedUtc,
-                document.ContentHash);
-
-            activeCommand = update;
-            var rowsAffected = await update.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
-            activeCommand = null;
-
-            if (rowsAffected == 0)
-            {
-                await using var insert = connection.CreateCommand();
-                insert.Transaction = sqliteTransaction;
-                insert.CommandText = @"INSERT INTO search_document (
+        await using var command = connection.CreateCommand();
+        command.Transaction = sqliteTransaction;
+        command.CommandText = @"INSERT INTO search_document (
     file_id,
     title,
     author,
@@ -98,7 +151,9 @@ WHERE file_id = $file_id;";
     metadata_json,
     created_utc,
     modified_utc,
-    content_hash)
+    content_hash,
+    stored_content_hash,
+    stored_token_hash)
 VALUES (
     $file_id,
     $title,
@@ -108,28 +163,53 @@ VALUES (
     $metadata_json,
     $created_utc,
     $modified_utc,
-    $content_hash);";
+    $content_hash,
+    $stored_content_hash,
+    $stored_token_hash)
+ON CONFLICT(file_id) DO UPDATE SET
+    title = excluded.title,
+    author = excluded.author,
+    mime = excluded.mime,
+    metadata_text = excluded.metadata_text,
+    metadata_json = excluded.metadata_json,
+    created_utc = excluded.created_utc,
+    modified_utc = excluded.modified_utc,
+    content_hash = excluded.content_hash,
+    stored_content_hash = excluded.stored_content_hash,
+    stored_token_hash = excluded.stored_token_hash
+WHERE search_document.stored_content_hash IS NULL
+   OR search_document.stored_content_hash = $expected_old_hash;";
 
-                ConfigureSearchDocumentParameters(
-                    insert,
-                    document.FileId,
-                    normalizedTitle,
-                    normalizedAuthor,
-                    document.Mime,
-                    normalizedMetadataText,
-                    document.MetadataJson,
-                    document.CreatedUtc,
-                    document.ModifiedUtc,
-                    document.ContentHash);
+        var contentHashValue = string.IsNullOrWhiteSpace(document.ContentHash)
+            ? storedContentHash
+            : document.ContentHash;
 
-                activeCommand = insert;
-                await insert.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
-                activeCommand = null;
-            }
+        ConfigureSearchDocumentParameters(
+            command,
+            document.FileId,
+            normalizedTitle,
+            normalizedAuthor,
+            document.Mime,
+            normalizedMetadataText,
+            document.MetadataJson,
+            document.CreatedUtc,
+            document.ModifiedUtc,
+            contentHashValue,
+            storedContentHash,
+            storedTokenHash,
+            expectedContentHash);
+
+        try
+        {
+            return await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (SqliteException ex) when (IsBusy(ex))
+        {
+            throw;
         }
         catch (SqliteException ex)
         {
-            LogSqliteFailure(ex, activeCommand);
+            LogSqliteFailure(ex, command);
             if (ex.IndicatesFatalFulltextFailure())
             {
                 throw new SearchIndexCorruptedException(
@@ -197,6 +277,9 @@ VALUES (
         return sqliteTransaction;
     }
 
+    private static bool IsBusy(SqliteException exception)
+        => exception.SqliteErrorCode == SqliteBusyErrorCode;
+
     private string? NormalizeOptional(string? value)
     {
         return string.IsNullOrWhiteSpace(value)
@@ -214,7 +297,10 @@ VALUES (
         string? metadataJson,
         DateTimeOffset createdUtc,
         DateTimeOffset modifiedUtc,
-        string? contentHash)
+        string? contentHash,
+        string? storedContentHash,
+        string? storedTokenHash,
+        string? expectedOldHash)
     {
         if (string.IsNullOrEmpty(mime))
         {
@@ -231,6 +317,9 @@ VALUES (
         command.Parameters.Add("$created_utc", SqliteType.Text).Value = createdUtc.ToString("O", CultureInfo.InvariantCulture);
         command.Parameters.Add("$modified_utc", SqliteType.Text).Value = modifiedUtc.ToString("O", CultureInfo.InvariantCulture);
         command.Parameters.Add("$content_hash", SqliteType.Text).Value = (object?)contentHash ?? DBNull.Value;
+        command.Parameters.Add("$stored_content_hash", SqliteType.Text).Value = (object?)storedContentHash ?? DBNull.Value;
+        command.Parameters.Add("$stored_token_hash", SqliteType.Text).Value = (object?)storedTokenHash ?? DBNull.Value;
+        command.Parameters.Add("$expected_old_hash", SqliteType.Text).Value = (object?)expectedOldHash ?? DBNull.Value;
     }
 
     private void LogSqliteFailure(SqliteException exception, SqliteCommand? command)


### PR DESCRIPTION
## Summary
- add optimistic concurrency checks and SQLITE_BUSY retry handling to the search projection upsert pipeline
- persist the stored content/token hash alongside the search document and extend schema inspection to expect the new columns
- update file persistence, import, and repair flows to pass expected and new hashes and surface a dedicated stale-update exception

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68f3ea3a2e4c8326a5c6af7af6e3c2c1