### PR TITLE
Refactor infrastructure bootstrap to run fully async

### DIFF
--- a/Veriado.Infrastructure/Persistence/DesignTime/AppDbContextFactory.cs
+++ b/Veriado.Infrastructure/Persistence/DesignTime/AppDbContextFactory.cs
@@ -25,11 +25,6 @@ public sealed class AppDbContextFactory : IDesignTimeDbContextFactory<AppDbConte
         builder.UseSqlite(connectionProvider.ConnectionString, sqlite => sqlite.CommandTimeout(30));
         builder.AddInterceptors(pragmaInterceptor);
 
-        SqliteFulltextSupportDetector.Detect(
-            infrastructureOptions,
-            connectionProvider,
-            NullLogger.Instance);
-
         return new AppDbContext(builder.Options, infrastructureOptions, NullLogger<AppDbContext>.Instance);
     }
 

--- a/Veriado.Infrastructure/Persistence/Interceptors/DomainEventsInterceptor.cs
+++ b/Veriado.Infrastructure/Persistence/Interceptors/DomainEventsInterceptor.cs
@@ -44,12 +44,6 @@ internal sealed class DomainEventsInterceptor : SaveChangesInterceptor
         return base.SavingChangesAsync(eventData, result, cancellationToken);
     }
 
-    public override int SavedChanges(SaveChangesCompletedEventData eventData, int result)
-    {
-        ProcessPendingEventsAsync(eventData, CancellationToken.None).GetAwaiter().GetResult();
-        return base.SavedChanges(eventData, result);
-    }
-
     public override async ValueTask<int> SavedChangesAsync(
         SaveChangesCompletedEventData eventData,
         int result,

--- a/Veriado.WinUI/AppHost.cs
+++ b/Veriado.WinUI/AppHost.cs
@@ -75,9 +75,8 @@ internal sealed class AppHost : IAsyncDisposable
         using (var gate = new NamedGlobalMutex(mutexKey))
         {
             gate.Acquire(TimeSpan.FromSeconds(30));
-            await host.Services.InitializeInfrastructureAsync().ConfigureAwait(false);
+            await host.StartAsync().ConfigureAwait(false);
         }
-        await host.StartAsync().ConfigureAwait(false);
         await host.Services.GetRequiredService<IHotStateService>().InitializeAsync().ConfigureAwait(false);
         return new AppHost(host);
     }


### PR DESCRIPTION
## Summary
- stop performing synchronous infrastructure setup during service registration and move PRAGMA/full-text detection into `InitializeInfrastructureAsync`
- add an async `SqliteFulltextSupportDetector` while removing synchronous waits from the SQLite connection pool and domain events interceptor
- ensure the WinUI host starts asynchronously while holding the migration mutex

## Testing
- dotnet build Veriado.sln *(fails: dotnet not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f49aa226a8832691cc5e0ca19ff1ef