### PR TITLE
Fix FileValidity usage in FilesPage for renamed DTO properties

### DIFF
--- a/Veriado.WinUI/Views/Files/FilesPage.xaml.cs
+++ b/Veriado.WinUI/Views/Files/FilesPage.xaml.cs
@@ -224,8 +224,8 @@ public sealed partial class FilesPage : Page
         }
 
         var culture = CultureInfo.CurrentCulture;
-        var issued = validity.IssuedAtUtc.ToLocalTime();
-        var validUntil = validity.ValidUntilUtc.ToLocalTime();
+        var issued = validity.IssuedAt.ToLocalTime();
+        var validUntil = validity.ValidUntil.ToLocalTime();
         return $"Platnost: {issued.ToString("d", culture)} – {validUntil.ToString("d", culture)}";
     }
 
@@ -239,7 +239,7 @@ public sealed partial class FilesPage : Page
         }
 
         var now = _serverClock.NowLocal.Date;
-        var validUntil = validity.ValidUntilUtc.ToLocalTime().Date;
+        var validUntil = validity.ValidUntil.ToLocalTime().Date;
         daysRemaining = (validUntil - now).Days;
         return true;
     }


### PR DESCRIPTION
## Summary
- update FilesPage validity helper to use the renamed IssuedAt/ValidUntil properties
- ensure days-remaining and tooltip calculations access the new DTO members

## Testing
- dotnet build Veriado.sln *(fails: command not found)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e41c63e9c83269fda94e4b9e0ee90)