### PR TITLE
Fix StoragePath normalization string literals

### DIFF
--- a/Veriado.Domain/ValueObjects/StoragePath.cs
+++ b/Veriado.Domain/ValueObjects/StoragePath.cs
@@ -135,11 +135,11 @@ public sealed class StoragePath : IEquatable<StoragePath>
 
     private static string NormalizeToPlatformSeparators(string path)
         => path
-            .Replace('\', Path.DirectorySeparatorChar)
-            .Replace('/', Path.DirectorySeparatorChar);
+            .Replace("\\", Path.DirectorySeparatorChar.ToString())
+            .Replace("/", Path.DirectorySeparatorChar.ToString());
 
     private static string NormalizeForStorage(string path)
-        => path.Replace('\', '/');
+        => path.Replace("\\", "/");
 
     /// <inheritdoc />
     public override string ToString() => Value;


### PR DESCRIPTION
## Summary
- replace the character-based Replace calls with string-based overloads to avoid invalid character literal errors on Windows

## Testing
- not run (dotnet SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68fbb1f0c7b883269e2ffec1990b4f6f