### PR TITLE
Guard HasTrackedChanges against disposed semaphore

### DIFF
--- a/Veriado.Infrastructure/Persistence/AppDbContext.cs
+++ b/Veriado.Infrastructure/Persistence/AppDbContext.cs
@@ -23,6 +23,9 @@ public sealed class AppDbContext : DbContext
 
     internal SemaphoreSlim SaveChangesSemaphore { get; } = new(1, 1);
 
+    internal bool IsSaveChangesSemaphoreDisposed
+        => Volatile.Read(ref _semaphoreDisposed) != 0;
+
     public AppDbContext(DbContextOptions<AppDbContext> options, InfrastructureOptions infrastructureOptions, ILogger<AppDbContext> logger)
         : base(options)
     {

--- a/Veriado.Infrastructure/Persistence/EfFilePersistenceUnitOfWork.cs
+++ b/Veriado.Infrastructure/Persistence/EfFilePersistenceUnitOfWork.cs
@@ -29,6 +29,11 @@ internal sealed class EfFilePersistenceUnitOfWork : IFilePersistenceUnitOfWork
         {
             try
             {
+                if (_dbContext.IsSaveChangesSemaphoreDisposed)
+                {
+                    return false;
+                }
+
                 var semaphore = _dbContext.SaveChangesSemaphore;
                 if (semaphore is null)
                 {


### PR DESCRIPTION
## Summary
- expose AppDbContext disposal state for the SaveChanges semaphore
- short-circuit HasTrackedChanges when the semaphore has already been disposed

## Testing
- dotnet test *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_6900685b6d748326a2fed7cd2671ce45