### PR TITLE
Make AppHost migration gate asynchronous

### DIFF
--- a/Veriado.WinUI/AppHost.cs
+++ b/Veriado.WinUI/AppHost.cs
@@ -74,7 +74,9 @@ internal sealed class AppHost : IAsyncDisposable
 
         using (var gate = new NamedGlobalMutex(mutexKey))
         {
-            gate.Acquire(TimeSpan.FromSeconds(30));
+            await Task
+                .Run(() => gate.Acquire(TimeSpan.FromSeconds(30)))
+                .ConfigureAwait(false);
             await host.StartAsync().ConfigureAwait(false);
         }
         await host.Services.GetRequiredService<IHotStateService>().InitializeAsync().ConfigureAwait(false);


### PR DESCRIPTION
## Summary
- run the WinUI migration mutex acquisition on a background thread so the host start remains asynchronous

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68f4cfca05d483269c2380cc02bf58fe