### PR TITLE
Fix dialog request arguments and validation helpers

### DIFF
--- a/Veriado.WinUI/ViewModels/Files/EditableFileDetailModel.cs
+++ b/Veriado.WinUI/ViewModels/Files/EditableFileDetailModel.cs
@@ -137,7 +137,7 @@ public sealed partial class EditableFileDetailModel : ObservableValidator
 
         foreach (var pair in errors)
         {
-            SetErrors(pair.Key ?? string.Empty, pair.Value);
+            SetValidationErrors(pair.Key ?? string.Empty, pair.Value);
         }
     }
 
@@ -145,7 +145,7 @@ public sealed partial class EditableFileDetailModel : ObservableValidator
     {
         foreach (var member in ValidatedMembers)
         {
-            SetErrors(member, Array.Empty<string>());
+            SetValidationErrors(member, Array.Empty<string>());
         }
     }
 
@@ -184,26 +184,31 @@ public sealed partial class EditableFileDetailModel : ObservableValidator
     {
         if (ValidFrom is null && ValidTo is null)
         {
-            SetErrors(nameof(ValidFrom), Array.Empty<string>());
-            SetErrors(nameof(ValidTo), Array.Empty<string>());
+            SetValidationErrors(nameof(ValidFrom), Array.Empty<string>());
+            SetValidationErrors(nameof(ValidTo), Array.Empty<string>());
             return;
         }
 
         if (ValidFrom is null || ValidTo is null)
         {
-            SetErrors(nameof(ValidFrom), ValidFrom is null ? new[] { "Datum začátku platnosti je povinné." } : Array.Empty<string>());
-            SetErrors(nameof(ValidTo), ValidTo is null ? new[] { "Datum ukončení platnosti je povinné." } : Array.Empty<string>());
+            SetValidationErrors(nameof(ValidFrom), ValidFrom is null ? new[] { "Datum začátku platnosti je povinné." } : Array.Empty<string>());
+            SetValidationErrors(nameof(ValidTo), ValidTo is null ? new[] { "Datum ukončení platnosti je povinné." } : Array.Empty<string>());
             return;
         }
 
         if (ValidFrom > ValidTo)
         {
-            SetErrors(nameof(ValidFrom), new[] { "Začátek platnosti musí být dříve než konec." });
-            SetErrors(nameof(ValidTo), new[] { "Konec platnosti musí být po začátku." });
+            SetValidationErrors(nameof(ValidFrom), new[] { "Začátek platnosti musí být dříve než konec." });
+            SetValidationErrors(nameof(ValidTo), new[] { "Konec platnosti musí být po začátku." });
             return;
         }
 
-        SetErrors(nameof(ValidFrom), Array.Empty<string>());
-        SetErrors(nameof(ValidTo), Array.Empty<string>());
+        SetValidationErrors(nameof(ValidFrom), Array.Empty<string>());
+        SetValidationErrors(nameof(ValidTo), Array.Empty<string>());
+    }
+
+    private void SetValidationErrors(string propertyName, IEnumerable<string> errors)
+    {
+        base.SetErrors(propertyName, errors);
     }
 }

--- a/Veriado.WinUI/ViewModels/Files/FileDetailDialogViewModel.cs
+++ b/Veriado.WinUI/ViewModels/Files/FileDetailDialogViewModel.cs
@@ -269,8 +269,8 @@ public sealed partial class FileDetailDialogViewModel : ObservableObject, IDialo
             "Konflikt při ukládání",
             textBlock,
             "Znovu načíst",
-            secondaryButtonText: "Zavřít",
-            defaultButton: ContentDialogButton.Primary);
+            SecondaryButtonText: "Zavřít",
+            DefaultButton: ContentDialogButton.Primary);
 
         var result = await _dialogService.ShowDialogAsync(request, cancellationToken).ConfigureAwait(false);
         if (result.IsPrimary)


### PR DESCRIPTION
## Summary
- use the correct named parameters when constructing the conflict dialog request
- wrap ObservableValidator.SetErrors usage in a helper so validation errors compile again

## Testing
- not run (environment limitation)


------
https://chatgpt.com/codex/tasks/task_e_69024933cd00832682a54f290d85c0c0