### PR TITLE
Fix scoped DbContext usage in file save pipeline

### DIFF
--- a/Veriado.WinUI/Views/Files/FileDetailDialog.xaml.cs
+++ b/Veriado.WinUI/Views/Files/FileDetailDialog.xaml.cs
@@ -22,7 +22,10 @@ public sealed partial class FileDetailDialog : ContentDialog
         }
 
         args.Cancel = true;
-        await ViewModel.SaveCommand.ExecuteAsync(null);
+        if (await ViewModel.ExecuteSaveAsync())
+        {
+            sender.Hide();
+        }
     }
 
     private void OnSecondaryButtonClick(ContentDialog sender, ContentDialogButtonClickEventArgs args)


### PR DESCRIPTION
## Summary
- create asynchronous service scopes when dispatching domain events and add trace logging for scope lifetime
- add trace logging to the EF-backed file persistence unit of work lifecycle without disposing the injected context
- update the file detail dialog flow to await save operations and only close the dialog after a successful save

## Testing
- dotnet build *(fails: `dotnet` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_690ce66affe883268e342466b77d4391