### PR TITLE
Fix manual validation event usage

### DIFF
--- a/Veriado.WinUI/ViewModels/Files/EditableFileDetailModel.cs
+++ b/Veriado.WinUI/ViewModels/Files/EditableFileDetailModel.cs
@@ -12,7 +12,7 @@ namespace Veriado.WinUI.ViewModels.Files;
 /// <summary>
 /// Represents an editable snapshot of a file detail with validation support for the dialog.
 /// </summary>
-public sealed partial class EditableFileDetailModel : ObservableValidator
+public sealed partial class EditableFileDetailModel : ObservableValidator, INotifyDataErrorInfo
 {
     private EditableFileDetailDto _snapshot = null!;
     private readonly Dictionary<string, string[]> _externalErrors = new(StringComparer.Ordinal);
@@ -270,7 +270,7 @@ public sealed partial class EditableFileDetailModel : ObservableValidator
 
     private void RaiseManualErrorsChanged(string propertyName, bool hadManualErrors)
     {
-        ErrorsChanged?.Invoke(this, new DataErrorsChangedEventArgs(propertyName));
+        OnErrorsChanged(propertyName);
 
         var hasManualErrors = _externalErrors.Count > 0;
 
@@ -292,7 +292,7 @@ public sealed partial class EditableFileDetailModel : ObservableValidator
 
         foreach (var key in keys)
         {
-            ErrorsChanged?.Invoke(this, new DataErrorsChangedEventArgs(key));
+            OnErrorsChanged(key);
         }
 
         OnPropertyChanged(nameof(HasErrors));


### PR DESCRIPTION
## Summary
- implement INotifyDataErrorInfo on EditableFileDetailModel to satisfy explicit members
- raise validation notifications with OnErrorsChanged instead of invoking the event directly

## Testing
- dotnet build (fails: dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_690253be247c832698e392820bcf50b9