### PR TITLE
Handle disposed context when checking tracked changes

### DIFF
--- a/Veriado.Infrastructure/Persistence/EfFilePersistenceUnitOfWork.cs
+++ b/Veriado.Infrastructure/Persistence/EfFilePersistenceUnitOfWork.cs
@@ -27,7 +27,22 @@ internal sealed class EfFilePersistenceUnitOfWork : IFilePersistenceUnitOfWork
     {
         get
         {
-            var semaphore = _dbContext.SaveChangesSemaphore;
+            SemaphoreSlim? semaphore;
+
+            try
+            {
+                semaphore = _dbContext.SaveChangesSemaphore;
+            }
+            catch (ObjectDisposedException)
+            {
+                return false;
+            }
+
+            if (semaphore is null)
+            {
+                return false;
+            }
+
             var lockAcquired = false;
 
             try


### PR DESCRIPTION
## Summary
- guard access to the context save changes semaphore against disposal
- return false when the semaphore is unavailable instead of throwing

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ffca74d2c083269a4ea3dff95f7d0e