### PR TITLE
Refactor FilesPage validity badge binding to MVVM converters

### DIFF
--- a/Veriado.WinUI/Converters/ValidityToBackgroundBrushConverter.cs
+++ b/Veriado.WinUI/Converters/ValidityToBackgroundBrushConverter.cs
@@ -1,0 +1,33 @@
+using System;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Media;
+using Veriado.WinUI.Resources;
+using Veriado.WinUI.ViewModels.Files;
+
+namespace Veriado.WinUI.Converters;
+
+public sealed class ValidityToBackgroundBrushConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, string language)
+    {
+        if (value is not ValidityState state)
+        {
+            return AppColorPalette.ValidityLongTermBackgroundBrush;
+        }
+
+        return state switch
+        {
+            ValidityState.Expired => AppColorPalette.ValidityExpiredBackgroundBrush,
+            ValidityState.ExpiringToday => AppColorPalette.ValidityExpiredBackgroundBrush,
+            ValidityState.ExpiringSoon => AppColorPalette.ValidityExpiringSoonBackgroundBrush,
+            ValidityState.ExpiringLater => AppColorPalette.ValidityExpiringLaterBackgroundBrush,
+            ValidityState.LongTerm => AppColorPalette.ValidityLongTermBackgroundBrush,
+            _ => AppColorPalette.ValidityLongTermBackgroundBrush,
+        };
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, string language)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/Veriado.WinUI/Converters/ValidityToForegroundBrushConverter.cs
+++ b/Veriado.WinUI/Converters/ValidityToForegroundBrushConverter.cs
@@ -1,0 +1,31 @@
+using System;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Media;
+using Veriado.WinUI.Resources;
+using Veriado.WinUI.ViewModels.Files;
+
+namespace Veriado.WinUI.Converters;
+
+public sealed class ValidityToForegroundBrushConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, string language)
+    {
+        if (value is not ValidityState state)
+        {
+            return AppColorPalette.ValidityDarkForegroundBrush;
+        }
+
+        return state switch
+        {
+            ValidityState.Expired => AppColorPalette.ValidityLightForegroundBrush,
+            ValidityState.ExpiringToday => AppColorPalette.ValidityLightForegroundBrush,
+            ValidityState.ExpiringSoon => AppColorPalette.ValidityLightForegroundBrush,
+            _ => AppColorPalette.ValidityDarkForegroundBrush,
+        };
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, string language)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/Veriado.WinUI/Converters/ValidityToTextConverter.cs
+++ b/Veriado.WinUI/Converters/ValidityToTextConverter.cs
@@ -1,0 +1,40 @@
+using System;
+using Microsoft.UI.Xaml.Data;
+using Veriado.WinUI.ViewModels.Files;
+
+namespace Veriado.WinUI.Converters;
+
+public sealed class ValidityToTextConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, string language)
+    {
+        if (value is not ValidityState state)
+        {
+            return string.Empty;
+        }
+
+        return state switch
+        {
+            ValidityState.None => string.Empty,
+            ValidityState.Expired => "Platnost skončila",
+            ValidityState.ExpiringToday => "Dnes končí",
+            ValidityState.ExpiringSoon or ValidityState.ExpiringLater or ValidityState.LongTerm => FormatRemaining(parameter),
+            _ => string.Empty,
+        };
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, string language)
+    {
+        throw new NotImplementedException();
+    }
+
+    private static string FormatRemaining(object parameter)
+    {
+        return parameter switch
+        {
+            int days => $"Zbývá {days} dní",
+            int? days when days.HasValue => $"Zbývá {days.Value} dní",
+            _ => string.Empty,
+        };
+    }
+}

--- a/Veriado.WinUI/Converters/ValidityToTooltipConverter.cs
+++ b/Veriado.WinUI/Converters/ValidityToTooltipConverter.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Globalization;
+using Microsoft.UI.Xaml.Data;
+using Veriado.WinUI.ViewModels.Files;
+
+namespace Veriado.WinUI.Converters;
+
+public sealed class ValidityToTooltipConverter : IValueConverter
+{
+    public object? Convert(object value, Type targetType, object parameter, string language)
+    {
+        if (value is not ValidityState state || state == ValidityState.None)
+        {
+            return null;
+        }
+
+        var context = ExtractContext(parameter);
+        if (context.IssuedAt is not { } issuedAt || context.ValidUntil is not { } validUntil)
+        {
+            return null;
+        }
+
+        var culture = CultureInfo.CurrentCulture;
+        return $"Platnost: {issuedAt.ToString("d", culture)} – {validUntil.ToString("d", culture)}";
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, string language)
+    {
+        throw new NotImplementedException();
+    }
+
+    private static ValidityTooltipContext ExtractContext(object parameter)
+    {
+        return parameter switch
+        {
+            ValidityTooltipContext context => context,
+            ValidityTooltipContext? nullable when nullable.HasValue => nullable.Value,
+            _ => default,
+        };
+    }
+}

--- a/Veriado.WinUI/Converters/ValidityToVisibilityConverter.cs
+++ b/Veriado.WinUI/Converters/ValidityToVisibilityConverter.cs
@@ -1,0 +1,24 @@
+using System;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Data;
+using Veriado.WinUI.ViewModels.Files;
+
+namespace Veriado.WinUI.Converters;
+
+public sealed class ValidityToVisibilityConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, string language)
+    {
+        if (value is ValidityState state && state != ValidityState.None)
+        {
+            return Visibility.Visible;
+        }
+
+        return Visibility.Collapsed;
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, string language)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/Veriado.WinUI/ViewModels/Files/FileSummaryItemViewModel.cs
+++ b/Veriado.WinUI/ViewModels/Files/FileSummaryItemViewModel.cs
@@ -1,0 +1,110 @@
+using System;
+using CommunityToolkit.Mvvm.ComponentModel;
+using Veriado.Contracts.Files;
+
+namespace Veriado.WinUI.ViewModels.Files;
+
+public enum ValidityState
+{
+    None,
+    Expired,
+    ExpiringToday,
+    ExpiringSoon,
+    ExpiringLater,
+    LongTerm,
+}
+
+public readonly record struct ValidityTooltipContext(DateTimeOffset? IssuedAt, DateTimeOffset? ValidUntil);
+
+public partial class FileSummaryItemViewModel : ObservableObject
+{
+    public FileSummaryItemViewModel(FileSummaryDto dto, DateTimeOffset referenceTime)
+    {
+        Dto = dto ?? throw new ArgumentNullException(nameof(dto));
+        UpdateValidity(referenceTime);
+    }
+
+    public FileSummaryDto Dto { get; }
+
+    public bool HasValidity => ValidityState != ValidityState.None;
+
+    public ValidityTooltipContext ValidityTooltipContext => new(ValidityIssuedAt, ValidityValidUntil);
+
+    [ObservableProperty]
+    private ValidityState validityState;
+
+    [ObservableProperty]
+    private int? validityDaysRemaining;
+
+    [ObservableProperty]
+    private DateTimeOffset? validityIssuedAt;
+
+    [ObservableProperty]
+    private DateTimeOffset? validityValidUntil;
+
+    public void UpdateValidity(DateTimeOffset referenceTime)
+    {
+        if (Dto.Validity is { } validity)
+        {
+            var issuedAt = validity.IssuedAt.ToLocalTime();
+            var validUntil = validity.ValidUntil.ToLocalTime();
+
+            ValidityIssuedAt = issuedAt;
+            ValidityValidUntil = validUntil;
+
+            var referenceDate = referenceTime.ToLocalTime().Date;
+            var validUntilDate = validUntil.Date;
+            var daysRemaining = (validUntilDate - referenceDate).Days;
+
+            ValidityDaysRemaining = daysRemaining;
+            ValidityState = DetermineState(daysRemaining);
+        }
+        else
+        {
+            ValidityIssuedAt = null;
+            ValidityValidUntil = null;
+            ValidityDaysRemaining = null;
+            ValidityState = ValidityState.None;
+        }
+    }
+
+    private static ValidityState DetermineState(int daysRemaining)
+    {
+        if (daysRemaining < 0)
+        {
+            return ValidityState.Expired;
+        }
+
+        if (daysRemaining == 0)
+        {
+            return ValidityState.ExpiringToday;
+        }
+
+        if (daysRemaining <= 7)
+        {
+            return ValidityState.ExpiringSoon;
+        }
+
+        if (daysRemaining <= 30)
+        {
+            return ValidityState.ExpiringLater;
+        }
+
+        return ValidityState.LongTerm;
+    }
+
+    partial void OnValidityStateChanged(ValidityState value)
+    {
+        OnPropertyChanged(nameof(HasValidity));
+    }
+
+    partial void OnValidityIssuedAtChanged(DateTimeOffset? value)
+    {
+        OnPropertyChanged(nameof(ValidityTooltipContext));
+    }
+
+    partial void OnValidityValidUntilChanged(DateTimeOffset? value)
+    {
+        OnPropertyChanged(nameof(ValidityTooltipContext));
+    }
+}

--- a/Veriado.WinUI/Views/Files/FilesPage.xaml
+++ b/Veriado.WinUI/Views/Files/FilesPage.xaml
@@ -8,12 +8,17 @@
     xmlns:controls="using:Microsoft.UI.Xaml.Controls"
     xmlns:views="using:Veriado.WinUI.Views.Files"
     xmlns:converters="using:Veriado.WinUI.Converters"
-    xmlns:contracts="using:Veriado.Contracts.Files"
+    xmlns:viewModels="using:Veriado.WinUI.ViewModels.Files"
     mc:Ignorable="d">
     <Page.Resources>
         <converters:NullableIntToDoubleConverter x:Key="NullableIntToDoubleConverter" />
         <converters:NullableLongToDoubleConverter x:Key="NullableLongToDoubleConverter" />
         <converters:SizeToHumanConverter x:Key="SizeToHumanConverter" />
+        <converters:ValidityToTextConverter x:Key="ValidityToTextConverter" />
+        <converters:ValidityToTooltipConverter x:Key="ValidityToTooltipConverter" />
+        <converters:ValidityToBackgroundBrushConverter x:Key="ValidityToBackgroundBrushConverter" />
+        <converters:ValidityToForegroundBrushConverter x:Key="ValidityToForegroundBrushConverter" />
+        <converters:ValidityToVisibilityConverter x:Key="ValidityToVisibilityConverter" />
     </Page.Resources>
 
     <Grid Padding="24" RowSpacing="16" ColumnSpacing="24">
@@ -239,7 +244,7 @@
                     </controls:ItemsRepeater.Layout>
 
                     <controls:ItemsRepeater.ItemTemplate>
-                        <DataTemplate x:DataType="contracts:FileSummaryDto">
+                        <DataTemplate x:DataType="viewModels:FileSummaryItemViewModel">
                             <Border
                                 Margin="8"
                                 Padding="12"
@@ -256,7 +261,7 @@
                                     <StackPanel Spacing="4">
                                         <StackPanel Orientation="Horizontal" Spacing="8">
                                             <TextBlock
-                                                Text="{x:Bind Name}"
+                                                Text="{x:Bind Dto.Name}"
                                                 FontWeight="SemiBold"
                                                 TextWrapping="Wrap"
                                                 VerticalAlignment="Center" />
@@ -264,23 +269,23 @@
                                                 Padding="6,2"
                                                 CornerRadius="4"
                                                 VerticalAlignment="Center"
-                                                Visibility="{x:Bind PageRoot.GetValidityVisibility(this), Mode=OneWay}"
-                                                Background="{x:Bind PageRoot.GetValidityBackgroundBrush(this), Mode=OneWay}"
-                                                ToolTipService.ToolTip="{x:Bind PageRoot.GetValidityTooltip(this), Mode=OneWay}">
+                                                Visibility="{x:Bind ValidityState, Converter={StaticResource ValidityToVisibilityConverter}}"
+                                                Background="{x:Bind ValidityState, Converter={StaticResource ValidityToBackgroundBrushConverter}}"
+                                                ToolTipService.ToolTip="{x:Bind ValidityState, Converter={StaticResource ValidityToTooltipConverter}, ConverterParameter=ValidityTooltipContext}">
                                                 <TextBlock
-                                                    Text="{x:Bind PageRoot.GetValidityText(this), Mode=OneWay}"
+                                                    Text="{x:Bind ValidityState, Converter={StaticResource ValidityToTextConverter}, ConverterParameter=ValidityDaysRemaining}"
                                                     FontSize="12"
-                                                    Foreground="{x:Bind PageRoot.GetValidityForegroundBrush(this), Mode=OneWay}"
+                                                    Foreground="{x:Bind ValidityState, Converter={StaticResource ValidityToForegroundBrushConverter}}"
                                                     TextWrapping="WrapWholeWords" />
                                             </Border>
                                         </StackPanel>
                                         <TextBlock
-                                            Text="{x:Bind Mime}"
+                                            Text="{x:Bind Dto.Mime}"
                                             FontSize="12"
                                             Opacity="0.7"
                                             TextTrimming="CharacterEllipsis" />
                                         <TextBlock
-                                            Text="{x:Bind Size, Converter={StaticResource SizeToHumanConverter}}"
+                                            Text="{x:Bind Dto.Size, Converter={StaticResource SizeToHumanConverter}}"
                                             FontSize="12" />
                                     </StackPanel>
                                     <Button
@@ -290,7 +295,7 @@
                                         VerticalAlignment="Center"
                                         Content="Detail"
                                         Command="{Binding DataContext.OpenDetailCommand, ElementName=PageRoot}"
-                                        CommandParameter="{x:Bind Mode=OneWay}" />
+                                        CommandParameter="{x:Bind Dto}" />
                                 </Grid>
                             </Border>
                         </DataTemplate>

--- a/Veriado.WinUI/Views/Files/FilesPage.xaml.cs
+++ b/Veriado.WinUI/Views/Files/FilesPage.xaml.cs
@@ -1,13 +1,9 @@
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 using System.Threading;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml.Media;
-using Veriado.Contracts.Files;
-using Veriado.WinUI.Helpers;
 using Veriado.WinUI.Services.Abstractions;
 using Veriado.WinUI.ViewModels.Files;
 
@@ -16,18 +12,15 @@ namespace Veriado.WinUI.Views.Files;
 public sealed partial class FilesPage : Page
 {
     private readonly IFilesSearchSuggestionsProvider _suggestionsProvider;
-    private readonly IServerClock _serverClock;
     private readonly DispatcherTimer _validityRefreshTimer;
     private CancellationTokenSource? _suggestionRequestSource;
 
     public FilesPage(
         FilesPageViewModel viewModel,
-        IFilesSearchSuggestionsProvider suggestionsProvider,
-        IServerClock serverClock)
+        IFilesSearchSuggestionsProvider suggestionsProvider)
     {
         ViewModel = viewModel ?? throw new ArgumentNullException(nameof(viewModel));
         _suggestionsProvider = suggestionsProvider ?? throw new ArgumentNullException(nameof(suggestionsProvider));
-        _serverClock = serverClock ?? throw new ArgumentNullException(nameof(serverClock));
         _validityRefreshTimer = new DispatcherTimer
         {
             Interval = TimeSpan.FromMinutes(1),
@@ -144,60 +137,6 @@ public sealed partial class FilesPage : Page
         source.Dispose();
     }
 
-    public Visibility GetValidityVisibility(FileSummaryDto? file)
-    {
-        return file?.Validity is null ? Visibility.Collapsed : Visibility.Visible;
-    }
-
-    public string GetValidityText(FileSummaryDto? file)
-    {
-        if (!FileValidityHelper.TryGetBadge(file?.Validity, _serverClock.NowLocal, out var badge))
-        {
-            return string.Empty;
-        }
-
-        return badge.Text;
-    }
-
-    public Brush GetValidityBackgroundBrush(FileSummaryDto? file)
-    {
-        var badge = FileValidityHelper.GetBadge(file?.Validity, _serverClock.NowLocal);
-        return badge.Background;
-    }
-
-    public Brush GetValidityForegroundBrush(FileSummaryDto? file)
-    {
-        var badge = FileValidityHelper.GetBadge(file?.Validity, _serverClock.NowLocal);
-        return badge.Foreground;
-    }
-
-    public string? GetValidityTooltip(FileSummaryDto? file)
-    {
-        if (file?.Validity is not { } validity)
-        {
-            return null;
-        }
-
-        var culture = CultureInfo.CurrentCulture;
-        var issued = validity.IssuedAt.ToLocalTime();
-        var validUntil = validity.ValidUntil.ToLocalTime();
-        return $"Platnost: {issued.ToString("d", culture)} – {validUntil.ToString("d", culture)}";
-    }
-
-    public bool TryGetDaysRemaining(FileSummaryDto? file, out int daysRemaining)
-    {
-        daysRemaining = 0;
-
-        if (FileValidityHelper.TryGetBadge(file?.Validity, _serverClock.NowLocal, out var badge)
-            && badge.DaysRemaining is { } remaining)
-        {
-            daysRemaining = remaining;
-            return true;
-        }
-
-        return false;
-    }
-
     private void OnValidityRefreshTimerTick(object? sender, object e)
     {
         UpdateValidityBadges();
@@ -205,6 +144,6 @@ public sealed partial class FilesPage : Page
 
     private void UpdateValidityBadges()
     {
-        Bindings?.Update();
+        ViewModel.RefreshValidityStates();
     }
 }


### PR DESCRIPTION
## Summary
- introduce FileSummaryItemViewModel that computes validity state metadata from FileSummaryDto items
- add converters to translate validity state into text, tooltip, brushes, and visibility for the list badges
- update FilesPage view model and XAML to use the new MVVM pipeline instead of calling page helpers

## Testing
- dotnet build Veriado.WinUI/Veriado.csproj *(fails: `dotnet` is not available in the execution environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69105216f7108326ad21c5d62491b885)