### PR TITLE
Adjust file validity validation logic

### DIFF
--- a/Veriado.WinUI/ViewModels/Files/EditableFileDetailModel.cs
+++ b/Veriado.WinUI/ViewModels/Files/EditableFileDetailModel.cs
@@ -289,19 +289,9 @@ public sealed partial class EditableFileDetailModel : ObservableValidator, INoti
             return;
         }
 
-        if (ValidFrom is null || ValidTo is null)
+        if (ValidFrom is not null && ValidTo is not null && ValidFrom > ValidTo)
         {
-            const string message = "Both validity dates must be set.";
-            SetValidationErrors(nameof(ValidFrom), new[] { message });
-            SetValidationErrors(nameof(ValidTo), new[] { message });
-            result?.AddError(nameof(ValidFrom), message);
-            result?.AddError(nameof(ValidTo), message);
-            return;
-        }
-
-        if (ValidFrom > ValidTo)
-        {
-            const string message = "Valid from cannot be after valid to.";
+            const string message = "Platnost od nesmí být později než platnost do.";
             SetValidationErrors(nameof(ValidFrom), new[] { message });
             SetValidationErrors(nameof(ValidTo), new[] { message });
             result?.AddError(nameof(ValidFrom), message);


### PR DESCRIPTION
## Summary
- relax the file validity validation so that only an inverted date range is reported as an error
- update the validation message to clearly describe the invalid range in Czech

## Testing
- dotnet test *(fails: command not found: dotnet)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690db9bd031c8326a29bd9509d81432f)