### PR TITLE
Implement filesystem row version triggers

### DIFF
--- a/Veriado.Domain/Primitives/AggregateRoot.cs
+++ b/Veriado.Domain/Primitives/AggregateRoot.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Veriado.Domain.Primitives;
 
 /// <summary>
@@ -8,7 +10,7 @@ public abstract class AggregateRoot : EntityBase
     /// <summary>
     /// Gets the optimistic concurrency token for the aggregate root.
     /// </summary>
-    public ulong Version { get; private set; }
+    public byte[] RowVersion { get; private set; } = Array.Empty<byte>();
 
     /// <summary>
     /// Initializes a new instance of the <see cref="AggregateRoot"/> class.
@@ -17,15 +19,5 @@ public abstract class AggregateRoot : EntityBase
     protected AggregateRoot(Guid id)
         : base(id)
     {
-    }
-
-    internal void IncrementVersion()
-    {
-        Version++;
-    }
-
-    internal void SetVersion(ulong version)
-    {
-        Version = version;
     }
 }

--- a/Veriado.Infrastructure/Persistence/Configurations/Converters.cs
+++ b/Veriado.Infrastructure/Persistence/Configurations/Converters.cs
@@ -1,4 +1,5 @@
-using System.Buffers.Binary;
+using System;
+using System.Collections;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
@@ -83,27 +84,8 @@ internal static class Converters
             ? Fts5Policy.Default
             : JsonSerializer.Deserialize<Fts5Policy>(json, JsonOptions) ?? Fts5Policy.Default);
 
-    public static readonly ValueConverter<ulong, byte[]> UInt64ToBytes = new(
-        value => ConvertUInt64ToBytes(value),
-        bytes => ConvertBytesToUInt64(bytes));
-
-    public static readonly ValueComparer<ulong> UInt64Comparer = new(
-        (left, right) => left == right,
-        value => value.GetHashCode());
-    private static byte[] ConvertUInt64ToBytes(ulong value)
-    {
-        var buffer = new byte[sizeof(ulong)];
-        BinaryPrimitives.WriteUInt64LittleEndian(buffer, value);
-        return buffer;
-    }
-
-    private static ulong ConvertBytesToUInt64(byte[] bytes)
-    {
-        if (bytes == null || bytes.Length != sizeof(ulong))
-        {
-            return 0UL;
-        }
-
-        return BinaryPrimitives.ReadUInt64LittleEndian(bytes);
-    }
+    public static readonly ValueComparer<byte[]> RowVersionComparer = new(
+        (left, right) => StructuralComparisons.StructuralEqualityComparer.Equals(left, right),
+        value => value is null ? 0 : StructuralComparisons.StructuralEqualityComparer.GetHashCode(value),
+        value => value is null ? Array.Empty<byte>() : (byte[])value.Clone());
 }

--- a/Veriado.Infrastructure/Persistence/Configurations/FileEntityConfiguration.cs
+++ b/Veriado.Infrastructure/Persistence/Configurations/FileEntityConfiguration.cs
@@ -105,15 +105,14 @@ internal sealed class FileEntityConfiguration : IEntityTypeConfiguration<FileEnt
                 .HasConversion(Converters.UtcTimestampToString);
         });
 
-        var versionProperty = builder.Property(file => file.Version)
+        var versionProperty = builder.Property(file => file.RowVersion)
             .HasColumnName("row_version")
             .HasColumnType("BLOB")
-            .HasConversion(Converters.UInt64ToBytes)
             .IsRequired()
             .IsConcurrencyToken()
             .ValueGeneratedOnAddOrUpdate();
 
-        versionProperty.Metadata.SetValueComparer(Converters.UInt64Comparer);
+        versionProperty.Metadata.SetValueComparer(Converters.RowVersionComparer);
 
         builder.Property(file => file.IsReadOnly)
             .HasColumnName("is_read_only")

--- a/Veriado.Infrastructure/Persistence/Configurations/FileSystemEntityConfiguration.cs
+++ b/Veriado.Infrastructure/Persistence/Configurations/FileSystemEntityConfiguration.cs
@@ -35,15 +35,14 @@ internal sealed class FileSystemEntityConfiguration : IEntityTypeConfiguration<F
             .HasConversion(Converters.FileHashToString)
             .IsRequired();
 
-        var versionProperty = builder.Property(entity => entity.Version)
+        var versionProperty = builder.Property(entity => entity.RowVersion)
             .HasColumnName("row_version")
             .HasColumnType("BLOB")
-            .HasConversion(Converters.UInt64ToBytes)
             .IsRequired()
             .IsConcurrencyToken()
             .ValueGeneratedOnAddOrUpdate();
 
-        versionProperty.Metadata.SetValueComparer(Converters.UInt64Comparer);
+        versionProperty.Metadata.SetValueComparer(Converters.RowVersionComparer);
 
         builder.Property(entity => entity.Size)
             .HasColumnName("size")

--- a/Veriado.Infrastructure/Persistence/Migrations/20240518120000_AddFilesystemRowVersionTriggers.cs
+++ b/Veriado.Infrastructure/Persistence/Migrations/20240518120000_AddFilesystemRowVersionTriggers.cs
@@ -1,0 +1,60 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Veriado.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddFilesystemRowVersionTriggers : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql("""
+UPDATE filesystem_entities
+SET row_version = randomblob(8)
+WHERE row_version IS NULL OR length(row_version) = 0;
+""");
+
+            migrationBuilder.Sql("""
+DROP TRIGGER IF EXISTS trg_fs_rowversion_insert;
+CREATE TRIGGER trg_fs_rowversion_insert
+AFTER INSERT ON filesystem_entities
+FOR EACH ROW
+WHEN NEW.row_version IS NULL OR length(NEW.row_version) = 0
+BEGIN
+    UPDATE filesystem_entities
+    SET row_version = randomblob(8)
+    WHERE rowid = NEW.rowid;
+END;
+""");
+
+            migrationBuilder.Sql("""
+DROP TRIGGER IF EXISTS trg_fs_rowversion_update;
+CREATE TRIGGER trg_fs_rowversion_update
+AFTER UPDATE ON filesystem_entities
+FOR EACH ROW
+BEGIN
+    UPDATE filesystem_entities
+    SET row_version = randomblob(8)
+    WHERE rowid = NEW.rowid;
+END;
+""");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql("DROP TRIGGER IF EXISTS trg_fs_rowversion_insert;");
+            migrationBuilder.Sql("DROP TRIGGER IF EXISTS trg_fs_rowversion_update;");
+        }
+
+        // Verification SQL:
+        // PRAGMA table_info('filesystem_entities');
+        // SELECT name, tbl_name, sql
+        // FROM sqlite_master
+        // WHERE type='trigger' AND tbl_name='filesystem_entities';
+        // -- quick manual test: vlož jeden řádek „natvrdo“ a zkontroluj row_version
+        // -- (pouze pokud víš, co děláš – jinak testuj přes aplikaci).
+    }
+}

--- a/Veriado.Infrastructure/Persistence/Migrations/AppDbContextModelSnapshot.cs
+++ b/Veriado.Infrastructure/Persistence/Migrations/AppDbContextModelSnapshot.cs
@@ -92,7 +92,7 @@ namespace Veriado.Infrastructure.Persistence.Migrations
                         .HasColumnType("BIGINT")
                         .HasColumnName("size");
 
-                    b.Property<byte[]>("Version")
+                    b.Property<byte[]>("RowVersion")
                         .IsConcurrencyToken()
                         .IsRequired()
                         .ValueGeneratedOnAddOrUpdate()
@@ -174,7 +174,7 @@ namespace Veriado.Infrastructure.Persistence.Migrations
                         .HasColumnType("TEXT")
                         .HasColumnName("title");
 
-                    b.Property<byte[]>("Version")
+                    b.Property<byte[]>("RowVersion")
                         .IsConcurrencyToken()
                         .IsRequired()
                         .ValueGeneratedOnAddOrUpdate()


### PR DESCRIPTION
## Summary
- update aggregate roots to expose a byte[] RowVersion concurrency token managed by the database
- configure file and filesystem entities to use structural byte[] comparers for the row_version column
- add a migration that backfills row_version values and installs SQLite triggers to generate fresh randomblob(8) tokens on insert and update while removing interceptor-based version mutations

## Testing
- dotnet build *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68fe2d19fb948326bebcbea08fc08c08