### PR TITLE
Fix WinUI file detail bindings

### DIFF
--- a/Veriado.WinUI/ViewModels/Files/FileDetailDialogViewModel.cs
+++ b/Veriado.WinUI/ViewModels/Files/FileDetailDialogViewModel.cs
@@ -1,10 +1,16 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
 using Veriado.Contracts.Common;
 using Veriado.Contracts.Files;
+using Veriado.Services.Files;
+using Veriado.WinUI.Services.Abstractions;
+using Veriado.WinUI.ViewModels.Base;
 
 namespace Veriado.WinUI.ViewModels.Files;
 
@@ -19,7 +25,7 @@ public enum FileDetailDialogState
 
 public partial class FileDetailDialogViewModel : ViewModelBase, INotifyDataErrorInfo
 {
-    private static readonly Regex MimeRegex = new("^[^/\\\\\s]+/[^/\\\s]+$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex MimeRegex = new(@"^[^/\s\\]+/[^/\s\\]+$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
     private readonly Guid _fileId;
     private readonly IFileQueryService _fileQueryService;

--- a/Veriado.WinUI/Views/Files/FileDetailDialog.xaml
+++ b/Veriado.WinUI/Views/Files/FileDetailDialog.xaml
@@ -108,26 +108,29 @@
                 </StackPanel>
             </StackPanel>
 
-            <StackPanel x:Name="MetadataSection" Spacing="12" IsEnabled="{Binding IsInteractionEnabled}">
-                <TextBlock FontWeight="SemiBold" Text="Základní vlastnosti" />
-                <TextBox
-                    x:Name="MimeTextBox"
-                    Header="MIME"
-                    Text="{Binding Mime, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-                <TextBox
-                    x:Name="AuthorTextBox"
-                    Header="Autor"
-                    Text="{Binding Author, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-                <ToggleSwitch
-                    x:Name="ReadOnlyToggle"
-                    Header="Pouze pro čtení"
-                    IsOn="{Binding IsReadOnly, Mode=TwoWay}" />
-            </StackPanel>
+            <ContentControl IsEnabled="{Binding IsInteractionEnabled}">
+                <StackPanel x:Name="MetadataSection" Spacing="12">
+                    <TextBlock FontWeight="SemiBold" Text="Základní vlastnosti" />
+                    <TextBox
+                        x:Name="MimeTextBox"
+                        Header="MIME"
+                        Text="{Binding Mime, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                    <TextBox
+                        x:Name="AuthorTextBox"
+                        Header="Autor"
+                        Text="{Binding Author, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                    <ToggleSwitch
+                        x:Name="ReadOnlyToggle"
+                        Header="Pouze pro čtení"
+                        IsOn="{Binding IsReadOnly, Mode=TwoWay}" />
+                </StackPanel>
+            </ContentControl>
 
-            <StackPanel x:Name="ValiditySection" Spacing="12" IsEnabled="{Binding IsInteractionEnabled}">
-                <TextBlock FontWeight="SemiBold" Text="Platnost" />
-                <TextBlock Text="{Binding ValiditySummaryText}" TextWrapping="Wrap" />
-                <Grid ColumnSpacing="12">
+            <ContentControl IsEnabled="{Binding IsInteractionEnabled}">
+                <StackPanel x:Name="ValiditySection" Spacing="12">
+                    <TextBlock FontWeight="SemiBold" Text="Platnost" />
+                    <TextBlock Text="{Binding ValiditySummaryText}" TextWrapping="Wrap" />
+                    <Grid ColumnSpacing="12">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="*" />
                         <ColumnDefinition Width="*" />

--- a/Veriado.WinUI/Views/Files/FilesPage.xaml
+++ b/Veriado.WinUI/Views/Files/FilesPage.xaml
@@ -264,8 +264,8 @@
                                         HorizontalAlignment="Right"
                                         VerticalAlignment="Center"
                                         Content="Detail"
-                                        Command="{x:Bind ElementName=PageRoot, Path=ViewModel.OpenDetailCommand, Mode=OneWay}"
-                                        CommandParameter="{x:Bind Mode=OneWay}" />
+                                        Command="{Binding DataContext.OpenDetailCommand, ElementName=PageRoot}"
+                                        CommandParameter="{Binding}" />
                                 </Grid>
                             </Border>
                         </DataTemplate>


### PR DESCRIPTION
## Summary
- add the missing service imports and regex normalization updates to the file detail dialog view model
- wrap metadata and validity sections in content controls so IsEnabled bindings compile
- fix the file list item template to bind the detail command without relying on ElementName in x:Bind

## Testing
- not run (dotnet CLI is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_6900fed8d2d483269fade3bffa675cff