### PR TITLE
Inline FTS upsert with token guard

### DIFF
--- a/Veriado.Application.Tests/Infrastructure/Search/SearchProjectionIntegrationTests.cs
+++ b/Veriado.Application.Tests/Infrastructure/Search/SearchProjectionIntegrationTests.cs
@@ -209,7 +209,7 @@ public sealed class SearchProjectionIntegrationTests : IAsyncLifetime
         {
             await unitOfWork.SaveChangesAsync(CancellationToken.None).ConfigureAwait(false);
             projectionScope.EnsureActive();
-            await Assert.ThrowsAsync<StaleSearchProjectionUpdateException>(() => projection.UpsertAsync(
+            await Assert.ThrowsAsync<AnalyzerOrContentDriftException>(() => projection.UpsertAsync(
                     file,
                     initialContentHash,
                     initialTokenHash,


### PR DESCRIPTION
## Summary
- ensure file write handlers perform guarded FTS upserts and inline force replacements within the active EF transaction
- update the search projection service to guard on both content and token hashes while providing an unconditional force-replace fallback
- align the search projection integration test with the new analyzer drift handling semantics

## Testing
- Not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68f4c73989608326a535c8f4f70df40e