### PR TITLE
Handle AppWindow closing confirmation without deferral

### DIFF
--- a/Veriado.WinUI/Views/Shell/MainShell.xaml.cs
+++ b/Veriado.WinUI/Views/Shell/MainShell.xaml.cs
@@ -86,23 +86,26 @@ public sealed partial class MainShell : Window, INavigationHost
 
     private async void OnAppWindowClosing(AppWindow sender, AppWindowClosingEventArgs args)
     {
-        var deferral = args.GetDeferral();
+        args.Cancel = true;
 
-        try
+        if (_appWindow is null)
         {
-            var confirmed = await _dialogService
-                .ConfirmAsync("Ukončit aplikaci?", "Opravdu si přejete ukončit aplikaci?", "Ukončit", "Zůstat")
-                .ConfigureAwait(true);
+            return;
+        }
 
-            if (!confirmed)
-            {
-                args.Cancel = true;
-            }
-        }
-        finally
+        _appWindow.Closing -= OnAppWindowClosing;
+
+        var confirmed = await _dialogService
+            .ConfirmAsync("Ukončit aplikaci?", "Opravdu si přejete ukončit aplikaci?", "Ukončit", "Zůstat")
+            .ConfigureAwait(true);
+
+        if (confirmed)
         {
-            deferral.Complete();
+            Close();
+            return;
         }
+
+        _appWindow.Closing += OnAppWindowClosing;
     }
 
     private void OnViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)


### PR DESCRIPTION
## Summary
- cancel the closing request up front and detach the handler while awaiting the confirmation dialog
- close the window manually when the user confirms, otherwise restore the closing handler

## Testing
- dotnet build *(fails: command not found in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910a083e1e08326837017d8b6a3766b)