### PR TITLE
Fix transparent brush in ValidityColors

### DIFF
--- a/Veriado.WinUI/Helpers/ValidityColors.cs
+++ b/Veriado.WinUI/Helpers/ValidityColors.cs
@@ -13,5 +13,5 @@ public static class ValidityColors
 
     public static SolidColorBrush Expired { get; } = new(Color.FromArgb(0xFF, 0xD9, 0x2F, 0x2F));
 
-    public static SolidColorBrush Transparent { get; } = new(Colors.Transparent);
+    public static SolidColorBrush Transparent { get; } = new(Color.FromArgb(0x00, 0x00, 0x00, 0x00));
 }


### PR DESCRIPTION
## Summary
- replace the Transparent brush initialization to avoid referencing an unavailable Colors class

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691089ea97c883269e8737d5ad6e483b)