### PR TITLE
Fix FilesPage detail command parameter binding

### DIFF
--- a/Veriado.WinUI/Views/Files/FilesPage.xaml
+++ b/Veriado.WinUI/Views/Files/FilesPage.xaml
@@ -265,7 +265,7 @@
                                         VerticalAlignment="Center"
                                         Content="Detail"
                                         Command="{Binding DataContext.OpenDetailCommand, ElementName=PageRoot}"
-                                        CommandParameter="{Binding}" />
+                                        CommandParameter="{x:Bind Mode=OneWay}" />
                                 </Grid>
                             </Border>
                         </DataTemplate>


### PR DESCRIPTION
## Summary
- ensure the file detail button passes the selected file to the OpenDetailCommand by using x:Bind for the command parameter

## Testing
- `dotnet build Veriado.sln` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_6904f24703548326b9e519ccba58d0e6