### PR TITLE
Fix contentless SQLite FTS rebuild workflow

### DIFF
--- a/Veriado.Infrastructure/Integrity/FulltextIntegrityService.cs
+++ b/Veriado.Infrastructure/Integrity/FulltextIntegrityService.cs
@@ -618,7 +618,7 @@ LIMIT $batchSize;";
 
         await ExecuteStatementsAsync(
                 connection,
-                new[] { SqliteFulltextSchemaSql.RebuildStatement },
+                SqliteFulltextSchemaSql.ReindexStatements.ToArray(),
                 "rebuild",
                 cancellationToken)
             .ConfigureAwait(false);

--- a/Veriado.Infrastructure/Persistence/Migrations/20251026112230_InitialCreate.cs
+++ b/Veriado.Infrastructure/Persistence/Migrations/20251026112230_InitialCreate.cs
@@ -393,7 +393,7 @@ namespace Veriado.Infrastructure.Persistence.Migrations
             }
 
             migrationBuilder.Sql(SqliteFulltextSchemaSql.PopulateStatement);
-            migrationBuilder.Sql(SqliteFulltextSchemaSql.RebuildStatement);
+            migrationBuilder.Sql(SqliteFulltextSchemaSql.OptimizeStatement);
         }
 
         /// <inheritdoc />

--- a/Veriado.Infrastructure/Persistence/Schema/SqliteFulltextSchemaSql.cs
+++ b/Veriado.Infrastructure/Persistence/Schema/SqliteFulltextSchemaSql.cs
@@ -92,8 +92,15 @@ END;",
 SELECT rowid, title, author, mime, metadata_text, metadata_json
 FROM search_document;";
 
-    public static string RebuildStatement { get; } =
-        "INSERT INTO search_document_fts(search_document_fts) VALUES('rebuild');";
+    public static string OptimizeStatement { get; } =
+        "INSERT INTO search_document_fts(search_document_fts) VALUES('optimize');";
+
+    public static IReadOnlyList<string> ReindexStatements { get; } = new[]
+    {
+        "DELETE FROM search_document_fts;",
+        PopulateStatement,
+        OptimizeStatement,
+    };
 
     public static IReadOnlyDictionary<string, string> SearchDocumentColumnDefinitions { get; } =
         new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)


### PR DESCRIPTION
## Summary
- replace the FTS5 rebuild pragma with an optimize command compatible with the contentless virtual table
- update the schema manager and integrity repair routines to run the multi-step reindex sequence
- adjust the initial migration to avoid issuing the unsupported rebuild command

## Testing
- dotnet build *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68fe107eb0388326974da2af43074fe5