### PR TITLE
Introduce streaming ingestion abstractions

### DIFF
--- a/Veriado.Application/Abstractions/IStorageWriter.cs
+++ b/Veriado.Application/Abstractions/IStorageWriter.cs
@@ -1,0 +1,52 @@
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Veriado.Domain.ValueObjects;
+
+namespace Veriado.Appl.Abstractions;
+
+/// <summary>
+/// Provides low-level streaming primitives for writing binary content to storage.
+/// </summary>
+public interface IStorageWriter
+{
+    /// <summary>
+    /// Reserves a storage location for a new blob.
+    /// </summary>
+    /// <param name="preferredPath">An optional preferred logical path.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A reservation that must be used for subsequent operations.</returns>
+    ValueTask<StorageReservation> ReservePathAsync(string? preferredPath, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Opens a writable stream targeting the reserved storage path.
+    /// </summary>
+    /// <param name="reservation">The reservation returned by <see cref="ReservePathAsync"/>.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A writable stream that should be disposed after use.</returns>
+    ValueTask<Stream> OpenWriteAsync(StorageReservation reservation, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Finalizes the write operation and materializes a storage metadata snapshot.
+    /// </summary>
+    /// <param name="reservation">The reservation to finalize.</param>
+    /// <param name="context">The commit context describing the written content.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The storage metadata describing the stored content.</returns>
+    ValueTask<StorageResult> CommitAsync(StorageReservation reservation, StorageCommitContext context, CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// Represents a reserved logical storage path.
+/// </summary>
+/// <param name="Provider">The storage provider that will host the content.</param>
+/// <param name="Path">The logical storage path.</param>
+public sealed record class StorageReservation(StorageProvider Provider, StoragePath Path);
+
+/// <summary>
+/// Provides the metadata required to finalize a storage write operation.
+/// </summary>
+/// <param name="Length">The total number of bytes written.</param>
+/// <param name="Sha256">The SHA-256 hash of the written content.</param>
+/// <param name="Sha1">The optional SHA-1 hash of the written content.</param>
+public sealed record class StorageCommitContext(long Length, string Sha256, string? Sha1);

--- a/Veriado.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/Veriado.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
@@ -176,7 +176,9 @@ public static class ServiceCollectionExtensions
         services.TryAddSingleton<IClock, SystemClock>();
         services.AddSingleton<SuggestionMaintenanceService>();
         services.AddSingleton<IDatabaseMaintenanceService, SqliteDatabaseMaintenanceService>();
-        services.AddSingleton<IFileStorage, LocalFileStorage>();
+        services.AddSingleton<LocalFileStorage>();
+        services.AddSingleton<IFileStorage>(sp => sp.GetRequiredService<LocalFileStorage>());
+        services.AddSingleton<IStorageWriter>(sp => sp.GetRequiredService<LocalFileStorage>());
 
         services.AddSingleton<ISearchQueryService, SqliteFts5QueryService>();
         services.AddSingleton<ISearchHistoryService, SearchHistoryService>();

--- a/Veriado.Services/Import/Ingestion/FileOpenSharePolicy.cs
+++ b/Veriado.Services/Import/Ingestion/FileOpenSharePolicy.cs
@@ -1,0 +1,22 @@
+namespace Veriado.Services.Import.Ingestion;
+
+/// <summary>
+/// Controls how source files are shared with other processes while being imported.
+/// </summary>
+public enum FileOpenSharePolicy
+{
+    /// <summary>
+    /// Opens the file for read-only access while allowing other readers.
+    /// </summary>
+    ReadOnly,
+
+    /// <summary>
+    /// Opens the file for reading while allowing other readers and writers.
+    /// </summary>
+    ReadWrite,
+
+    /// <summary>
+    /// Opens the file for reading while allowing writers and delete operations.
+    /// </summary>
+    ReadWriteDelete,
+}

--- a/Veriado.Services/Import/Ingestion/FileOpener.cs
+++ b/Veriado.Services/Import/Ingestion/FileOpener.cs
@@ -1,0 +1,111 @@
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace Veriado.Services.Import.Ingestion;
+
+/// <summary>
+/// Provides helper utilities for opening files with retry and diagnostics.
+/// </summary>
+internal static class FileOpener
+{
+    public static async Task<FileStream> OpenForReadWithRetryAsync(
+        string path,
+        ImportOptions options,
+        ILogger? logger,
+        CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(path);
+        ArgumentNullException.ThrowIfNull(options);
+
+        var normalizedBufferSize = Math.Max(options.BufferSize, 4096);
+        var share = ResolveShare(options.SharePolicy);
+        var attempts = 0;
+        var delay = NormalizeDelay(options.RetryBaseDelay);
+        var maxDelay = NormalizeDelay(options.MaxRetryDelay);
+
+        while (true)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            try
+            {
+                var stream = new FileStream(
+                    path,
+                    FileMode.Open,
+                    FileAccess.Read,
+                    share,
+                    normalizedBufferSize,
+                    FileOptions.Asynchronous | FileOptions.SequentialScan);
+                if (attempts > 0 && logger is not null)
+                {
+                    logger.LogDebug(
+                        "Successfully opened {File} for reading after {Attempts} retries.",
+                        path,
+                        attempts);
+                }
+
+                return stream;
+            }
+            catch (Exception ex) when (IsRetryable(ex) && attempts < options.MaxRetryCount)
+            {
+                attempts++;
+                var nextDelay = TimeSpan.FromMilliseconds(Math.Min(maxDelay.TotalMilliseconds, delay.TotalMilliseconds));
+                if (logger is not null)
+                {
+                    logger.LogWarning(
+                        ex,
+                        "Encountered transient error while opening {File}. Retrying attempt {Attempt}/{MaxAttempts} after {Delay}.",
+                        path,
+                        attempts,
+                        options.MaxRetryCount,
+                        nextDelay);
+                }
+
+                await Task.Delay(nextDelay, cancellationToken).ConfigureAwait(false);
+                delay = TimeSpan.FromMilliseconds(Math.Min(maxDelay.TotalMilliseconds, delay.TotalMilliseconds * 2));
+                continue;
+            }
+        }
+    }
+
+    private static FileShare ResolveShare(FileOpenSharePolicy policy)
+        => policy switch
+        {
+            FileOpenSharePolicy.ReadOnly => FileShare.Read,
+            FileOpenSharePolicy.ReadWrite => FileShare.ReadWrite,
+            FileOpenSharePolicy.ReadWriteDelete => FileShare.ReadWrite | FileShare.Delete,
+            _ => FileShare.Read,
+        };
+
+    private static bool IsRetryable(Exception ex)
+    {
+        if (ex is IOException io)
+        {
+            var hresult = io.HResult;
+            return hresult == ESharingViolation || hresult == ELockViolation;
+        }
+
+        if (ex is UnauthorizedAccessException)
+        {
+            return RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+        }
+
+        return false;
+    }
+
+    private static int ESharingViolation => unchecked((int)0x80070020);
+    private static int ELockViolation => unchecked((int)0x80070021);
+
+    private static TimeSpan NormalizeDelay(TimeSpan value)
+    {
+        if (value <= TimeSpan.Zero)
+        {
+            return TimeSpan.FromMilliseconds(100);
+        }
+
+        return value;
+    }
+}

--- a/Veriado.Services/Import/Ingestion/IFileIngestor.cs
+++ b/Veriado.Services/Import/Ingestion/IFileIngestor.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Veriado.Appl.Abstractions;
+
+namespace Veriado.Services.Import.Ingestion;
+
+/// <summary>
+/// Provides streaming ingestion support for files imported from the local file system.
+/// </summary>
+public interface IFileIngestor
+{
+    /// <summary>
+    /// Streams the source file into the configured storage provider.
+    /// </summary>
+    /// <param name="request">The ingestion request.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The ingestion result containing storage metadata.</returns>
+    Task<FileIngestResult> IngestAsync(FileIngestRequest request, CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// Describes a file ingestion request.
+/// </summary>
+public sealed record class FileIngestRequest
+{
+    public FileIngestRequest(string sourcePath, string? preferredStoragePath, ImportOptions? options = null)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(sourcePath);
+
+        SourcePath = sourcePath;
+        PreferredStoragePath = preferredStoragePath;
+        Options = options ?? new ImportOptions();
+    }
+
+    /// <summary>
+    /// Gets the absolute path to the source file that should be imported.
+    /// </summary>
+    public string SourcePath { get; }
+
+    /// <summary>
+    /// Gets the optional preferred storage path.
+    /// </summary>
+    public string? PreferredStoragePath { get; }
+
+    /// <summary>
+    /// Gets the ingestion options.
+    /// </summary>
+    public ImportOptions Options { get; }
+}
+
+/// <summary>
+/// Describes the outcome of a file ingestion operation.
+/// </summary>
+/// <param name="Storage">The storage metadata snapshot.</param>
+/// <param name="Sha1Hex">The optional SHA-1 hash computed for the content.</param>
+public sealed record class FileIngestResult(StorageResult Storage, string? Sha1Hex);

--- a/Veriado.Services/Import/Ingestion/ImportOptions.cs
+++ b/Veriado.Services/Import/Ingestion/ImportOptions.cs
@@ -1,0 +1,34 @@
+using System;
+
+namespace Veriado.Services.Import.Ingestion;
+
+/// <summary>
+/// Provides configuration for streaming file ingestion.
+/// </summary>
+public sealed record class ImportOptions
+{
+    /// <summary>
+    /// Gets or sets the buffer size used while copying content between streams.
+    /// </summary>
+    public int BufferSize { get; init; } = 128 * 1024;
+
+    /// <summary>
+    /// Gets or sets the maximum number of retries when the source file is temporarily unavailable.
+    /// </summary>
+    public int MaxRetryCount { get; init; } = 5;
+
+    /// <summary>
+    /// Gets or sets the base backoff delay applied between retries when opening the source file.
+    /// </summary>
+    public TimeSpan RetryBaseDelay { get; init; } = TimeSpan.FromMilliseconds(200);
+
+    /// <summary>
+    /// Gets or sets the maximum backoff delay applied when retrying to open the source file.
+    /// </summary>
+    public TimeSpan MaxRetryDelay { get; init; } = TimeSpan.FromSeconds(2);
+
+    /// <summary>
+    /// Gets or sets the file sharing policy used when opening the source file.
+    /// </summary>
+    public FileOpenSharePolicy SharePolicy { get; init; } = FileOpenSharePolicy.ReadWrite;
+}

--- a/Veriado.Services/Import/Ingestion/StreamingFileIngestor.cs
+++ b/Veriado.Services/Import/Ingestion/StreamingFileIngestor.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Buffers;
+using System.IO;
+using System.Security.Cryptography;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Veriado.Appl.Abstractions;
+
+namespace Veriado.Services.Import.Ingestion;
+
+/// <summary>
+/// Streams file content into the configured storage writer without materialising it in memory.
+/// </summary>
+public sealed class StreamingFileIngestor : IFileIngestor
+{
+    private readonly IStorageWriter _storage;
+    private readonly ILogger<StreamingFileIngestor> _logger;
+
+    public StreamingFileIngestor(IStorageWriter storage, ILogger<StreamingFileIngestor>? logger = null)
+    {
+        _storage = storage ?? throw new ArgumentNullException(nameof(storage));
+        _logger = logger ?? NullLogger<StreamingFileIngestor>.Instance;
+    }
+
+    public async Task<FileIngestResult> IngestAsync(FileIngestRequest request, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var options = request.Options ?? new ImportOptions();
+        var bufferSize = Math.Max(options.BufferSize, 16 * 1024);
+
+        var reservation = await _storage
+            .ReservePathAsync(request.PreferredStoragePath, cancellationToken)
+            .ConfigureAwait(false);
+
+        await using var source = await FileOpener
+            .OpenForReadWithRetryAsync(request.SourcePath, options, _logger, cancellationToken)
+            .ConfigureAwait(false);
+        await using var destination = await _storage
+            .OpenWriteAsync(reservation, cancellationToken)
+            .ConfigureAwait(false);
+
+        var buffer = ArrayPool<byte>.Shared.Rent(bufferSize);
+        using var sha256 = SHA256.Create();
+        using var sha1 = SHA1.Create();
+        long totalBytes = 0;
+
+        try
+        {
+            while (true)
+            {
+                var read = await source
+                    .ReadAsync(buffer.AsMemory(0, buffer.Length), cancellationToken)
+                    .ConfigureAwait(false);
+                if (read == 0)
+                {
+                    break;
+                }
+
+                await destination
+                    .WriteAsync(buffer.AsMemory(0, read), cancellationToken)
+                    .ConfigureAwait(false);
+
+                _ = sha256.TransformBlock(buffer, 0, read, outputBuffer: null, outputOffset: 0);
+                _ = sha1.TransformBlock(buffer, 0, read, outputBuffer: null, outputOffset: 0);
+                totalBytes += read;
+            }
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+
+        sha256.TransformFinalBlock(Array.Empty<byte>(), 0, 0);
+        sha1.TransformFinalBlock(Array.Empty<byte>(), 0, 0);
+
+        await destination.FlushAsync(cancellationToken).ConfigureAwait(false);
+
+        var sha256Hex = Convert.ToHexString(sha256.Hash ?? Array.Empty<byte>());
+        var sha1Hex = Convert.ToHexString(sha1.Hash ?? Array.Empty<byte>());
+        var commitContext = new StorageCommitContext(totalBytes, sha256Hex, sha1Hex);
+
+        var storageResult = await _storage
+            .CommitAsync(reservation, commitContext, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (!string.Equals(storageResult.Hash.Value, sha256Hex, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException("Storage hash differs from computed SHA-256 hash.");
+        }
+
+        if (storageResult.Size.Value != totalBytes)
+        {
+            throw new InvalidOperationException("Storage size differs from streamed length.");
+        }
+
+        _logger.LogDebug(
+            "Streamed {Length} bytes from {Source} to {Destination} (SHA256 {Hash}).",
+            totalBytes,
+            request.SourcePath,
+            storageResult.Path.Value,
+            sha256Hex);
+
+        return new FileIngestResult(storageResult, sha1Hex);
+    }
+}


### PR DESCRIPTION
## Summary
- add a storage-writer abstraction that supports reserving paths, opening write streams, and committing metadata
- register the shared LocalFileStorage implementation for both IFileStorage and the new IStorageWriter contract
- add streaming ingestion helpers (options, retrying file opener, and a streaming ingestor) that compute hashes while copying

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68fbc27ac84083268d1a0919b9ec5bd1