### PR TITLE
Propagate concurrency tokens through file operations

### DIFF
--- a/Veriado.Application/UseCases/Files/ApplySystemMetadata/ApplySystemMetadataCommand.cs
+++ b/Veriado.Application/UseCases/Files/ApplySystemMetadata/ApplySystemMetadataCommand.cs
@@ -11,6 +11,7 @@ namespace Veriado.Appl.UseCases.Files.ApplySystemMetadata;
 /// <param name="OwnerSid">The owner security identifier.</param>
 /// <param name="HardLinkCount">The hard link count.</param>
 /// <param name="AlternateDataStreamCount">The ADS count.</param>
+/// <param name="ExpectedVersion">The optional optimistic concurrency token.</param>
 public sealed record ApplySystemMetadataCommand(
     Guid FileId,
     FileAttributesFlags Attributes,
@@ -19,4 +20,5 @@ public sealed record ApplySystemMetadataCommand(
     DateTimeOffset LastAccessUtc,
     string? OwnerSid,
     uint? HardLinkCount,
-    uint? AlternateDataStreamCount) : IRequest<AppResult<FileSummaryDto>>;
+    uint? AlternateDataStreamCount,
+    int? ExpectedVersion = null) : IRequest<AppResult<FileSummaryDto>>;

--- a/Veriado.Application/UseCases/Files/ApplySystemMetadata/ApplySystemMetadataHandler.cs
+++ b/Veriado.Application/UseCases/Files/ApplySystemMetadata/ApplySystemMetadataHandler.cs
@@ -33,6 +33,11 @@ public sealed class ApplySystemMetadataHandler : FileWriteHandlerBase, IRequestH
                 return AppResult<FileSummaryDto>.NotFound($"File '{request.FileId}' was not found.");
             }
 
+            if (EnsureExpectedVersion(file, request.ExpectedVersion) is { } concurrencyConflict)
+            {
+                return concurrencyConflict;
+            }
+
             var metadata = new FileSystemMetadata(
                 request.Attributes,
                 UtcTimestamp.From(request.CreatedUtc),

--- a/Veriado.Application/UseCases/Files/ClearFileValidity/ClearFileValidityCommand.cs
+++ b/Veriado.Application/UseCases/Files/ClearFileValidity/ClearFileValidityCommand.cs
@@ -4,4 +4,6 @@ namespace Veriado.Appl.UseCases.Files.ClearFileValidity;
 /// Command to clear validity information from a file.
 /// </summary>
 /// <param name="FileId">The file identifier.</param>
-public sealed record ClearFileValidityCommand(Guid FileId) : IRequest<AppResult<FileSummaryDto>>;
+/// <param name="ExpectedVersion">The optional optimistic concurrency token.</param>
+public sealed record ClearFileValidityCommand(Guid FileId, int? ExpectedVersion = null)
+    : IRequest<AppResult<FileSummaryDto>>;

--- a/Veriado.Application/UseCases/Files/ClearFileValidity/ClearFileValidityHandler.cs
+++ b/Veriado.Application/UseCases/Files/ClearFileValidity/ClearFileValidityHandler.cs
@@ -33,6 +33,11 @@ public sealed class ClearFileValidityHandler : FileWriteHandlerBase, IRequestHan
                 return AppResult<FileSummaryDto>.NotFound($"File '{request.FileId}' was not found.");
             }
 
+            if (EnsureExpectedVersion(file, request.ExpectedVersion) is { } concurrencyConflict)
+            {
+                return concurrencyConflict;
+            }
+
             var timestamp = CurrentTimestamp();
             file.ClearValidity(timestamp);
             await PersistAsync(file, FilePersistenceOptions.Default, cancellationToken);

--- a/Veriado.Application/UseCases/Files/Common/FileWriteHandlerBase.cs
+++ b/Veriado.Application/UseCases/Files/Common/FileWriteHandlerBase.cs
@@ -192,6 +192,20 @@ public abstract class FileWriteHandlerBase
 
         await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
     }
+
+    protected static AppResult<FileSummaryDto>? EnsureExpectedVersion(FileEntity file, int? expectedVersion)
+    {
+        ArgumentNullException.ThrowIfNull(file);
+        if (!expectedVersion.HasValue)
+        {
+            return null;
+        }
+
+        return file.ContentRevision == expectedVersion.Value
+            ? null
+            : AppResult<FileSummaryDto>.Conflict(
+                "The file was modified by another operation. Please reload the file and try again.");
+    }
     private sealed class ClockAdapter : Veriado.Domain.Primitives.IClock
     {
         private readonly IClock _inner;

--- a/Veriado.Application/UseCases/Files/SetFileReadOnly/SetFileReadOnlyCommand.cs
+++ b/Veriado.Application/UseCases/Files/SetFileReadOnly/SetFileReadOnlyCommand.cs
@@ -5,4 +5,8 @@ namespace Veriado.Appl.UseCases.Files.SetFileReadOnly;
 /// </summary>
 /// <param name="FileId">The file identifier.</param>
 /// <param name="IsReadOnly">The desired read-only status.</param>
-public sealed record SetFileReadOnlyCommand(Guid FileId, bool IsReadOnly) : IRequest<AppResult<FileSummaryDto>>;
+/// <param name="ExpectedVersion">The optional optimistic concurrency token.</param>
+public sealed record SetFileReadOnlyCommand(
+    Guid FileId,
+    bool IsReadOnly,
+    int? ExpectedVersion = null) : IRequest<AppResult<FileSummaryDto>>;

--- a/Veriado.Application/UseCases/Files/SetFileReadOnly/SetFileReadOnlyHandler.cs
+++ b/Veriado.Application/UseCases/Files/SetFileReadOnly/SetFileReadOnlyHandler.cs
@@ -33,6 +33,11 @@ public sealed class SetFileReadOnlyHandler : FileWriteHandlerBase, IRequestHandl
                 return AppResult<FileSummaryDto>.NotFound($"File '{request.FileId}' was not found.");
             }
 
+            if (EnsureExpectedVersion(file, request.ExpectedVersion) is { } concurrencyConflict)
+            {
+                return concurrencyConflict;
+            }
+
             var timestamp = CurrentTimestamp();
             file.SetReadOnly(request.IsReadOnly, timestamp);
             await PersistAsync(file, FilePersistenceOptions.Default, cancellationToken);

--- a/Veriado.Application/UseCases/Files/SetFileValidity/SetFileValidityCommand.cs
+++ b/Veriado.Application/UseCases/Files/SetFileValidity/SetFileValidityCommand.cs
@@ -8,9 +8,11 @@ namespace Veriado.Appl.UseCases.Files.SetFileValidity;
 /// <param name="ValidUntilUtc">The timestamp when the document expires.</param>
 /// <param name="HasPhysicalCopy">Indicates whether a physical copy exists.</param>
 /// <param name="HasElectronicCopy">Indicates whether an electronic copy exists.</param>
+/// <param name="ExpectedVersion">The optional optimistic concurrency token.</param>
 public sealed record SetFileValidityCommand(
     Guid FileId,
     DateTimeOffset IssuedAtUtc,
     DateTimeOffset ValidUntilUtc,
     bool HasPhysicalCopy,
-    bool HasElectronicCopy) : IRequest<AppResult<FileSummaryDto>>;
+    bool HasElectronicCopy,
+    int? ExpectedVersion = null) : IRequest<AppResult<FileSummaryDto>>;

--- a/Veriado.Application/UseCases/Files/SetFileValidity/SetFileValidityHandler.cs
+++ b/Veriado.Application/UseCases/Files/SetFileValidity/SetFileValidityHandler.cs
@@ -33,6 +33,11 @@ public sealed class SetFileValidityHandler : FileWriteHandlerBase, IRequestHandl
                 return AppResult<FileSummaryDto>.NotFound($"File '{request.FileId}' was not found.");
             }
 
+            if (EnsureExpectedVersion(file, request.ExpectedVersion) is { } concurrencyConflict)
+            {
+                return concurrencyConflict;
+            }
+
             var issued = UtcTimestamp.From(request.IssuedAtUtc);
             var validUntil = UtcTimestamp.From(request.ValidUntilUtc);
             var timestamp = CurrentTimestamp();

--- a/Veriado.Application/UseCases/Files/UpdateFileMetadata/UpdateFileMetadataCommand.cs
+++ b/Veriado.Application/UseCases/Files/UpdateFileMetadata/UpdateFileMetadataCommand.cs
@@ -6,4 +6,9 @@ namespace Veriado.Appl.UseCases.Files.UpdateFileMetadata;
 /// <param name="FileId">The identifier of the file.</param>
 /// <param name="Mime">The optional new MIME type.</param>
 /// <param name="Author">The optional new author.</param>
-public sealed record UpdateFileMetadataCommand(Guid FileId, string? Mime, string? Author) : IRequest<AppResult<FileSummaryDto>>;
+/// <param name="ExpectedVersion">The optional optimistic concurrency token.</param>
+public sealed record UpdateFileMetadataCommand(
+    Guid FileId,
+    string? Mime,
+    string? Author,
+    int? ExpectedVersion = null) : IRequest<AppResult<FileSummaryDto>>;

--- a/Veriado.Application/UseCases/Files/UpdateFileMetadata/UpdateFileMetadataHandler.cs
+++ b/Veriado.Application/UseCases/Files/UpdateFileMetadata/UpdateFileMetadataHandler.cs
@@ -33,6 +33,11 @@ public sealed class UpdateFileMetadataHandler : FileWriteHandlerBase, IRequestHa
                 return AppResult<FileSummaryDto>.NotFound($"File '{request.FileId}' was not found.");
             }
 
+            if (EnsureExpectedVersion(file, request.ExpectedVersion) is { } concurrencyConflict)
+            {
+                return concurrencyConflict;
+            }
+
             MimeType? mime = request.Mime is null ? null : MimeType.From(request.Mime);
             var timestamp = CurrentTimestamp();
             file.UpdateMetadata(mime, request.Author, timestamp);


### PR DESCRIPTION
## Summary
- propagate expected file versions into metadata, validity, read-only, and system metadata commands so optimistic concurrency tokens reach the write handlers
- add shared guard logic in file write handlers to return conflicts when the persisted version no longer matches the request

## Testing
- `dotnet build Veriado.sln` *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_69008e12482883268cbd50f4fa436a5f