### PR TITLE
Fix nullable pattern matching in validity converters

### DIFF
--- a/Veriado.WinUI/Converters/ValidityToTextConverter.cs
+++ b/Veriado.WinUI/Converters/ValidityToTextConverter.cs
@@ -30,11 +30,11 @@ public sealed class ValidityToTextConverter : IValueConverter
 
     private static string FormatRemaining(object parameter)
     {
-        return parameter switch
+        if (parameter is int days)
         {
-            int days => $"Zbývá {days} dní",
-            int? days when days.HasValue => $"Zbývá {days.Value} dní",
-            _ => string.Empty,
-        };
+            return $"Zbývá {days} dní";
+        }
+
+        return string.Empty;
     }
 }

--- a/Veriado.WinUI/Converters/ValidityToTooltipConverter.cs
+++ b/Veriado.WinUI/Converters/ValidityToTooltipConverter.cs
@@ -31,11 +31,11 @@ public sealed class ValidityToTooltipConverter : IValueConverter
 
     private static ValidityTooltipContext ExtractContext(object parameter)
     {
-        return parameter switch
+        if (parameter is ValidityTooltipContext context)
         {
-            ValidityTooltipContext context => context,
-            ValidityTooltipContext? nullable when nullable.HasValue => nullable.Value,
-            _ => default,
-        };
+            return context;
+        }
+
+        return default;
     }
 }


### PR DESCRIPTION
## Summary
- replace the tooltip converter's nullable pattern match with a simple validity context check
- simplify the text converter's remaining-days formatter to avoid nullable pattern usage that causes CS8116

## Testing
- dotnet build *(fails: dotnet not available in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910664aedbc8326bb0b0738a2676f1d)