### PR TITLE
Adopt async-safe change tracking and domain event handling

### DIFF
--- a/Veriado.Application/Abstractions/IFilePersistenceUnitOfWork.cs
+++ b/Veriado.Application/Abstractions/IFilePersistenceUnitOfWork.cs
@@ -8,7 +8,8 @@ public interface IFilePersistenceUnitOfWork
     /// <summary>
     /// Gets a value indicating whether the underlying persistence context is tracking changes.
     /// </summary>
-    bool HasTrackedChanges { get; }
+    /// <param name="cancellationToken">The cancellation token.</param>
+    Task<bool> HasTrackedChangesAsync(CancellationToken cancellationToken);
 
     /// <summary>
     /// Begins a new transactional scope for subsequent operations.

--- a/Veriado.Application/UseCases/Files/Common/FileWriteHandlerBase.cs
+++ b/Veriado.Application/UseCases/Files/Common/FileWriteHandlerBase.cs
@@ -86,7 +86,7 @@ public abstract class FileWriteHandlerBase
         }
         else
         {
-            if (!_unitOfWork.HasTrackedChanges
+            if (!await _unitOfWork.HasTrackedChangesAsync(cancellationToken).ConfigureAwait(false)
                 && file.DomainEvents.Count == 0
                 && (fileSystem?.DomainEvents.Count ?? 0) == 0
                 && !file.SearchIndex.IsStale)

--- a/Veriado.Infrastructure/Persistence/Interceptors/DomainEventsInterceptor.cs
+++ b/Veriado.Infrastructure/Persistence/Interceptors/DomainEventsInterceptor.cs
@@ -28,16 +28,6 @@ internal sealed class DomainEventsInterceptor : SaveChangesInterceptor
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
-    public override InterceptionResult<int> SavingChanges(DbContextEventData eventData, InterceptionResult<int> result)
-    {
-        if (eventData.Context is AppDbContext context)
-        {
-            ProcessDomainEventsAsync(context, CancellationToken.None).GetAwaiter().GetResult();
-        }
-
-        return base.SavingChanges(eventData, result);
-    }
-
     public override async ValueTask<InterceptionResult<int>> SavingChangesAsync(
         DbContextEventData eventData,
         InterceptionResult<int> result,


### PR DESCRIPTION
## Summary
- remove the synchronous SaveChanges interceptor path that blocked while dispatching domain events
- expose an asynchronous HasTrackedChanges check that awaits the DbContext semaphore
- update file write handler logic to await the asynchronous change tracking check

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_6905e433f7b48326bd2aeb6f9b225d62