### PR TITLE
Fix dialog aware scoping

### DIFF
--- a/Veriado.WinUI/Services/DialogService.cs
+++ b/Veriado.WinUI/Services/DialogService.cs
@@ -112,9 +112,11 @@ public sealed class DialogService : IDialogService
             });
         }
 
-        if (viewModel is IDialogAware aware)
+        var dialogAware = viewModel as IDialogAware;
+
+        if (dialogAware is not null)
         {
-            aware.CloseRequested += RequestClose;
+            dialogAware.CloseRequested += RequestClose;
         }
 
         using var registration = cancellationToken.Register(() =>
@@ -148,9 +150,9 @@ public sealed class DialogService : IDialogService
         }
         finally
         {
-            if (viewModel is IDialogAware aware)
+            if (dialogAware is not null)
             {
-                aware.CloseRequested -= RequestClose;
+                dialogAware.CloseRequested -= RequestClose;
             }
         }
     }


### PR DESCRIPTION
## Summary
- reuse a single IDialogAware instance to wire dialog close events
- prevent conflicting scoped variable declarations in DialogService

## Testing
- not run (dotnet CLI unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_6902698d97b483268476707d8f63bafe