### PR TITLE
Fix named mutex acquisition during startup

### DIFF
--- a/Veriado.WinUI/AppHost.cs
+++ b/Veriado.WinUI/AppHost.cs
@@ -74,9 +74,7 @@ internal sealed class AppHost : IAsyncDisposable
 
         using (var gate = new NamedGlobalMutex(mutexKey))
         {
-            await Task
-                .Run(() => gate.Acquire(TimeSpan.FromSeconds(30)))
-                .ConfigureAwait(false);
+            gate.Acquire(TimeSpan.FromSeconds(30));
             await host.StartAsync().ConfigureAwait(false);
         }
         await host.Services.GetRequiredService<IHotStateService>().InitializeAsync().ConfigureAwait(false);


### PR DESCRIPTION
## Summary
- acquire the global mutex on the same thread that disposes it during startup
- prevent cross-thread mutex release exceptions when launching the WinUI app

## Testing
- `dotnet build Veriado.WinUI/Veriado.csproj` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68fe1301b8cc8326b449476bcd2547ce