### PR TITLE
Implement domain events interceptor and search reindex handling

### DIFF
--- a/Veriado.Application.Tests/Domain/Files/FileEntityTests.cs
+++ b/Veriado.Application.Tests/Domain/Files/FileEntityTests.cs
@@ -1,0 +1,43 @@
+using System.Linq;
+using Veriado.Domain.Files;
+using Veriado.Domain.Search.Events;
+using Veriado.Domain.ValueObjects;
+using Xunit;
+
+namespace Veriado.Application.Tests.Domain.Files;
+
+public static class FileEntityFactory
+{
+    public static FileEntity CreateSample(Guid? fileSystemId = null)
+    {
+        var resolvedFileSystemId = fileSystemId ?? Guid.NewGuid();
+        return FileEntity.CreateNew(
+            FileName.From("document.pdf"),
+            FileExtension.From("pdf"),
+            MimeType.From("application/pdf"),
+            "Initial Author",
+            resolvedFileSystemId,
+            FileHash.From(new string('A', 64)),
+            ByteSize.From(1024),
+            ContentVersion.Initial,
+            UtcTimestamp.From(DateTimeOffset.UtcNow));
+    }
+}
+
+public class FileEntityTests
+{
+    [Fact]
+    public void UpdateMetadata_RaisesSearchReindexRequested()
+    {
+        var file = FileEntityFactory.CreateSample();
+        file.ClearDomainEvents();
+
+        var when = UtcTimestamp.From(DateTimeOffset.UtcNow.AddMinutes(5));
+
+        file.UpdateMetadata(MimeType.From("application/msword"), "Updated Author", when);
+
+        var reindexEvent = Assert.IsType<SearchReindexRequested>(Assert.Single(file.DomainEvents.Where(evt => evt is SearchReindexRequested)));
+        Assert.Equal(file.Id, reindexEvent.FileId);
+        Assert.Equal(ReindexReason.MetadataChanged, reindexEvent.Reason);
+    }
+}

--- a/Veriado.Application.Tests/Infrastructure/DomainEventsInterceptorTests.cs
+++ b/Veriado.Application.Tests/Infrastructure/DomainEventsInterceptorTests.cs
@@ -1,0 +1,154 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Veriado.Application.Tests.Domain.Files;
+using Veriado.Domain.FileSystem;
+using Veriado.Domain.Metadata;
+using Veriado.Domain.Search.Events;
+using Veriado.Domain.ValueObjects;
+using Veriado.Infrastructure.Events;
+using Veriado.Infrastructure.Events.Handlers;
+using Veriado.Infrastructure.Persistence.Interceptors;
+using Veriado.Infrastructure.Persistence.Options;
+using Veriado.Infrastructure.Search;
+using Xunit;
+
+namespace Veriado.Application.Tests.Infrastructure;
+
+public sealed class DomainEventsInterceptorTests : IAsyncLifetime
+{
+    private readonly ServiceProvider _serviceProvider;
+    private readonly SqliteConnection _connection;
+
+    public DomainEventsInterceptorTests()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton<TestSearchIndexCoordinator>();
+        services.AddSingleton<ISearchIndexCoordinator>(sp => sp.GetRequiredService<TestSearchIndexCoordinator>());
+        services.AddSingleton<AuditEventProjector>();
+        services.AddSingleton<IDomainEventDispatcher, DomainEventDispatcher>();
+        services.AddSingleton<DomainEventsInterceptor>();
+        services.AddSingleton<IDomainEventHandler<SearchReindexRequested>, SearchReindexRequestedHandler>();
+
+        _serviceProvider = services.BuildServiceProvider();
+        _connection = new SqliteConnection("Filename=:memory:");
+    }
+
+    public async Task InitializeAsync()
+    {
+        await _connection.OpenAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _connection.DisposeAsync();
+        await _serviceProvider.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task SaveChanges_DispatchesDomainEventsAndClears()
+    {
+        await using var context = CreateContext();
+
+        await context.Database.EnsureDeletedAsync();
+        await context.Database.EnsureCreatedAsync();
+
+        var fileSystem = CreateFileSystem();
+        fileSystem.ClearDomainEvents();
+        context.FileSystems.Add(fileSystem);
+
+        var file = FileEntityFactory.CreateSample(fileSystem.Id);
+        context.Files.Add(file);
+
+        var coordinator = _serviceProvider.GetRequiredService<TestSearchIndexCoordinator>();
+        coordinator.Reset();
+
+        await context.SaveChangesAsync();
+
+        Assert.Empty(file.DomainEvents);
+        Assert.Equal((ulong)1, file.Version);
+
+        var requests = coordinator.Requests;
+        var request = Assert.Single(requests);
+        Assert.Equal(file.Id, request.FileId);
+        Assert.Equal(ReindexReason.Created, request.Reason);
+
+        var eventLogs = await context.DomainEventLog.ToListAsync();
+        Assert.Equal(3, eventLogs.Count);
+        Assert.All(eventLogs, log => Assert.Equal(file.Id.ToString("D"), log.AggregateId));
+    }
+
+    [Fact]
+    public async Task SubsequentSave_DoesNotRedispatchDomainEvents()
+    {
+        await using var context = CreateContext();
+
+        await context.Database.EnsureDeletedAsync();
+        await context.Database.EnsureCreatedAsync();
+
+        var fileSystem = CreateFileSystem();
+        fileSystem.ClearDomainEvents();
+        context.FileSystems.Add(fileSystem);
+
+        var file = FileEntityFactory.CreateSample(fileSystem.Id);
+        context.Files.Add(file);
+
+        var coordinator = _serviceProvider.GetRequiredService<TestSearchIndexCoordinator>();
+        coordinator.Reset();
+
+        await context.SaveChangesAsync();
+        coordinator.Reset();
+        var logCount = await context.DomainEventLog.CountAsync();
+
+        await context.SaveChangesAsync();
+
+        Assert.Equal(logCount, await context.DomainEventLog.CountAsync());
+        Assert.Empty(coordinator.Requests);
+        Assert.Empty(file.DomainEvents);
+    }
+
+    private AppDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseSqlite(_connection)
+            .AddInterceptors(_serviceProvider.GetRequiredService<DomainEventsInterceptor>())
+            .Options;
+
+        var infrastructureOptions = new InfrastructureOptions { DbPath = ":memory:" };
+        var logger = _serviceProvider.GetRequiredService<ILogger<AppDbContext>>();
+        return new AppDbContext(options, infrastructureOptions, logger);
+    }
+
+    private static FileSystemEntity CreateFileSystem()
+    {
+        return FileSystemEntity.CreateNew(
+            StorageProvider.Local,
+            StoragePath.From("/content/sample.bin"),
+            FileHash.From(new string('A', 64)),
+            ByteSize.From(1024),
+            MimeType.From("application/octet-stream"),
+            FileAttributesFlags.None,
+            ownerSid: null,
+            isEncrypted: false,
+            createdUtc: UtcTimestamp.From(DateTimeOffset.UtcNow),
+            lastWriteUtc: UtcTimestamp.From(DateTimeOffset.UtcNow),
+            lastAccessUtc: UtcTimestamp.From(DateTimeOffset.UtcNow));
+    }
+
+    private sealed class TestSearchIndexCoordinator : ISearchIndexCoordinator
+    {
+        private readonly List<(Guid FileId, ReindexReason Reason, DateTimeOffset When)> _requests = new();
+
+        public IReadOnlyList<(Guid FileId, ReindexReason Reason, DateTimeOffset When)> Requests => _requests;
+
+        public Task EnqueueAsync(DbContext dbContext, Guid fileId, ReindexReason reason, DateTimeOffset requestedUtc, CancellationToken cancellationToken)
+        {
+            _requests.Add((fileId, reason, requestedUtc));
+            return Task.CompletedTask;
+        }
+
+        public void Reset() => _requests.Clear();
+    }
+}

--- a/Veriado.Application/Abstractions/IFileRepository.cs
+++ b/Veriado.Application/Abstractions/IFileRepository.cs
@@ -76,11 +76,4 @@ public interface IFileRepository
     /// <param name="cancellationToken">The cancellation token.</param>
     Task UpdateAsync(FileEntity file, FileSystemEntity fileSystem, FilePersistenceOptions options, CancellationToken cancellationToken);
 
-    /// <summary>
-    /// Persists domain events emitted by the supplied aggregates into the audit and event log tables.
-    /// </summary>
-    /// <param name="file">The file aggregate that produced events.</param>
-    /// <param name="fileSystem">The optional file system aggregate that produced events.</param>
-    /// <param name="cancellationToken">The cancellation token.</param>
-    Task PersistDomainEventsAsync(FileEntity? file, FileSystemEntity? fileSystem, CancellationToken cancellationToken);
 }

--- a/Veriado.Application/Abstractions/ISearchIndexCoordinator.cs
+++ b/Veriado.Application/Abstractions/ISearchIndexCoordinator.cs
@@ -1,0 +1,9 @@
+using Microsoft.EntityFrameworkCore;
+using Veriado.Domain.Search.Events;
+
+namespace Veriado.Appl.Abstractions;
+
+public interface ISearchIndexCoordinator
+{
+    Task EnqueueAsync(DbContext dbContext, Guid fileId, ReindexReason reason, DateTimeOffset requestedUtc, CancellationToken cancellationToken);
+}

--- a/Veriado.Application/UseCases/Files/Common/FileWriteHandlerBase.cs
+++ b/Veriado.Application/UseCases/Files/Common/FileWriteHandlerBase.cs
@@ -148,8 +148,6 @@ public abstract class FileWriteHandlerBase
             }
         }
 
-        await _repository.PersistDomainEventsAsync(file, fileSystem, cancellationToken).ConfigureAwait(false);
-
         await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
     }
 }

--- a/Veriado.Domain/Primitives/AggregateRoot.cs
+++ b/Veriado.Domain/Primitives/AggregateRoot.cs
@@ -18,4 +18,14 @@ public abstract class AggregateRoot : EntityBase
         : base(id)
     {
     }
+
+    internal void IncrementVersion()
+    {
+        Version++;
+    }
+
+    internal void SetVersion(ulong version)
+    {
+        Version = version;
+    }
 }

--- a/Veriado.Infrastructure/Events/DomainEventDispatcher.cs
+++ b/Veriado.Infrastructure/Events/DomainEventDispatcher.cs
@@ -1,0 +1,67 @@
+using System.Reflection;
+using Veriado.Domain.Primitives;
+
+namespace Veriado.Infrastructure.Events;
+
+internal sealed class DomainEventDispatcher : IDomainEventDispatcher
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ILogger<DomainEventDispatcher> _logger;
+
+    public DomainEventDispatcher(IServiceScopeFactory scopeFactory, ILogger<DomainEventDispatcher> logger)
+    {
+        _scopeFactory = scopeFactory ?? throw new ArgumentNullException(nameof(scopeFactory));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task DispatchAsync(AppDbContext dbContext, IReadOnlyList<IDomainEvent> domainEvents, CancellationToken cancellationToken)
+    {
+        if (domainEvents.Count == 0)
+        {
+            return;
+        }
+
+        using var scope = _scopeFactory.CreateScope();
+        var provider = scope.ServiceProvider;
+
+        foreach (var domainEvent in domainEvents)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var handlerEnumerableType = typeof(IEnumerable<>).MakeGenericType(typeof(IDomainEventHandler<>).MakeGenericType(domainEvent.GetType()));
+            if (provider.GetService(handlerEnumerableType) is not IEnumerable<object> handlers)
+            {
+                if (_logger.IsEnabled(LogLevel.Debug))
+                {
+                    _logger.LogDebug("No handlers registered for domain event {EventType}", domainEvent.GetType().FullName);
+                }
+
+                continue;
+            }
+
+            foreach (var handler in handlers)
+            {
+                await InvokeHandlerAsync(handler, dbContext, domainEvent, cancellationToken).ConfigureAwait(false);
+            }
+        }
+    }
+
+    private static Task InvokeHandlerAsync(object handler, AppDbContext context, IDomainEvent domainEvent, CancellationToken cancellationToken)
+    {
+        var method = typeof(DomainEventDispatcher)
+            .GetMethod(nameof(InvokeHandlerCore), BindingFlags.Static | BindingFlags.NonPublic)!
+            .MakeGenericMethod(domainEvent.GetType());
+
+        return (Task)method.Invoke(null, new[] { handler, context, domainEvent, cancellationToken })!;
+    }
+
+    private static Task InvokeHandlerCore<TEvent>(
+        IDomainEventHandler<TEvent> handler,
+        AppDbContext context,
+        TEvent domainEvent,
+        CancellationToken cancellationToken)
+        where TEvent : IDomainEvent
+    {
+        return handler.HandleAsync(context, domainEvent, cancellationToken);
+    }
+}

--- a/Veriado.Infrastructure/Events/Handlers/SearchReindexRequestedHandler.cs
+++ b/Veriado.Infrastructure/Events/Handlers/SearchReindexRequestedHandler.cs
@@ -1,0 +1,18 @@
+using Veriado.Domain.Search.Events;
+
+namespace Veriado.Infrastructure.Events.Handlers;
+
+internal sealed class SearchReindexRequestedHandler : IDomainEventHandler<SearchReindexRequested>
+{
+    private readonly ISearchIndexCoordinator _coordinator;
+
+    public SearchReindexRequestedHandler(ISearchIndexCoordinator coordinator)
+    {
+        _coordinator = coordinator ?? throw new ArgumentNullException(nameof(coordinator));
+    }
+
+    public Task HandleAsync(AppDbContext dbContext, SearchReindexRequested domainEvent, CancellationToken cancellationToken)
+    {
+        return _coordinator.EnqueueAsync(dbContext, domainEvent.FileId, domainEvent.Reason, domainEvent.OccurredOnUtc, cancellationToken);
+    }
+}

--- a/Veriado.Infrastructure/Events/IDomainEventDispatcher.cs
+++ b/Veriado.Infrastructure/Events/IDomainEventDispatcher.cs
@@ -1,0 +1,8 @@
+using Veriado.Domain.Primitives;
+
+namespace Veriado.Infrastructure.Events;
+
+internal interface IDomainEventDispatcher
+{
+    Task DispatchAsync(AppDbContext dbContext, IReadOnlyList<IDomainEvent> domainEvents, CancellationToken cancellationToken);
+}

--- a/Veriado.Infrastructure/Events/IDomainEventHandler.cs
+++ b/Veriado.Infrastructure/Events/IDomainEventHandler.cs
@@ -1,0 +1,10 @@
+using Veriado.Domain.Primitives;
+using Veriado.Infrastructure.Persistence;
+
+namespace Veriado.Infrastructure.Events;
+
+internal interface IDomainEventHandler<in TEvent>
+    where TEvent : IDomainEvent
+{
+    Task HandleAsync(AppDbContext dbContext, TEvent domainEvent, CancellationToken cancellationToken);
+}

--- a/Veriado.Infrastructure/Persistence/Interceptors/DomainEventsInterceptor.cs
+++ b/Veriado.Infrastructure/Persistence/Interceptors/DomainEventsInterceptor.cs
@@ -1,0 +1,250 @@
+using System.Collections.Concurrent;
+using System.Globalization;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Veriado.Domain.Primitives;
+using Veriado.Infrastructure.Events;
+using Veriado.Infrastructure.Persistence.EventLog;
+
+namespace Veriado.Infrastructure.Persistence.Interceptors;
+
+internal sealed class DomainEventsInterceptor : SaveChangesInterceptor
+{
+    private static readonly JsonSerializerOptions EventSerializerOptions = new(JsonSerializerDefaults.Web);
+
+    private readonly AuditEventProjector _auditProjector;
+    private readonly IDomainEventDispatcher _dispatcher;
+    private readonly ILogger<DomainEventsInterceptor> _logger;
+    private readonly ConcurrentDictionary<DbContextId, DomainEventBatch> _pending = new();
+    private readonly ConcurrentDictionary<DbContextId, bool> _suppressed = new();
+
+    public DomainEventsInterceptor(
+        AuditEventProjector auditProjector,
+        IDomainEventDispatcher dispatcher,
+        ILogger<DomainEventsInterceptor> logger)
+    {
+        _auditProjector = auditProjector ?? throw new ArgumentNullException(nameof(auditProjector));
+        _dispatcher = dispatcher ?? throw new ArgumentNullException(nameof(dispatcher));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public override InterceptionResult<int> SavingChanges(DbContextEventData eventData, InterceptionResult<int> result)
+    {
+        CapturePendingEvents(eventData);
+        return base.SavingChanges(eventData, result);
+    }
+
+    public override ValueTask<InterceptionResult<int>> SavingChangesAsync(
+        DbContextEventData eventData,
+        InterceptionResult<int> result,
+        CancellationToken cancellationToken = default)
+    {
+        CapturePendingEvents(eventData);
+        return base.SavingChangesAsync(eventData, result, cancellationToken);
+    }
+
+    public override int SavedChanges(SaveChangesCompletedEventData eventData, int result)
+    {
+        ProcessPendingEventsAsync(eventData, CancellationToken.None).GetAwaiter().GetResult();
+        return base.SavedChanges(eventData, result);
+    }
+
+    public override async ValueTask<int> SavedChangesAsync(
+        SaveChangesCompletedEventData eventData,
+        int result,
+        CancellationToken cancellationToken = default)
+    {
+        await ProcessPendingEventsAsync(eventData, cancellationToken).ConfigureAwait(false);
+        return await base.SavedChangesAsync(eventData, result, cancellationToken).ConfigureAwait(false);
+    }
+
+    public override void SaveChangesFailed(DbContextErrorEventData eventData)
+    {
+        ResetPendingState(eventData);
+        base.SaveChangesFailed(eventData);
+    }
+
+    public override Task SaveChangesFailedAsync(
+        DbContextErrorEventData eventData,
+        CancellationToken cancellationToken = default)
+    {
+        ResetPendingState(eventData);
+        return base.SaveChangesFailedAsync(eventData, cancellationToken);
+    }
+
+    private void CapturePendingEvents(DbContextEventData eventData)
+    {
+        if (eventData.Context is not AppDbContext context)
+        {
+            return;
+        }
+
+        var contextId = context.ContextId;
+        if (_suppressed.ContainsKey(contextId))
+        {
+            return;
+        }
+
+        var batch = new DomainEventBatch();
+        CaptureAggregateVersions(context, batch);
+        CaptureDomainEvents(context, batch);
+
+        if (batch.HasData)
+        {
+            _pending[contextId] = batch;
+        }
+    }
+
+    private static void CaptureAggregateVersions(AppDbContext context, DomainEventBatch batch)
+    {
+        foreach (var entry in context.ChangeTracker.Entries<AggregateRoot>())
+        {
+            if (entry.State is not (EntityState.Modified or EntityState.Added))
+            {
+                continue;
+            }
+
+            var versionProperty = entry.Property(root => root.Version);
+            var originalVersion = versionProperty.CurrentValue;
+            batch.AggregateVersions.Add(new AggregateVersionSnapshot(entry, originalVersion));
+            entry.Entity.IncrementVersion();
+            versionProperty.IsModified = true;
+        }
+    }
+
+    private static void CaptureDomainEvents(AppDbContext context, DomainEventBatch batch)
+    {
+        foreach (var entry in context.ChangeTracker.Entries<EntityBase>())
+        {
+            if (entry.Entity.DomainEvents.Count == 0)
+            {
+                continue;
+            }
+
+            foreach (var domainEvent in entry.Entity.DomainEvents)
+            {
+                batch.DomainEvents.Add(new PendingDomainEvent(entry.Entity, entry.Entity.Id, domainEvent));
+            }
+        }
+    }
+
+    private async Task ProcessPendingEventsAsync(SaveChangesCompletedEventData eventData, CancellationToken cancellationToken)
+    {
+        if (eventData.Context is not AppDbContext context)
+        {
+            return;
+        }
+
+        var contextId = context.ContextId;
+        if (_suppressed.TryRemove(contextId, out _))
+        {
+            return;
+        }
+
+        if (!_pending.TryRemove(contextId, out var batch))
+        {
+            return;
+        }
+
+        if (batch.DomainEvents.Count == 0)
+        {
+            return;
+        }
+
+        if (_logger.IsEnabled(LogLevel.Debug))
+        {
+            _logger.LogDebug(
+                "Dispatching {EventCount} domain events for context {ContextId}",
+                batch.DomainEvents.Count,
+                contextId);
+        }
+
+        var domainEventTuples = batch.DomainEvents
+            .Select(evt => (evt.AggregateId, evt.DomainEvent))
+            .ToList();
+
+        var hasAuditChanges = _auditProjector.Project(context, domainEventTuples);
+
+        await _dispatcher
+            .DispatchAsync(context, domainEventTuples.Select(tuple => tuple.DomainEvent).ToList(), cancellationToken)
+            .ConfigureAwait(false);
+
+        var logs = CreateLogEntries(domainEventTuples);
+        if (logs.Count > 0)
+        {
+            await context.DomainEventLog.AddRangeAsync(logs, cancellationToken).ConfigureAwait(false);
+        }
+
+        if (context.ChangeTracker.HasChanges())
+        {
+            try
+            {
+                _suppressed[contextId] = true;
+                await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            }
+            finally
+            {
+                _suppressed.TryRemove(contextId, out _);
+            }
+        }
+
+        foreach (var group in batch.DomainEvents.GroupBy(evt => evt.Source))
+        {
+            group.Key.ClearDomainEvents();
+        }
+    }
+
+    private static List<DomainEventLogEntry> CreateLogEntries(IReadOnlyList<(Guid AggregateId, IDomainEvent DomainEvent)> events)
+    {
+        var logs = new List<DomainEventLogEntry>(events.Count);
+
+        foreach (var (aggregateId, domainEvent) in events)
+        {
+            var eventType = domainEvent.GetType();
+            logs.Add(new DomainEventLogEntry
+            {
+                EventType = eventType.FullName ?? eventType.Name,
+                EventJson = JsonSerializer.Serialize(domainEvent, eventType, EventSerializerOptions),
+                AggregateId = aggregateId.ToString("D", CultureInfo.InvariantCulture),
+                OccurredUtc = domainEvent.OccurredOnUtc,
+            });
+        }
+
+        return logs;
+    }
+
+    private void ResetPendingState(DbContextEventData eventData)
+    {
+        if (eventData.Context is not AppDbContext context)
+        {
+            return;
+        }
+
+        var contextId = context.ContextId;
+        _suppressed.TryRemove(contextId, out _);
+
+        if (!_pending.TryRemove(contextId, out var batch))
+        {
+            return;
+        }
+
+        foreach (var snapshot in batch.AggregateVersions)
+        {
+            snapshot.Entry.Entity.SetVersion(snapshot.OriginalVersion);
+            snapshot.Entry.Property(root => root.Version).CurrentValue = snapshot.OriginalVersion;
+            snapshot.Entry.Property(root => root.Version).IsModified = false;
+        }
+    }
+
+    private sealed class DomainEventBatch
+    {
+        public List<PendingDomainEvent> DomainEvents { get; } = new();
+        public List<AggregateVersionSnapshot> AggregateVersions { get; } = new();
+        public bool HasData => DomainEvents.Count > 0 || AggregateVersions.Count > 0;
+    }
+
+    private sealed record PendingDomainEvent(EntityBase Source, Guid AggregateId, IDomainEvent DomainEvent);
+
+    private sealed record AggregateVersionSnapshot(EntityEntry<AggregateRoot> Entry, ulong OriginalVersion);
+}

--- a/Veriado.Infrastructure/Repositories/FileRepository.cs
+++ b/Veriado.Infrastructure/Repositories/FileRepository.cs
@@ -1,11 +1,5 @@
-using System.Globalization;
 using System.Runtime.CompilerServices;
-using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
-using Veriado.Domain.Primitives;
-using Veriado.Domain.Search.Events;
-using Veriado.Infrastructure.Events;
-using Veriado.Infrastructure.Persistence.EventLog;
 
 namespace Veriado.Infrastructure.Repositories;
 
@@ -14,20 +8,15 @@ namespace Veriado.Infrastructure.Repositories;
 /// </summary>
 internal sealed class FileRepository : IFileRepository
 {
-    private static readonly JsonSerializerOptions EventSerializerOptions = new(JsonSerializerDefaults.Web);
-
     private readonly AppDbContext _db;
     private readonly IDbContextFactory<ReadOnlyDbContext> _readFactory;
-    private readonly AuditEventProjector _auditProjector;
 
     public FileRepository(
         AppDbContext db,
-        IDbContextFactory<ReadOnlyDbContext> readFactory,
-        AuditEventProjector auditProjector)
+        IDbContextFactory<ReadOnlyDbContext> readFactory)
     {
         _db = db ?? throw new ArgumentNullException(nameof(db));
         _readFactory = readFactory ?? throw new ArgumentNullException(nameof(readFactory));
-        _auditProjector = auditProjector ?? throw new ArgumentNullException(nameof(auditProjector));
     }
 
     public async Task<FileEntity?> GetAsync(Guid id, CancellationToken cancellationToken = default)
@@ -155,93 +144,4 @@ internal sealed class FileRepository : IFileRepository
     // - Delete: FileRepository.DeleteAsync currently invoked directly (no dedicated handler yet)
     // - Import workflows (ImportService.ImportFileAsync / ImportFolderStreamAsync) orchestrate the create/replace commands above.
 
-    public async Task PersistDomainEventsAsync(
-        FileEntity? file,
-        FileSystemEntity? fileSystem,
-        CancellationToken cancellationToken)
-    {
-        var domainEvents = CollectDomainEvents(file, fileSystem);
-        if (domainEvents.Count == 0)
-        {
-            ClearDomainEvents(file, fileSystem);
-            return;
-        }
-
-        await StoreDomainEventsAsync(_db, _auditProjector, domainEvents, cancellationToken).ConfigureAwait(false);
-        ClearDomainEvents(file, fileSystem);
-    }
-
-    private static List<(Guid AggregateId, IDomainEvent DomainEvent)> CollectDomainEvents(
-        FileEntity? file,
-        FileSystemEntity? fileSystem)
-    {
-        var events = new List<(Guid, IDomainEvent)>();
-
-        if (file is not null)
-        {
-            foreach (var domainEvent in file.DomainEvents)
-            {
-                events.Add((file.Id, domainEvent));
-            }
-        }
-
-        if (fileSystem is not null)
-        {
-            foreach (var domainEvent in fileSystem.DomainEvents)
-            {
-                events.Add((fileSystem.Id, domainEvent));
-            }
-        }
-
-        return events;
-    }
-
-    private static void ClearDomainEvents(FileEntity? file, FileSystemEntity? fileSystem)
-    {
-        file?.ClearDomainEvents();
-        fileSystem?.ClearDomainEvents();
-    }
-
-    private static async Task StoreDomainEventsAsync(
-        AppDbContext context,
-        AuditEventProjector auditProjector,
-        IReadOnlyList<(Guid AggregateId, IDomainEvent DomainEvent)> domainEvents,
-        CancellationToken cancellationToken)
-    {
-        if (domainEvents.Count == 0)
-        {
-            return;
-        }
-
-        var logs = new List<DomainEventLogEntry>(domainEvents.Count);
-
-        foreach (var (aggregateId, domainEvent) in domainEvents)
-        {
-            var eventType = domainEvent.GetType();
-            logs.Add(new DomainEventLogEntry
-            {
-                EventType = eventType.FullName ?? eventType.Name,
-                EventJson = JsonSerializer.Serialize(domainEvent, eventType, EventSerializerOptions),
-                AggregateId = aggregateId.ToString("D", CultureInfo.InvariantCulture),
-                OccurredUtc = domainEvent.OccurredOnUtc,
-            });
-
-            if (domainEvent is SearchReindexRequested)
-            {
-                // TODO(FTS Sync): Handle SearchReindexRequested synchronously once FTS updates run inside the transaction.
-            }
-        }
-
-        var hasAuditChanges = auditProjector.Project(context, domainEvents);
-
-        if (logs.Count > 0)
-        {
-            await context.DomainEventLog.AddRangeAsync(logs, cancellationToken).ConfigureAwait(false);
-        }
-
-        if (logs.Count > 0 || hasAuditChanges)
-        {
-            await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
-        }
-    }
 }

--- a/Veriado.Infrastructure/Search/SearchIndexCoordinator.cs
+++ b/Veriado.Infrastructure/Search/SearchIndexCoordinator.cs
@@ -1,0 +1,37 @@
+using Microsoft.EntityFrameworkCore;
+using Veriado.Domain.Search.Events;
+using Veriado.Infrastructure.Persistence.EventLog;
+
+namespace Veriado.Infrastructure.Search;
+
+internal sealed class SearchIndexCoordinator : ISearchIndexCoordinator
+{
+    private readonly ILogger<SearchIndexCoordinator> _logger;
+
+    public SearchIndexCoordinator(ILogger<SearchIndexCoordinator> logger)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task EnqueueAsync(DbContext dbContext, Guid fileId, ReindexReason reason, DateTimeOffset requestedUtc, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(dbContext);
+
+        if (dbContext is not AppDbContext context)
+        {
+            throw new ArgumentException("SearchIndexCoordinator requires AppDbContext for enqueue operations.", nameof(dbContext));
+        }
+
+        await context.ReindexQueue.AddAsync(new ReindexQueueEntry
+        {
+            FileId = fileId,
+            Reason = reason,
+            EnqueuedUtc = requestedUtc,
+        }, cancellationToken).ConfigureAwait(false);
+
+        if (_logger.IsEnabled(LogLevel.Debug))
+        {
+            _logger.LogDebug("Queued search reindex for file {FileId} due to {Reason}", fileId, reason);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a DomainEventsInterceptor that increments aggregate versions, persists audit/event logs, and dispatches domain events through a new dispatcher abstraction
- register the interceptor and domain event infrastructure, implement a SearchReindexRequested handler that enqueues work via an ISearchIndexCoordinator, and simplify the file repository so it no longer flushes events manually
- add tests covering search reindex event creation and the interceptor's dispatch behaviour after SaveChanges

## Testing
- `dotnet test` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f3f03dd4148326996642c3e868c7b7