### PR TITLE
Force Czech culture in WinUI application

### DIFF
--- a/Veriado.WinUI/App.xaml.cs
+++ b/Veriado.WinUI/App.xaml.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Globalization;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Veriado.WinUI.ViewModels.Startup;
@@ -22,6 +23,12 @@ public partial class App : WinUIApplication
     public App()
     {
         InitializeComponent();
+
+        var czechCulture = CultureInfo.GetCultureInfo("cs-CZ");
+        CultureInfo.DefaultThreadCurrentCulture = czechCulture;
+        CultureInfo.DefaultThreadCurrentUICulture = czechCulture;
+        CultureInfo.CurrentCulture = czechCulture;
+        CultureInfo.CurrentUICulture = czechCulture;
     }
 
     public static new App Current => (App)WinUIApplication.Current;


### PR DESCRIPTION
## Summary
- set the default thread culture and UI culture to Czech during WinUI application startup

## Testing
- `dotnet build Veriado.sln` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_6905d0f0fd708326843e3a79fbfc1369