### PR TITLE
Harden storage path resolution

### DIFF
--- a/Veriado.Application.Tests/Storage/StoragePathTests.cs
+++ b/Veriado.Application.Tests/Storage/StoragePathTests.cs
@@ -16,14 +16,13 @@ public sealed class StoragePathTests : IDisposable
         Directory.CreateDirectory(_root);
     }
 
-    [Fact]
-    public void From_WithRelativePathInsideRoot_ReturnsNormalizedStoragePath()
+    [Theory]
+    [MemberData(nameof(GetValidRelativePaths))]
+    public void From_WithValidRelativePath_ReturnsNormalizedStoragePath(string relative, string expected)
     {
-        var relative = Path.Combine("folder", "child", "file.txt");
-
         var storagePath = StoragePath.From(_root, relative);
 
-        Assert.Equal("folder/child/file.txt", storagePath.Value);
+        Assert.Equal(expected, storagePath.Value);
     }
 
     [Theory]
@@ -44,6 +43,15 @@ public sealed class StoragePathTests : IDisposable
         yield return new object[] { "./../outside.txt" };
         yield return new object[] { @"\\server\share\file.txt" };
         yield return new object[] { @"//server/share/file.txt" };
+        yield return new object[] { Path.GetFullPath(Path.Combine(Path.GetTempPath(), "..", "outside.txt")) };
+    }
+
+    public static IEnumerable<object[]> GetValidRelativePaths()
+    {
+        yield return new object[] { Path.Combine("folder", "child", "file.txt"), "folder/child/file.txt" };
+        yield return new object[] { Path.Combine("folder", "..", "sibling", "file.txt"), "sibling/file.txt" };
+        yield return new object[] { Path.Combine(".", "folder", "file.txt"), "folder/file.txt" };
+        yield return new object[] { Path.Combine("folder", ".", "nested", "file.txt"), "folder/nested/file.txt" };
     }
 
     public void Dispose()


### PR DESCRIPTION
## Summary
- harden StoragePath.From to reject paths escaping the storage root
- mirror the same root-boundary enforcement within LocalFileStorage
- expand storage path unit tests to cover traversal, UNC, and valid relative scenarios

## Testing
- `dotnet test` *(fails: dotnet CLI is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f4cd946bc0832690d78e23cab633f1