### PR TITLE
Handle disposed DbContext during SaveChanges

### DIFF
--- a/Veriado.Infrastructure/Persistence/EfFilePersistenceUnitOfWork.cs
+++ b/Veriado.Infrastructure/Persistence/EfFilePersistenceUnitOfWork.cs
@@ -171,7 +171,8 @@ internal sealed class EfFilePersistenceUnitOfWork : IFilePersistenceUnitOfWork
         }
         catch (ObjectDisposedException ex)
         {
-            throw new ObjectDisposedException(nameof(AppDbContext), "The underlying DbContext instance has been disposed.", ex);
+            _logger.LogError(ex, "The underlying DbContext instance has been disposed while attempting to save changes.");
+            throw new ObjectDisposedException(nameof(AppDbContext), "The underlying DbContext instance has been disposed.");
         }
         catch (DbUpdateConcurrencyException ex)
         {


### PR DESCRIPTION
## Summary
- log an error when SaveChangesAsync encounters a disposed DbContext
- rethrow ObjectDisposedException using a supported constructor signature

## Testing
- `dotnet build Veriado.sln` *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_69006d91783883269737ec0cc6eb1156