### PR TITLE
Fix AppDbContext disposal override

### DIFF
--- a/Veriado.Infrastructure/Persistence/AppDbContext.cs
+++ b/Veriado.Infrastructure/Persistence/AppDbContext.cs
@@ -166,14 +166,10 @@ public sealed class AppDbContext : DbContext
         }
     }
 
-    protected override void Dispose(bool disposing)
+    public override void Dispose()
     {
-        if (disposing)
-        {
-            DisposeSemaphore();
-        }
-
-        base.Dispose(disposing);
+        DisposeSemaphore();
+        base.Dispose();
     }
 
     public override async ValueTask DisposeAsync()


### PR DESCRIPTION
## Summary
- update `AppDbContext` to override the parameterless `Dispose` method
- ensure the semaphore is released prior to delegating to the base class

## Testing
- dotnet build *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68ffc9884e548326b4a60bdbf00cb98e