### PR TITLE
Prevent synchronous SaveChanges usage to avoid domain event deadlocks

### DIFF
--- a/Veriado.Infrastructure/Persistence/AppDbContext.cs
+++ b/Veriado.Infrastructure/Persistence/AppDbContext.cs
@@ -188,6 +188,16 @@ public sealed class AppDbContext : DbContext
         EnsureSaveChangesSemaphoreInitialized();
     }
 
+    public override int SaveChanges()
+    {
+        throw new NotSupportedException("Synchronous SaveChanges is not supported. Use SaveChangesAsync instead.");
+    }
+
+    public override int SaveChanges(bool acceptAllChangesOnSuccess)
+    {
+        throw new NotSupportedException("Synchronous SaveChanges is not supported. Use SaveChangesAsync instead.");
+    }
+
     public override void Dispose()
     {
         DisposeSemaphore();

--- a/Veriado.Infrastructure/Persistence/Interceptors/DomainEventsInterceptor.cs
+++ b/Veriado.Infrastructure/Persistence/Interceptors/DomainEventsInterceptor.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Concurrent;
 using System.Globalization;
 using System.Text.Json;
@@ -26,6 +27,19 @@ internal sealed class DomainEventsInterceptor : SaveChangesInterceptor
         _auditProjector = auditProjector ?? throw new ArgumentNullException(nameof(auditProjector));
         _dispatcher = dispatcher ?? throw new ArgumentNullException(nameof(dispatcher));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public override InterceptionResult<int> SavingChanges(
+        DbContextEventData eventData,
+        InterceptionResult<int> result)
+    {
+        if (eventData.Context is AppDbContext)
+        {
+            throw new NotSupportedException(
+                "Synchronous SaveChanges is not supported. Use SaveChangesAsync to process domain events without risking deadlocks.");
+        }
+
+        return base.SavingChanges(eventData, result);
     }
 
     public override async ValueTask<InterceptionResult<int>> SavingChangesAsync(


### PR DESCRIPTION
## Summary
- block synchronous SaveChanges entry points so domain events are always processed on the async pipeline
- add coverage ensuring synchronous SaveChanges calls fail fast with guidance to use SaveChangesAsync

## Testing
- not run (dotnet SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_6905f52e835c8326854ca8e6f7efc820