### PR TITLE
Adjust StoragePath normalization separator replacements

### DIFF
--- a/Veriado.Domain/ValueObjects/StoragePath.cs
+++ b/Veriado.Domain/ValueObjects/StoragePath.cs
@@ -134,12 +134,20 @@ public sealed class StoragePath : IEquatable<StoragePath>
             || Path.IsPathRooted(relativePath);
 
     private static string NormalizeToPlatformSeparators(string path)
-        => path
-            .Replace("\\", Path.DirectorySeparatorChar.ToString())
-            .Replace("/", Path.DirectorySeparatorChar.ToString());
+    {
+        var separator = Path.DirectorySeparatorChar.ToString();
+
+        return path
+            .Replace("\\", separator)
+            .Replace("/", separator);
+    }
 
     private static string NormalizeForStorage(string path)
-        => path.Replace("\\", "/");
+    {
+        var separator = Path.DirectorySeparatorChar.ToString();
+
+        return path.Replace(separator, "/");
+    }
 
     /// <inheritdoc />
     public override string ToString() => Value;


### PR DESCRIPTION
## Summary
- use the platform directory separator string when replacing backslashes during normalization
- align storage normalization to reuse the same separator string for replacements

## Testing
- not run (dotnet SDK not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68fc7443c5d48326a58928e25f1cb786