### PR TITLE
Display remaining validity on files page

### DIFF
--- a/Veriado.WinUI/AppHost.cs
+++ b/Veriado.WinUI/AppHost.cs
@@ -53,6 +53,7 @@ internal sealed class AppHost : IAsyncDisposable
                 services.AddSingleton<INavigationService, NavigationService>();
                 services.AddSingleton<IDialogService, DialogService>();
                 services.AddSingleton<ITimeFormattingService, TimeFormattingService>();
+                services.AddSingleton<IServerClock, ServerClock>();
                 services.AddSingleton<IPickerService, PickerService>();
                 services.AddSingleton<IStatusService, StatusService>();
 

--- a/Veriado.WinUI/Services/Abstractions/IServerClock.cs
+++ b/Veriado.WinUI/Services/Abstractions/IServerClock.cs
@@ -1,0 +1,8 @@
+namespace Veriado.WinUI.Services.Abstractions;
+
+public interface IServerClock
+{
+    DateTimeOffset NowUtc { get; }
+
+    DateTimeOffset NowLocal { get; }
+}

--- a/Veriado.WinUI/Services/ServerClock.cs
+++ b/Veriado.WinUI/Services/ServerClock.cs
@@ -1,0 +1,10 @@
+using Veriado.WinUI.Services.Abstractions;
+
+namespace Veriado.WinUI.Services;
+
+public sealed class ServerClock : IServerClock
+{
+    public DateTimeOffset NowUtc => DateTimeOffset.UtcNow;
+
+    public DateTimeOffset NowLocal => NowUtc.ToLocalTime();
+}

--- a/Veriado.WinUI/Views/Files/FilesPage.xaml
+++ b/Veriado.WinUI/Views/Files/FilesPage.xaml
@@ -254,10 +254,26 @@
                                         <ColumnDefinition Width="Auto" />
                                     </Grid.ColumnDefinitions>
                                     <StackPanel Spacing="4">
-                                        <TextBlock
-                                            Text="{x:Bind Name}"
-                                            FontWeight="SemiBold"
-                                            TextWrapping="Wrap" />
+                                        <StackPanel Orientation="Horizontal" Spacing="8">
+                                            <TextBlock
+                                                Text="{x:Bind Name}"
+                                                FontWeight="SemiBold"
+                                                TextWrapping="Wrap"
+                                                VerticalAlignment="Center" />
+                                            <Border
+                                                Padding="6,2"
+                                                CornerRadius="4"
+                                                VerticalAlignment="Center"
+                                                Visibility="{x:Bind PageRoot.GetValidityVisibility(this), Mode=OneWay}"
+                                                Background="{x:Bind PageRoot.GetValidityBackgroundBrush(this), Mode=OneWay}"
+                                                ToolTipService.ToolTip="{x:Bind PageRoot.GetValidityTooltip(this), Mode=OneWay}">
+                                                <TextBlock
+                                                    Text="{x:Bind PageRoot.GetValidityText(this), Mode=OneWay}"
+                                                    FontSize="12"
+                                                    Foreground="{x:Bind PageRoot.GetValidityForegroundBrush(this), Mode=OneWay}"
+                                                    TextWrapping="WrapWholeWords" />
+                                            </Border>
+                                        </StackPanel>
                                         <TextBlock
                                             Text="{x:Bind Mime}"
                                             FontSize="12"


### PR DESCRIPTION
## Summary
- show a validity badge in the files list when validity metadata is available
- refresh badge text and colors every minute using a dispatcher timer tied to a server clock abstraction
- add an injectable server clock service for consistent UTC to local time conversions

## Testing
- `dotnet build` *(fails: dotnet CLI is not available in the execution environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690dd388636483269027c05b915b8974)