### PR TITLE
Fix SQLite diagnostics FTS version query

### DIFF
--- a/Veriado.Infrastructure/Repositories/DiagnosticsRepository.cs
+++ b/Veriado.Infrastructure/Repositories/DiagnosticsRepository.cs
@@ -44,7 +44,17 @@ internal sealed class DiagnosticsRepository : IDiagnosticsRepository
         string? version;
         if (_options.IsFulltextAvailable)
         {
-            var rawVersion = await GetScalarAsync(connection, "SELECT fts5();", cancellationToken).ConfigureAwait(false);
+            string rawVersion;
+            try
+            {
+                rawVersion = await GetScalarAsync(connection, "SELECT fts5_source_id();", cancellationToken)
+                    .ConfigureAwait(false);
+            }
+            catch (SqliteException)
+            {
+                rawVersion = string.Empty;
+            }
+
             version = string.IsNullOrWhiteSpace(rawVersion) ? null : rawVersion;
         }
         else


### PR DESCRIPTION
## Summary
- correct the diagnostics repository to query the FTS5 source identifier instead of invoking the table-valued fts5() function
- ensure the version lookup gracefully handles SqliteException failures and returns a nullable value

## Testing
- not run (dotnet CLI not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68fe350be3a883268d3b642727d082ca