### PR TITLE
Add centralized theme color palette for WinUI

### DIFF
--- a/Veriado.WinUI/Resources/AppColorPalette.cs
+++ b/Veriado.WinUI/Resources/AppColorPalette.cs
@@ -1,0 +1,98 @@
+namespace Veriado.WinUI.Resources;
+
+using System.Collections.Generic;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Media;
+using Windows.UI;
+
+public static class AppColorPalette
+{
+    private const string AppAccentBrushKey = "AppAccentBrush";
+    private const string AppBackgroundBrushKey = "AppBackgroundBrush";
+    private const string AppSurfaceBrushKey = "AppSurfaceBrush";
+    private const string AppNavigationBackgroundBrushKey = "AppNavigationBackgroundBrush";
+    private const string AppNavigationForegroundBrushKey = "AppNavigationForegroundBrush";
+    private const string AppTextPrimaryBrushKey = "AppTextPrimaryBrush";
+    private const string AppValidityExpiredBackgroundBrushKey = "AppValidityExpiredBackgroundBrush";
+    private const string AppValidityExpiringSoonBackgroundBrushKey = "AppValidityExpiringSoonBackgroundBrush";
+    private const string AppValidityExpiringLaterBackgroundBrushKey = "AppValidityExpiringLaterBackgroundBrush";
+    private const string AppValidityLongTermBackgroundBrushKey = "AppValidityLongTermBackgroundBrush";
+    private const string AppValidityLightForegroundBrushKey = "AppValidityLightForegroundBrush";
+    private const string AppValidityDarkForegroundBrushKey = "AppValidityDarkForegroundBrush";
+
+    public static SolidColorBrush AccentBrush => GetBrush(AppAccentBrushKey);
+    public static SolidColorBrush BackgroundBrush => GetBrush(AppBackgroundBrushKey);
+    public static SolidColorBrush SurfaceBrush => GetBrush(AppSurfaceBrushKey);
+    public static SolidColorBrush NavigationBackgroundBrush => GetBrush(AppNavigationBackgroundBrushKey);
+    public static SolidColorBrush NavigationForegroundBrush => GetBrush(AppNavigationForegroundBrushKey);
+    public static SolidColorBrush TextPrimaryBrush => GetBrush(AppTextPrimaryBrushKey);
+
+    public static SolidColorBrush ValidityExpiredBackgroundBrush => GetBrush(AppValidityExpiredBackgroundBrushKey);
+    public static SolidColorBrush ValidityExpiringSoonBackgroundBrush => GetBrush(AppValidityExpiringSoonBackgroundBrushKey);
+    public static SolidColorBrush ValidityExpiringLaterBackgroundBrush => GetBrush(AppValidityExpiringLaterBackgroundBrushKey);
+    public static SolidColorBrush ValidityLongTermBackgroundBrush => GetBrush(AppValidityLongTermBackgroundBrushKey);
+    public static SolidColorBrush ValidityLightForegroundBrush => GetBrush(AppValidityLightForegroundBrushKey);
+    public static SolidColorBrush ValidityDarkForegroundBrush => GetBrush(AppValidityDarkForegroundBrushKey);
+
+    public static Color AccentColor => AccentBrush.Color;
+    public static Color BackgroundColor => BackgroundBrush.Color;
+    public static Color SurfaceColor => SurfaceBrush.Color;
+    public static Color NavigationBackgroundColor => NavigationBackgroundBrush.Color;
+    public static Color NavigationForegroundColor => NavigationForegroundBrush.Color;
+    public static Color TextPrimaryColor => TextPrimaryBrush.Color;
+
+    public static Color ValidityExpiredBackgroundColor => ValidityExpiredBackgroundBrush.Color;
+    public static Color ValidityExpiringSoonBackgroundColor => ValidityExpiringSoonBackgroundBrush.Color;
+    public static Color ValidityExpiringLaterBackgroundColor => ValidityExpiringLaterBackgroundBrush.Color;
+    public static Color ValidityLongTermBackgroundColor => ValidityLongTermBackgroundBrush.Color;
+    public static Color ValidityLightForegroundColor => ValidityLightForegroundBrush.Color;
+    public static Color ValidityDarkForegroundColor => ValidityDarkForegroundBrush.Color;
+
+    private static SolidColorBrush GetBrush(string resourceKey)
+    {
+        return (SolidColorBrush)GetResource(resourceKey);
+    }
+
+    private static object GetResource(string resourceKey)
+    {
+        var application = Application.Current
+            ?? throw new InvalidOperationException("Application.Current is not available.");
+
+        if (application.Resources.TryGetValue(resourceKey, out var value) && value is not null)
+        {
+            return value;
+        }
+
+        var mergedMatch = FindInMergedDictionaries(application.Resources.MergedDictionaries, resourceKey);
+        if (mergedMatch is not null)
+        {
+            return mergedMatch;
+        }
+
+        throw new InvalidOperationException($"Resource '{resourceKey}' was not found in the application resources.");
+    }
+
+    private static object? FindInMergedDictionaries(IList<ResourceDictionary> dictionaries, string resourceKey)
+    {
+        for (var index = dictionaries.Count - 1; index >= 0; index--)
+        {
+            var dictionary = dictionaries[index];
+
+            if (dictionary.TryGetValue(resourceKey, out var value) && value is not null)
+            {
+                return value;
+            }
+
+            if (dictionary.MergedDictionaries.Count > 0)
+            {
+                var nested = FindInMergedDictionaries(dictionary.MergedDictionaries, resourceKey);
+                if (nested is not null)
+                {
+                    return nested;
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/Veriado.WinUI/Resources/Theme.xaml
+++ b/Veriado.WinUI/Resources/Theme.xaml
@@ -10,6 +10,12 @@
       <Color x:Key="AppNavigationBackgroundColor">#FFF0F2F7</Color>
       <Color x:Key="AppNavigationForegroundColor">#FF101820</Color>
       <Color x:Key="AppTextPrimaryColor">#FF1B1F23</Color>
+      <Color x:Key="AppValidityExpiredBackgroundColor">#FFD13438</Color>
+      <Color x:Key="AppValidityExpiringSoonBackgroundColor">#FFF1C21B</Color>
+      <Color x:Key="AppValidityExpiringLaterBackgroundColor">#FF8BC34A</Color>
+      <Color x:Key="AppValidityLongTermBackgroundColor">#FFE5E7EB</Color>
+      <Color x:Key="AppValidityLightForegroundColor">#FFFFFFFF</Color>
+      <Color x:Key="AppValidityDarkForegroundColor">#FF1B1F23</Color>
     </ResourceDictionary>
     <ResourceDictionary x:Key="Dark">
       <Color x:Key="AppAccentColor">#FF4CC2FF</Color>
@@ -18,6 +24,12 @@
       <Color x:Key="AppNavigationBackgroundColor">#FF2C313C</Color>
       <Color x:Key="AppNavigationForegroundColor">#FFE7ECF4</Color>
       <Color x:Key="AppTextPrimaryColor">#FFE7ECF4</Color>
+      <Color x:Key="AppValidityExpiredBackgroundColor">#FFB3261E</Color>
+      <Color x:Key="AppValidityExpiringSoonBackgroundColor">#FFE6B400</Color>
+      <Color x:Key="AppValidityExpiringLaterBackgroundColor">#FF4CAF50</Color>
+      <Color x:Key="AppValidityLongTermBackgroundColor">#FF3A3D45</Color>
+      <Color x:Key="AppValidityLightForegroundColor">#FFFFFFFF</Color>
+      <Color x:Key="AppValidityDarkForegroundColor">#FFE7ECF4</Color>
     </ResourceDictionary>
   </ResourceDictionary.ThemeDictionaries>
 
@@ -27,4 +39,10 @@
   <SolidColorBrush x:Key="AppNavigationBackgroundBrush" Color="{ThemeResource AppNavigationBackgroundColor}" />
   <SolidColorBrush x:Key="AppNavigationForegroundBrush" Color="{ThemeResource AppNavigationForegroundColor}" />
   <SolidColorBrush x:Key="AppTextPrimaryBrush" Color="{ThemeResource AppTextPrimaryColor}" />
+  <SolidColorBrush x:Key="AppValidityExpiredBackgroundBrush" Color="{ThemeResource AppValidityExpiredBackgroundColor}" />
+  <SolidColorBrush x:Key="AppValidityExpiringSoonBackgroundBrush" Color="{ThemeResource AppValidityExpiringSoonBackgroundColor}" />
+  <SolidColorBrush x:Key="AppValidityExpiringLaterBackgroundBrush" Color="{ThemeResource AppValidityExpiringLaterBackgroundColor}" />
+  <SolidColorBrush x:Key="AppValidityLongTermBackgroundBrush" Color="{ThemeResource AppValidityLongTermBackgroundColor}" />
+  <SolidColorBrush x:Key="AppValidityLightForegroundBrush" Color="{ThemeResource AppValidityLightForegroundColor}" />
+  <SolidColorBrush x:Key="AppValidityDarkForegroundBrush" Color="{ThemeResource AppValidityDarkForegroundColor}" />
 </ResourceDictionary>

--- a/Veriado.WinUI/Views/Files/FilesPage.xaml.cs
+++ b/Veriado.WinUI/Views/Files/FilesPage.xaml.cs
@@ -7,20 +7,20 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
 using Veriado.Contracts.Files;
+using Veriado.WinUI.Resources;
 using Veriado.WinUI.Services.Abstractions;
 using Veriado.WinUI.ViewModels.Files;
-using Windows.UI;
 
 namespace Veriado.WinUI.Views.Files;
 
 public sealed partial class FilesPage : Page
 {
-    private static readonly SolidColorBrush ExpiredBackgroundBrush = new(Colors.Red);
-    private static readonly SolidColorBrush ExpiringSoonBackgroundBrush = new(Colors.Orange);
-    private static readonly SolidColorBrush ExpiringLaterBackgroundBrush = new(Colors.Yellow);
-    private static readonly SolidColorBrush LongTermBackgroundBrush = new(Colors.Gray);
-    private static readonly SolidColorBrush LightForegroundBrush = new(Colors.White);
-    private static readonly SolidColorBrush DarkForegroundBrush = new(Colors.Black);
+    private static SolidColorBrush ExpiredBackgroundBrush => AppColorPalette.ValidityExpiredBackgroundBrush;
+    private static SolidColorBrush ExpiringSoonBackgroundBrush => AppColorPalette.ValidityExpiringSoonBackgroundBrush;
+    private static SolidColorBrush ExpiringLaterBackgroundBrush => AppColorPalette.ValidityExpiringLaterBackgroundBrush;
+    private static SolidColorBrush LongTermBackgroundBrush => AppColorPalette.ValidityLongTermBackgroundBrush;
+    private static SolidColorBrush LightForegroundBrush => AppColorPalette.ValidityLightForegroundBrush;
+    private static SolidColorBrush DarkForegroundBrush => AppColorPalette.ValidityDarkForegroundBrush;
 
     private readonly IFilesSearchSuggestionsProvider _suggestionsProvider;
     private readonly IServerClock _serverClock;


### PR DESCRIPTION
## Summary
- add theme-specific validity colors and brushes for both light and dark modes
- provide an `AppColorPalette` helper to access shared brushes and colors from code
- update the files page to rely on the shared palette instead of hard-coded brushes

## Testing
- dotnet build Veriado.sln *(fails: dotnet CLI is not available in the execution environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e3a0239a083269ddbfa51e8f67a28)