### PR TITLE
Refactor dialog service to use XamlRoot for WinUI dialogs

### DIFF
--- a/Veriado.WinUI/Services/Abstractions/IDialogService.cs
+++ b/Veriado.WinUI/Services/Abstractions/IDialogService.cs
@@ -9,6 +9,8 @@ public interface IDialogService
     Task ShowErrorAsync(string title, string message);
     Task ShowAsync(string title, UIElement content, string primaryButtonText = "OK");
 
+    Task<ContentDialogResult> ShowDialogAsync(ContentDialog dialog, CancellationToken cancellationToken = default);
+
     Task<DialogResult> ShowDialogAsync<TViewModel>(TViewModel viewModel, CancellationToken cancellationToken = default) where TViewModel : class;
     Task<DialogResult> ShowDialogAsync(DialogRequest request, CancellationToken cancellationToken = default);
 }


### PR DESCRIPTION
## Summary
- switch ContentDialog initialization from HWND binding to XamlRoot so WinUI dialogs can open without CCW cast failures
- add a reusable ShowDialogAsync overload that applies the parent window theme, XamlRoot, and cancellation handling
- expose the new overload on IDialogService and update dialog call paths to rely on it

## Testing
- `dotnet build Veriado.sln` *(fails: dotnet CLI is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_690510d41d7c832686aebb4f419c7fa8