### PR TITLE
Add missing ISearchIndexCoordinator import for tests

### DIFF
--- a/Veriado.Application.Tests/Infrastructure/DomainEventsInterceptorTests.cs
+++ b/Veriado.Application.Tests/Infrastructure/DomainEventsInterceptorTests.cs
@@ -2,6 +2,7 @@ using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Veriado.Appl.Abstractions;
 using Veriado.Application.Tests.Domain.Files;
 using Veriado.Domain.FileSystem;
 using Veriado.Domain.Metadata;


### PR DESCRIPTION
## Summary
- add the Veriado.Appl.Abstractions namespace to the interceptor tests so the ISearchIndexCoordinator type resolves

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68f3f658d3288326b7dbf82444aff388