### PR TITLE
Guard import batches against nested transactions follow-up

### DIFF
--- a/Veriado.Infrastructure/Import/FileImportService.cs
+++ b/Veriado.Infrastructure/Import/FileImportService.cs
@@ -172,8 +172,8 @@ public sealed class FileImportService : IFileImportWriter
                 if (ownsTransaction)
                 {
                     await transaction!.CommitAsync(ct).ConfigureAwait(false);
+                    _dbContext.ChangeTracker.Clear();
                 }
-                _dbContext.ChangeTracker.Clear();
                 return (new ImportResult(imported, skipped, updated), 0);
             }
 
@@ -307,8 +307,8 @@ public sealed class FileImportService : IFileImportWriter
             if (ownsTransaction)
             {
                 await transaction!.CommitAsync(ct).ConfigureAwait(false);
+                _dbContext.ChangeTracker.Clear();
             }
-            _dbContext.ChangeTracker.Clear();
             return (new ImportResult(imported, skipped, updated), busyRetries);
         }
         finally


### PR DESCRIPTION
## Summary
- only clear the EF Core change tracker when the import service owns the transaction

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ff9e8270a48326a7b0f8961d8989a6