### PR TITLE
Refactor file detail dialog architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,16 @@ Veriado je desktopová aplikace pro katalogizaci dokumentů s plnotextovým vyhl
 - **Veriado.Application.Tests** – integrační testy ověřující doménové události, reindex a konzistenci perzistence.【F:Veriado.Application.Tests/Infrastructure/DomainEventsInterceptorTests.cs†L19-L154】
 - **tools/** – pomocné skripty, např. `fts5-benchmark.csx` pro měření výkonu fulltextu.
 
+## File Detail – architektura & bindingy
+- `FilesPageViewModel.OpenDetailCommand` vytváří viewmodel dialogu přes `IDialogService`, načte detail souboru a po potvrzení vyvolá refresh seznamu.【F:Veriado.WinUI/ViewModels/Files/FilesPageViewModel.cs†L600-L636】
+- `FileDetailDialogViewModel` implementuje `IDialogAware`, spravuje `EditableFileDetailModel` s DataAnnotations validací a orchestruje uložení přes aplikační `IFileService` včetně zobrazení chyb a konfliktů.【F:Veriado.WinUI/ViewModels/Files/FileDetailDialogViewModel.cs†L14-L221】
+- `EditableFileDetailModel` dedikuje validaci a mapování na DTO, řeší datovou konzistenci (platnost, povinná pole) a propaguje chyby do UI pomocí `ObservableValidator`.【F:Veriado.WinUI/ViewModels/Files/EditableFileDetailModel.cs†L1-L178】
+- `FileDetailDialog.xaml` definuje `ContentDialog` s `x:Bind` vazbami, inline výpisem chyb, převodníkem pro datum platnosti a blokem souhrnných metadat.【F:Veriado.WinUI/Views/Files/FileDetailDialog.xaml†L1-L138】
+- `DialogService` rozpozná dialogové viewmodely (`IDialogAware`), přiřadí odpovídající view přes `IDialogViewFactory` a řídí jejich životní cyklus včetně asynchronního zavření.【F:Veriado.WinUI/Services/DialogService.cs†L1-L141】
+- Aplikační `FileService` sjednocuje načtení detailu, přejmenování, update metadat i platnosti a převádí chybové stavy na doménově smysluplné výjimky pro UI.【F:Veriado.Services/Files/FileService.cs†L1-L188】
+- `FileDetailDto` v aplikační vrstvě poskytuje konzistentní přenosový objekt pro detail a editaci dokumentu, včetně verzí a platnosti.【F:Veriado.Application/Files/Contracts/FileDetailDto.cs†L1-L33】
+- `IDialogViewFactory` + `FileDetailDialogFactory` umožňují DI konstruovat ContentDialogy s odpovídajícími viewmodely bez service-locator patternu.【F:Veriado.WinUI/Services/Abstractions/IDialogViewFactory.cs†L1-L12】【F:Veriado.WinUI/Services/DialogFactories/FileDetailDialogFactory.cs†L1-L25】
+
 ## Požadavky
 - .NET 8 SDK
 - Windows 10 19041+ pro běh WinUI klienta (x86/x64/ARM64)

--- a/Veriado.Application/Files/Contracts/FileDetailDto.cs
+++ b/Veriado.Application/Files/Contracts/FileDetailDto.cs
@@ -1,0 +1,43 @@
+namespace Veriado.Application.Files.Contracts;
+
+/// <summary>
+/// Represents an editable snapshot of a file aggregate exposed to the presentation layer.
+/// </summary>
+public sealed class FileDetailDto
+{
+    public Guid Id { get; init; }
+
+    public string FileName { get; init; } = string.Empty;
+
+    public string Extension { get; init; } = string.Empty;
+
+    public string MimeType { get; init; } = string.Empty;
+
+    public string? Author { get; init; }
+
+    public bool IsReadOnly { get; init; }
+
+    public long Size { get; init; }
+
+    public DateTimeOffset CreatedAt { get; init; }
+
+    public DateTimeOffset ModifiedAt { get; init; }
+
+    public int Version { get; init; }
+
+    public DateTimeOffset? ValidFrom { get; init; }
+
+    public DateTimeOffset? ValidTo { get; init; }
+
+    public bool HasValidity => ValidFrom is not null && ValidTo is not null;
+
+    public string DisplayName => string.IsNullOrWhiteSpace(Extension)
+        ? FileName
+        : string.Create(FileName.Length + Extension.Length + 1, (FileName, Extension), static (span, tuple) =>
+        {
+            var (name, extension) = tuple;
+            name.AsSpan().CopyTo(span);
+            span[name.Length] = '.';
+            extension.AsSpan().CopyTo(span[(name.Length + 1)..]);
+        });
+}

--- a/Veriado.Application/Files/IFileService.cs
+++ b/Veriado.Application/Files/IFileService.cs
@@ -1,0 +1,13 @@
+using Veriado.Application.Files.Contracts;
+
+namespace Veriado.Application.Files;
+
+/// <summary>
+/// Exposes application-level operations for working with editable file details.
+/// </summary>
+public interface IFileService
+{
+    Task<FileDetailDto> GetDetailAsync(Guid id, CancellationToken cancellationToken);
+
+    Task UpdateAsync(FileDetailDto detail, CancellationToken cancellationToken);
+}

--- a/Veriado.Services/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/Veriado.Services/DependencyInjection/ServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using Veriado.Appl.DependencyInjection;
+using Veriado.Application.Files;
 using Veriado.Contracts.Search.Abstractions;
 using Veriado.Services.Diagnostics;
 using Veriado.Services.Files;
@@ -28,6 +29,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IImportService, ImportService>();
         services.AddScoped<IFileQueryService, FileQueryService>();
         services.AddScoped<IFileOperationsService, FileOperationsService>();
+        services.AddScoped<IFileService, FileService>();
         services.AddScoped<IFileContentService, FileContentService>();
         services.AddScoped<IMaintenanceService, MaintenanceService>();
         services.AddScoped<IHealthService, HealthService>();

--- a/Veriado.Services/Files/Exceptions/FileDetailConcurrencyException.cs
+++ b/Veriado.Services/Files/Exceptions/FileDetailConcurrencyException.cs
@@ -1,0 +1,12 @@
+namespace Veriado.Services.Files.Exceptions;
+
+/// <summary>
+/// Represents an optimistic concurrency conflict detected while saving file details.
+/// </summary>
+public sealed class FileDetailConcurrencyException : Exception
+{
+    public FileDetailConcurrencyException(string message)
+        : base(message)
+    {
+    }
+}

--- a/Veriado.Services/Files/Exceptions/FileDetailNotFoundException.cs
+++ b/Veriado.Services/Files/Exceptions/FileDetailNotFoundException.cs
@@ -1,0 +1,15 @@
+namespace Veriado.Services.Files.Exceptions;
+
+/// <summary>
+/// Represents a missing file when attempting to load or update details.
+/// </summary>
+public sealed class FileDetailNotFoundException : Exception
+{
+    public FileDetailNotFoundException(Guid id)
+        : base($"File '{id}' was not found.")
+    {
+        FileId = id;
+    }
+
+    public Guid FileId { get; }
+}

--- a/Veriado.Services/Files/Exceptions/FileDetailServiceException.cs
+++ b/Veriado.Services/Files/Exceptions/FileDetailServiceException.cs
@@ -1,0 +1,12 @@
+namespace Veriado.Services.Files.Exceptions;
+
+/// <summary>
+/// Represents a generic failure when persisting file details.
+/// </summary>
+public sealed class FileDetailServiceException : Exception
+{
+    public FileDetailServiceException(string message)
+        : base(message)
+    {
+    }
+}

--- a/Veriado.Services/Files/Exceptions/FileDetailValidationException.cs
+++ b/Veriado.Services/Files/Exceptions/FileDetailValidationException.cs
@@ -1,0 +1,15 @@
+namespace Veriado.Services.Files.Exceptions;
+
+/// <summary>
+/// Represents a validation failure returned from the application layer when persisting file details.
+/// </summary>
+public sealed class FileDetailValidationException : Exception
+{
+    public FileDetailValidationException(string message, IReadOnlyDictionary<string, string[]> errors)
+        : base(message)
+    {
+        Errors = errors ?? throw new ArgumentNullException(nameof(errors));
+    }
+
+    public IReadOnlyDictionary<string, string[]> Errors { get; }
+}

--- a/Veriado.Services/Files/FileService.cs
+++ b/Veriado.Services/Files/FileService.cs
@@ -1,0 +1,222 @@
+using System.Collections.Generic;
+using System.Linq;
+using Veriado.Application.Files;
+using Veriado.Application.Files.Contracts;
+using Veriado.Contracts.Common;
+using Veriado.Contracts.Files;
+using Veriado.Services.Files.Exceptions;
+
+namespace Veriado.Services.Files;
+
+/// <summary>
+/// Provides an application-facing façade for loading and updating file details.
+/// </summary>
+public sealed class FileService : IFileService
+{
+    private readonly IFileQueryService _fileQueryService;
+    private readonly IFileOperationsService _fileOperationsService;
+
+    public FileService(IFileQueryService fileQueryService, IFileOperationsService fileOperationsService)
+    {
+        _fileQueryService = fileQueryService ?? throw new ArgumentNullException(nameof(fileQueryService));
+        _fileOperationsService = fileOperationsService ?? throw new ArgumentNullException(nameof(fileOperationsService));
+    }
+
+    public async Task<FileDetailDto> GetDetailAsync(Guid id, CancellationToken cancellationToken)
+    {
+        var detail = await _fileQueryService.GetDetailAsync(id, cancellationToken).ConfigureAwait(false);
+        if (detail is null)
+        {
+            throw new FileDetailNotFoundException(id);
+        }
+
+        return Map(detail);
+    }
+
+    public async Task UpdateAsync(FileDetailDto detail, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(detail);
+
+        var current = await _fileQueryService.GetDetailAsync(detail.Id, cancellationToken).ConfigureAwait(false);
+        if (current is null)
+        {
+            throw new FileDetailNotFoundException(detail.Id);
+        }
+
+        if (!string.Equals(current.Name, detail.FileName, StringComparison.Ordinal))
+        {
+            await EnsureSuccessAsync(
+                await _fileOperationsService.RenameAsync(detail.Id, detail.FileName, cancellationToken).ConfigureAwait(false))
+                .ConfigureAwait(false);
+
+            current = await _fileQueryService.GetDetailAsync(detail.Id, cancellationToken).ConfigureAwait(false)
+                ?? throw new FileDetailNotFoundException(detail.Id);
+        }
+
+        var metadataPatch = BuildMetadataPatch(current, detail);
+        if (metadataPatch is not null)
+        {
+            await EnsureSuccessAsync(
+                await _fileOperationsService
+                    .UpdateMetadataAsync(detail.Id, metadataPatch, current.Version, cancellationToken)
+                    .ConfigureAwait(false)).ConfigureAwait(false);
+
+            current = await _fileQueryService.GetDetailAsync(detail.Id, cancellationToken).ConfigureAwait(false)
+                ?? throw new FileDetailNotFoundException(detail.Id);
+        }
+
+        await UpdateValidityAsync(current, detail, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static FileDetailDto Map(Veriado.Contracts.Files.FileDetailDto detail)
+    {
+        return new FileDetailDto
+        {
+            Id = detail.Id,
+            FileName = detail.Name,
+            Extension = detail.Extension,
+            MimeType = detail.Mime,
+            Author = string.IsNullOrWhiteSpace(detail.Author) ? null : detail.Author,
+            IsReadOnly = detail.IsReadOnly,
+            Size = detail.Size,
+            CreatedAt = detail.CreatedUtc,
+            ModifiedAt = detail.LastModifiedUtc,
+            Version = detail.Version,
+            ValidFrom = detail.Validity?.IssuedAt,
+            ValidTo = detail.Validity?.ValidUntil,
+        };
+    }
+
+    private static FileMetadataPatchDto? BuildMetadataPatch(Veriado.Contracts.Files.FileDetailDto current, FileDetailDto desired)
+    {
+        string? mimePatch = null;
+        string? authorPatch = null;
+        bool? isReadOnlyPatch = null;
+
+        if (!string.Equals(current.Mime, desired.MimeType, StringComparison.OrdinalIgnoreCase))
+        {
+            mimePatch = desired.MimeType;
+        }
+
+        if (!string.Equals(current.Author, desired.Author, StringComparison.Ordinal))
+        {
+            authorPatch = desired.Author;
+        }
+
+        if (current.IsReadOnly != desired.IsReadOnly)
+        {
+            isReadOnlyPatch = desired.IsReadOnly;
+        }
+
+        if (mimePatch is null && authorPatch is null && isReadOnlyPatch is null)
+        {
+            return null;
+        }
+
+        return new FileMetadataPatchDto
+        {
+            Mime = mimePatch,
+            Author = authorPatch,
+            IsReadOnly = isReadOnlyPatch,
+        };
+    }
+
+    private async Task UpdateValidityAsync(Veriado.Contracts.Files.FileDetailDto current, FileDetailDto desired, CancellationToken cancellationToken)
+    {
+        var currentValidity = current.Validity;
+        var desiredRange = (ValidFrom: desired.ValidFrom, ValidTo: desired.ValidTo);
+
+        if (desiredRange.ValidFrom is null || desiredRange.ValidTo is null)
+        {
+            if (currentValidity is null)
+            {
+                return;
+            }
+
+            await EnsureSuccessAsync(
+                await _fileOperationsService
+                    .ClearValidityAsync(desired.Id, current.Version, cancellationToken)
+                    .ConfigureAwait(false)).ConfigureAwait(false);
+            return;
+        }
+
+        if (currentValidity is not null
+            && currentValidity.IssuedAt == desiredRange.ValidFrom
+            && currentValidity.ValidUntil == desiredRange.ValidTo)
+        {
+            return;
+        }
+
+        var validity = new FileValidityDto(
+            desiredRange.ValidFrom.Value,
+            desiredRange.ValidTo.Value,
+            currentValidity?.HasPhysicalCopy ?? false,
+            currentValidity?.HasElectronicCopy ?? false);
+
+        await EnsureSuccessAsync(
+            await _fileOperationsService
+                .SetValidityAsync(desired.Id, validity, current.Version, cancellationToken)
+                .ConfigureAwait(false)).ConfigureAwait(false);
+    }
+
+    private static Task EnsureSuccessAsync(ApiResponse<Guid> response)
+    {
+        EnsureSuccessCore(response.IsSuccess, response.Errors);
+        return Task.CompletedTask;
+    }
+
+    private static Task EnsureSuccessAsync(ApiResponse response)
+    {
+        EnsureSuccessCore(response.IsSuccess, response.Errors);
+        return Task.CompletedTask;
+    }
+
+    private static void EnsureSuccessCore(bool isSuccess, IReadOnlyList<ApiError> errors)
+    {
+        if (isSuccess)
+        {
+            return;
+        }
+
+        if (errors.Count == 0)
+        {
+            throw new FileDetailServiceException("Unexpected failure while processing file detail request.");
+        }
+
+        if (errors.Any(IsConflict))
+        {
+            throw new FileDetailConcurrencyException(errors[0].Message);
+        }
+
+        var validationErrors = errors.Where(IsValidation).ToArray();
+        if (validationErrors.Length > 0)
+        {
+            var lookup = new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase);
+            foreach (var error in validationErrors)
+            {
+                var key = error.Target ?? string.Empty;
+                if (!lookup.TryGetValue(key, out var messages))
+                {
+                    lookup[key] = new[] { error.Message };
+                }
+                else
+                {
+                    var merged = new string[messages.Length + 1];
+                    messages.CopyTo(merged, 0);
+                    merged[^1] = error.Message;
+                    lookup[key] = merged;
+                }
+            }
+
+            throw new FileDetailValidationException("Zadaná data nejsou platná.", lookup);
+        }
+
+        throw new FileDetailServiceException(errors[0].Message);
+    }
+
+    private static bool IsValidation(ApiError error)
+        => string.Equals(error.Code, "validation_error", StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsConflict(ApiError error)
+        => string.Equals(error.Code, "conflict", StringComparison.OrdinalIgnoreCase);
+}

--- a/Veriado.WinUI/AppHost.cs
+++ b/Veriado.WinUI/AppHost.cs
@@ -7,10 +7,13 @@ using Veriado.Mapping.DependencyInjection;
 using Veriado.Services;
 using Veriado.Services.DependencyInjection;
 using Veriado.WinUI.Services;
+using Veriado.WinUI.Services.Abstractions;
+using Veriado.WinUI.Services.DialogFactories;
 using Veriado.WinUI.ViewModels.Files;
 using Veriado.WinUI.ViewModels.Import;
 using Veriado.WinUI.ViewModels.Settings;
 using Veriado.WinUI.ViewModels.Shell;
+using Veriado.WinUI.Views.Files;
 using Veriado.Appl.DependencyInjection;
 using Veriado.WinUI.DependencyInjection;
 
@@ -54,9 +57,13 @@ internal sealed class AppHost : IAsyncDisposable
                 services.AddSingleton<IStatusService, StatusService>();
 
                 services.AddSingleton<MainShellViewModel>();
+                services.AddTransient<FileDetailDialogViewModel>();
                 services.AddTransient<FilesPageViewModel>();
                 services.AddTransient<ImportPageViewModel>();
                 services.AddTransient<SettingsPageViewModel>();
+
+                services.AddTransient<FileDetailDialog>();
+                services.AddTransient<IDialogViewFactory, FileDetailDialogFactory>();
 
                 services.AddWinUiShell();
 

--- a/Veriado.WinUI/Converters/NullableDateTimeOffsetConverter.cs
+++ b/Veriado.WinUI/Converters/NullableDateTimeOffsetConverter.cs
@@ -1,0 +1,31 @@
+using System;
+using Microsoft.UI.Xaml.Data;
+
+namespace Veriado.WinUI.Converters;
+
+/// <summary>
+/// Converts between nullable <see cref="DateTimeOffset"/> values and the non-nullable values required by <see cref="DatePicker"/>.
+/// </summary>
+public sealed class NullableDateTimeOffsetConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, string language)
+    {
+        if (value is DateTimeOffset dto)
+        {
+            return dto;
+        }
+
+        var now = DateTimeOffset.Now;
+        return new DateTimeOffset(now.Year, now.Month, now.Day, 0, 0, 0, now.Offset);
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, string language)
+    {
+        if (value is DateTimeOffset dto)
+        {
+            return dto;
+        }
+
+        return null;
+    }
+}

--- a/Veriado.WinUI/Services/Abstractions/IDialogService.cs
+++ b/Veriado.WinUI/Services/Abstractions/IDialogService.cs
@@ -2,11 +2,14 @@ namespace Veriado.WinUI.Services.Abstractions;
 
 public interface IDialogService
 {
+    TViewModel CreateViewModel<TViewModel>() where TViewModel : class;
+
     Task<bool> ConfirmAsync(string title, string message, string confirmText = "OK", string cancelText = "Cancel");
     Task ShowInfoAsync(string title, string message);
     Task ShowErrorAsync(string title, string message);
     Task ShowAsync(string title, UIElement content, string primaryButtonText = "OK");
 
+    Task<DialogResult> ShowDialogAsync<TViewModel>(TViewModel viewModel, CancellationToken cancellationToken = default) where TViewModel : class;
     Task<DialogResult> ShowDialogAsync(DialogRequest request, CancellationToken cancellationToken = default);
 }
 

--- a/Veriado.WinUI/Services/Abstractions/IDialogViewFactory.cs
+++ b/Veriado.WinUI/Services/Abstractions/IDialogViewFactory.cs
@@ -1,0 +1,13 @@
+using Microsoft.UI.Xaml.Controls;
+
+namespace Veriado.WinUI.Services.Abstractions;
+
+/// <summary>
+/// Provides a factory abstraction for creating dialog instances bound to view models.
+/// </summary>
+public interface IDialogViewFactory
+{
+    bool CanCreate(object viewModel);
+
+    ContentDialog Create(object viewModel);
+}

--- a/Veriado.WinUI/Services/DialogFactories/FileDetailDialogFactory.cs
+++ b/Veriado.WinUI/Services/DialogFactories/FileDetailDialogFactory.cs
@@ -1,0 +1,27 @@
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.UI.Xaml.Controls;
+using Veriado.WinUI.Services.Abstractions;
+using Veriado.WinUI.ViewModels.Files;
+using Veriado.WinUI.Views.Files;
+
+namespace Veriado.WinUI.Services.DialogFactories;
+
+public sealed class FileDetailDialogFactory : IDialogViewFactory
+{
+    private readonly IServiceProvider _serviceProvider;
+
+    public FileDetailDialogFactory(IServiceProvider serviceProvider)
+    {
+        _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
+    }
+
+    public bool CanCreate(object viewModel) => viewModel is FileDetailDialogViewModel;
+
+    public ContentDialog Create(object viewModel)
+    {
+        var dialog = _serviceProvider.GetRequiredService<FileDetailDialog>();
+        dialog.DataContext = viewModel;
+        return dialog;
+    }
+}

--- a/Veriado.WinUI/Services/DialogService.cs
+++ b/Veriado.WinUI/Services/DialogService.cs
@@ -1,13 +1,26 @@
+using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.UI.Xaml.Controls;
+using Veriado.WinUI.Services.Abstractions;
+using Veriado.WinUI.ViewModels.Base;
+
 namespace Veriado.WinUI.Services;
 
 public sealed class DialogService : IDialogService
 {
     private readonly IWindowProvider _window;
+    private readonly IServiceProvider _serviceProvider;
+    private readonly IReadOnlyList<IDialogViewFactory> _factories;
 
-    public DialogService(IWindowProvider window)
+    public DialogService(IWindowProvider window, IServiceProvider serviceProvider, IEnumerable<IDialogViewFactory> factories)
     {
         _window = window ?? throw new ArgumentNullException(nameof(window));
+        _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
+        _factories = factories?.ToArray() ?? throw new ArgumentNullException(nameof(factories));
     }
+
+    public TViewModel CreateViewModel<TViewModel>() where TViewModel : class
+        => _serviceProvider.GetRequiredService<TViewModel>();
 
     public async Task<bool> ConfirmAsync(string title, string message, string confirmText = "OK", string cancelText = "Cancel")
     {
@@ -37,14 +50,20 @@ public sealed class DialogService : IDialogService
         await ShowDialogAsync(request).ConfigureAwait(false);
     }
 
+    public async Task<DialogResult> ShowDialogAsync<TViewModel>(TViewModel viewModel, CancellationToken cancellationToken = default)
+        where TViewModel : class
+    {
+        ArgumentNullException.ThrowIfNull(viewModel);
+
+        var dialog = ResolveDialog(viewModel);
+        return await ShowDialogInternalAsync(dialog, viewModel, cancellationToken).ConfigureAwait(false);
+    }
+
     public async Task<DialogResult> ShowDialogAsync(DialogRequest request, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(request);
         ArgumentNullException.ThrowIfNull(request.Content);
 
-        var window = _window.GetActiveWindow();
-        var hwnd = _window.GetHwnd(window);
-        var xamlRoot = _window.GetXamlRoot(window);
         var dialog = new ContentDialog
         {
             Title = request.Title,
@@ -53,13 +72,54 @@ public sealed class DialogService : IDialogService
             SecondaryButtonText = request.SecondaryButtonText,
             CloseButtonText = request.CloseButtonText,
             DefaultButton = request.DefaultButton,
-            XamlRoot = xamlRoot,
         };
+
+        return await ShowDialogInternalAsync(dialog, null, cancellationToken).ConfigureAwait(false);
+    }
+
+    private ContentDialog ResolveDialog(object viewModel)
+    {
+        foreach (var factory in _factories)
+        {
+            if (factory.CanCreate(viewModel))
+            {
+                return factory.Create(viewModel);
+            }
+        }
+
+        throw new InvalidOperationException($"No dialog factory registered for view model type '{viewModel.GetType().FullName}'.");
+    }
+
+    private async Task<DialogResult> ShowDialogInternalAsync(ContentDialog dialog, object? viewModel, CancellationToken cancellationToken)
+    {
+        var window = _window.GetActiveWindow();
+        var hwnd = _window.GetHwnd(window);
+        dialog.XamlRoot = _window.GetXamlRoot(window);
 
         WinRT.Interop.InitializeWithWindow.Initialize(dialog, hwnd);
 
+        DialogResult? requestedResult = null;
+
+        void RequestClose(object? sender, DialogResult result)
+        {
+            requestedResult = result;
+            _ = dialog.DispatcherQueue.TryEnqueue(() =>
+            {
+                if (dialog.IsLoaded)
+                {
+                    dialog.Hide();
+                }
+            });
+        }
+
+        if (viewModel is IDialogAware aware)
+        {
+            aware.CloseRequested += RequestClose;
+        }
+
         using var registration = cancellationToken.Register(() =>
         {
+            requestedResult = DialogResult.Canceled();
             _ = dialog.DispatcherQueue.TryEnqueue(() =>
             {
                 if (dialog.IsLoaded)
@@ -69,14 +129,29 @@ public sealed class DialogService : IDialogService
             });
         });
 
-        var result = await dialog.ShowAsync();
-
-        if (cancellationToken.IsCancellationRequested)
+        try
         {
-            return DialogResult.Canceled();
-        }
+            var result = await dialog.ShowAsync();
 
-        var wasCloseButton = result == ContentDialogResult.None && !string.IsNullOrWhiteSpace(request.CloseButtonText);
-        return DialogResult.From(result, wasCloseButton);
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return DialogResult.Canceled();
+            }
+
+            if (requestedResult is { } custom)
+            {
+                return custom;
+            }
+
+            var wasCloseButton = result == ContentDialogResult.None && !string.IsNullOrWhiteSpace(dialog.CloseButtonText);
+            return DialogResult.From(result, wasCloseButton);
+        }
+        finally
+        {
+            if (viewModel is IDialogAware aware)
+            {
+                aware.CloseRequested -= RequestClose;
+            }
+        }
     }
 }

--- a/Veriado.WinUI/ViewModels/Base/IDialogAware.cs
+++ b/Veriado.WinUI/ViewModels/Base/IDialogAware.cs
@@ -1,0 +1,12 @@
+using System;
+using Veriado.WinUI.Services.Abstractions;
+
+namespace Veriado.WinUI.ViewModels.Base;
+
+/// <summary>
+/// Defines a contract for view models hosted within dialogs to signal completion.
+/// </summary>
+public interface IDialogAware
+{
+    event EventHandler<DialogResult> CloseRequested;
+}

--- a/Veriado.WinUI/ViewModels/Files/EditableFileDetailModel.cs
+++ b/Veriado.WinUI/ViewModels/Files/EditableFileDetailModel.cs
@@ -1,0 +1,209 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using CommunityToolkit.Mvvm.ComponentModel;
+using Veriado.Application.Files.Contracts;
+
+namespace Veriado.WinUI.ViewModels.Files;
+
+/// <summary>
+/// Represents an editable snapshot of a file detail with validation support for the dialog.
+/// </summary>
+public sealed partial class EditableFileDetailModel : ObservableValidator
+{
+    private static readonly string[] ValidatedMembers =
+    {
+        nameof(FileName),
+        nameof(MimeType),
+        nameof(Author),
+        nameof(ValidFrom),
+        nameof(ValidTo),
+        string.Empty,
+    };
+
+    private FileDetailDto _snapshot = null!;
+
+    private EditableFileDetailModel()
+    {
+    }
+
+    public Guid Id { get; private set; }
+
+    public string Extension { get; private set; } = string.Empty;
+
+    [ObservableProperty]
+    [Required(ErrorMessage = "Název souboru je povinný.")]
+    [StringLength(255, MinimumLength = 1, ErrorMessage = "Název musí mít 1 až 255 znaků.")]
+    private string fileName = string.Empty;
+
+    [ObservableProperty]
+    [Required(ErrorMessage = "MIME typ je povinný.")]
+    [StringLength(200, MinimumLength = 1, ErrorMessage = "MIME typ nesmí být delší než 200 znaků.")]
+    private string mimeType = string.Empty;
+
+    [ObservableProperty]
+    [StringLength(200, ErrorMessage = "Autor nesmí být delší než 200 znaků.")]
+    private string? author;
+
+    [ObservableProperty]
+    private bool isReadOnly;
+
+    [ObservableProperty]
+    private long size;
+
+    [ObservableProperty]
+    private DateTimeOffset createdAt;
+
+    [ObservableProperty]
+    private DateTimeOffset modifiedAt;
+
+    [ObservableProperty]
+    private int version;
+
+    [ObservableProperty]
+    private DateTimeOffset? validFrom;
+
+    [ObservableProperty]
+    private DateTimeOffset? validTo;
+
+    public string DisplayName => _snapshot.DisplayName;
+
+    public bool HasValidity => ValidFrom is not null && ValidTo is not null;
+
+    public bool IsDirty
+        => !string.Equals(FileName, _snapshot.FileName, StringComparison.Ordinal)
+            || !string.Equals(MimeType, _snapshot.MimeType, StringComparison.OrdinalIgnoreCase)
+            || !string.Equals(Author, _snapshot.Author, StringComparison.Ordinal)
+            || IsReadOnly != _snapshot.IsReadOnly
+            || !Nullable.Equals(ValidFrom, _snapshot.ValidFrom)
+            || !Nullable.Equals(ValidTo, _snapshot.ValidTo);
+
+    public static EditableFileDetailModel FromDto(FileDetailDto detail)
+    {
+        ArgumentNullException.ThrowIfNull(detail);
+
+        var model = new EditableFileDetailModel
+        {
+            _snapshot = detail,
+            Id = detail.Id,
+            Extension = detail.Extension,
+            fileName = detail.FileName,
+            mimeType = detail.MimeType,
+            author = detail.Author,
+            isReadOnly = detail.IsReadOnly,
+            size = detail.Size,
+            createdAt = detail.CreatedAt,
+            modifiedAt = detail.ModifiedAt,
+            version = detail.Version,
+            validFrom = detail.ValidFrom,
+            validTo = detail.ValidTo,
+        };
+
+        model.ResetValidation();
+        return model;
+    }
+
+    public FileDetailDto ToDto()
+    {
+        return new FileDetailDto
+        {
+            Id = Id,
+            FileName = FileName,
+            Extension = Extension,
+            MimeType = MimeType,
+            Author = Author,
+            IsReadOnly = IsReadOnly,
+            Size = Size,
+            CreatedAt = CreatedAt,
+            ModifiedAt = ModifiedAt,
+            Version = Version,
+            ValidFrom = ValidFrom,
+            ValidTo = ValidTo,
+        };
+    }
+
+    public void UpdateSnapshot(FileDetailDto detail)
+    {
+        ArgumentNullException.ThrowIfNull(detail);
+        _snapshot = detail;
+        Version = detail.Version;
+        ModifiedAt = detail.ModifiedAt;
+    }
+
+    public void ApplyServerErrors(IReadOnlyDictionary<string, string[]> errors)
+    {
+        ArgumentNullException.ThrowIfNull(errors);
+        ResetValidation();
+
+        foreach (var pair in errors)
+        {
+            SetErrors(pair.Key ?? string.Empty, pair.Value);
+        }
+    }
+
+    public void ResetValidation()
+    {
+        foreach (var member in ValidatedMembers)
+        {
+            SetErrors(member, Array.Empty<string>());
+        }
+    }
+
+    public void ValidateAll()
+    {
+        ValidateAllProperties();
+        ValidateValidityRange();
+    }
+
+    partial void OnFileNameChanged(string value)
+    {
+        ValidateProperty(value, nameof(FileName));
+    }
+
+    partial void OnMimeTypeChanged(string value)
+    {
+        ValidateProperty(value, nameof(MimeType));
+    }
+
+    partial void OnAuthorChanged(string? value)
+    {
+        ValidateProperty(value, nameof(Author));
+    }
+
+    partial void OnValidFromChanged(DateTimeOffset? value)
+    {
+        ValidateValidityRange();
+    }
+
+    partial void OnValidToChanged(DateTimeOffset? value)
+    {
+        ValidateValidityRange();
+    }
+
+    private void ValidateValidityRange()
+    {
+        if (ValidFrom is null && ValidTo is null)
+        {
+            SetErrors(nameof(ValidFrom), Array.Empty<string>());
+            SetErrors(nameof(ValidTo), Array.Empty<string>());
+            return;
+        }
+
+        if (ValidFrom is null || ValidTo is null)
+        {
+            SetErrors(nameof(ValidFrom), ValidFrom is null ? new[] { "Datum začátku platnosti je povinné." } : Array.Empty<string>());
+            SetErrors(nameof(ValidTo), ValidTo is null ? new[] { "Datum ukončení platnosti je povinné." } : Array.Empty<string>());
+            return;
+        }
+
+        if (ValidFrom > ValidTo)
+        {
+            SetErrors(nameof(ValidFrom), new[] { "Začátek platnosti musí být dříve než konec." });
+            SetErrors(nameof(ValidTo), new[] { "Konec platnosti musí být po začátku." });
+            return;
+        }
+
+        SetErrors(nameof(ValidFrom), Array.Empty<string>());
+        SetErrors(nameof(ValidTo), Array.Empty<string>());
+    }
+}

--- a/Veriado.WinUI/ViewModels/Files/FileDetailDialogViewModel.cs
+++ b/Veriado.WinUI/ViewModels/Files/FileDetailDialogViewModel.cs
@@ -1,797 +1,280 @@
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
-using System.Text.RegularExpressions;
-using System.Threading;
-using System.Threading.Tasks;
-using Veriado.Contracts.Common;
-using Veriado.Contracts.Files;
-using Veriado.Services.Files;
+using Microsoft.UI.Xaml.Controls;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Veriado.Application.Files;
+using Veriado.Application.Files.Contracts;
+using Veriado.Services.Files.Exceptions;
 using Veriado.WinUI.Services.Abstractions;
 using Veriado.WinUI.ViewModels.Base;
+using System.Threading;
 
 namespace Veriado.WinUI.ViewModels.Files;
 
-public enum FileDetailDialogState
+/// <summary>
+/// ViewModel for the file detail dialog that coordinates loading, validation and persistence.
+/// </summary>
+public sealed partial class FileDetailDialogViewModel : ObservableObject, IDialogAware
 {
-    Idle,
-    Loading,
-    Loaded,
-    Saving,
-    Error,
-}
+    private readonly IFileService _fileService;
+    private readonly IDialogService _dialogService;
+    private EditableFileDetailModel? _file;
+    private FileDetailDto? _snapshot;
+    private CancellationTokenSource? _saveCancellation;
 
-public partial class FileDetailDialogViewModel : ViewModelBase, INotifyDataErrorInfo
-{
-    private static readonly Regex MimeRegex = new(@"^[^/\s\\]+/[^/\s\\]+$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
-
-    private readonly Guid _fileId;
-    private readonly IFileQueryService _fileQueryService;
-    private readonly IFileOperationsService _fileOperationsService;
-    private readonly ITimeFormattingService _timeFormattingService;
-    private readonly AsyncRelayCommand _saveMetadataCommand;
-    private readonly AsyncRelayCommand _saveValidityCommand;
-    private readonly AsyncRelayCommand _clearValidityCommand;
-    private readonly Dictionary<string, List<string>> _validationErrors = new(StringComparer.OrdinalIgnoreCase);
-
-    private MetadataSnapshot _originalMetadata;
-    private ValiditySnapshot? _originalValidity;
-    private bool _isInitialized;
-
-    public FileDetailDialogViewModel(
-        FileSummaryDto summary,
-        IFileQueryService fileQueryService,
-        IFileOperationsService fileOperationsService,
-        ITimeFormattingService timeFormattingService,
-        IMessenger messenger,
-        IStatusService statusService,
-        IDispatcherService dispatcher,
-        IExceptionHandler exceptionHandler)
-        : base(messenger, statusService, dispatcher, exceptionHandler)
+    public FileDetailDialogViewModel(IFileService fileService, IDialogService dialogService)
     {
-        ArgumentNullException.ThrowIfNull(summary);
-        _fileQueryService = fileQueryService ?? throw new ArgumentNullException(nameof(fileQueryService));
-        _fileOperationsService = fileOperationsService ?? throw new ArgumentNullException(nameof(fileOperationsService));
-        _timeFormattingService = timeFormattingService ?? throw new ArgumentNullException(nameof(timeFormattingService));
-        _fileId = summary.Id;
+        _fileService = fileService ?? throw new ArgumentNullException(nameof(fileService));
+        _dialogService = dialogService ?? throw new ArgumentNullException(nameof(dialogService));
 
-        DisplayName = BuildDisplayName(summary);
-        Title = summary.Title;
-        Mime = summary.Mime;
-        Author = summary.Author;
-        IsReadOnly = summary.IsReadOnly;
-        Size = summary.Size;
-        Version = summary.Version;
-        CreatedUtc = summary.CreatedUtc;
-        LastModifiedUtc = summary.LastModifiedUtc;
-        IsIndexStale = summary.IsIndexStale;
-        LastIndexedUtc = summary.LastIndexedUtc;
-        IndexedTitle = summary.IndexedTitle;
-        IndexSchemaVersion = summary.IndexSchemaVersion;
-        IndexedContentHash = summary.IndexedContentHash;
-
-        _originalMetadata = CaptureMetadataSnapshot();
-        _originalValidity = null;
-
-        _saveMetadataCommand = new AsyncRelayCommand(SaveMetadataAsync, CanSaveMetadata);
-        _saveValidityCommand = new AsyncRelayCommand(SaveValidityAsync, CanSaveValidity);
-        _clearValidityCommand = new AsyncRelayCommand(ClearValidityAsync, CanClearValidity);
+        SaveCommand = new AsyncRelayCommand(ExecuteSaveAsync, CanSave);
+        CancelCommand = new RelayCommand(ExecuteCancel, () => !IsSaving);
+        ClearValidityCommand = new RelayCommand(ExecuteClearValidity, CanClearValidity);
     }
 
-    public event EventHandler? ChangesSaved;
+    public event EventHandler<DialogResult>? CloseRequested;
 
-    public event EventHandler<DataErrorsChangedEventArgs>? ErrorsChanged;
-
-    [ObservableProperty]
-    private string displayName = string.Empty;
-
-    [ObservableProperty]
-    private string? title;
-
-    [ObservableProperty]
-    private string? mime;
-
-    [ObservableProperty]
-    private string? author;
-
-    [ObservableProperty]
-    private bool isReadOnly;
+    public EditableFileDetailModel? File
+    {
+        get => _file;
+        private set
+        {
+            if (SetProperty(ref _file, value))
+            {
+                OnPropertyChanged(nameof(HasErrors));
+                SaveCommand.NotifyCanExecuteChanged();
+            }
+        }
+    }
 
     [ObservableProperty]
-    private long size;
+    private bool isLoading;
 
     [ObservableProperty]
-    private int version;
-
-    [ObservableProperty]
-    private DateTimeOffset createdUtc;
-
-    [ObservableProperty]
-    private DateTimeOffset lastModifiedUtc;
-
-    [ObservableProperty]
-    private bool isIndexStale;
-
-    [ObservableProperty]
-    private DateTimeOffset? lastIndexedUtc;
-
-    [ObservableProperty]
-    private string? indexedTitle;
-
-    [ObservableProperty]
-    private int indexSchemaVersion;
-
-    [ObservableProperty]
-    private string? indexedContentHash;
-
-    [ObservableProperty]
-    private DateTimeOffset? validityIssuedDate;
-
-    [ObservableProperty]
-    private TimeSpan validityIssuedTime = TimeSpan.Zero;
-
-    [ObservableProperty]
-    private DateTimeOffset? validityUntilDate;
-
-    [ObservableProperty]
-    private TimeSpan validityUntilTime = TimeSpan.Zero;
-
-    [ObservableProperty]
-    private bool validityHasPhysicalCopy;
-
-    [ObservableProperty]
-    private bool validityHasElectronicCopy;
-
-    [ObservableProperty]
-    private FileDetailDialogState state = FileDetailDialogState.Idle;
+    private bool isSaving;
 
     [ObservableProperty]
     private string? errorMessage;
 
-    [ObservableProperty]
-    private bool isMetadataDirty;
+    public bool HasErrors => File?.HasErrors ?? false;
 
-    [ObservableProperty]
-    private bool isValidityDirty;
+    public IAsyncRelayCommand SaveCommand { get; }
 
-    [ObservableProperty]
-    private bool hasPersistedChanges;
+    public IRelayCommand CancelCommand { get; }
 
-    public IAsyncRelayCommand SaveMetadataCommand => _saveMetadataCommand;
+    public IRelayCommand ClearValidityCommand { get; }
 
-    public IAsyncRelayCommand SaveValidityCommand => _saveValidityCommand;
-
-    public IAsyncRelayCommand ClearValidityCommand => _clearValidityCommand;
-
-    public string CreatedLocalText => _timeFormattingService.Format(CreatedUtc);
-
-    public string LastModifiedLocalText => _timeFormattingService.Format(LastModifiedUtc);
-
-    public string LastIndexedLocalText => _timeFormattingService.FormatOrDash(LastIndexedUtc);
-
-    public bool HasValidity => ValidityIssuedDate.HasValue && ValidityUntilDate.HasValue;
-
-    public bool IsInteractionEnabled => !IsBusy && State is not FileDetailDialogState.Loading and not FileDetailDialogState.Saving;
-
-    public string ValiditySummaryText
+    public IEnumerable<string> GetErrors(string propertyName)
     {
-        get
+        if (File is null)
         {
-            if (!HasValidity)
-            {
-                return "Platnost nenastavena.";
-            }
+            return Array.Empty<string>();
+        }
 
-            var candidate = BuildValiditySnapshot(validateCompleteness: false);
-            if (candidate is null)
-            {
-                return "Platnost nenastavena.";
-            }
+        return File
+            .GetErrors(propertyName)
+            ?.Cast<object?>()
+            .Select(static error => error?.ToString() ?? string.Empty)
+            ?? Array.Empty<string>();
+    }
 
-            var issuedText = _timeFormattingService.Format(candidate.Value.IssuedUtc);
-            var untilText = _timeFormattingService.Format(candidate.Value.ValidUntilUtc);
-            var flags = BuildCopyFlags();
-            return string.IsNullOrEmpty(flags)
-                ? $"Platí od {issuedText} do {untilText}."
-                : $"Platí od {issuedText} do {untilText}. ({flags})";
+    public async Task LoadAsync(Guid id, CancellationToken cancellationToken)
+    {
+        try
+        {
+            IsLoading = true;
+            var detail = await _fileService.GetDetailAsync(id, cancellationToken).ConfigureAwait(false);
+            Attach(detail);
+            ErrorMessage = null;
+        }
+        catch (FileDetailNotFoundException ex)
+        {
+            await _dialogService.ShowErrorAsync("Soubor nenalezen", ex.Message).ConfigureAwait(false);
+            throw;
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            await _dialogService.ShowErrorAsync("Chyba načítání", ex.Message).ConfigureAwait(false);
+            throw;
+        }
+        finally
+        {
+            IsLoading = false;
         }
     }
 
-    public bool HasErrors => _validationErrors.Count > 0;
-
-    public Task InitializeAsync(CancellationToken cancellationToken)
+    public async Task SaveAsync(CancellationToken cancellationToken)
     {
-        State = FileDetailDialogState.Loading;
-        return SafeExecuteAsync(async token =>
-        {
-            using var linked = CancellationTokenSource.CreateLinkedTokenSource(token, cancellationToken);
-            var detail = await _fileQueryService.GetDetailAsync(_fileId, linked.Token).ConfigureAwait(false);
-            if (detail is null)
-            {
-                await Dispatcher.Enqueue(() =>
-                {
-                    ErrorMessage = "Soubor se nepodařilo načíst.";
-                    State = FileDetailDialogState.Error;
-                });
-                return;
-            }
-
-            var metadataSnapshot = new MetadataSnapshot(Normalize(detail.Mime), Normalize(detail.Author), detail.IsReadOnly);
-            ValiditySnapshot? validitySnapshot = detail.Validity is null ? null : ValiditySnapshot.From(detail.Validity);
-
-            await Dispatcher.Enqueue(() =>
-            {
-                Title = detail.Title;
-                Mime = detail.Mime;
-                Author = detail.Author;
-                IsReadOnly = detail.IsReadOnly;
-                Size = detail.Size;
-                Version = detail.Version;
-                CreatedUtc = detail.CreatedUtc;
-                LastModifiedUtc = detail.LastModifiedUtc;
-                IsIndexStale = detail.IsIndexStale;
-                LastIndexedUtc = detail.LastIndexedUtc;
-                IndexedTitle = detail.IndexedTitle;
-                IndexSchemaVersion = detail.IndexSchemaVersion;
-                IndexedContentHash = detail.IndexedContentHash;
-                ApplyValidity(detail.Validity);
-
-                _originalMetadata = metadataSnapshot;
-                _originalValidity = validitySnapshot;
-                _isInitialized = true;
-                HasPersistedChanges = false;
-                ErrorMessage = null;
-                State = FileDetailDialogState.Loaded;
-
-                ValidateMetadata();
-                ValidateValidity();
-                UpdateDirtyFlags();
-            });
-        }, "Načítám detail souboru…", cancellationToken);
-    }
-
-    public IEnumerable GetErrors(string? propertyName)
-    {
-        if (string.IsNullOrWhiteSpace(propertyName))
-        {
-            return _validationErrors.Values.SelectMany(static x => x);
-        }
-
-        if (_validationErrors.TryGetValue(propertyName, out var errors))
-        {
-            return errors;
-        }
-
-        return Array.Empty<string>();
-    }
-
-    partial void OnIsBusyChanged(bool value)
-    {
-        OnPropertyChanged(nameof(IsInteractionEnabled));
-        UpdateCommandStates();
-    }
-
-    partial void OnStateChanged(FileDetailDialogState value)
-    {
-        OnPropertyChanged(nameof(IsInteractionEnabled));
-        UpdateCommandStates();
-    }
-
-    partial void OnErrorMessageChanged(string? value)
-    {
-        HasError = !string.IsNullOrWhiteSpace(value);
-    }
-
-    partial void OnMimeChanged(string? value)
-    {
-        ValidateMime();
-        UpdateMetadataDirtyState();
-    }
-
-    partial void OnAuthorChanged(string? value)
-    {
-        ValidateAuthor();
-        UpdateMetadataDirtyState();
-    }
-
-    partial void OnIsReadOnlyChanged(bool value)
-    {
-        UpdateMetadataDirtyState();
-    }
-
-    partial void OnValidityIssuedDateChanged(DateTimeOffset? value)
-    {
-        ValidateValidity();
-        UpdateValidityDirtyState();
-        OnPropertyChanged(nameof(HasValidity));
-        OnPropertyChanged(nameof(ValiditySummaryText));
-    }
-
-    partial void OnValidityIssuedTimeChanged(TimeSpan value)
-    {
-        ValidateValidity();
-        UpdateValidityDirtyState();
-        OnPropertyChanged(nameof(ValiditySummaryText));
-    }
-
-    partial void OnValidityUntilDateChanged(DateTimeOffset? value)
-    {
-        ValidateValidity();
-        UpdateValidityDirtyState();
-        OnPropertyChanged(nameof(HasValidity));
-        OnPropertyChanged(nameof(ValiditySummaryText));
-    }
-
-    partial void OnValidityUntilTimeChanged(TimeSpan value)
-    {
-        ValidateValidity();
-        UpdateValidityDirtyState();
-        OnPropertyChanged(nameof(ValiditySummaryText));
-    }
-
-    partial void OnValidityHasPhysicalCopyChanged(bool value)
-    {
-        UpdateValidityDirtyState();
-        OnPropertyChanged(nameof(ValiditySummaryText));
-    }
-
-    partial void OnValidityHasElectronicCopyChanged(bool value)
-    {
-        UpdateValidityDirtyState();
-        OnPropertyChanged(nameof(ValiditySummaryText));
-    }
-
-    partial void OnCreatedUtcChanged(DateTimeOffset value) => OnPropertyChanged(nameof(CreatedLocalText));
-
-    partial void OnLastModifiedUtcChanged(DateTimeOffset value) => OnPropertyChanged(nameof(LastModifiedLocalText));
-
-    partial void OnLastIndexedUtcChanged(DateTimeOffset? value) => OnPropertyChanged(nameof(LastIndexedLocalText));
-
-    private bool CanSaveMetadata()
-    {
-        return _isInitialized && !IsBusy && !HasErrors && IsMetadataDirty;
-    }
-
-    private async Task SaveMetadataAsync()
-    {
-        if (!CanSaveMetadata())
+        if (File is null)
         {
             return;
         }
 
-        await SafeExecuteAsync(async token =>
-        {
-            State = FileDetailDialogState.Saving;
-            ErrorMessage = null;
+        File.ResetValidation();
+        File.ValidateAll();
+        OnPropertyChanged(nameof(HasErrors));
 
-            var patch = BuildMetadataPatch();
-            if (patch is null)
-            {
-                State = FileDetailDialogState.Loaded;
-                return;
-            }
-
-            var response = await _fileOperationsService
-                .UpdateMetadataAsync(_fileId, patch, Version, token)
-                .ConfigureAwait(false);
-
-            if (!response.IsSuccess)
-            {
-                var message = ExtractErrorMessage(response, "Nepodařilo se uložit vlastnosti souboru.");
-                await Dispatcher.Enqueue(() =>
-                {
-                    ErrorMessage = message;
-                    State = FileDetailDialogState.Error;
-                    StatusService.Error(message);
-                });
-                return;
-            }
-
-            await Dispatcher.Enqueue(() =>
-            {
-                _originalMetadata = CaptureMetadataSnapshot();
-                IsMetadataDirty = false;
-                HasPersistedChanges = true;
-                Version += 1;
-                ErrorMessage = null;
-                State = FileDetailDialogState.Loaded;
-                StatusService.Info("Vlastnosti souboru byly uloženy.");
-                ChangesSaved?.Invoke(this, EventArgs.Empty);
-            });
-        }, "Ukládám vlastnosti…");
-    }
-
-    private bool CanSaveValidity()
-    {
-        return _isInitialized && !IsBusy && !HasErrors && IsValidityDirty;
-    }
-
-    private async Task SaveValidityAsync()
-    {
-        if (!CanSaveValidity())
+        if (File.HasErrors)
         {
             return;
         }
 
-        await SafeExecuteAsync(async token =>
+        try
         {
-            State = FileDetailDialogState.Saving;
+            IsSaving = true;
             ErrorMessage = null;
+            var dto = File.ToDto();
+            await _fileService.UpdateAsync(dto, cancellationToken).ConfigureAwait(false);
+            _snapshot = dto;
+            File.UpdateSnapshot(dto);
+            CloseRequested?.Invoke(this, new DialogResult(DialogOutcome.Primary));
+        }
+        catch (FileDetailValidationException ex)
+        {
+            File.ApplyServerErrors(ex.Errors);
+            OnPropertyChanged(nameof(HasErrors));
+            ErrorMessage = ex.Message;
+        }
+        catch (FileDetailConcurrencyException ex)
+        {
+            ErrorMessage = ex.Message;
+            await HandleConcurrencyAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (FileDetailServiceException ex)
+        {
+            ErrorMessage = ex.Message;
+            await _dialogService.ShowErrorAsync("Uložení selhalo", ex.Message).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            ErrorMessage = ex.Message;
+            await _dialogService.ShowErrorAsync("Uložení selhalo", ex.Message).ConfigureAwait(false);
+        }
+        finally
+        {
+            IsSaving = false;
+            CancelCommand.NotifyCanExecuteChanged();
+            SaveCommand.NotifyCanExecuteChanged();
+        }
+    }
 
-            var candidate = BuildValiditySnapshot(validateCompleteness: true);
-            if (candidate is null)
-            {
-                State = FileDetailDialogState.Loaded;
-                return;
-            }
+    private bool CanSave()
+        => !IsLoading && !IsSaving && File is not null;
 
-            var dto = new FileValidityDto(
-                candidate.Value.IssuedUtc,
-                candidate.Value.ValidUntilUtc,
-                candidate.Value.HasPhysicalCopy,
-                candidate.Value.HasElectronicCopy);
+    private async Task ExecuteSaveAsync()
+    {
+        if (IsSaving)
+        {
+            return;
+        }
 
-            var response = await _fileOperationsService
-                .SetValidityAsync(_fileId, dto, Version, token)
-                .ConfigureAwait(false);
+        using var cts = new CancellationTokenSource();
+        _saveCancellation = cts;
+        try
+        {
+            await SaveAsync(cts.Token).ConfigureAwait(false);
+        }
+        finally
+        {
+            _saveCancellation = null;
+        }
+    }
 
-            if (!response.IsSuccess)
-            {
-                var message = ExtractErrorMessage(response, "Nepodařilo se uložit platnost dokumentu.");
-                await Dispatcher.Enqueue(() =>
-                {
-                    ErrorMessage = message;
-                    State = FileDetailDialogState.Error;
-                    StatusService.Error(message);
-                });
-                return;
-            }
+    private void ExecuteCancel()
+    {
+        if (IsSaving)
+        {
+            _saveCancellation?.Cancel();
+            return;
+        }
 
-            await Dispatcher.Enqueue(() =>
-            {
-                _originalValidity = candidate;
-                ApplyValidity(dto);
-                IsValidityDirty = false;
-                HasPersistedChanges = true;
-                Version += 1;
-                ErrorMessage = null;
-                State = FileDetailDialogState.Loaded;
-                StatusService.Info("Platnost dokumentu byla uložena.");
-                ChangesSaved?.Invoke(this, EventArgs.Empty);
-            });
-        }, "Ukládám platnost…");
+        CloseRequested?.Invoke(this, new DialogResult(DialogOutcome.Close));
+    }
+
+    private void Attach(FileDetailDto detail)
+    {
+        _snapshot = detail;
+        if (File is { } current)
+        {
+            current.PropertyChanged -= OnFilePropertyChanged;
+            current.ErrorsChanged -= OnFileErrorsChanged;
+        }
+
+        var model = EditableFileDetailModel.FromDto(detail);
+        model.PropertyChanged += OnFilePropertyChanged;
+        model.ErrorsChanged += OnFileErrorsChanged;
+        File = model;
+        ClearValidityCommand.NotifyCanExecuteChanged();
+    }
+
+    private async Task HandleConcurrencyAsync(CancellationToken cancellationToken)
+    {
+        if (_snapshot is null)
+        {
+            return;
+        }
+
+        var textBlock = new TextBlock
+        {
+            Text = "Dokument byl mezitím upraven jiným uživatelem. Chcete znovu načíst aktuální data?",
+            TextWrapping = TextWrapping.Wrap,
+            MaxWidth = 420,
+        };
+
+        var request = new DialogRequest(
+            "Konflikt při ukládání",
+            textBlock,
+            "Znovu načíst",
+            secondaryButtonText: "Zavřít",
+            defaultButton: ContentDialogButton.Primary);
+
+        var result = await _dialogService.ShowDialogAsync(request, cancellationToken).ConfigureAwait(false);
+        if (result.IsPrimary)
+        {
+            await LoadAsync(_snapshot.Id, cancellationToken).ConfigureAwait(false);
+        }
+        else if (result.IsSecondary)
+        {
+            CloseRequested?.Invoke(this, new DialogResult(DialogOutcome.Close));
+        }
+    }
+
+    private void OnFilePropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName is nameof(EditableFileDetailModel.HasValidity))
+        {
+            OnPropertyChanged(nameof(HasErrors));
+        }
+
+        SaveCommand.NotifyCanExecuteChanged();
+        ClearValidityCommand.NotifyCanExecuteChanged();
+    }
+
+    private void OnFileErrorsChanged(object? sender, DataErrorsChangedEventArgs e)
+    {
+        OnPropertyChanged(nameof(HasErrors));
+        SaveCommand.NotifyCanExecuteChanged();
+        ClearValidityCommand.NotifyCanExecuteChanged();
+    }
+
+    private void ExecuteClearValidity()
+    {
+        if (File is null)
+        {
+            return;
+        }
+
+        File.ValidFrom = null;
+        File.ValidTo = null;
+        File.ValidateAll();
+        OnPropertyChanged(nameof(HasErrors));
+        SaveCommand.NotifyCanExecuteChanged();
+        ClearValidityCommand.NotifyCanExecuteChanged();
     }
 
     private bool CanClearValidity()
-    {
-        return _isInitialized && !IsBusy && (IsValidityDirty || _originalValidity is not null);
-    }
-
-    private async Task ClearValidityAsync()
-    {
-        if (!CanClearValidity())
-        {
-            return;
-        }
-
-        await SafeExecuteAsync(async token =>
-        {
-            State = FileDetailDialogState.Saving;
-            ErrorMessage = null;
-
-            var response = await _fileOperationsService
-                .ClearValidityAsync(_fileId, Version, token)
-                .ConfigureAwait(false);
-
-            if (!response.IsSuccess)
-            {
-                var message = ExtractErrorMessage(response, "Nepodařilo se zrušit platnost dokumentu.");
-                await Dispatcher.Enqueue(() =>
-                {
-                    ErrorMessage = message;
-                    State = FileDetailDialogState.Error;
-                    StatusService.Error(message);
-                });
-                return;
-            }
-
-            await Dispatcher.Enqueue(() =>
-            {
-                _originalValidity = null;
-                ApplyValidity(null);
-                IsValidityDirty = false;
-                HasPersistedChanges = true;
-                Version += 1;
-                ErrorMessage = null;
-                State = FileDetailDialogState.Loaded;
-                StatusService.Info("Platnost dokumentu byla zrušena.");
-                ChangesSaved?.Invoke(this, EventArgs.Empty);
-            });
-        }, "Ruším platnost…");
-    }
-
-    private void ApplyValidity(FileValidityDto? validity)
-    {
-        if (validity is null)
-        {
-            ValidityIssuedDate = null;
-            ValidityIssuedTime = TimeSpan.Zero;
-            ValidityUntilDate = null;
-            ValidityUntilTime = TimeSpan.Zero;
-            ValidityHasPhysicalCopy = false;
-            ValidityHasElectronicCopy = false;
-        }
-        else
-        {
-            var issued = _timeFormattingService.Split(validity.IssuedAt);
-            var until = _timeFormattingService.Split(validity.ValidUntil);
-
-            ValidityIssuedDate = issued.Date;
-            ValidityIssuedTime = issued.TimeOfDay;
-            ValidityUntilDate = until.Date;
-            ValidityUntilTime = until.TimeOfDay;
-            ValidityHasPhysicalCopy = validity.HasPhysicalCopy;
-            ValidityHasElectronicCopy = validity.HasElectronicCopy;
-        }
-
-        OnPropertyChanged(nameof(HasValidity));
-        OnPropertyChanged(nameof(ValiditySummaryText));
-    }
-
-    private void UpdateCommandStates()
-    {
-        _saveMetadataCommand.NotifyCanExecuteChanged();
-        _saveValidityCommand.NotifyCanExecuteChanged();
-        _clearValidityCommand.NotifyCanExecuteChanged();
-    }
-
-    private void UpdateDirtyFlags()
-    {
-        UpdateMetadataDirtyState();
-        UpdateValidityDirtyState();
-    }
-
-    private void UpdateMetadataDirtyState()
-    {
-        if (!_isInitialized)
-        {
-            return;
-        }
-
-        IsMetadataDirty = !CaptureMetadataSnapshot().Equals(_originalMetadata);
-    }
-
-    private void UpdateValidityDirtyState()
-    {
-        if (!_isInitialized)
-        {
-            return;
-        }
-
-        var candidate = BuildValiditySnapshot(validateCompleteness: false);
-        if (_originalValidity is null && candidate is null)
-        {
-            IsValidityDirty = false;
-            return;
-        }
-
-        IsValidityDirty = !Equals(candidate, _originalValidity);
-    }
-
-    private MetadataSnapshot CaptureMetadataSnapshot()
-    {
-        return new MetadataSnapshot(Normalize(Mime), Normalize(Author), IsReadOnly);
-    }
-
-    private FileMetadataPatchDto? BuildMetadataPatch()
-    {
-        var current = CaptureMetadataSnapshot();
-        var original = _originalMetadata;
-
-        if (current.Equals(original))
-        {
-            return null;
-        }
-
-        return new FileMetadataPatchDto
-        {
-            Mime = !string.Equals(current.Mime, original.Mime, StringComparison.OrdinalIgnoreCase) ? current.Mime : null,
-            Author = !string.Equals(current.Author, original.Author, StringComparison.Ordinal) ? current.Author : null,
-            IsReadOnly = current.IsReadOnly != original.IsReadOnly ? current.IsReadOnly : null,
-        };
-    }
-
-    private ValiditySnapshot? BuildValiditySnapshot(bool validateCompleteness)
-    {
-        if (!ValidityIssuedDate.HasValue && !ValidityUntilDate.HasValue)
-        {
-            return null;
-        }
-
-        if (!ValidityIssuedDate.HasValue || !ValidityUntilDate.HasValue)
-        {
-            if (validateCompleteness)
-            {
-                var message = "Vyplňte oba datumy platnosti.";
-                SetErrors(nameof(ValidityIssuedDate), ValidityIssuedDate.HasValue ? Array.Empty<string>() : new[] { message });
-                SetErrors(nameof(ValidityUntilDate), ValidityUntilDate.HasValue ? Array.Empty<string>() : new[] { message });
-                ErrorMessage = message;
-            }
-
-            return null;
-        }
-
-        ClearErrors(nameof(ValidityIssuedDate));
-        ClearErrors(nameof(ValidityUntilDate));
-
-        var issuedUtc = _timeFormattingService.ComposeUtc(ValidityIssuedDate.Value, ValidityIssuedTime);
-        var untilUtc = _timeFormattingService.ComposeUtc(ValidityUntilDate.Value, ValidityUntilTime);
-
-        if (validateCompleteness && untilUtc < issuedUtc)
-        {
-            const string rangeMessage = "Datum konce platnosti musí následovat po začátku platnosti.";
-            SetErrors(nameof(ValidityUntilDate), new[] { rangeMessage });
-            ErrorMessage = rangeMessage;
-            return null;
-        }
-
-        return new ValiditySnapshot(issuedUtc, untilUtc, ValidityHasPhysicalCopy, ValidityHasElectronicCopy);
-    }
-
-    private void ValidateMetadata()
-    {
-        ValidateMime();
-        ValidateAuthor();
-    }
-
-    private void ValidateMime()
-    {
-        var normalized = Normalize(Mime);
-        if (string.IsNullOrEmpty(normalized))
-        {
-            ClearErrors(nameof(Mime));
-            return;
-        }
-
-        if (!MimeRegex.IsMatch(normalized))
-        {
-            SetErrors(nameof(Mime), new[] { "Zadejte platný MIME typ ve formátu typ/podtyp." });
-        }
-        else
-        {
-            ClearErrors(nameof(Mime));
-        }
-    }
-
-    private void ValidateAuthor()
-    {
-        var normalized = Normalize(Author);
-        if (string.IsNullOrEmpty(normalized))
-        {
-            ClearErrors(nameof(Author));
-            return;
-        }
-
-        if (normalized.Length > 200)
-        {
-            SetErrors(nameof(Author), new[] { "Autor může mít maximálně 200 znaků." });
-        }
-        else
-        {
-            ClearErrors(nameof(Author));
-        }
-    }
-
-    private void ValidateValidity()
-    {
-        var snapshot = BuildValiditySnapshot(validateCompleteness: false);
-        if (snapshot is null)
-        {
-            ClearErrors(nameof(ValidityIssuedDate));
-            ClearErrors(nameof(ValidityUntilDate));
-            return;
-        }
-
-        if (snapshot.Value.ValidUntilUtc < snapshot.Value.IssuedUtc)
-        {
-            const string rangeMessage = "Datum konce platnosti musí následovat po začátku platnosti.";
-            SetErrors(nameof(ValidityUntilDate), new[] { rangeMessage });
-        }
-        else
-        {
-            ClearErrors(nameof(ValidityIssuedDate));
-            ClearErrors(nameof(ValidityUntilDate));
-        }
-    }
-
-    private void SetErrors(string propertyName, IEnumerable<string> errors)
-    {
-        var errorList = errors.ToList();
-        if (errorList.Count == 0)
-        {
-            ClearErrors(propertyName);
-            return;
-        }
-
-        _validationErrors[propertyName] = errorList;
-        ErrorsChanged?.Invoke(this, new DataErrorsChangedEventArgs(propertyName));
-        OnPropertyChanged(nameof(HasErrors));
-        UpdateCommandStates();
-    }
-
-    private void ClearErrors(string propertyName)
-    {
-        if (_validationErrors.Remove(propertyName))
-        {
-            ErrorsChanged?.Invoke(this, new DataErrorsChangedEventArgs(propertyName));
-            OnPropertyChanged(nameof(HasErrors));
-            if (_validationErrors.Count == 0 && State != FileDetailDialogState.Error)
-            {
-                ErrorMessage = null;
-            }
-            UpdateCommandStates();
-        }
-    }
-
-    private static string? Normalize(string? value)
-    {
-        if (string.IsNullOrWhiteSpace(value))
-        {
-            return null;
-        }
-
-        return value.Trim();
-    }
-
-    private static string BuildDisplayName(FileSummaryDto summary)
-    {
-        if (string.IsNullOrWhiteSpace(summary.Extension))
-        {
-            return summary.Name;
-        }
-
-        return $"{summary.Name}.{summary.Extension}";
-    }
-
-    private static string ExtractErrorMessage(ApiResponse<Guid> response, string fallback)
-    {
-        if (response.Errors is { Count: > 0 })
-        {
-            var message = response.Errors[0].Message;
-            if (!string.IsNullOrWhiteSpace(message))
-            {
-                return message;
-            }
-        }
-
-        return fallback;
-    }
-
-    private string BuildCopyFlags()
-    {
-        var flags = new[]
-        {
-            ValidityHasPhysicalCopy ? "fyzická kopie" : null,
-            ValidityHasElectronicCopy ? "elektronická kopie" : null,
-        };
-
-        var filtered = flags.Where(static flag => !string.IsNullOrWhiteSpace(flag)).ToArray();
-        return filtered.Length == 0 ? string.Empty : string.Join(", ", filtered);
-    }
-
-    private readonly record struct MetadataSnapshot(string? Mime, string? Author, bool IsReadOnly);
-
-    private readonly record struct ValiditySnapshot(
-        DateTimeOffset IssuedUtc,
-        DateTimeOffset ValidUntilUtc,
-        bool HasPhysicalCopy,
-        bool HasElectronicCopy)
-    {
-        public static ValiditySnapshot From(FileValidityDto dto)
-        {
-            return new ValiditySnapshot(dto.IssuedAt, dto.ValidUntil, dto.HasPhysicalCopy, dto.HasElectronicCopy);
-        }
-    }
+        => File is { ValidFrom: not null } || File is { ValidTo: not null };
 }

--- a/Veriado.WinUI/Views/Files/FileDetailDialog.xaml
+++ b/Veriado.WinUI/Views/Files/FileDetailDialog.xaml
@@ -1,172 +1,175 @@
-<UserControl
+<ContentDialog
     x:Class="Veriado.WinUI.Views.Files.FileDetailDialog"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:controls="using:Microsoft.UI.Xaml.Controls"
+    xmlns:converters="using:Veriado.WinUI.Converters"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:converters="using:Veriado.WinUI.Converters"
-    mc:Ignorable="d">
-    <UserControl.Resources>
+    mc:Ignorable="d"
+    Title="Detail souboru"
+    PrimaryButtonText="Uložit"
+    SecondaryButtonText="Zrušit"
+    DefaultButton="Primary"
+    IsPrimaryButtonEnabled="{x:Bind ViewModel.File != null && !ViewModel.HasErrors && !ViewModel.IsSaving, Mode=OneWay}">
+    <ContentDialog.Resources>
         <converters:SizeToHumanConverter x:Key="SizeToHumanConverter" />
-    </UserControl.Resources>
-    <ScrollViewer VerticalScrollBarVisibility="Auto">
-        <StackPanel Padding="12" Spacing="16">
-            <Grid ColumnSpacing="12" VerticalAlignment="Center">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="*" />
-                    <ColumnDefinition Width="Auto" />
-                </Grid.ColumnDefinitions>
+        <converters:NullableDateTimeOffsetConverter x:Key="NullableDateTimeOffsetConverter" />
+    </ContentDialog.Resources>
+
+    <Grid RowSpacing="16" Width="540">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <Grid Grid.Row="0" ColumnSpacing="12" VerticalAlignment="Center">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+            <StackPanel Orientation="Vertical" Spacing="4">
                 <TextBlock
-                    Grid.Column="0"
-                    Text="{Binding DisplayName}"
+                    Text="{x:Bind ViewModel.File.DisplayName, Mode=OneWay}"
                     FontSize="24"
                     FontWeight="SemiBold"
-                    TextWrapping="WrapWholeWords" />
-                <controls:ProgressRing
-                    x:Name="BusyIndicator"
-                    Grid.Column="1"
-                    Width="28"
-                    Height="28"
-                    IsActive="{Binding IsBusy}" />
-            </Grid>
-
-            <CommandBar
-                x:Name="ActionCommandBar"
-                DefaultLabelPosition="Collapsed"
-                IsDynamicOverflowEnabled="False"
-                IsEnabled="{Binding IsInteractionEnabled}">
-                <CommandBar.PrimaryCommands>
-                    <AppBarButton
-                        x:Name="SaveMetadataButton"
-                        Label="Uložit vlastnosti"
-                        Command="{Binding SaveMetadataCommand}">
-                        <AppBarButton.Icon>
-                            <SymbolIcon Symbol="Save" />
-                        </AppBarButton.Icon>
-                        <AppBarButton.KeyboardAccelerators>
-                            <KeyboardAccelerator Key="S" Modifiers="Control" />
-                        </AppBarButton.KeyboardAccelerators>
-                    </AppBarButton>
-                    <AppBarButton
-                        x:Name="SaveValidityButton"
-                        Label="Uložit platnost"
-                        Command="{Binding SaveValidityCommand}">
-                        <AppBarButton.Icon>
-                            <SymbolIcon Symbol="Save" />
-                        </AppBarButton.Icon>
-                        <AppBarButton.KeyboardAccelerators>
-                            <KeyboardAccelerator Key="S" Modifiers="Control, Shift" />
-                        </AppBarButton.KeyboardAccelerators>
-                    </AppBarButton>
-                </CommandBar.PrimaryCommands>
-                <CommandBar.SecondaryCommands>
-                    <AppBarButton
-                        x:Name="ClearValidityButton"
-                        Label="Zrušit platnost"
-                        Command="{Binding ClearValidityCommand}">
-                        <AppBarButton.Icon>
-                            <SymbolIcon Symbol="Delete" />
-                        </AppBarButton.Icon>
-                        <AppBarButton.KeyboardAccelerators>
-                            <KeyboardAccelerator Key="Delete" Modifiers="Control" />
-                        </AppBarButton.KeyboardAccelerators>
-                    </AppBarButton>
-                </CommandBar.SecondaryCommands>
-            </CommandBar>
-
-            <controls:InfoBar
-                x:Name="ErrorInfoBar"
-                IsClosable="False"
-                IsOpen="{Binding HasError}"
-                Severity="Error"
-                Title="Chyba"
-                Message="{Binding ErrorMessage}" />
-
-            <StackPanel x:Name="SummarySection" Spacing="8">
-                <TextBlock FontWeight="SemiBold" Text="Souhrn" />
-                <TextBlock TextWrapping="Wrap" Text="{Binding Title, TargetNullValue='Bez názvu'}" />
-                <StackPanel Orientation="Horizontal" Spacing="4">
-                    <TextBlock FontWeight="SemiBold" Text="Velikost:" />
-                    <TextBlock Text="{Binding Size, Converter={StaticResource SizeToHumanConverter}}" />
-                </StackPanel>
-                <StackPanel Orientation="Horizontal" Spacing="4">
-                    <TextBlock FontWeight="SemiBold" Text="Vytvořeno:" />
-                    <TextBlock Text="{Binding CreatedLocalText}" />
-                </StackPanel>
-                <StackPanel Orientation="Horizontal" Spacing="4">
-                    <TextBlock FontWeight="SemiBold" Text="Upraveno:" />
-                    <TextBlock Text="{Binding LastModifiedLocalText}" />
-                </StackPanel>
-                <StackPanel Orientation="Horizontal" Spacing="4">
-                    <TextBlock FontWeight="SemiBold" Text="Indexováno:" />
-                    <TextBlock Text="{Binding LastIndexedLocalText}" />
-                </StackPanel>
-                <StackPanel Orientation="Horizontal" Spacing="4">
-                    <TextBlock FontWeight="SemiBold" Text="Verze:" />
-                    <TextBlock Text="{Binding Version}" />
-                </StackPanel>
+                    TextWrapping="Wrap" />
+                <TextBlock Text="{x:Bind ViewModel.File.MimeType, Mode=OneWay}" />
             </StackPanel>
+            <ProgressRing
+                Grid.Column="1"
+                Width="28"
+                Height="28"
+                IsActive="{x:Bind ViewModel.IsSaving || ViewModel.IsLoading, Mode=OneWay}" />
+        </Grid>
 
-            <ContentControl IsEnabled="{Binding IsInteractionEnabled}">
-                <StackPanel x:Name="MetadataSection" Spacing="12">
-                    <TextBlock FontWeight="SemiBold" Text="Základní vlastnosti" />
+        <ScrollViewer Grid.Row="1" VerticalScrollMode="Auto" VerticalScrollBarVisibility="Auto">
+            <StackPanel Spacing="20">
+                <StackPanel Spacing="8">
+                    <TextBlock Text="Souhrn" FontWeight="SemiBold" />
+                    <StackPanel Orientation="Horizontal" Spacing="4">
+                        <TextBlock Text="Velikost:" FontWeight="SemiBold" />
+                        <TextBlock Text="{x:Bind ViewModel.File.Size, Mode=OneWay, Converter={StaticResource SizeToHumanConverter}}" />
+                    </StackPanel>
+                    <StackPanel Orientation="Horizontal" Spacing="4">
+                        <TextBlock Text="Vytvořeno:" FontWeight="SemiBold" />
+                        <TextBlock Text="{x:Bind ViewModel.File.CreatedAt, Mode=OneWay}" />
+                    </StackPanel>
+                    <StackPanel Orientation="Horizontal" Spacing="4">
+                        <TextBlock Text="Upraveno:" FontWeight="SemiBold" />
+                        <TextBlock Text="{x:Bind ViewModel.File.ModifiedAt, Mode=OneWay}" />
+                    </StackPanel>
+                    <StackPanel Orientation="Horizontal" Spacing="4">
+                        <TextBlock Text="Verze:" FontWeight="SemiBold" />
+                        <TextBlock Text="{x:Bind ViewModel.File.Version, Mode=OneWay}" />
+                    </StackPanel>
+                </StackPanel>
+
+                <StackPanel Spacing="12">
+                    <TextBlock Text="Metadata" FontWeight="SemiBold" />
                     <TextBox
-                        x:Name="MimeTextBox"
+                        Header="Název souboru"
+                        Text="{x:Bind ViewModel.File.FileName, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                        IsEnabled="{x:Bind !ViewModel.IsSaving && !ViewModel.IsLoading, Mode=OneWay}" />
+                    <ItemsControl ItemsSource="{x:Bind ViewModel.GetErrors(nameof(ViewModel.File.FileName)), Mode=OneWay}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate x:DataType="x:String">
+                                <TextBlock
+                                    Foreground="{ThemeResource SystemFillColorCriticalBrush}"
+                                    FontSize="12"
+                                    Text="{x:Bind}" />
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+
+                    <TextBox
                         Header="MIME"
-                        Text="{Binding Mime, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-                    <TextBox
-                        x:Name="AuthorTextBox"
-                        Header="Autor"
-                        Text="{Binding Author, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-                    <ToggleSwitch
-                        x:Name="ReadOnlyToggle"
-                        Header="Pouze pro čtení"
-                        IsOn="{Binding IsReadOnly, Mode=TwoWay}" />
-                </StackPanel>
-            </ContentControl>
+                        Text="{x:Bind ViewModel.File.MimeType, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                        IsEnabled="{x:Bind !ViewModel.IsSaving && !ViewModel.IsLoading, Mode=OneWay}" />
+                    <ItemsControl ItemsSource="{x:Bind ViewModel.GetErrors(nameof(ViewModel.File.MimeType)), Mode=OneWay}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate x:DataType="x:String">
+                                <TextBlock
+                                    Foreground="{ThemeResource SystemFillColorCriticalBrush}"
+                                    FontSize="12"
+                                    Text="{x:Bind}" />
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
 
-            <ContentControl IsEnabled="{Binding IsInteractionEnabled}">
-                <StackPanel x:Name="ValiditySection" Spacing="12">
-                    <TextBlock FontWeight="SemiBold" Text="Platnost" />
-                    <TextBlock Text="{Binding ValiditySummaryText}" TextWrapping="Wrap" />
-                    <Grid ColumnSpacing="12">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="*" />
-                        <ColumnDefinition Width="*" />
-                    </Grid.ColumnDefinitions>
-                    <StackPanel Grid.Column="0" Spacing="4">
-                        <TextBlock Text="Platí od" />
-                        <controls:DatePicker
-                            x:Name="ValidityFromDatePicker"
-                            Date="{Binding ValidityIssuedDate, Mode=TwoWay}" />
-                        <controls:TimePicker
-                            x:Name="ValidityFromTimePicker"
-                            Time="{Binding ValidityIssuedTime, Mode=TwoWay}"
-                            ClockIdentifier="24HourClock" />
-                    </StackPanel>
-                    <StackPanel Grid.Column="1" Spacing="4">
-                        <TextBlock Text="Platí do" />
-                        <controls:DatePicker
-                            x:Name="ValidityToDatePicker"
-                            Date="{Binding ValidityUntilDate, Mode=TwoWay}" />
-                        <controls:TimePicker
-                            x:Name="ValidityToTimePicker"
-                            Time="{Binding ValidityUntilTime, Mode=TwoWay}"
-                            ClockIdentifier="24HourClock" />
-                    </StackPanel>
-                </Grid>
-                <StackPanel Orientation="Horizontal" Spacing="12">
-                    <CheckBox
-                        x:Name="PhysicalCopyCheckBox"
-                        Content="Fyzická kopie"
-                        IsChecked="{Binding ValidityHasPhysicalCopy, Mode=TwoWay}" />
-                    <CheckBox
-                        x:Name="ElectronicCopyCheckBox"
-                        Content="Elektronická kopie"
-                        IsChecked="{Binding ValidityHasElectronicCopy, Mode=TwoWay}" />
+                    <TextBox
+                        Header="Autor"
+                        Text="{x:Bind ViewModel.File.Author, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                        IsEnabled="{x:Bind !ViewModel.IsSaving && !ViewModel.IsLoading, Mode=OneWay}" />
+                    <ItemsControl ItemsSource="{x:Bind ViewModel.GetErrors(nameof(ViewModel.File.Author)), Mode=OneWay}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate x:DataType="x:String">
+                                <TextBlock
+                                    Foreground="{ThemeResource SystemFillColorCriticalBrush}"
+                                    FontSize="12"
+                                    Text="{x:Bind}" />
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+
+                    <ToggleSwitch
+                        Header="Pouze pro čtení"
+                        IsOn="{x:Bind ViewModel.File.IsReadOnly, Mode=TwoWay}"
+                        IsEnabled="{x:Bind !ViewModel.IsSaving && !ViewModel.IsLoading, Mode=OneWay}" />
                 </StackPanel>
+
+                <StackPanel Spacing="12">
+                    <TextBlock Text="Platnost" FontWeight="SemiBold" />
+                    <Button
+                        Content="Zrušit platnost"
+                        Command="{x:Bind ViewModel.ClearValidityCommand, Mode=OneWay}"
+                        IsEnabled="{x:Bind ViewModel.ClearValidityCommand.CanExecute(null), Mode=OneWay}" />
+                    <Grid ColumnSpacing="12">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+                        <StackPanel Grid.Column="0" Spacing="4">
+                            <TextBlock Text="Platí od" />
+                            <DatePicker
+                                Date="{x:Bind ViewModel.File.ValidFrom, Mode=TwoWay, Converter={StaticResource NullableDateTimeOffsetConverter}, UpdateSourceTrigger=PropertyChanged}"
+                                IsEnabled="{x:Bind !ViewModel.IsSaving && !ViewModel.IsLoading, Mode=OneWay}" />
+                            <ItemsControl ItemsSource="{x:Bind ViewModel.GetErrors(nameof(ViewModel.File.ValidFrom)), Mode=OneWay}">
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate x:DataType="x:String">
+                                        <TextBlock
+                                            Foreground="{ThemeResource SystemFillColorCriticalBrush}"
+                                            FontSize="12"
+                                            Text="{x:Bind}" />
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+                        </StackPanel>
+                        <StackPanel Grid.Column="1" Spacing="4">
+                            <TextBlock Text="Platí do" />
+                            <DatePicker
+                                Date="{x:Bind ViewModel.File.ValidTo, Mode=TwoWay, Converter={StaticResource NullableDateTimeOffsetConverter}, UpdateSourceTrigger=PropertyChanged}"
+                                IsEnabled="{x:Bind !ViewModel.IsSaving && !ViewModel.IsLoading, Mode=OneWay}" />
+                            <ItemsControl ItemsSource="{x:Bind ViewModel.GetErrors(nameof(ViewModel.File.ValidTo)), Mode=OneWay}">
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate x:DataType="x:String">
+                                        <TextBlock
+                                            Foreground="{ThemeResource SystemFillColorCriticalBrush}"
+                                            FontSize="12"
+                                            Text="{x:Bind}" />
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+                        </StackPanel>
+                    </Grid>
+                </StackPanel>
+
+                <InfoBar
+                    IsClosable="False"
+                    IsOpen="{x:Bind ViewModel.ErrorMessage != null, Mode=OneWay}"
+                    Severity="Error"
+                    Title="Chyba"
+                    Message="{x:Bind ViewModel.ErrorMessage, Mode=OneWay}" />
             </StackPanel>
-        </StackPanel>
-    </ScrollViewer>
-</UserControl>
+        </ScrollViewer>
+    </Grid>
+</ContentDialog>

--- a/Veriado.WinUI/Views/Files/FileDetailDialog.xaml.cs
+++ b/Veriado.WinUI/Views/Files/FileDetailDialog.xaml.cs
@@ -1,193 +1,38 @@
-using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Linq;
-using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml.Media;
 using Veriado.WinUI.ViewModels.Files;
-using Windows.UI;
 
 namespace Veriado.WinUI.Views.Files;
 
-public sealed partial class FileDetailDialog : UserControl
+public sealed partial class FileDetailDialog : ContentDialog
 {
-    private FileDetailDialogViewModel? _viewModel;
-    private Brush? _errorBrush;
-
     public FileDetailDialog()
     {
         InitializeComponent();
-        Loaded += OnLoaded;
-        Unloaded += OnUnloaded;
-        DataContextChanged += OnDataContextChanged;
+        PrimaryButtonClick += OnPrimaryButtonClick;
+        SecondaryButtonClick += OnSecondaryButtonClick;
     }
 
-    private void OnLoaded(object sender, RoutedEventArgs e)
-    {
-        AttachViewModel(DataContext as FileDetailDialogViewModel);
-    }
+    public FileDetailDialogViewModel? ViewModel => DataContext as FileDetailDialogViewModel;
 
-    private void OnUnloaded(object sender, RoutedEventArgs e)
+    private async void OnPrimaryButtonClick(ContentDialog sender, ContentDialogButtonClickEventArgs args)
     {
-        AttachViewModel(null);
-    }
-
-    private void OnDataContextChanged(FrameworkElement sender, DataContextChangedEventArgs args)
-    {
-        AttachViewModel(args.NewValue as FileDetailDialogViewModel);
-    }
-
-    private void OnViewModelErrorsChanged(object? sender, DataErrorsChangedEventArgs e)
-    {
-        if (_viewModel is null)
+        if (ViewModel is null)
         {
             return;
         }
 
-        if (string.IsNullOrEmpty(e.PropertyName))
-        {
-            UpdateAllValidationStates();
-        }
-        else
-        {
-            UpdateValidationState(e.PropertyName);
-        }
+        args.Cancel = true;
+        await ViewModel.SaveCommand.ExecuteAsync(null);
     }
 
-    private void AttachViewModel(FileDetailDialogViewModel? viewModel)
+    private void OnSecondaryButtonClick(ContentDialog sender, ContentDialogButtonClickEventArgs args)
     {
-        if (ReferenceEquals(_viewModel, viewModel))
+        if (ViewModel is null)
         {
             return;
         }
 
-        if (_viewModel is not null)
-        {
-            _viewModel.ErrorsChanged -= OnViewModelErrorsChanged;
-        }
-
-        _viewModel = viewModel;
-
-        if (_viewModel is not null)
-        {
-            _viewModel.ErrorsChanged += OnViewModelErrorsChanged;
-            UpdateAllValidationStates();
-        }
-        else
-        {
-            ClearAllValidationStates();
-        }
-    }
-
-    private void UpdateAllValidationStates()
-    {
-        UpdateValidationState(nameof(FileDetailDialogViewModel.Mime));
-        UpdateValidationState(nameof(FileDetailDialogViewModel.Author));
-        UpdateValidationState(nameof(FileDetailDialogViewModel.ValidityIssuedDate));
-        UpdateValidationState(nameof(FileDetailDialogViewModel.ValidityUntilDate));
-    }
-
-    private void UpdateValidationState(string propertyName)
-    {
-        if (_viewModel is null)
-        {
-            return;
-        }
-
-        var errors = _viewModel
-            .GetErrors(propertyName)
-            .OfType<string>()
-            .Where(static error => !string.IsNullOrWhiteSpace(error))
-            .ToList();
-
-        switch (propertyName)
-        {
-            case nameof(FileDetailDialogViewModel.Mime):
-                ApplyErrors(MimeTextBox, errors);
-                break;
-            case nameof(FileDetailDialogViewModel.Author):
-                ApplyErrors(AuthorTextBox, errors);
-                break;
-            case nameof(FileDetailDialogViewModel.ValidityIssuedDate):
-                ApplyErrors(ValidityFromDatePicker, errors);
-                break;
-            case nameof(FileDetailDialogViewModel.ValidityUntilDate):
-                ApplyErrors(ValidityToDatePicker, errors);
-                break;
-        }
-    }
-
-    private void ClearAllValidationStates()
-    {
-        ApplyErrors(MimeTextBox, Array.Empty<string>());
-        ApplyErrors(AuthorTextBox, Array.Empty<string>());
-        ApplyErrors(ValidityFromDatePicker, Array.Empty<string>());
-        ApplyErrors(ValidityToDatePicker, Array.Empty<string>());
-    }
-
-    private void ApplyErrors(Control? control, IReadOnlyCollection<string> errors)
-    {
-        if (control is null)
-        {
-            return;
-        }
-
-        if (errors.Count == 0)
-        {
-            ToolTipService.SetToolTip(control, null);
-            ClearErrorStyling(control);
-            return;
-        }
-
-        var message = string.Join(Environment.NewLine, errors);
-        ToolTipService.SetToolTip(control, message);
-        ApplyErrorStyling(control);
-    }
-
-    private void ApplyErrorStyling(Control control)
-    {
-        var brush = GetErrorBrush();
-        switch (control)
-        {
-            case TextBox textBox:
-                textBox.BorderBrush = brush;
-                break;
-            case DatePicker datePicker:
-                datePicker.BorderBrush = brush;
-                break;
-        }
-    }
-
-    private static void ClearErrorStyling(Control control)
-    {
-        switch (control)
-        {
-            case TextBox textBox:
-                textBox.ClearValue(TextBox.BorderBrushProperty);
-                break;
-            case DatePicker datePicker:
-                datePicker.ClearValue(DatePicker.BorderBrushProperty);
-                break;
-        }
-    }
-
-    private Brush GetErrorBrush()
-    {
-        if (_errorBrush is not null)
-        {
-            return _errorBrush;
-        }
-
-        if (Application.Current?.Resources.TryGetValue("SystemFillColorCriticalBrush", out var resource) == true && resource is Brush brush)
-        {
-            _errorBrush = brush;
-        }
-        else
-        {
-            _errorBrush = new SolidColorBrush(Colors.Red);
-        }
-
-        return _errorBrush;
+        args.Cancel = true;
+        ViewModel.CancelCommand.Execute(null);
     }
 }


### PR DESCRIPTION
## Summary
- rebuild the file detail experience around a new `FileDetailDialogViewModel` resolved through `IDialogService`, refreshing the file list after successful edits
- introduce an `EditableFileDetailModel`, new ContentDialog UI with inline validation, and nullable date conversion helpers for validity editing
- add an application-level `IFileService`, supporting exceptions, and extend the dialog infrastructure with typed factories for MVVM-friendly ContentDialogs

## Testing
- ⚠️ `dotnet build Veriado.sln` *(dotnet is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_69010bb1368c8326b112183e41c5a666