### PR TITLE
Ensure manual error notifications propagate in editable file detail model

### DIFF
--- a/Veriado.WinUI/ViewModels/Files/EditableFileDetailModel.cs
+++ b/Veriado.WinUI/ViewModels/Files/EditableFileDetailModel.cs
@@ -16,6 +16,21 @@ public sealed partial class EditableFileDetailModel : ObservableValidator, INoti
 {
     private EditableFileDetailDto _snapshot = null!;
     private readonly Dictionary<string, string[]> _externalErrors = new(StringComparer.Ordinal);
+    private event EventHandler<DataErrorsChangedEventArgs>? _manualErrorsChanged;
+
+    public new event EventHandler<DataErrorsChangedEventArgs>? ErrorsChanged
+    {
+        add
+        {
+            base.ErrorsChanged += value;
+            _manualErrorsChanged += value;
+        }
+        remove
+        {
+            base.ErrorsChanged -= value;
+            _manualErrorsChanged -= value;
+        }
+    }
 
     private EditableFileDetailModel()
     {
@@ -270,7 +285,7 @@ public sealed partial class EditableFileDetailModel : ObservableValidator, INoti
 
     private void RaiseManualErrorsChanged(string propertyName, bool hadManualErrors)
     {
-        OnErrorsChanged(propertyName);
+        _manualErrorsChanged?.Invoke(this, new DataErrorsChangedEventArgs(propertyName));
 
         var hasManualErrors = _externalErrors.Count > 0;
 
@@ -292,7 +307,7 @@ public sealed partial class EditableFileDetailModel : ObservableValidator, INoti
 
         foreach (var key in keys)
         {
-            OnErrorsChanged(key);
+            _manualErrorsChanged?.Invoke(this, new DataErrorsChangedEventArgs(key));
         }
 
         OnPropertyChanged(nameof(HasErrors));


### PR DESCRIPTION
## Summary
- forward subscribers to both the base and manual `ErrorsChanged` notifications
- raise manual validation updates using explicit `DataErrorsChangedEventArgs`

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_690258a646a48326bf84c6880cfefbdf