### PR TITLE
Fix scoped DbContext handling and WinUI dialog save flow

### DIFF
--- a/Veriado.Application/Abstractions/IFilePersistenceUnitOfWork.cs
+++ b/Veriado.Application/Abstractions/IFilePersistenceUnitOfWork.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Veriado.Appl.Abstractions;
 
 /// <summary>
@@ -22,6 +24,13 @@ public interface IFilePersistenceUnitOfWork
     /// </summary>
     /// <param name="cancellationToken">The cancellation token.</param>
     Task SaveChangesAsync(CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// Represents a unit of work that owns its underlying persistence context and must be disposed by the caller.
+/// </summary>
+public interface IFactoryFilePersistenceUnitOfWork : IFilePersistenceUnitOfWork, IAsyncDisposable
+{
 }
 
 /// <summary>

--- a/Veriado.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/Veriado.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
@@ -146,14 +146,14 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<ISearchIndexCoordinator, SearchIndexCoordinator>();
         services.AddSingleton<IDomainEventHandler<SearchReindexRequested>, SearchReindexRequestedHandler>();
 
-        services.AddDbContextPool<AppDbContext>((sp, builder) =>
+        services.AddDbContext<AppDbContext>((sp, builder) =>
         {
             var connectionProvider = sp.GetRequiredService<IConnectionStringProvider>();
             builder.UseSqlite(connectionProvider.ConnectionString, sqlite => sqlite.CommandTimeout(30));
             builder.AddInterceptors(
                 sp.GetRequiredService<SqlitePragmaInterceptor>(),
                 sp.GetRequiredService<DomainEventsInterceptor>());
-        }, poolSize: 128);
+        });
         services.AddDbContextFactory<AppDbContext>((sp, builder) =>
         {
             var connectionProvider = sp.GetRequiredService<IConnectionStringProvider>();
@@ -202,6 +202,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IFileImportWriter, FileImportService>();
         services.AddScoped<IFileRepository, FileRepository>();
         services.AddScoped<IFilePersistenceUnitOfWork, EfFilePersistenceUnitOfWork>();
+        services.AddTransient<IFactoryFilePersistenceUnitOfWork, FactoryFilePersistenceUnitOfWork>();
         services.AddScoped<IReadOnlyFileContextFactory, ReadOnlyFileContextFactory>();
         services.AddScoped<IFileReadRepository, FileReadRepository>();
         services.AddSingleton<IDiagnosticsRepository, DiagnosticsRepository>();

--- a/Veriado.Infrastructure/Persistence/FactoryFilePersistenceUnitOfWork.cs
+++ b/Veriado.Infrastructure/Persistence/FactoryFilePersistenceUnitOfWork.cs
@@ -1,0 +1,37 @@
+using System;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Veriado.Appl.Abstractions;
+
+namespace Veriado.Infrastructure.Persistence;
+
+/// <summary>
+/// Provides a factory-backed unit of work that owns its DbContext instance.
+/// </summary>
+internal sealed class FactoryFilePersistenceUnitOfWork : IFactoryFilePersistenceUnitOfWork
+{
+    private readonly EfFilePersistenceUnitOfWork _inner;
+
+    public FactoryFilePersistenceUnitOfWork(
+        IDbContextFactory<AppDbContext> dbContextFactory,
+        ILoggerFactory loggerFactory)
+    {
+        ArgumentNullException.ThrowIfNull(dbContextFactory);
+        ArgumentNullException.ThrowIfNull(loggerFactory);
+
+        var context = dbContextFactory.CreateDbContext();
+        var logger = loggerFactory.CreateLogger<EfFilePersistenceUnitOfWork>();
+        _inner = new EfFilePersistenceUnitOfWork(context, logger, ownsContext: true);
+    }
+
+    public Task<bool> HasTrackedChangesAsync(CancellationToken cancellationToken)
+        => _inner.HasTrackedChangesAsync(cancellationToken);
+
+    public Task<IFilePersistenceTransaction> BeginTransactionAsync(CancellationToken cancellationToken)
+        => _inner.BeginTransactionAsync(cancellationToken);
+
+    public Task SaveChangesAsync(CancellationToken cancellationToken)
+        => _inner.SaveChangesAsync(cancellationToken);
+
+    public ValueTask DisposeAsync() => _inner.DisposeAsync();
+}

--- a/Veriado.WinUI/Services/Abstractions/IDialogService.cs
+++ b/Veriado.WinUI/Services/Abstractions/IDialogService.cs
@@ -1,8 +1,10 @@
+using Microsoft.Extensions.DependencyInjection;
+
 namespace Veriado.WinUI.Services.Abstractions;
 
 public interface IDialogService
 {
-    TViewModel CreateViewModel<TViewModel>() where TViewModel : class;
+    DialogViewModelScope<TViewModel> CreateViewModel<TViewModel>() where TViewModel : class;
 
     Task<bool> ConfirmAsync(string title, string message, string confirmText = "OK", string cancelText = "Cancel");
     Task ShowInfoAsync(string title, string message);
@@ -13,6 +15,21 @@ public interface IDialogService
 
     Task<DialogResult> ShowDialogAsync<TViewModel>(TViewModel viewModel, CancellationToken cancellationToken = default) where TViewModel : class;
     Task<DialogResult> ShowDialogAsync(DialogRequest request, CancellationToken cancellationToken = default);
+}
+
+public sealed class DialogViewModelScope<TViewModel> : IAsyncDisposable where TViewModel : class
+{
+    private readonly AsyncServiceScope _scope;
+
+    internal DialogViewModelScope(AsyncServiceScope scope, TViewModel viewModel)
+    {
+        _scope = scope;
+        ViewModel = viewModel;
+    }
+
+    public TViewModel ViewModel { get; }
+
+    public ValueTask DisposeAsync() => _scope.DisposeAsync();
 }
 
 public sealed record DialogRequest(

--- a/Veriado.WinUI/ViewModels/Files/FilesPageViewModel.cs
+++ b/Veriado.WinUI/ViewModels/Files/FilesPageViewModel.cs
@@ -646,7 +646,8 @@ public partial class FilesPageViewModel : ViewModelBase
 
         try
         {
-            var dialogViewModel = _dialogService.CreateViewModel<FileDetailDialogViewModel>();
+            await using var dialogScope = _dialogService.CreateViewModel<FileDetailDialogViewModel>();
+            var dialogViewModel = dialogScope.ViewModel;
             await dialogViewModel.LoadAsync(summary.Id, dialogCts.Token).ConfigureAwait(false);
 
             var result = await _dialogService.ShowDialogAsync(dialogViewModel, dialogCts.Token).ConfigureAwait(false);

--- a/Veriado.WinUI/Views/Files/FileDetailDialog.xaml.cs
+++ b/Veriado.WinUI/Views/Files/FileDetailDialog.xaml.cs
@@ -16,15 +16,24 @@ public sealed partial class FileDetailDialog : ContentDialog
 
     private async void OnPrimaryButtonClick(ContentDialog sender, ContentDialogButtonClickEventArgs args)
     {
-        if (ViewModel is null)
+        var viewModel = ViewModel;
+        if (viewModel is null)
         {
             return;
         }
 
         args.Cancel = true;
-        if (await ViewModel.ExecuteSaveAsync())
+        var deferral = args.GetDeferral();
+        try
         {
-            sender.Hide();
+            if (await viewModel.ExecuteSaveAsync())
+            {
+                sender.Hide();
+            }
+        }
+        finally
+        {
+            deferral.Complete();
         }
     }
 

--- a/Veriado.WinUI/appsettings.json
+++ b/Veriado.WinUI/appsettings.json
@@ -1,4 +1,11 @@
 {
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.EntityFrameworkCore": "Debug",
+      "Veriado.Infrastructure.Persistence.EfFilePersistenceUnitOfWork": "Debug"
+    }
+  },
   "Infrastructure": {
     "Workers": 1,
     "WriteQueueCapacity": 10000


### PR DESCRIPTION
## Summary
- register AppDbContext with scoped lifetime and add a factory-backed unit of work that owns its context when required
- improve diagnostics around EF unit of work lifetimes and enable EF Core logging in the WinUI host
- update dialog/viewmodel lifetimes and ContentDialog deferral to keep scopes alive through async saves

## Testing
- Not run (dotnet CLI not available in container): `dotnet build Veriado.sln`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691077314ed4832691e8f5952bd66055)