### PR TITLE
Ensure SQLite row version columns insert non-null values

### DIFF
--- a/Veriado.Infrastructure/GlobalUsings.cs
+++ b/Veriado.Infrastructure/GlobalUsings.cs
@@ -7,6 +7,7 @@ global using System.Threading;
 global using System.Threading.Tasks;
 global using Microsoft.Data.Sqlite;
 global using Microsoft.EntityFrameworkCore;
+global using Microsoft.EntityFrameworkCore.Metadata;
 global using Microsoft.EntityFrameworkCore.Metadata.Builders;
 global using Microsoft.EntityFrameworkCore.Migrations;
 global using Microsoft.Extensions.Logging;

--- a/Veriado.Infrastructure/Persistence/Configurations/FileEntityConfiguration.cs
+++ b/Veriado.Infrastructure/Persistence/Configurations/FileEntityConfiguration.cs
@@ -112,6 +112,7 @@ internal sealed class FileEntityConfiguration : IEntityTypeConfiguration<FileEnt
             .IsConcurrencyToken()
             .ValueGeneratedOnAddOrUpdate();
 
+        versionProperty.Metadata.SetBeforeSaveBehavior(PropertySaveBehavior.Save);
         versionProperty.Metadata.SetValueComparer(Converters.RowVersionComparer);
 
         builder.Property(file => file.IsReadOnly)

--- a/Veriado.Infrastructure/Persistence/Configurations/FileSystemEntityConfiguration.cs
+++ b/Veriado.Infrastructure/Persistence/Configurations/FileSystemEntityConfiguration.cs
@@ -42,6 +42,7 @@ internal sealed class FileSystemEntityConfiguration : IEntityTypeConfiguration<F
             .IsConcurrencyToken()
             .ValueGeneratedOnAddOrUpdate();
 
+        versionProperty.Metadata.SetBeforeSaveBehavior(PropertySaveBehavior.Save);
         versionProperty.Metadata.SetValueComparer(Converters.RowVersionComparer);
 
         builder.Property(entity => entity.Size)


### PR DESCRIPTION
## Summary
- configure the file and filesystem row version properties to allow EF Core to send seed values on insert
- expose PropertySaveBehavior via a global using so the new configuration compiles

## Testing
- dotnet build Veriado.sln *(fails: `dotnet` is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fe56b93bfc8326ab65e5f195c3c249