### PR TITLE
Enable scope-based validation and partial file updates

### DIFF
--- a/Veriado.WinUI/ViewModels/Validation/ValidationResult.cs
+++ b/Veriado.WinUI/ViewModels/Validation/ValidationResult.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Collections.Generic;
+
+namespace Veriado.WinUI.ViewModels.Validation;
+
+/// <summary>
+/// Represents a collection of validation errors grouped by property name.
+/// </summary>
+public sealed class ValidationResult
+{
+    private readonly Dictionary<string, List<string>> _errors = new(StringComparer.Ordinal);
+
+    public bool IsValid => _errors.Count == 0;
+
+    public IReadOnlyDictionary<string, IReadOnlyList<string>> Errors
+    {
+        get
+        {
+            var snapshot = new Dictionary<string, IReadOnlyList<string>>(_errors.Count, StringComparer.Ordinal);
+            foreach (var pair in _errors)
+            {
+                snapshot[pair.Key] = pair.Value.AsReadOnly();
+            }
+
+            return snapshot;
+        }
+    }
+
+    public void AddError(string propertyName, string message)
+    {
+        propertyName = string.IsNullOrEmpty(propertyName) ? string.Empty : propertyName;
+
+        if (string.IsNullOrWhiteSpace(message))
+        {
+            return;
+        }
+
+        if (!_errors.TryGetValue(propertyName, out var list))
+        {
+            list = new List<string>();
+            _errors[propertyName] = list;
+        }
+
+        foreach (var existing in list)
+        {
+            if (string.Equals(existing, message, StringComparison.Ordinal))
+            {
+                return;
+            }
+        }
+
+        list.Add(message);
+    }
+
+    public IEnumerable<string> GetErrors(string propertyName)
+    {
+        propertyName = string.IsNullOrEmpty(propertyName) ? string.Empty : propertyName;
+        return _errors.TryGetValue(propertyName, out var list) ? list : Array.Empty<string>();
+    }
+}


### PR DESCRIPTION
## Summary
- add a scoped validation API to `EditableFileDetailModel`, including explicit validity checks and the supporting `ValidationResult` helper
- teach `FileDetailDialogViewModel` to detect per-section changes, validate only the affected scope, and build partial update requests
- keep metadata and validity errors independent so unchanged sections no longer block saving other edits

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_690b7790884c83268fa7b5392d6f9c67