### PR TITLE
Avoid confirming search index when projection skipped

### DIFF
--- a/Veriado.Application/Abstractions/IFileSearchProjection.cs
+++ b/Veriado.Application/Abstractions/IFileSearchProjection.cs
@@ -14,7 +14,7 @@ public interface IFileSearchProjection
     /// <param name="tokenHash">The analyzer token hash captured for the projection.</param>
     /// <param name="guard">The projection transaction guard.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
-    Task UpsertAsync(
+    Task<bool> UpsertAsync(
         FileEntity file,
         string? expectedContentHash,
         string? expectedTokenHash,
@@ -31,7 +31,7 @@ public interface IFileSearchProjection
     /// <param name="tokenHash">The analyzer token hash captured for the projection.</param>
     /// <param name="guard">The projection transaction guard.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
-    Task ForceReplaceAsync(
+    Task<bool> ForceReplaceAsync(
         FileEntity file,
         string? newContentHash,
         string? tokenHash,

--- a/Veriado.Application/UseCases/Files/Common/FileWriteHandlerBase.cs
+++ b/Veriado.Application/UseCases/Files/Common/FileWriteHandlerBase.cs
@@ -145,9 +145,11 @@ public abstract class FileWriteHandlerBase
                         var newContentHash = file.ContentHash.Value;
                         var newTokenHash = signature.TokenHash;
 
+                        var projectionPerformed = false;
+
                         try
                         {
-                            await _searchProjection
+                            projectionPerformed = await _searchProjection
                                 .UpsertAsync(
                                     file,
                                     expectedContentHash,
@@ -160,7 +162,7 @@ public abstract class FileWriteHandlerBase
                         }
                         catch (AnalyzerOrContentDriftException)
                         {
-                            await _searchProjection
+                            projectionPerformed = await _searchProjection
                                 .ForceReplaceAsync(
                                     file,
                                     newContentHash,
@@ -168,6 +170,11 @@ public abstract class FileWriteHandlerBase
                                     _projectionScope,
                                     ct)
                                 .ConfigureAwait(false);
+                        }
+
+                        if (!projectionPerformed)
+                        {
+                            return;
                         }
 
                         var schemaVersion = searchState?.SchemaVersion ?? 1;


### PR DESCRIPTION
## Summary
- have synchronous projection APIs report whether any indexing work executed
- gate search index confirmation on successful projection across file writes, bulk import, and integrity repair paths
- propagate batch projection results so skipped projections do not mark documents as fresh

## Testing
- dotnet test *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f658d2ffbc8326a97006986ca97d85