### PR TITLE
Return updated file detail after saving

### DIFF
--- a/Veriado.Application/Files/IFileService.cs
+++ b/Veriado.Application/Files/IFileService.cs
@@ -9,5 +9,5 @@ public interface IFileService
 {
     Task<EditableFileDetailDto> GetDetailAsync(Guid id, CancellationToken cancellationToken);
 
-    Task UpdateAsync(EditableFileDetailDto detail, CancellationToken cancellationToken);
+    Task<EditableFileDetailDto> UpdateAsync(EditableFileDetailDto detail, CancellationToken cancellationToken);
 }

--- a/Veriado.Services/Files/FileService.cs
+++ b/Veriado.Services/Files/FileService.cs
@@ -33,7 +33,7 @@ public sealed class FileService : IFileService
         return Map(detail);
     }
 
-    public async Task UpdateAsync(EditableFileDetailDto detail, CancellationToken cancellationToken)
+    public async Task<EditableFileDetailDto> UpdateAsync(EditableFileDetailDto detail, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(detail);
 
@@ -66,6 +66,11 @@ public sealed class FileService : IFileService
         }
 
         await UpdateValidityAsync(current, detail, cancellationToken).ConfigureAwait(false);
+
+        current = await _fileQueryService.GetDetailAsync(detail.Id, cancellationToken).ConfigureAwait(false)
+            ?? throw new FileDetailNotFoundException(detail.Id);
+
+        return Map(current);
     }
 
     private static EditableFileDetailDto Map(Veriado.Contracts.Files.FileDetailDto detail)

--- a/Veriado.WinUI/ViewModels/Files/EditableFileDetailModel.cs
+++ b/Veriado.WinUI/ViewModels/Files/EditableFileDetailModel.cs
@@ -139,8 +139,23 @@ public sealed partial class EditableFileDetailModel : ObservableValidator, INoti
     {
         ArgumentNullException.ThrowIfNull(detail);
         _snapshot = detail;
-        Version = detail.Version;
+
+        Id = detail.Id;
+        Extension = detail.Extension;
+        FileName = detail.FileName;
+        MimeType = detail.MimeType;
+        Author = detail.Author;
+        IsReadOnly = detail.IsReadOnly;
+        Size = detail.Size;
+        CreatedAt = detail.CreatedAt;
         ModifiedAt = detail.ModifiedAt;
+        Version = detail.Version;
+        ValidFrom = detail.ValidFrom;
+        ValidTo = detail.ValidTo;
+
+        ResetValidation();
+        OnPropertyChanged(nameof(DisplayName));
+        OnPropertyChanged(nameof(IsDirty));
     }
 
     public void ApplyServerErrors(IReadOnlyDictionary<string, string[]> errors)

--- a/Veriado.WinUI/ViewModels/Files/FileDetailDialogViewModel.cs
+++ b/Veriado.WinUI/ViewModels/Files/FileDetailDialogViewModel.cs
@@ -180,9 +180,9 @@ public sealed partial class FileDetailDialogViewModel : ObservableObject, IDialo
             IsSaving = true;
             ErrorMessage = null;
             var dto = File.ToDto();
-            await _fileService.UpdateAsync(dto, cancellationToken).ConfigureAwait(false);
-            _snapshot = dto;
-            File.UpdateSnapshot(dto);
+            var updated = await _fileService.UpdateAsync(dto, cancellationToken).ConfigureAwait(false);
+            _snapshot = updated;
+            File = EditableFileDetailModel.FromDto(updated);
             CloseRequested?.Invoke(this, new DialogResult(DialogOutcome.Primary));
         }
         catch (FileDetailValidationException ex)


### PR DESCRIPTION
## Summary
- change `IFileService.UpdateAsync` to return the refreshed file detail
- have `FileService.UpdateAsync` reload and return the final state after orchestration
- refresh the dialog model from the returned DTO and update snapshot handling to copy all fields

## Testing
- dotnet test *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_690a42e2e6e4832695c819b5546ef93c