### PR TITLE
Ensure ReplaceFileContent updates file system snapshot

### DIFF
--- a/Veriado.Domain/FileSystem/FileSystemEntity.cs
+++ b/Veriado.Domain/FileSystem/FileSystemEntity.cs
@@ -256,6 +256,8 @@ public sealed partial class FileSystemEntity : AggregateRoot
         IsMissing = false;
         MissingSinceUtc = null;
         LastWriteUtc = whenUtc;
+        LastAccessUtc = whenUtc;
+        LastLinkedUtc = whenUtc;
 
         RaiseDomainEvent(new FileSystemContentChanged(Id, Provider, Path, Hash, Size, Mime, ContentVersion, IsEncrypted, whenUtc));
     }


### PR DESCRIPTION
## Summary
- ensure ReplaceFileContent fetches the backing FileSystemEntity and updates its snapshot before linking new content
- refresh file system access/link timestamps when content metadata is replaced

## Testing
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68f4c3a2ac708326a13b627f0d2f2d3e