### PR TITLE
Improve WinUI file filters validation and search UX

### DIFF
--- a/Veriado.WinUI/ViewModels/Files/EditableFileDetailModel.cs
+++ b/Veriado.WinUI/ViewModels/Files/EditableFileDetailModel.cs
@@ -60,6 +60,7 @@ public sealed partial class EditableFileDetailModel : ObservableValidator, INoti
     [ObservableProperty]
     [Required(ErrorMessage = "MIME typ je povinný.")]
     [StringLength(200, MinimumLength = 1, ErrorMessage = "MIME typ nesmí být delší než 200 znaků.")]
+    [RegularExpression(@"^\s*[^/\s]+/[^/\s]+\s*$", ErrorMessage = "MIME typ musí být ve formátu type/subtype.")]
     private string mimeType = string.Empty;
 
     [ObservableProperty]

--- a/Veriado.WinUI/Views/Files/FilesPage.xaml
+++ b/Veriado.WinUI/Views/Files/FilesPage.xaml
@@ -35,9 +35,12 @@
 
             <Grid x:Uid="FilesPage_SearchRow" Grid.Row="0">
                 <AutoSuggestBox
+                    x:Name="SearchAutoSuggestBox"
                     x:Uid="FilesPage_SearchBox"
                     PlaceholderText="Hledat soubory"
-                    Text="{x:Bind ViewModel.SearchText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                    Text="{x:Bind ViewModel.SearchText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                    QuerySubmitted="OnSearchQuerySubmitted"
+                    SuggestionRequested="OnSearchSuggestionRequested" />
             </Grid>
 
             <ScrollViewer
@@ -53,11 +56,17 @@
                             <TextBox
                                 x:Uid="FilesPage_ExtensionTextBox"
                                 PlaceholderText="Přípona"
+                                MaxLength="16"
                                 Text="{x:Bind ViewModel.ExtensionFilter, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                             <TextBox
                                 x:Uid="FilesPage_MimeTextBox"
                                 PlaceholderText="MIME"
                                 Text="{x:Bind ViewModel.MimeFilter, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                            <controls:InfoBar
+                                IsClosable="False"
+                                IsOpen="{x:Bind ViewModel.HasMimeFilterError, Mode=OneWay}"
+                                Message="{x:Bind ViewModel.MimeFilterErrorMessage, Mode=OneWay}"
+                                Severity="Error" />
                             <TextBox
                                 x:Uid="FilesPage_AuthorTextBox"
                                 PlaceholderText="Autor"

--- a/Veriado.WinUI/Views/Files/FilesPage.xaml.cs
+++ b/Veriado.WinUI/Views/Files/FilesPage.xaml.cs
@@ -1,14 +1,23 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Veriado.WinUI.Services.Abstractions;
 using Veriado.WinUI.ViewModels.Files;
 
 namespace Veriado.WinUI.Views.Files;
 
 public sealed partial class FilesPage : Page
 {
-    public FilesPage(FilesPageViewModel viewModel)
+    private readonly IFilesSearchSuggestionsProvider _suggestionsProvider;
+    private CancellationTokenSource? _suggestionRequestSource;
+
+    public FilesPage(FilesPageViewModel viewModel, IFilesSearchSuggestionsProvider suggestionsProvider)
     {
         ViewModel = viewModel ?? throw new ArgumentNullException(nameof(viewModel));
+        _suggestionsProvider = suggestionsProvider ?? throw new ArgumentNullException(nameof(suggestionsProvider));
         DataContext = ViewModel;
         InitializeComponent();
         Loaded += OnLoaded;
@@ -27,11 +36,91 @@ public sealed partial class FilesPage : Page
     private void OnUnloaded(object sender, RoutedEventArgs e)
     {
         ViewModel.StopHealthMonitoring();
+        CancelSuggestionRequest();
     }
 
     private Task ExecuteInitialRefreshAsync()
     {
         return ViewModel.RefreshCommand.ExecuteAsync(null);
+    }
+
+    private async void OnSearchSuggestionRequested(AutoSuggestBox sender, AutoSuggestBoxSuggestionRequestedEventArgs args)
+    {
+        var deferral = args.Request.GetDeferral();
+
+        try
+        {
+            CancelSuggestionRequest();
+
+            var cts = new CancellationTokenSource();
+            _suggestionRequestSource = cts;
+
+            IReadOnlyList<string> suggestions;
+            try
+            {
+                suggestions = await _suggestionsProvider.GetSuggestionsAsync(cts.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                return;
+            }
+
+            if (cts.IsCancellationRequested)
+            {
+                return;
+            }
+
+            var query = args.QueryText?.Trim();
+            IEnumerable<string> filtered = suggestions;
+
+            if (!string.IsNullOrEmpty(query))
+            {
+                filtered = suggestions.Where(suggestion => suggestion.Contains(query, StringComparison.OrdinalIgnoreCase));
+            }
+
+            sender.ItemsSource = filtered.ToArray();
+        }
+        catch (OperationCanceledException)
+        {
+            // Intentionally ignored.
+        }
+        catch
+        {
+            sender.ItemsSource = Array.Empty<string>();
+        }
+        finally
+        {
+            deferral.Complete();
+        }
+    }
+
+    private async void OnSearchQuerySubmitted(AutoSuggestBox sender, AutoSuggestBoxQuerySubmittedEventArgs args)
+    {
+        var query = args.ChosenSuggestion as string ?? args.QueryText ?? string.Empty;
+        var normalized = string.IsNullOrWhiteSpace(query) ? null : query.Trim();
+
+        if (!string.Equals(ViewModel.SearchText, normalized, StringComparison.Ordinal))
+        {
+            ViewModel.SearchText = normalized;
+        }
+
+        await ViewModel.RefreshCommand.ExecuteAsync(null);
+    }
+
+    private void CancelSuggestionRequest()
+    {
+        var source = Interlocked.Exchange(ref _suggestionRequestSource, null);
+        if (source is null)
+        {
+            return;
+        }
+
+        if (!source.IsCancellationRequested)
+        {
+            source.Cancel();
+        }
+
+        source.Dispose();
     }
 
 }


### PR DESCRIPTION
## Summary
- validate MIME types in the file detail dialog to match server expectations
- align grid filter inputs with backend rules and surface validation feedback immediately
- integrate hot search suggestions and clear the query when filters are reset for a smoother UX

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_690ccc4f42748326a498d6f7cf473e80