### PR TITLE
Rename editable file detail DTO to avoid namespace conflicts

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Veriado je desktopová aplikace pro katalogizaci dokumentů s plnotextovým vyhl
 - `FileDetailDialog.xaml` definuje `ContentDialog` s `x:Bind` vazbami, inline výpisem chyb, převodníkem pro datum platnosti a blokem souhrnných metadat.【F:Veriado.WinUI/Views/Files/FileDetailDialog.xaml†L1-L138】
 - `DialogService` rozpozná dialogové viewmodely (`IDialogAware`), přiřadí odpovídající view přes `IDialogViewFactory` a řídí jejich životní cyklus včetně asynchronního zavření.【F:Veriado.WinUI/Services/DialogService.cs†L1-L141】
 - Aplikační `FileService` sjednocuje načtení detailu, přejmenování, update metadat i platnosti a převádí chybové stavy na doménově smysluplné výjimky pro UI.【F:Veriado.Services/Files/FileService.cs†L1-L188】
-- `FileDetailDto` v aplikační vrstvě poskytuje konzistentní přenosový objekt pro detail a editaci dokumentu, včetně verzí a platnosti.【F:Veriado.Application/Files/Contracts/FileDetailDto.cs†L1-L33】
+- `EditableFileDetailDto` v aplikační vrstvě poskytuje konzistentní přenosový objekt pro detail a editaci dokumentu, včetně verzí a platnosti.【F:Veriado.Application/Files/Contracts/EditableFileDetailDto.cs†L1-L33】
 - `IDialogViewFactory` + `FileDetailDialogFactory` umožňují DI konstruovat ContentDialogy s odpovídajícími viewmodely bez service-locator patternu.【F:Veriado.WinUI/Services/Abstractions/IDialogViewFactory.cs†L1-L12】【F:Veriado.WinUI/Services/DialogFactories/FileDetailDialogFactory.cs†L1-L25】
 
 ## Požadavky

--- a/Veriado.Application/Files/Contracts/EditableFileDetailDto.cs
+++ b/Veriado.Application/Files/Contracts/EditableFileDetailDto.cs
@@ -1,9 +1,9 @@
-namespace Veriado.Application.Files.Contracts;
+namespace Veriado.Appl.Files.Contracts;
 
 /// <summary>
 /// Represents an editable snapshot of a file aggregate exposed to the presentation layer.
 /// </summary>
-public sealed class FileDetailDto
+public sealed class EditableFileDetailDto
 {
     public Guid Id { get; init; }
 

--- a/Veriado.Application/Files/IFileService.cs
+++ b/Veriado.Application/Files/IFileService.cs
@@ -1,13 +1,13 @@
-using Veriado.Application.Files.Contracts;
+using Veriado.Appl.Files.Contracts;
 
-namespace Veriado.Application.Files;
+namespace Veriado.Appl.Files;
 
 /// <summary>
 /// Exposes application-level operations for working with editable file details.
 /// </summary>
 public interface IFileService
 {
-    Task<FileDetailDto> GetDetailAsync(Guid id, CancellationToken cancellationToken);
+    Task<EditableFileDetailDto> GetDetailAsync(Guid id, CancellationToken cancellationToken);
 
-    Task UpdateAsync(FileDetailDto detail, CancellationToken cancellationToken);
+    Task UpdateAsync(EditableFileDetailDto detail, CancellationToken cancellationToken);
 }

--- a/Veriado.Services/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/Veriado.Services/DependencyInjection/ServiceCollectionExtensions.cs
@@ -1,6 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using Veriado.Appl.DependencyInjection;
-using Veriado.Application.Files;
+using Veriado.Appl.Files;
 using Veriado.Contracts.Search.Abstractions;
 using Veriado.Services.Diagnostics;
 using Veriado.Services.Files;

--- a/Veriado.Services/Files/FileService.cs
+++ b/Veriado.Services/Files/FileService.cs
@@ -1,7 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
-using Veriado.Application.Files;
-using Veriado.Application.Files.Contracts;
+using Veriado.Appl.Files;
+using Veriado.Appl.Files.Contracts;
 using Veriado.Contracts.Common;
 using Veriado.Contracts.Files;
 using Veriado.Services.Files.Exceptions;
@@ -22,7 +22,7 @@ public sealed class FileService : IFileService
         _fileOperationsService = fileOperationsService ?? throw new ArgumentNullException(nameof(fileOperationsService));
     }
 
-    public async Task<FileDetailDto> GetDetailAsync(Guid id, CancellationToken cancellationToken)
+    public async Task<EditableFileDetailDto> GetDetailAsync(Guid id, CancellationToken cancellationToken)
     {
         var detail = await _fileQueryService.GetDetailAsync(id, cancellationToken).ConfigureAwait(false);
         if (detail is null)
@@ -33,7 +33,7 @@ public sealed class FileService : IFileService
         return Map(detail);
     }
 
-    public async Task UpdateAsync(FileDetailDto detail, CancellationToken cancellationToken)
+    public async Task UpdateAsync(EditableFileDetailDto detail, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(detail);
 
@@ -68,9 +68,9 @@ public sealed class FileService : IFileService
         await UpdateValidityAsync(current, detail, cancellationToken).ConfigureAwait(false);
     }
 
-    private static FileDetailDto Map(Veriado.Contracts.Files.FileDetailDto detail)
+    private static EditableFileDetailDto Map(Veriado.Contracts.Files.FileDetailDto detail)
     {
-        return new FileDetailDto
+        return new EditableFileDetailDto
         {
             Id = detail.Id,
             FileName = detail.Name,
@@ -87,7 +87,7 @@ public sealed class FileService : IFileService
         };
     }
 
-    private static FileMetadataPatchDto? BuildMetadataPatch(Veriado.Contracts.Files.FileDetailDto current, FileDetailDto desired)
+    private static FileMetadataPatchDto? BuildMetadataPatch(Veriado.Contracts.Files.FileDetailDto current, EditableFileDetailDto desired)
     {
         string? mimePatch = null;
         string? authorPatch = null;
@@ -121,7 +121,7 @@ public sealed class FileService : IFileService
         };
     }
 
-    private async Task UpdateValidityAsync(Veriado.Contracts.Files.FileDetailDto current, FileDetailDto desired, CancellationToken cancellationToken)
+    private async Task UpdateValidityAsync(Veriado.Contracts.Files.FileDetailDto current, EditableFileDetailDto desired, CancellationToken cancellationToken)
     {
         var currentValidity = current.Validity;
         var desiredRange = (ValidFrom: desired.ValidFrom, ValidTo: desired.ValidTo);

--- a/Veriado.WinUI/ViewModels/Files/EditableFileDetailModel.cs
+++ b/Veriado.WinUI/ViewModels/Files/EditableFileDetailModel.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using CommunityToolkit.Mvvm.ComponentModel;
-using Veriado.Application.Files.Contracts;
+using Veriado.Appl.Files.Contracts;
 
 namespace Veriado.WinUI.ViewModels.Files;
 
@@ -21,7 +21,7 @@ public sealed partial class EditableFileDetailModel : ObservableValidator
         string.Empty,
     };
 
-    private FileDetailDto _snapshot = null!;
+    private EditableFileDetailDto _snapshot = null!;
 
     private EditableFileDetailModel()
     {
@@ -78,7 +78,7 @@ public sealed partial class EditableFileDetailModel : ObservableValidator
             || !Nullable.Equals(ValidFrom, _snapshot.ValidFrom)
             || !Nullable.Equals(ValidTo, _snapshot.ValidTo);
 
-    public static EditableFileDetailModel FromDto(FileDetailDto detail)
+    public static EditableFileDetailModel FromDto(EditableFileDetailDto detail)
     {
         ArgumentNullException.ThrowIfNull(detail);
 
@@ -103,9 +103,9 @@ public sealed partial class EditableFileDetailModel : ObservableValidator
         return model;
     }
 
-    public FileDetailDto ToDto()
+    public EditableFileDetailDto ToDto()
     {
-        return new FileDetailDto
+        return new EditableFileDetailDto
         {
             Id = Id,
             FileName = FileName,
@@ -122,7 +122,7 @@ public sealed partial class EditableFileDetailModel : ObservableValidator
         };
     }
 
-    public void UpdateSnapshot(FileDetailDto detail)
+    public void UpdateSnapshot(EditableFileDetailDto detail)
     {
         ArgumentNullException.ThrowIfNull(detail);
         _snapshot = detail;

--- a/Veriado.WinUI/ViewModels/Files/FileDetailDialogViewModel.cs
+++ b/Veriado.WinUI/ViewModels/Files/FileDetailDialogViewModel.cs
@@ -6,12 +6,12 @@ using System.Threading;
 using Microsoft.UI.Xaml.Controls;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
-using Veriado.Application.Files;
+using Veriado.Appl.Files;
+using Veriado.Appl.Files.Contracts;
 using Veriado.Services.Files.Exceptions;
 using Veriado.WinUI.Services.Abstractions;
 using Veriado.WinUI.ViewModels.Base;
 
-using FileDetailDto = Veriado.Application.Files.Contracts.FileDetailDto;
 
 namespace Veriado.WinUI.ViewModels.Files;
 
@@ -23,7 +23,7 @@ public sealed partial class FileDetailDialogViewModel : ObservableObject, IDialo
     private readonly IFileService _fileService;
     private readonly IDialogService _dialogService;
     private EditableFileDetailModel _file = CreatePlaceholderModel();
-    private FileDetailDto? _snapshot;
+    private EditableFileDetailDto? _snapshot;
     private CancellationTokenSource? _saveCancellation;
     private bool _isLoading;
     private bool _isSaving;
@@ -245,7 +245,7 @@ public sealed partial class FileDetailDialogViewModel : ObservableObject, IDialo
         CloseRequested?.Invoke(this, new DialogResult(DialogOutcome.Close));
     }
 
-    private void Attach(FileDetailDto detail)
+    private void Attach(EditableFileDetailDto detail)
     {
         _snapshot = detail;
         File = EditableFileDetailModel.FromDto(detail);
@@ -327,7 +327,7 @@ public sealed partial class FileDetailDialogViewModel : ObservableObject, IDialo
     }
     private static EditableFileDetailModel CreatePlaceholderModel()
     {
-        return EditableFileDetailModel.FromDto(new FileDetailDto
+        return EditableFileDetailModel.FromDto(new EditableFileDetailDto
         {
             Id = Guid.Empty,
             FileName = string.Empty,


### PR DESCRIPTION
## Summary
- rename the application-layer editable file detail DTO to avoid collisions with the contracts DTO
- update application, services, and WinUI layers to consume `EditableFileDetailDto` from the new `Veriado.Appl.Files` namespace
- refresh dependency registration and documentation references to match the renamed DTO

## Testing
- Not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_6902466b673c83268e84be85e093cff1