### PR TITLE
Fix SQLite schema updates for legacy versions

### DIFF
--- a/Veriado.Infrastructure/Persistence/Schema/SqliteFulltextSchemaSql.cs
+++ b/Veriado.Infrastructure/Persistence/Schema/SqliteFulltextSchemaSql.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace Veriado.Infrastructure.Persistence.Schema;
@@ -59,8 +60,6 @@ internal static class SqliteFulltextSchemaSql
     stored_content_hash TEXT,
     stored_token_hash   TEXT
 );",
-        "ALTER TABLE search_document ADD COLUMN IF NOT EXISTS stored_content_hash TEXT;",
-        "ALTER TABLE search_document ADD COLUMN IF NOT EXISTS stored_token_hash TEXT;",
         "CREATE INDEX IF NOT EXISTS idx_search_document_mime ON search_document(mime);",
         "CREATE INDEX IF NOT EXISTS idx_search_document_modified ON search_document(modified_utc DESC);",
         @"CREATE VIRTUAL TABLE IF NOT EXISTS search_document_fts USING fts5(
@@ -95,4 +94,19 @@ FROM search_document;";
 
     public static string RebuildStatement { get; } =
         "INSERT INTO search_document_fts(search_document_fts) VALUES('rebuild');";
+
+    public static IReadOnlyDictionary<string, string> SearchDocumentColumnDefinitions { get; } =
+        new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["title"] = "title TEXT",
+            ["author"] = "author TEXT",
+            ["mime"] = "mime TEXT",
+            ["metadata_text"] = "metadata_text TEXT",
+            ["metadata_json"] = "metadata_json TEXT",
+            ["created_utc"] = "created_utc TEXT",
+            ["modified_utc"] = "modified_utc TEXT",
+            ["content_hash"] = "content_hash TEXT",
+            ["stored_content_hash"] = "stored_content_hash TEXT",
+            ["stored_token_hash"] = "stored_token_hash TEXT",
+        };
 }


### PR DESCRIPTION
## Summary
- stop issuing ALTER TABLE ... IF NOT EXISTS clauses that older SQLite engines do not understand
- detect missing search_document columns and add them individually so legacy databases can be upgraded safely

## Testing
- dotnet build *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68fe0c3fcbfc8326a05d3dd86a0817f6