### PR TITLE
Improve Czech pluralization for validity days

### DIFF
--- a/Veriado.WinUI/Helpers/CzechPluralization.cs
+++ b/Veriado.WinUI/Helpers/CzechPluralization.cs
@@ -1,0 +1,29 @@
+using System;
+
+namespace Veriado.WinUI.Helpers;
+
+internal static class CzechPluralization
+{
+    public static string FormatDays(int days)
+    {
+        return $"{days} {GetDayNoun(days)}";
+    }
+
+    public static string GetDayNoun(int days)
+    {
+        var absoluteValue = Math.Abs(days);
+        var remainder100 = absoluteValue % 100;
+
+        if (remainder100 is >= 11 and <= 14)
+        {
+            return "dní";
+        }
+
+        return (absoluteValue % 10) switch
+        {
+            1 => "den",
+            2 or 3 or 4 => "dny",
+            _ => "dní",
+        };
+    }
+}

--- a/Veriado.WinUI/Helpers/FileValidityHelper.cs
+++ b/Veriado.WinUI/Helpers/FileValidityHelper.cs
@@ -82,7 +82,7 @@ public static class FileValidityHelper
             FileValidityStatus.None => string.Empty,
             FileValidityStatus.Expired => "Platnost skončila",
             FileValidityStatus.ExpiringToday => "Dnes končí",
-            _ => $"Zbývá {daysRemaining} dní",
+            _ => $"Zbývá {CzechPluralization.FormatDays(daysRemaining)}",
         };
     }
 

--- a/Veriado.WinUI/Helpers/ValidityHelper.cs
+++ b/Veriado.WinUI/Helpers/ValidityHelper.cs
@@ -38,9 +38,9 @@ public static class ValidityHelper
 
         return string.Format(
             CultureInfo.CurrentCulture,
-            "Platné: {0} – {1} ({2} dní zbývá)",
+            "Platné: {0} – {1} (zbývá {2})",
             from.Value.ToString(DateFormats.ShortDate, CultureInfo.CurrentCulture),
             to.Value.ToString(DateFormats.ShortDate, CultureInfo.CurrentCulture),
-            days.Value);
+            CzechPluralization.FormatDays(days.Value));
     }
 }


### PR DESCRIPTION
## Summary
- add a helper to produce Czech plural forms for day counts
- update validity badge and tooltip text to use the inflected day labels

## Testing
- not run (missing `dotnet` CLI in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910b0e3c43c8326b53095bb1082bace)