### PR TITLE
Improve file detail dialog resilience and validation

### DIFF
--- a/Veriado.Contracts/Files/ClearValidityRequest.cs
+++ b/Veriado.Contracts/Files/ClearValidityRequest.cs
@@ -9,4 +9,9 @@ public sealed class ClearValidityRequest
     /// Gets or sets the identifier of the file to update.
     /// </summary>
     public Guid FileId { get; init; }
+
+    /// <summary>
+    /// Gets or sets an optional optimistic concurrency token based on the file version.
+    /// </summary>
+    public int? ExpectedVersion { get; init; }
 }

--- a/Veriado.Contracts/Files/FileMetadataPatchDto.cs
+++ b/Veriado.Contracts/Files/FileMetadataPatchDto.cs
@@ -1,0 +1,13 @@
+namespace Veriado.Contracts.Files;
+
+/// <summary>
+/// Represents a partial update payload for mutable file metadata.
+/// </summary>
+public sealed class FileMetadataPatchDto
+{
+    public string? Mime { get; init; }
+
+    public string? Author { get; init; }
+
+    public bool? IsReadOnly { get; init; }
+}

--- a/Veriado.Contracts/Files/SetValidityRequest.cs
+++ b/Veriado.Contracts/Files/SetValidityRequest.cs
@@ -29,4 +29,9 @@ public sealed class SetValidityRequest
     /// Gets or sets a value indicating whether an electronic copy exists.
     /// </summary>
     public bool HasElectronicCopy { get; init; }
+
+    /// <summary>
+    /// Gets or sets an optional optimistic concurrency token based on the file version.
+    /// </summary>
+    public int? ExpectedVersion { get; init; }
 }

--- a/Veriado.Contracts/Files/UpdateMetadataRequest.cs
+++ b/Veriado.Contracts/Files/UpdateMetadataRequest.cs
@@ -30,4 +30,9 @@ public sealed class UpdateMetadataRequest
     /// </summary>
     public FileSystemMetadataDto? SystemMetadata { get; init; }
 
+    /// <summary>
+    /// Gets or sets an optional optimistic concurrency token based on the file version.
+    /// </summary>
+    public int? ExpectedVersion { get; init; }
+
 }

--- a/Veriado.Services/Files/FileOperationsService.cs
+++ b/Veriado.Services/Files/FileOperationsService.cs
@@ -37,9 +37,21 @@ public sealed class FileOperationsService : IFileOperationsService
         return ToIdResponse(result);
     }
 
-    public async Task<ApiResponse<Guid>> UpdateMetadataAsync(UpdateMetadataRequest request, CancellationToken cancellationToken)
+    public async Task<ApiResponse<Guid>> UpdateMetadataAsync(
+        Guid fileId,
+        FileMetadataPatchDto patch,
+        int? expectedVersion,
+        CancellationToken cancellationToken)
     {
-        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(patch);
+        var request = new UpdateMetadataRequest
+        {
+            FileId = fileId,
+            Mime = patch.Mime,
+            Author = patch.Author,
+            IsReadOnly = patch.IsReadOnly,
+            ExpectedVersion = expectedVersion,
+        };
         var mapping = await _mappingPipeline.MapUpdateMetadataAsync(request, cancellationToken).ConfigureAwait(false);
         if (!mapping.IsSuccess)
         {
@@ -76,7 +88,11 @@ public sealed class FileOperationsService : IFileOperationsService
         return ToIdResponse(result);
     }
 
-    public async Task<ApiResponse<Guid>> SetValidityAsync(Guid fileId, FileValidityDto validity, CancellationToken cancellationToken)
+    public async Task<ApiResponse<Guid>> SetValidityAsync(
+        Guid fileId,
+        FileValidityDto validity,
+        int? expectedVersion,
+        CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(validity);
         var request = new SetValidityRequest
@@ -86,6 +102,7 @@ public sealed class FileOperationsService : IFileOperationsService
             ValidUntil = validity.ValidUntil,
             HasElectronicCopy = validity.HasElectronicCopy,
             HasPhysicalCopy = validity.HasPhysicalCopy,
+            ExpectedVersion = expectedVersion,
         };
 
         var mapping = await _mappingPipeline.MapSetValidityAsync(request, cancellationToken).ConfigureAwait(false);
@@ -99,10 +116,13 @@ public sealed class FileOperationsService : IFileOperationsService
         return ToIdResponse(result);
     }
 
-    public async Task<ApiResponse<Guid>> ClearValidityAsync(Guid fileId, CancellationToken cancellationToken)
+    public async Task<ApiResponse<Guid>> ClearValidityAsync(
+        Guid fileId,
+        int? expectedVersion,
+        CancellationToken cancellationToken)
     {
         var mapping = await _mappingPipeline
-            .MapClearValidityAsync(new ClearValidityRequest { FileId = fileId }, cancellationToken)
+            .MapClearValidityAsync(new ClearValidityRequest { FileId = fileId, ExpectedVersion = expectedVersion }, cancellationToken)
             .ConfigureAwait(false);
         if (!mapping.IsSuccess)
         {

--- a/Veriado.Services/Files/IFileOperationsService.cs
+++ b/Veriado.Services/Files/IFileOperationsService.cs
@@ -7,13 +7,21 @@ public interface IFileOperationsService
 {
     Task<ApiResponse<Guid>> RenameAsync(Guid fileId, string newName, CancellationToken cancellationToken);
 
-    Task<ApiResponse<Guid>> UpdateMetadataAsync(UpdateMetadataRequest request, CancellationToken cancellationToken);
+    Task<ApiResponse<Guid>> UpdateMetadataAsync(
+        Guid fileId,
+        FileMetadataPatchDto patch,
+        int? expectedVersion,
+        CancellationToken cancellationToken);
 
     Task<ApiResponse<Guid>> SetReadOnlyAsync(Guid fileId, bool isReadOnly, CancellationToken cancellationToken);
 
-    Task<ApiResponse<Guid>> SetValidityAsync(Guid fileId, FileValidityDto validity, CancellationToken cancellationToken);
+    Task<ApiResponse<Guid>> SetValidityAsync(
+        Guid fileId,
+        FileValidityDto validity,
+        int? expectedVersion,
+        CancellationToken cancellationToken);
 
-    Task<ApiResponse<Guid>> ClearValidityAsync(Guid fileId, CancellationToken cancellationToken);
+    Task<ApiResponse<Guid>> ClearValidityAsync(Guid fileId, int? expectedVersion, CancellationToken cancellationToken);
 
     Task<ApiResponse<Guid>> ReplaceContentAsync(Guid fileId, byte[] content, CancellationToken cancellationToken);
 

--- a/Veriado.WinUI/AppHost.cs
+++ b/Veriado.WinUI/AppHost.cs
@@ -49,6 +49,7 @@ internal sealed class AppHost : IAsyncDisposable
                 services.AddSingleton<IHotStateService, HotStateService>();
                 services.AddSingleton<INavigationService, NavigationService>();
                 services.AddSingleton<IDialogService, DialogService>();
+                services.AddSingleton<ITimeFormattingService, TimeFormattingService>();
                 services.AddSingleton<IPickerService, PickerService>();
                 services.AddSingleton<IStatusService, StatusService>();
 

--- a/Veriado.WinUI/Services/Abstractions/IDialogService.cs
+++ b/Veriado.WinUI/Services/Abstractions/IDialogService.cs
@@ -6,4 +6,46 @@ public interface IDialogService
     Task ShowInfoAsync(string title, string message);
     Task ShowErrorAsync(string title, string message);
     Task ShowAsync(string title, UIElement content, string primaryButtonText = "OK");
+
+    Task<DialogResult> ShowDialogAsync(DialogRequest request, CancellationToken cancellationToken = default);
+}
+
+public sealed record DialogRequest(
+    string Title,
+    UIElement Content,
+    string PrimaryButtonText,
+    string? SecondaryButtonText = null,
+    string? CloseButtonText = null,
+    ContentDialogButton DefaultButton = ContentDialogButton.Primary);
+
+public enum DialogOutcome
+{
+    None,
+    Primary,
+    Secondary,
+    Close,
+    Canceled,
+}
+
+public readonly record struct DialogResult(DialogOutcome Outcome)
+{
+    public bool IsPrimary => Outcome == DialogOutcome.Primary;
+
+    public bool IsSecondary => Outcome == DialogOutcome.Secondary;
+
+    public bool IsClose => Outcome == DialogOutcome.Close;
+
+    public bool IsCanceled => Outcome == DialogOutcome.Canceled;
+
+    public static DialogResult From(ContentDialogResult result, bool wasCloseButton)
+    {
+        return result switch
+        {
+            ContentDialogResult.Primary => new DialogResult(DialogOutcome.Primary),
+            ContentDialogResult.Secondary => new DialogResult(DialogOutcome.Secondary),
+            _ => new DialogResult(wasCloseButton ? DialogOutcome.Close : DialogOutcome.None),
+        };
+    }
+
+    public static DialogResult Canceled() => new(DialogOutcome.Canceled);
 }

--- a/Veriado.WinUI/Services/Abstractions/ITimeFormattingService.cs
+++ b/Veriado.WinUI/Services/Abstractions/ITimeFormattingService.cs
@@ -1,0 +1,32 @@
+namespace Veriado.WinUI.Services.Abstractions;
+
+/// <summary>
+/// Provides helpers for consistent time localization and formatting.
+/// </summary>
+public interface ITimeFormattingService
+{
+    /// <summary>
+    /// Converts the specified UTC timestamp to the local time zone.
+    /// </summary>
+    DateTimeOffset ToLocal(DateTimeOffset value);
+
+    /// <summary>
+    /// Formats a timestamp using the current culture.
+    /// </summary>
+    string Format(DateTimeOffset value);
+
+    /// <summary>
+    /// Formats an optional timestamp using the current culture, returning an en dash if missing.
+    /// </summary>
+    string FormatOrDash(DateTimeOffset? value);
+
+    /// <summary>
+    /// Decomposes a timestamp to its local date component and time of day.
+    /// </summary>
+    (DateTimeOffset Date, TimeSpan TimeOfDay) Split(DateTimeOffset value);
+
+    /// <summary>
+    /// Composes a timestamp from a local date and time of day and returns the UTC representation.
+    /// </summary>
+    DateTimeOffset ComposeUtc(DateTimeOffset localDate, TimeSpan timeOfDay);
+}

--- a/Veriado.WinUI/Services/TimeFormattingService.cs
+++ b/Veriado.WinUI/Services/TimeFormattingService.cs
@@ -1,0 +1,43 @@
+using System.Globalization;
+
+namespace Veriado.WinUI.Services;
+
+/// <summary>
+/// Implements formatting helpers for localized timestamps.
+/// </summary>
+public sealed class TimeFormattingService : ITimeFormattingService
+{
+    public DateTimeOffset ToLocal(DateTimeOffset value)
+    {
+        return value.ToLocalTime();
+    }
+
+    public string Format(DateTimeOffset value)
+    {
+        return ToLocal(value).ToString("g", CultureInfo.CurrentCulture);
+    }
+
+    public string FormatOrDash(DateTimeOffset? value)
+    {
+        return value.HasValue ? Format(value.Value) : "–";
+    }
+
+    public (DateTimeOffset Date, TimeSpan TimeOfDay) Split(DateTimeOffset value)
+    {
+        var local = ToLocal(value);
+        return (new DateTimeOffset(local.Date, local.Offset), local.TimeOfDay);
+    }
+
+    public DateTimeOffset ComposeUtc(DateTimeOffset localDate, TimeSpan timeOfDay)
+    {
+        var composed = new DateTimeOffset(
+            localDate.Year,
+            localDate.Month,
+            localDate.Day,
+            timeOfDay.Hours,
+            timeOfDay.Minutes,
+            timeOfDay.Seconds,
+            localDate.Offset);
+        return composed.ToUniversalTime();
+    }
+}

--- a/Veriado.WinUI/ViewModels/Files/FileDetailDialogViewModel.cs
+++ b/Veriado.WinUI/ViewModels/Files/FileDetailDialogViewModel.cs
@@ -1,36 +1,44 @@
-using System;
-using System.Globalization;
+using System.Collections;
+using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
-using System.Threading.Tasks;
-using CommunityToolkit.Mvvm.ComponentModel;
-using CommunityToolkit.Mvvm.Input;
-using CommunityToolkit.Mvvm.Messaging;
+using System.Text.RegularExpressions;
 using Veriado.Contracts.Common;
 using Veriado.Contracts.Files;
-using Veriado.Services.Files;
-using Veriado.WinUI.Services.Abstractions;
-using Veriado.WinUI.ViewModels.Base;
 
 namespace Veriado.WinUI.ViewModels.Files;
 
-public partial class FileDetailDialogViewModel : ViewModelBase
+public enum FileDetailDialogState
 {
+    Idle,
+    Loading,
+    Loaded,
+    Saving,
+    Error,
+}
+
+public partial class FileDetailDialogViewModel : ViewModelBase, INotifyDataErrorInfo
+{
+    private static readonly Regex MimeRegex = new("^[^/\\\\\s]+/[^/\\\s]+$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
     private readonly Guid _fileId;
     private readonly IFileQueryService _fileQueryService;
     private readonly IFileOperationsService _fileOperationsService;
+    private readonly ITimeFormattingService _timeFormattingService;
     private readonly AsyncRelayCommand _saveMetadataCommand;
     private readonly AsyncRelayCommand _saveValidityCommand;
     private readonly AsyncRelayCommand _clearValidityCommand;
+    private readonly Dictionary<string, List<string>> _validationErrors = new(StringComparer.OrdinalIgnoreCase);
 
-    private string? _originalMime;
-    private string? _originalAuthor;
-    private bool _originalIsReadOnly;
-    private FileValidityDto? _originalValidity;
+    private MetadataSnapshot _originalMetadata;
+    private ValiditySnapshot? _originalValidity;
+    private bool _isInitialized;
 
     public FileDetailDialogViewModel(
         FileSummaryDto summary,
         IFileQueryService fileQueryService,
         IFileOperationsService fileOperationsService,
+        ITimeFormattingService timeFormattingService,
         IMessenger messenger,
         IStatusService statusService,
         IDispatcherService dispatcher,
@@ -40,6 +48,7 @@ public partial class FileDetailDialogViewModel : ViewModelBase
         ArgumentNullException.ThrowIfNull(summary);
         _fileQueryService = fileQueryService ?? throw new ArgumentNullException(nameof(fileQueryService));
         _fileOperationsService = fileOperationsService ?? throw new ArgumentNullException(nameof(fileOperationsService));
+        _timeFormattingService = timeFormattingService ?? throw new ArgumentNullException(nameof(timeFormattingService));
         _fileId = summary.Id;
 
         DisplayName = BuildDisplayName(summary);
@@ -57,12 +66,17 @@ public partial class FileDetailDialogViewModel : ViewModelBase
         IndexSchemaVersion = summary.IndexSchemaVersion;
         IndexedContentHash = summary.IndexedContentHash;
 
+        _originalMetadata = CaptureMetadataSnapshot();
+        _originalValidity = null;
+
         _saveMetadataCommand = new AsyncRelayCommand(SaveMetadataAsync, CanSaveMetadata);
         _saveValidityCommand = new AsyncRelayCommand(SaveValidityAsync, CanSaveValidity);
         _clearValidityCommand = new AsyncRelayCommand(ClearValidityAsync, CanClearValidity);
     }
 
     public event EventHandler? ChangesSaved;
+
+    public event EventHandler<DataErrorsChangedEventArgs>? ErrorsChanged;
 
     [ObservableProperty]
     private string displayName = string.Empty;
@@ -124,21 +138,36 @@ public partial class FileDetailDialogViewModel : ViewModelBase
     [ObservableProperty]
     private bool validityHasElectronicCopy;
 
+    [ObservableProperty]
+    private FileDetailDialogState state = FileDetailDialogState.Idle;
+
+    [ObservableProperty]
+    private string? errorMessage;
+
+    [ObservableProperty]
+    private bool isMetadataDirty;
+
+    [ObservableProperty]
+    private bool isValidityDirty;
+
+    [ObservableProperty]
+    private bool hasPersistedChanges;
+
     public IAsyncRelayCommand SaveMetadataCommand => _saveMetadataCommand;
 
     public IAsyncRelayCommand SaveValidityCommand => _saveValidityCommand;
 
     public IAsyncRelayCommand ClearValidityCommand => _clearValidityCommand;
 
-    public string CreatedLocalText => FormatTimestamp(CreatedUtc);
+    public string CreatedLocalText => _timeFormattingService.Format(CreatedUtc);
 
-    public string LastModifiedLocalText => FormatTimestamp(LastModifiedUtc);
+    public string LastModifiedLocalText => _timeFormattingService.Format(LastModifiedUtc);
 
-    public string LastIndexedLocalText => LastIndexedUtc.HasValue
-        ? FormatTimestamp(LastIndexedUtc.Value)
-        : "–";
+    public string LastIndexedLocalText => _timeFormattingService.FormatOrDash(LastIndexedUtc);
 
     public bool HasValidity => ValidityIssuedDate.HasValue && ValidityUntilDate.HasValue;
+
+    public bool IsInteractionEnabled => !IsBusy && State is not FileDetailDialogState.Loading and not FileDetailDialogState.Saving;
 
     public string ValiditySummaryText
     {
@@ -149,10 +178,14 @@ public partial class FileDetailDialogViewModel : ViewModelBase
                 return "Platnost nenastavena.";
             }
 
-            var issued = ComposeLocalDateTime(ValidityIssuedDate!.Value, ValidityIssuedTime);
-            var until = ComposeLocalDateTime(ValidityUntilDate!.Value, ValidityUntilTime);
-            var issuedText = FormatTimestamp(issued);
-            var untilText = FormatTimestamp(until);
+            var candidate = BuildValiditySnapshot(validateCompleteness: false);
+            if (candidate is null)
+            {
+                return "Platnost nenastavena.";
+            }
+
+            var issuedText = _timeFormattingService.Format(candidate.Value.IssuedUtc);
+            var untilText = _timeFormattingService.Format(candidate.Value.ValidUntilUtc);
             var flags = BuildCopyFlags();
             return string.IsNullOrEmpty(flags)
                 ? $"Platí od {issuedText} do {untilText}."
@@ -160,21 +193,27 @@ public partial class FileDetailDialogViewModel : ViewModelBase
         }
     }
 
-    public Task InitializeAsync()
+    public bool HasErrors => _validationErrors.Count > 0;
+
+    public Task InitializeAsync(CancellationToken cancellationToken)
     {
+        State = FileDetailDialogState.Loading;
         return SafeExecuteAsync(async token =>
         {
-            var detail = await _fileQueryService.GetDetailAsync(_fileId, token).ConfigureAwait(false);
+            using var linked = CancellationTokenSource.CreateLinkedTokenSource(token, cancellationToken);
+            var detail = await _fileQueryService.GetDetailAsync(_fileId, linked.Token).ConfigureAwait(false);
             if (detail is null)
             {
-                StatusService.Error("Soubor se nepodařilo načíst.");
+                await Dispatcher.Enqueue(() =>
+                {
+                    ErrorMessage = "Soubor se nepodařilo načíst.";
+                    State = FileDetailDialogState.Error;
+                });
                 return;
             }
 
-            _originalMime = Normalize(detail.Mime);
-            _originalAuthor = Normalize(detail.Author);
-            _originalIsReadOnly = detail.IsReadOnly;
-            _originalValidity = detail.Validity;
+            var metadataSnapshot = new MetadataSnapshot(Normalize(detail.Mime), Normalize(detail.Author), detail.IsReadOnly);
+            ValiditySnapshot? validitySnapshot = detail.Validity is null ? null : ValiditySnapshot.From(detail.Validity);
 
             await Dispatcher.Enqueue(() =>
             {
@@ -192,51 +231,109 @@ public partial class FileDetailDialogViewModel : ViewModelBase
                 IndexSchemaVersion = detail.IndexSchemaVersion;
                 IndexedContentHash = detail.IndexedContentHash;
                 ApplyValidity(detail.Validity);
+
+                _originalMetadata = metadataSnapshot;
+                _originalValidity = validitySnapshot;
+                _isInitialized = true;
+                HasPersistedChanges = false;
+                ErrorMessage = null;
+                State = FileDetailDialogState.Loaded;
+
+                ValidateMetadata();
+                ValidateValidity();
+                UpdateDirtyFlags();
             });
-        }, "Načítám detail souboru…");
+        }, "Načítám detail souboru…", cancellationToken);
     }
 
-    partial void OnMimeChanged(string? value) => _saveMetadataCommand.NotifyCanExecuteChanged();
+    public IEnumerable GetErrors(string? propertyName)
+    {
+        if (string.IsNullOrWhiteSpace(propertyName))
+        {
+            return _validationErrors.Values.SelectMany(static x => x);
+        }
 
-    partial void OnAuthorChanged(string? value) => _saveMetadataCommand.NotifyCanExecuteChanged();
+        if (_validationErrors.TryGetValue(propertyName, out var errors))
+        {
+            return errors;
+        }
 
-    partial void OnIsReadOnlyChanged(bool value) => _saveMetadataCommand.NotifyCanExecuteChanged();
+        return Array.Empty<string>();
+    }
+
+    partial void OnIsBusyChanged(bool value)
+    {
+        OnPropertyChanged(nameof(IsInteractionEnabled));
+        UpdateCommandStates();
+    }
+
+    partial void OnStateChanged(FileDetailDialogState value)
+    {
+        OnPropertyChanged(nameof(IsInteractionEnabled));
+        UpdateCommandStates();
+    }
+
+    partial void OnErrorMessageChanged(string? value)
+    {
+        HasError = !string.IsNullOrWhiteSpace(value);
+    }
+
+    partial void OnMimeChanged(string? value)
+    {
+        ValidateMime();
+        UpdateMetadataDirtyState();
+    }
+
+    partial void OnAuthorChanged(string? value)
+    {
+        ValidateAuthor();
+        UpdateMetadataDirtyState();
+    }
+
+    partial void OnIsReadOnlyChanged(bool value)
+    {
+        UpdateMetadataDirtyState();
+    }
 
     partial void OnValidityIssuedDateChanged(DateTimeOffset? value)
     {
-        UpdateValidityCommands();
+        ValidateValidity();
+        UpdateValidityDirtyState();
         OnPropertyChanged(nameof(HasValidity));
         OnPropertyChanged(nameof(ValiditySummaryText));
     }
 
     partial void OnValidityIssuedTimeChanged(TimeSpan value)
     {
-        UpdateValidityCommands();
+        ValidateValidity();
+        UpdateValidityDirtyState();
         OnPropertyChanged(nameof(ValiditySummaryText));
     }
 
     partial void OnValidityUntilDateChanged(DateTimeOffset? value)
     {
-        UpdateValidityCommands();
+        ValidateValidity();
+        UpdateValidityDirtyState();
         OnPropertyChanged(nameof(HasValidity));
         OnPropertyChanged(nameof(ValiditySummaryText));
     }
 
     partial void OnValidityUntilTimeChanged(TimeSpan value)
     {
-        UpdateValidityCommands();
+        ValidateValidity();
+        UpdateValidityDirtyState();
         OnPropertyChanged(nameof(ValiditySummaryText));
     }
 
     partial void OnValidityHasPhysicalCopyChanged(bool value)
     {
-        UpdateValidityCommands();
+        UpdateValidityDirtyState();
         OnPropertyChanged(nameof(ValiditySummaryText));
     }
 
     partial void OnValidityHasElectronicCopyChanged(bool value)
     {
-        UpdateValidityCommands();
+        UpdateValidityDirtyState();
         OnPropertyChanged(nameof(ValiditySummaryText));
     }
 
@@ -248,148 +345,165 @@ public partial class FileDetailDialogViewModel : ViewModelBase
 
     private bool CanSaveMetadata()
     {
-        if (IsBusy)
-        {
-            return false;
-        }
-
-        var normalizedMime = Normalize(Mime);
-        var normalizedAuthor = Normalize(Author);
-        var mimeChanged = !string.Equals(normalizedMime, _originalMime, StringComparison.OrdinalIgnoreCase);
-        var authorChanged = !string.Equals(normalizedAuthor, _originalAuthor, StringComparison.Ordinal);
-        var readOnlyChanged = IsReadOnly != _originalIsReadOnly;
-        return mimeChanged || authorChanged || readOnlyChanged;
+        return _isInitialized && !IsBusy && !HasErrors && IsMetadataDirty;
     }
 
     private async Task SaveMetadataAsync()
     {
+        if (!CanSaveMetadata())
+        {
+            return;
+        }
+
         await SafeExecuteAsync(async token =>
         {
-            var normalizedMime = Normalize(Mime);
-            var normalizedAuthor = Normalize(Author);
-            var mimeChanged = !string.Equals(normalizedMime, _originalMime, StringComparison.OrdinalIgnoreCase);
-            var authorChanged = !string.Equals(normalizedAuthor, _originalAuthor, StringComparison.Ordinal);
-            var readOnlyChanged = IsReadOnly != _originalIsReadOnly;
+            State = FileDetailDialogState.Saving;
+            ErrorMessage = null;
 
-            if (!mimeChanged && !authorChanged && !readOnlyChanged)
+            var patch = BuildMetadataPatch();
+            if (patch is null)
             {
+                State = FileDetailDialogState.Loaded;
                 return;
             }
 
-            var request = new UpdateMetadataRequest
-            {
-                FileId = _fileId,
-                Mime = mimeChanged ? normalizedMime : null,
-                Author = authorChanged ? normalizedAuthor : null,
-                IsReadOnly = readOnlyChanged ? IsReadOnly : null,
-            };
+            var response = await _fileOperationsService
+                .UpdateMetadataAsync(_fileId, patch, Version, token)
+                .ConfigureAwait(false);
 
-            var response = await _fileOperationsService.UpdateMetadataAsync(request, token).ConfigureAwait(false);
             if (!response.IsSuccess)
             {
                 var message = ExtractErrorMessage(response, "Nepodařilo se uložit vlastnosti souboru.");
-                StatusService.Error(message);
+                await Dispatcher.Enqueue(() =>
+                {
+                    ErrorMessage = message;
+                    State = FileDetailDialogState.Error;
+                    StatusService.Error(message);
+                });
                 return;
             }
 
-            _originalMime = normalizedMime;
-            _originalAuthor = normalizedAuthor;
-            _originalIsReadOnly = IsReadOnly;
-
-            StatusService.Info("Vlastnosti souboru byly uloženy.");
-            ChangesSaved?.Invoke(this, EventArgs.Empty);
+            await Dispatcher.Enqueue(() =>
+            {
+                _originalMetadata = CaptureMetadataSnapshot();
+                IsMetadataDirty = false;
+                HasPersistedChanges = true;
+                Version += 1;
+                ErrorMessage = null;
+                State = FileDetailDialogState.Loaded;
+                StatusService.Info("Vlastnosti souboru byly uloženy.");
+                ChangesSaved?.Invoke(this, EventArgs.Empty);
+            });
         }, "Ukládám vlastnosti…");
-
-        _saveMetadataCommand.NotifyCanExecuteChanged();
     }
 
     private bool CanSaveValidity()
     {
-        if (IsBusy)
-        {
-            return false;
-        }
-
-        var candidate = BuildValidityCandidate(validateRange: false);
-        if (candidate is null)
-        {
-            return false;
-        }
-
-        return !Equals(candidate, _originalValidity);
+        return _isInitialized && !IsBusy && !HasErrors && IsValidityDirty;
     }
 
     private async Task SaveValidityAsync()
     {
+        if (!CanSaveValidity())
+        {
+            return;
+        }
+
         await SafeExecuteAsync(async token =>
         {
-            var candidate = BuildValidityCandidate(validateRange: true);
+            State = FileDetailDialogState.Saving;
+            ErrorMessage = null;
+
+            var candidate = BuildValiditySnapshot(validateCompleteness: true);
             if (candidate is null)
             {
+                State = FileDetailDialogState.Loaded;
                 return;
             }
 
-            var response = await _fileOperationsService.SetValidityAsync(_fileId, candidate, token).ConfigureAwait(false);
+            var dto = new FileValidityDto(
+                candidate.Value.IssuedUtc,
+                candidate.Value.ValidUntilUtc,
+                candidate.Value.HasPhysicalCopy,
+                candidate.Value.HasElectronicCopy);
+
+            var response = await _fileOperationsService
+                .SetValidityAsync(_fileId, dto, Version, token)
+                .ConfigureAwait(false);
+
             if (!response.IsSuccess)
             {
                 var message = ExtractErrorMessage(response, "Nepodařilo se uložit platnost dokumentu.");
-                StatusService.Error(message);
+                await Dispatcher.Enqueue(() =>
+                {
+                    ErrorMessage = message;
+                    State = FileDetailDialogState.Error;
+                    StatusService.Error(message);
+                });
                 return;
             }
 
-            _originalValidity = candidate;
-            await Dispatcher.Enqueue(() => ApplyValidity(candidate));
-
-            StatusService.Info("Platnost dokumentu byla uložena.");
-            ChangesSaved?.Invoke(this, EventArgs.Empty);
+            await Dispatcher.Enqueue(() =>
+            {
+                _originalValidity = candidate;
+                ApplyValidity(dto);
+                IsValidityDirty = false;
+                HasPersistedChanges = true;
+                Version += 1;
+                ErrorMessage = null;
+                State = FileDetailDialogState.Loaded;
+                StatusService.Info("Platnost dokumentu byla uložena.");
+                ChangesSaved?.Invoke(this, EventArgs.Empty);
+            });
         }, "Ukládám platnost…");
-
-        UpdateValidityCommands();
     }
 
     private bool CanClearValidity()
     {
-        if (IsBusy)
-        {
-            return false;
-        }
-
-        return _originalValidity is not null
-            || ValidityIssuedDate.HasValue
-            || ValidityUntilDate.HasValue
-            || ValidityHasPhysicalCopy
-            || ValidityHasElectronicCopy;
+        return _isInitialized && !IsBusy && (IsValidityDirty || _originalValidity is not null);
     }
 
     private async Task ClearValidityAsync()
     {
+        if (!CanClearValidity())
+        {
+            return;
+        }
+
         await SafeExecuteAsync(async token =>
         {
-            if (_originalValidity is null
-                && !ValidityIssuedDate.HasValue
-                && !ValidityUntilDate.HasValue
-                && !ValidityHasPhysicalCopy
-                && !ValidityHasElectronicCopy)
-            {
-                return;
-            }
+            State = FileDetailDialogState.Saving;
+            ErrorMessage = null;
 
-            var response = await _fileOperationsService.ClearValidityAsync(_fileId, token).ConfigureAwait(false);
+            var response = await _fileOperationsService
+                .ClearValidityAsync(_fileId, Version, token)
+                .ConfigureAwait(false);
+
             if (!response.IsSuccess)
             {
                 var message = ExtractErrorMessage(response, "Nepodařilo se zrušit platnost dokumentu.");
-                StatusService.Error(message);
+                await Dispatcher.Enqueue(() =>
+                {
+                    ErrorMessage = message;
+                    State = FileDetailDialogState.Error;
+                    StatusService.Error(message);
+                });
                 return;
             }
 
-            _originalValidity = null;
-            await Dispatcher.Enqueue(() => ApplyValidity(null));
-
-            StatusService.Info("Platnost dokumentu byla zrušena.");
-            ChangesSaved?.Invoke(this, EventArgs.Empty);
+            await Dispatcher.Enqueue(() =>
+            {
+                _originalValidity = null;
+                ApplyValidity(null);
+                IsValidityDirty = false;
+                HasPersistedChanges = true;
+                Version += 1;
+                ErrorMessage = null;
+                State = FileDetailDialogState.Loaded;
+                StatusService.Info("Platnost dokumentu byla zrušena.");
+                ChangesSaved?.Invoke(this, EventArgs.Empty);
+            });
         }, "Ruším platnost…");
-
-        UpdateValidityCommands();
     }
 
     private void ApplyValidity(FileValidityDto? validity)
@@ -405,13 +519,13 @@ public partial class FileDetailDialogViewModel : ViewModelBase
         }
         else
         {
-            var issuedLocal = validity.IssuedAt.ToLocalTime();
-            var untilLocal = validity.ValidUntil.ToLocalTime();
+            var issued = _timeFormattingService.Split(validity.IssuedAt);
+            var until = _timeFormattingService.Split(validity.ValidUntil);
 
-            ValidityIssuedDate = new DateTimeOffset(issuedLocal.Date, issuedLocal.Offset);
-            ValidityIssuedTime = issuedLocal.TimeOfDay;
-            ValidityUntilDate = new DateTimeOffset(untilLocal.Date, untilLocal.Offset);
-            ValidityUntilTime = untilLocal.TimeOfDay;
+            ValidityIssuedDate = issued.Date;
+            ValidityIssuedTime = issued.TimeOfDay;
+            ValidityUntilDate = until.Date;
+            ValidityUntilTime = until.TimeOfDay;
             ValidityHasPhysicalCopy = validity.HasPhysicalCopy;
             ValidityHasElectronicCopy = validity.HasElectronicCopy;
         }
@@ -420,45 +534,199 @@ public partial class FileDetailDialogViewModel : ViewModelBase
         OnPropertyChanged(nameof(ValiditySummaryText));
     }
 
-    private void UpdateValidityCommands()
+    private void UpdateCommandStates()
     {
+        _saveMetadataCommand.NotifyCanExecuteChanged();
         _saveValidityCommand.NotifyCanExecuteChanged();
         _clearValidityCommand.NotifyCanExecuteChanged();
     }
 
-    private FileValidityDto? BuildValidityCandidate(bool validateRange)
+    private void UpdateDirtyFlags()
     {
-        if (!ValidityIssuedDate.HasValue || !ValidityUntilDate.HasValue)
-        {
-            return null;
-        }
-
-        var issuedLocal = ComposeLocalDateTime(ValidityIssuedDate.Value, ValidityIssuedTime);
-        var untilLocal = ComposeLocalDateTime(ValidityUntilDate.Value, ValidityUntilTime);
-
-        if (validateRange && untilLocal < issuedLocal)
-        {
-            StatusService.Error("Datum konce platnosti musí následovat po začátku platnosti.");
-            return null;
-        }
-
-        return new FileValidityDto(
-            issuedLocal.ToUniversalTime(),
-            untilLocal.ToUniversalTime(),
-            ValidityHasPhysicalCopy,
-            ValidityHasElectronicCopy);
+        UpdateMetadataDirtyState();
+        UpdateValidityDirtyState();
     }
 
-    private static DateTimeOffset ComposeLocalDateTime(DateTimeOffset date, TimeSpan time)
+    private void UpdateMetadataDirtyState()
     {
-        return new DateTimeOffset(
-            date.Year,
-            date.Month,
-            date.Day,
-            time.Hours,
-            time.Minutes,
-            time.Seconds,
-            date.Offset);
+        if (!_isInitialized)
+        {
+            return;
+        }
+
+        IsMetadataDirty = !CaptureMetadataSnapshot().Equals(_originalMetadata);
+    }
+
+    private void UpdateValidityDirtyState()
+    {
+        if (!_isInitialized)
+        {
+            return;
+        }
+
+        var candidate = BuildValiditySnapshot(validateCompleteness: false);
+        if (_originalValidity is null && candidate is null)
+        {
+            IsValidityDirty = false;
+            return;
+        }
+
+        IsValidityDirty = !Equals(candidate, _originalValidity);
+    }
+
+    private MetadataSnapshot CaptureMetadataSnapshot()
+    {
+        return new MetadataSnapshot(Normalize(Mime), Normalize(Author), IsReadOnly);
+    }
+
+    private FileMetadataPatchDto? BuildMetadataPatch()
+    {
+        var current = CaptureMetadataSnapshot();
+        var original = _originalMetadata;
+
+        if (current.Equals(original))
+        {
+            return null;
+        }
+
+        return new FileMetadataPatchDto
+        {
+            Mime = !string.Equals(current.Mime, original.Mime, StringComparison.OrdinalIgnoreCase) ? current.Mime : null,
+            Author = !string.Equals(current.Author, original.Author, StringComparison.Ordinal) ? current.Author : null,
+            IsReadOnly = current.IsReadOnly != original.IsReadOnly ? current.IsReadOnly : null,
+        };
+    }
+
+    private ValiditySnapshot? BuildValiditySnapshot(bool validateCompleteness)
+    {
+        if (!ValidityIssuedDate.HasValue && !ValidityUntilDate.HasValue)
+        {
+            return null;
+        }
+
+        if (!ValidityIssuedDate.HasValue || !ValidityUntilDate.HasValue)
+        {
+            if (validateCompleteness)
+            {
+                var message = "Vyplňte oba datumy platnosti.";
+                SetErrors(nameof(ValidityIssuedDate), ValidityIssuedDate.HasValue ? Array.Empty<string>() : new[] { message });
+                SetErrors(nameof(ValidityUntilDate), ValidityUntilDate.HasValue ? Array.Empty<string>() : new[] { message });
+                ErrorMessage = message;
+            }
+
+            return null;
+        }
+
+        ClearErrors(nameof(ValidityIssuedDate));
+        ClearErrors(nameof(ValidityUntilDate));
+
+        var issuedUtc = _timeFormattingService.ComposeUtc(ValidityIssuedDate.Value, ValidityIssuedTime);
+        var untilUtc = _timeFormattingService.ComposeUtc(ValidityUntilDate.Value, ValidityUntilTime);
+
+        if (validateCompleteness && untilUtc < issuedUtc)
+        {
+            const string rangeMessage = "Datum konce platnosti musí následovat po začátku platnosti.";
+            SetErrors(nameof(ValidityUntilDate), new[] { rangeMessage });
+            ErrorMessage = rangeMessage;
+            return null;
+        }
+
+        return new ValiditySnapshot(issuedUtc, untilUtc, ValidityHasPhysicalCopy, ValidityHasElectronicCopy);
+    }
+
+    private void ValidateMetadata()
+    {
+        ValidateMime();
+        ValidateAuthor();
+    }
+
+    private void ValidateMime()
+    {
+        var normalized = Normalize(Mime);
+        if (string.IsNullOrEmpty(normalized))
+        {
+            ClearErrors(nameof(Mime));
+            return;
+        }
+
+        if (!MimeRegex.IsMatch(normalized))
+        {
+            SetErrors(nameof(Mime), new[] { "Zadejte platný MIME typ ve formátu typ/podtyp." });
+        }
+        else
+        {
+            ClearErrors(nameof(Mime));
+        }
+    }
+
+    private void ValidateAuthor()
+    {
+        var normalized = Normalize(Author);
+        if (string.IsNullOrEmpty(normalized))
+        {
+            ClearErrors(nameof(Author));
+            return;
+        }
+
+        if (normalized.Length > 200)
+        {
+            SetErrors(nameof(Author), new[] { "Autor může mít maximálně 200 znaků." });
+        }
+        else
+        {
+            ClearErrors(nameof(Author));
+        }
+    }
+
+    private void ValidateValidity()
+    {
+        var snapshot = BuildValiditySnapshot(validateCompleteness: false);
+        if (snapshot is null)
+        {
+            ClearErrors(nameof(ValidityIssuedDate));
+            ClearErrors(nameof(ValidityUntilDate));
+            return;
+        }
+
+        if (snapshot.Value.ValidUntilUtc < snapshot.Value.IssuedUtc)
+        {
+            const string rangeMessage = "Datum konce platnosti musí následovat po začátku platnosti.";
+            SetErrors(nameof(ValidityUntilDate), new[] { rangeMessage });
+        }
+        else
+        {
+            ClearErrors(nameof(ValidityIssuedDate));
+            ClearErrors(nameof(ValidityUntilDate));
+        }
+    }
+
+    private void SetErrors(string propertyName, IEnumerable<string> errors)
+    {
+        var errorList = errors.ToList();
+        if (errorList.Count == 0)
+        {
+            ClearErrors(propertyName);
+            return;
+        }
+
+        _validationErrors[propertyName] = errorList;
+        ErrorsChanged?.Invoke(this, new DataErrorsChangedEventArgs(propertyName));
+        OnPropertyChanged(nameof(HasErrors));
+        UpdateCommandStates();
+    }
+
+    private void ClearErrors(string propertyName)
+    {
+        if (_validationErrors.Remove(propertyName))
+        {
+            ErrorsChanged?.Invoke(this, new DataErrorsChangedEventArgs(propertyName));
+            OnPropertyChanged(nameof(HasErrors));
+            if (_validationErrors.Count == 0 && State != FileDetailDialogState.Error)
+            {
+                ErrorMessage = null;
+            }
+            UpdateCommandStates();
+        }
     }
 
     private static string? Normalize(string? value)
@@ -495,11 +763,6 @@ public partial class FileDetailDialogViewModel : ViewModelBase
         return fallback;
     }
 
-    private static string FormatTimestamp(DateTimeOffset value)
-    {
-        return value.ToLocalTime().ToString("g", CultureInfo.CurrentCulture);
-    }
-
     private string BuildCopyFlags()
     {
         var flags = new[]
@@ -512,4 +775,17 @@ public partial class FileDetailDialogViewModel : ViewModelBase
         return filtered.Length == 0 ? string.Empty : string.Join(", ", filtered);
     }
 
+    private readonly record struct MetadataSnapshot(string? Mime, string? Author, bool IsReadOnly);
+
+    private readonly record struct ValiditySnapshot(
+        DateTimeOffset IssuedUtc,
+        DateTimeOffset ValidUntilUtc,
+        bool HasPhysicalCopy,
+        bool HasElectronicCopy)
+    {
+        public static ValiditySnapshot From(FileValidityDto dto)
+        {
+            return new ValiditySnapshot(dto.IssuedAt, dto.ValidUntil, dto.HasPhysicalCopy, dto.HasElectronicCopy);
+        }
+    }
 }

--- a/Veriado.WinUI/Views/Files/FileDetailDialog.xaml
+++ b/Veriado.WinUI/Views/Files/FileDetailDialog.xaml
@@ -12,26 +12,78 @@
     </UserControl.Resources>
     <ScrollViewer VerticalScrollBarVisibility="Auto">
         <StackPanel Padding="12" Spacing="16">
-            <StackPanel Orientation="Horizontal" Spacing="12" VerticalAlignment="Center">
+            <Grid ColumnSpacing="12" VerticalAlignment="Center">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
                 <TextBlock
+                    Grid.Column="0"
                     Text="{Binding DisplayName}"
                     FontSize="24"
                     FontWeight="SemiBold"
                     TextWrapping="WrapWholeWords" />
                 <controls:ProgressRing
-                    Width="32"
-                    Height="32"
+                    x:Name="BusyIndicator"
+                    Grid.Column="1"
+                    Width="28"
+                    Height="28"
                     IsActive="{Binding IsBusy}" />
-            </StackPanel>
+            </Grid>
+
+            <CommandBar
+                x:Name="ActionCommandBar"
+                DefaultLabelPosition="Collapsed"
+                IsDynamicOverflowEnabled="False"
+                IsEnabled="{Binding IsInteractionEnabled}">
+                <CommandBar.PrimaryCommands>
+                    <AppBarButton
+                        x:Name="SaveMetadataButton"
+                        Label="Uložit vlastnosti"
+                        Command="{Binding SaveMetadataCommand}">
+                        <AppBarButton.Icon>
+                            <SymbolIcon Symbol="Save" />
+                        </AppBarButton.Icon>
+                        <AppBarButton.KeyboardAccelerators>
+                            <KeyboardAccelerator Key="S" Modifiers="Control" />
+                        </AppBarButton.KeyboardAccelerators>
+                    </AppBarButton>
+                    <AppBarButton
+                        x:Name="SaveValidityButton"
+                        Label="Uložit platnost"
+                        Command="{Binding SaveValidityCommand}">
+                        <AppBarButton.Icon>
+                            <SymbolIcon Symbol="Save" />
+                        </AppBarButton.Icon>
+                        <AppBarButton.KeyboardAccelerators>
+                            <KeyboardAccelerator Key="S" Modifiers="Control, Shift" />
+                        </AppBarButton.KeyboardAccelerators>
+                    </AppBarButton>
+                </CommandBar.PrimaryCommands>
+                <CommandBar.SecondaryCommands>
+                    <AppBarButton
+                        x:Name="ClearValidityButton"
+                        Label="Zrušit platnost"
+                        Command="{Binding ClearValidityCommand}">
+                        <AppBarButton.Icon>
+                            <SymbolIcon Symbol="Delete" />
+                        </AppBarButton.Icon>
+                        <AppBarButton.KeyboardAccelerators>
+                            <KeyboardAccelerator Key="Delete" Modifiers="Control" />
+                        </AppBarButton.KeyboardAccelerators>
+                    </AppBarButton>
+                </CommandBar.SecondaryCommands>
+            </CommandBar>
 
             <controls:InfoBar
+                x:Name="ErrorInfoBar"
                 IsClosable="False"
                 IsOpen="{Binding HasError}"
                 Severity="Error"
                 Title="Chyba"
-                Message="Nastala chyba při provedení operace." />
+                Message="{Binding ErrorMessage}" />
 
-            <StackPanel Spacing="8">
+            <StackPanel x:Name="SummarySection" Spacing="8">
                 <TextBlock FontWeight="SemiBold" Text="Souhrn" />
                 <TextBlock TextWrapping="Wrap" Text="{Binding Title, TargetNullValue='Bez názvu'}" />
                 <StackPanel Orientation="Horizontal" Spacing="4">
@@ -56,60 +108,60 @@
                 </StackPanel>
             </StackPanel>
 
-            <StackPanel Spacing="12">
+            <StackPanel x:Name="MetadataSection" Spacing="12" IsEnabled="{Binding IsInteractionEnabled}">
                 <TextBlock FontWeight="SemiBold" Text="Základní vlastnosti" />
-                <StackPanel Spacing="4">
-                    <TextBlock Text="MIME" />
-                    <TextBox Text="{Binding Mime, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-                </StackPanel>
-                <StackPanel Spacing="4">
-                    <TextBlock Text="Autor" />
-                    <TextBox Text="{Binding Author, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-                </StackPanel>
+                <TextBox
+                    x:Name="MimeTextBox"
+                    Header="MIME"
+                    Text="{Binding Mime, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                <TextBox
+                    x:Name="AuthorTextBox"
+                    Header="Autor"
+                    Text="{Binding Author, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                 <ToggleSwitch
+                    x:Name="ReadOnlyToggle"
                     Header="Pouze pro čtení"
                     IsOn="{Binding IsReadOnly, Mode=TwoWay}" />
-                <Button
-                    Content="Uložit vlastnosti"
-                    Command="{Binding SaveMetadataCommand}" />
             </StackPanel>
 
-            <StackPanel Spacing="12">
+            <StackPanel x:Name="ValiditySection" Spacing="12" IsEnabled="{Binding IsInteractionEnabled}">
                 <TextBlock FontWeight="SemiBold" Text="Platnost" />
                 <TextBlock Text="{Binding ValiditySummaryText}" TextWrapping="Wrap" />
-                <StackPanel Orientation="Horizontal" Spacing="8">
-                    <StackPanel Spacing="4">
+                <Grid ColumnSpacing="12">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+                    <StackPanel Grid.Column="0" Spacing="4">
                         <TextBlock Text="Platí od" />
                         <controls:DatePicker
+                            x:Name="ValidityFromDatePicker"
                             Date="{Binding ValidityIssuedDate, Mode=TwoWay}" />
                         <controls:TimePicker
+                            x:Name="ValidityFromTimePicker"
                             Time="{Binding ValidityIssuedTime, Mode=TwoWay}"
                             ClockIdentifier="24HourClock" />
                     </StackPanel>
-                    <StackPanel Spacing="4">
+                    <StackPanel Grid.Column="1" Spacing="4">
                         <TextBlock Text="Platí do" />
                         <controls:DatePicker
+                            x:Name="ValidityToDatePicker"
                             Date="{Binding ValidityUntilDate, Mode=TwoWay}" />
                         <controls:TimePicker
+                            x:Name="ValidityToTimePicker"
                             Time="{Binding ValidityUntilTime, Mode=TwoWay}"
                             ClockIdentifier="24HourClock" />
                     </StackPanel>
-                </StackPanel>
+                </Grid>
                 <StackPanel Orientation="Horizontal" Spacing="12">
                     <CheckBox
+                        x:Name="PhysicalCopyCheckBox"
                         Content="Fyzická kopie"
                         IsChecked="{Binding ValidityHasPhysicalCopy, Mode=TwoWay}" />
                     <CheckBox
+                        x:Name="ElectronicCopyCheckBox"
                         Content="Elektronická kopie"
                         IsChecked="{Binding ValidityHasElectronicCopy, Mode=TwoWay}" />
-                </StackPanel>
-                <StackPanel Orientation="Horizontal" Spacing="8">
-                    <Button
-                        Content="Uložit platnost"
-                        Command="{Binding SaveValidityCommand}" />
-                    <Button
-                        Content="Zrušit platnost"
-                        Command="{Binding ClearValidityCommand}" />
                 </StackPanel>
             </StackPanel>
         </StackPanel>

--- a/Veriado.WinUI/Views/Files/FilesPage.xaml
+++ b/Veriado.WinUI/Views/Files/FilesPage.xaml
@@ -240,7 +240,8 @@
                                 Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
                                 HorizontalAlignment="Stretch"
                                 HorizontalContentAlignment="Stretch"
-                                Click="OnOpenDetailClick">
+                                Command="{x:Bind ElementName=PageRoot, Path=ViewModel.OpenDetailCommand, Mode=OneWay}"
+                                CommandParameter="{x:Bind Mode=OneWay}">
                                 <StackPanel Spacing="4">
                                     <TextBlock
                                         Text="{x:Bind Name}"

--- a/Veriado.WinUI/Views/Files/FilesPage.xaml.cs
+++ b/Veriado.WinUI/Views/Files/FilesPage.xaml.cs
@@ -1,6 +1,5 @@
 using System;
 using Microsoft.UI.Xaml;
-using Veriado.Contracts.Files;
 using Veriado.WinUI.ViewModels.Files;
 
 namespace Veriado.WinUI.Views.Files;
@@ -35,11 +34,4 @@ public sealed partial class FilesPage : Page
         return ViewModel.RefreshCommand.ExecuteAsync(null);
     }
 
-    private async void OnOpenDetailClick(object sender, RoutedEventArgs e)
-    {
-        if (sender is FrameworkElement fe && fe.DataContext is FileSummaryDto dto)
-        {
-            await ViewModel.OpenDetailCommand.ExecuteAsync(dto);
-        }
-    }
 }


### PR DESCRIPTION
## Summary
- add reusable time formatting service and extend dialog service with cancelable dialog requests
- harden file detail dialog view model with state machine, validation, and diff-based metadata patches
- update files page flow and XAML to use safe commands, localized timestamps, and command bar driven actions
- extend file operations contracts to support partial metadata patches and optimistic concurrency tokens

## Testing
- `dotnet build Veriado.sln` *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_69007d9d5b1c8326aa7378f14024dfee