### PR TITLE
Fix file search suggestions handler for WinUI

### DIFF
--- a/Veriado.WinUI/Views/Files/FilesPage.xaml
+++ b/Veriado.WinUI/Views/Files/FilesPage.xaml
@@ -40,7 +40,7 @@
                     PlaceholderText="Hledat soubory"
                     Text="{x:Bind ViewModel.SearchText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                     QuerySubmitted="OnSearchQuerySubmitted"
-                    SuggestionRequested="OnSearchSuggestionRequested" />
+                    TextChanged="OnSearchTextChanged" />
             </Grid>
 
             <ScrollViewer

--- a/Veriado.WinUI/Views/Files/FilesPage.xaml.cs
+++ b/Veriado.WinUI/Views/Files/FilesPage.xaml.cs
@@ -44,9 +44,12 @@ public sealed partial class FilesPage : Page
         return ViewModel.RefreshCommand.ExecuteAsync(null);
     }
 
-    private async void OnSearchSuggestionRequested(AutoSuggestBox sender, AutoSuggestBoxSuggestionRequestedEventArgs args)
+    private async void OnSearchTextChanged(AutoSuggestBox sender, AutoSuggestBoxTextChangedEventArgs args)
     {
-        var deferral = args.Request.GetDeferral();
+        if (args.Reason != AutoSuggestionBoxTextChangeReason.UserInput)
+        {
+            return;
+        }
 
         try
         {
@@ -70,7 +73,7 @@ public sealed partial class FilesPage : Page
                 return;
             }
 
-            var query = args.QueryText?.Trim();
+            var query = sender.Text?.Trim();
             IEnumerable<string> filtered = suggestions;
 
             if (!string.IsNullOrEmpty(query))
@@ -87,10 +90,6 @@ public sealed partial class FilesPage : Page
         catch
         {
             sender.ItemsSource = Array.Empty<string>();
-        }
-        finally
-        {
-            deferral.Complete();
         }
     }
 


### PR DESCRIPTION
## Summary
- replace the AutoSuggestBox SuggestionRequested handler with the supported TextChanged event
- adjust the asynchronous suggestion retrieval logic to filter based on the current text input

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_690cd063442c8326a1cc45f324601bb5