### PR TITLE
Fix service namespace usage and expose persistence types

### DIFF
--- a/Veriado.Infrastructure/Events/DomainEventDispatcher.cs
+++ b/Veriado.Infrastructure/Events/DomainEventDispatcher.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using Microsoft.Extensions.DependencyInjection;
 using Veriado.Domain.Primitives;
 
 namespace Veriado.Infrastructure.Events;

--- a/Veriado.Infrastructure/Persistence/Audit/FileAuditRecord.cs
+++ b/Veriado.Infrastructure/Persistence/Audit/FileAuditRecord.cs
@@ -3,7 +3,7 @@ namespace Veriado.Infrastructure.Persistence.Audit;
 /// <summary>
 /// Represents a flattened audit row describing high-level file events.
 /// </summary>
-internal sealed class FileAuditRecord
+public sealed class FileAuditRecord
 {
     public Guid FileId { get; set; }
 
@@ -23,7 +23,7 @@ internal sealed class FileAuditRecord
 /// <summary>
 /// Enumerates supported audit actions for file level events.
 /// </summary>
-internal enum FileAuditAction
+public enum FileAuditAction
 {
     Created,
     Renamed,

--- a/Veriado.Infrastructure/Persistence/Audit/FileLinkAuditRecord.cs
+++ b/Veriado.Infrastructure/Persistence/Audit/FileLinkAuditRecord.cs
@@ -3,7 +3,7 @@ namespace Veriado.Infrastructure.Persistence.Audit;
 /// <summary>
 /// Represents an audit entry describing logical file linkage to file system resources.
 /// </summary>
-internal sealed class FileLinkAuditRecord
+public sealed class FileLinkAuditRecord
 {
     public Guid FileId { get; set; }
 
@@ -25,7 +25,7 @@ internal sealed class FileLinkAuditRecord
 /// <summary>
 /// Enumerates supported audit actions for file linkage operations.
 /// </summary>
-internal enum FileLinkAuditAction
+public enum FileLinkAuditAction
 {
     Linked,
     Relinked,

--- a/Veriado.Infrastructure/Persistence/Audit/FileSystemAuditRecord.cs
+++ b/Veriado.Infrastructure/Persistence/Audit/FileSystemAuditRecord.cs
@@ -3,7 +3,7 @@ namespace Veriado.Infrastructure.Persistence.Audit;
 /// <summary>
 /// Represents an audit entry capturing file system level events.
 /// </summary>
-internal sealed class FileSystemAuditRecord
+public sealed class FileSystemAuditRecord
 {
     public Guid FileSystemId { get; set; }
 
@@ -29,7 +29,7 @@ internal sealed class FileSystemAuditRecord
 /// <summary>
 /// Enumerates supported audit actions for file system events.
 /// </summary>
-internal enum FileSystemAuditAction
+public enum FileSystemAuditAction
 {
     ContentChanged,
     Moved,

--- a/Veriado.Infrastructure/Persistence/Entities/FileContentLinkRow.cs
+++ b/Veriado.Infrastructure/Persistence/Entities/FileContentLinkRow.cs
@@ -3,7 +3,7 @@ namespace Veriado.Infrastructure.Persistence.Entities;
 /// <summary>
 /// Represents a persisted snapshot of a file content link used for history tracking.
 /// </summary>
-internal sealed class FileContentLinkRow
+public sealed class FileContentLinkRow
 {
     public Guid FileId { get; set; }
 

--- a/Veriado.Infrastructure/Search/SearchProjectionService.cs
+++ b/Veriado.Infrastructure/Search/SearchProjectionService.cs
@@ -652,9 +652,9 @@ internal interface IBatchFileSearchProjection
         CancellationToken cancellationToken);
 }
 
-internal readonly record struct SearchProjectionBatchResult(int BusyRetries, int ProjectedItems);
+public readonly record struct SearchProjectionBatchResult(int BusyRetries, int ProjectedItems);
 
-internal readonly record struct SearchProjectionWorkItem(
+public readonly record struct SearchProjectionWorkItem(
     FileEntity File,
     string? ExpectedContentHash,
     string? ExpectedTokenHash,

--- a/Veriado.Services/Import/ImportService.cs
+++ b/Veriado.Services/Import/ImportService.cs
@@ -18,6 +18,7 @@ using Veriado.Appl.UseCases.Files.CheckFileHash;
 using Veriado.Application.Import;
 using ApplicationImportOptions = Veriado.Application.Import.ImportOptions;
 using StreamingImportOptions = Veriado.Services.Import.Ingestion.ImportOptions;
+using ContractsImportOptions = Veriado.Contracts.Import.ImportOptions;
 
 namespace Veriado.Services.Import;
 
@@ -145,7 +146,7 @@ public sealed class ImportService : IImportService
     /// <inheritdoc />
     public async IAsyncEnumerable<ImportProgressEvent> ImportFolderStreamAsync(
         string folderPath,
-        ImportOptions? options,
+        ContractsImportOptions? options,
         [EnumeratorCancellation] CancellationToken cancellationToken)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(folderPath);
@@ -1372,7 +1373,7 @@ public sealed class ImportService : IImportService
         => new(filePath, code, message, suggestion, null, _clock.UtcNow);
 
 
-    private static NormalizedImportOptions NormalizeOptions(ImportOptions? options)
+    private static NormalizedImportOptions NormalizeOptions(ContractsImportOptions? options)
     {
         var rawSearchPattern = options?.SearchPattern;
         var searchPatternResult = rawSearchPattern is null
@@ -1473,7 +1474,7 @@ public sealed class ImportService : IImportService
 
     private static NormalizedImportOptions NormalizeOptions(ImportFolderRequest request)
     {
-        return NormalizeOptions(new ImportOptions
+        return NormalizeOptions(new ContractsImportOptions
         {
             MaxFileSizeBytes = request.MaxFileSizeBytes,
             MaxDegreeOfParallelism = request.MaxDegreeOfParallelism,


### PR DESCRIPTION
## Summary
- add the missing dependency injection import to the domain event dispatcher
- expose persistence audit entities and search projection records used by public APIs
- resolve the import service ImportOptions ambiguity by aliasing the contract type

## Testing
- not run (dotnet CLI unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68fca55258c48326beb1e615547d073c