### PR TITLE
Fix expression tree null checks

### DIFF
--- a/Veriado.Infrastructure/Persistence/Configurations/Converters.cs
+++ b/Veriado.Infrastructure/Persistence/Configurations/Converters.cs
@@ -86,6 +86,6 @@ internal static class Converters
 
     public static readonly ValueComparer<byte[]> RowVersionComparer = new(
         (left, right) => StructuralComparisons.StructuralEqualityComparer.Equals(left, right),
-        value => value is null ? 0 : StructuralComparisons.StructuralEqualityComparer.GetHashCode(value),
-        value => value is null ? Array.Empty<byte>() : (byte[])value.Clone());
+        value => value == null ? 0 : StructuralComparisons.StructuralEqualityComparer.GetHashCode(value),
+        value => value == null ? Array.Empty<byte>() : (byte[])value.Clone());
 }


### PR DESCRIPTION
## Summary
- replace pattern matching null checks in the row version comparer with explicit equality comparisons to satisfy expression tree requirements

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68fe31609a0c83269445bebf0b48429e