### PR TITLE
Fix validity indicator bindings on FilesPage

### DIFF
--- a/Veriado.WinUI/Views/Files/FilesPage.xaml
+++ b/Veriado.WinUI/Views/Files/FilesPage.xaml
@@ -267,8 +267,8 @@
                                             Width="24"
                                             Height="24"
                                             CornerRadius="6"
-                                            Background="{Binding Validity.Status, Converter={StaticResource StatusToBrush}}"
-                                            Visibility="{Binding Validity.DaysRemaining, Converter={StaticResource NullToCollapsed}}"
+                                            Background="{x:Bind Validity.Status, Mode=OneWay, Converter={StaticResource StatusToBrush}}"
+                                            Visibility="{x:Bind Validity.DaysRemaining, Mode=OneWay, Converter={StaticResource NullToCollapsed}}"
                                             ToolTipService.ToolTip="{x:Bind Validity.Tooltip, Mode=OneWay}"
                                             AutomationProperties.Name="{x:Bind Validity.Tooltip, Mode=OneWay}">
                                             <TextBlock


### PR DESCRIPTION
## Summary
- switch the validity badge bindings in the Files page repeater to x:Bind so that they target the list item model

## Testing
- (not run)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69109075f47883268dd462eec4ea2f00)