### PR TITLE
Fix ContentHash query translation for file hash lookup

### DIFF
--- a/Veriado.Infrastructure/Repositories/FileRepository.cs
+++ b/Veriado.Infrastructure/Repositories/FileRepository.cs
@@ -127,7 +127,11 @@ internal sealed partial class FileRepository : IFileRepository
         await using var context = await _readFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
         try
         {
-            return await context.Files.AnyAsync(f => f.ContentHash == hash, cancellationToken).ConfigureAwait(false);
+            return await context.Files
+                .AnyAsync(
+                    f => f.Content != null && f.Content.ContentHash == hash,
+                    cancellationToken)
+                .ConfigureAwait(false);
         }
         catch (DbUpdateConcurrencyException ex)
         {


### PR DESCRIPTION
## Summary
- update the file hash existence query to reference the owned content hash so EF Core can translate it

## Testing
- not run (dotnet CLI unavailable in execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68fe20f0be7c8326902715369d9db96c