### PR TITLE
Handle cancellation gracefully in index audit service

### DIFF
--- a/Veriado.Infrastructure/Integrity/IndexAuditBackgroundService.cs
+++ b/Veriado.Infrastructure/Integrity/IndexAuditBackgroundService.cs
@@ -51,6 +51,10 @@ internal sealed class IndexAuditBackgroundService : BackgroundService
             {
                 await RunAuditAsync(stoppingToken).ConfigureAwait(false);
             }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
             catch (OperationCanceledException)
             {
                 throw;


### PR DESCRIPTION
## Summary
- break out of the index audit loop when the host cancellation token is triggered to avoid surfacing TaskCanceledException

## Testing
- dotnet build *(fails: command not found in container environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910a8060c30832687bb0857ac69eeb4)