### PR TITLE
Handle cancellation gracefully in health monitoring loop

### DIFF
--- a/Veriado.WinUI/ViewModels/Files/FilesPageViewModel.cs
+++ b/Veriado.WinUI/ViewModels/Files/FilesPageViewModel.cs
@@ -445,12 +445,18 @@ public partial class FilesPageViewModel : ViewModelBase
             await UpdateIndexingStatusAsync(cancellationToken).ConfigureAwait(false);
 
             using var timer = new PeriodicTimer(HealthPollingInterval);
-            while (await timer.WaitForNextTickAsync(cancellationToken).ConfigureAwait(false))
+
+            while (await timer.WaitForNextTickAsync().ConfigureAwait(false))
             {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    break;
+                }
+
                 await UpdateIndexingStatusAsync(cancellationToken).ConfigureAwait(false);
             }
         }
-        catch (OperationCanceledException)
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
             // Intentionally ignored.
         }


### PR DESCRIPTION
## Summary
- avoid passing the cancellation token to the periodic timer so the health monitor no longer throws when cancellation is requested
- ensure the monitor loop exits before invoking updates once cancellation has been signaled

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fe373a2cb88326a357ca10d4c1c4fc