### PR TITLE
Handle OperationCanceledException when cancelling file save

### DIFF
--- a/Veriado.WinUI/Views/Files/FileDetailDialog.xaml.cs
+++ b/Veriado.WinUI/Views/Files/FileDetailDialog.xaml.cs
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.UI.Xaml.Controls;
 using Veriado.WinUI.ViewModels.Files;
 
@@ -22,7 +23,15 @@ public sealed partial class FileDetailDialog : ContentDialog
         }
 
         args.Cancel = true;
-        await ViewModel.SaveCommand.ExecuteAsync(null);
+
+        try
+        {
+            await ViewModel.SaveCommand.ExecuteAsync(null);
+        }
+        catch (OperationCanceledException)
+        {
+            // No-op: cancellation keeps the dialog open without crashing the app.
+        }
     }
 
     private void OnSecondaryButtonClick(ContentDialog sender, ContentDialogButtonClickEventArgs args)


### PR DESCRIPTION
## Summary
- rebuild the file detail experience around a new `FileDetailDialogViewModel` resolved through `IDialogService`, refreshing the file list after successful edits
- introduce an `EditableFileDetailModel`, new ContentDialog UI with inline validation, and nullable date conversion helpers for validity editing
- add an application-level `IFileService`, supporting exceptions, and extend the dialog infrastructure with typed factories for MVVM-friendly ContentDialogs
- wrap the save execution in `FileDetailDialog` in a try/catch so cancelling a save does not surface an `OperationCanceledException`

## Testing
- ⚠️ `dotnet build Veriado.sln` *(dotnet is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_69011b8008d48326923438174a503ead