### PR TITLE
Add file deletion action to Files page

### DIFF
--- a/Veriado.Application/Abstractions/IFileRepository.cs
+++ b/Veriado.Application/Abstractions/IFileRepository.cs
@@ -76,4 +76,11 @@ public interface IFileRepository
     /// <param name="cancellationToken">The cancellation token.</param>
     Task UpdateAsync(FileEntity file, FileSystemEntity fileSystem, FilePersistenceOptions options, CancellationToken cancellationToken);
 
+    /// <summary>
+    /// Deletes the file aggregate with the provided identifier.
+    /// </summary>
+    /// <param name="id">The identifier of the file to delete.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    Task DeleteAsync(Guid id, CancellationToken cancellationToken);
+
 }

--- a/Veriado.Application/Files/IFileService.cs
+++ b/Veriado.Application/Files/IFileService.cs
@@ -10,4 +10,6 @@ public interface IFileService
     Task<EditableFileDetailDto> GetDetailAsync(Guid id, CancellationToken cancellationToken);
 
     Task<EditableFileDetailDto> UpdateAsync(EditableFileDetailDto detail, CancellationToken cancellationToken);
+
+    Task DeleteAsync(Guid id, CancellationToken cancellationToken);
 }

--- a/Veriado.Application/UseCases/Files/Common/FileWriteHandlerBase.cs
+++ b/Veriado.Application/UseCases/Files/Common/FileWriteHandlerBase.cs
@@ -61,6 +61,15 @@ public abstract class FileWriteHandlerBase
         CancellationToken cancellationToken)
         => PersistInternalAsync(file, fileSystem, addFirst: false, options, cancellationToken);
 
+    protected async Task DeleteAsync(FileEntity file, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(file);
+
+        await _repository.DeleteAsync(file.Id, cancellationToken).ConfigureAwait(false);
+        await CommitAsync(file, fileSystem: null, requiresProjection: true, deleteFromProjection: true, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
     private async Task PersistInternalAsync(
         FileEntity file,
         FileSystemEntity? fileSystem,

--- a/Veriado.Application/UseCases/Files/DeleteFile/DeleteFileCommand.cs
+++ b/Veriado.Application/UseCases/Files/DeleteFile/DeleteFileCommand.cs
@@ -1,0 +1,7 @@
+namespace Veriado.Appl.UseCases.Files.DeleteFile;
+
+/// <summary>
+/// Command for deleting a file aggregate.
+/// </summary>
+/// <param name="FileId">The identifier of the file to delete.</param>
+public sealed record DeleteFileCommand(Guid FileId) : IRequest<AppResult<Guid>>;

--- a/Veriado.Application/UseCases/Files/DeleteFile/DeleteFileHandler.cs
+++ b/Veriado.Application/UseCases/Files/DeleteFile/DeleteFileHandler.cs
@@ -1,0 +1,48 @@
+using Veriado.Appl.Abstractions;
+
+namespace Veriado.Appl.UseCases.Files.DeleteFile;
+
+/// <summary>
+/// Handles removal of file aggregates.
+/// </summary>
+public sealed class DeleteFileHandler : FileWriteHandlerBase, IRequestHandler<DeleteFileCommand, AppResult<Guid>>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DeleteFileHandler"/> class.
+    /// </summary>
+    public DeleteFileHandler(
+        IFileRepository repository,
+        IClock clock,
+        IMapper mapper,
+        IFilePersistenceUnitOfWork unitOfWork,
+        ISearchProjectionScope projectionScope,
+        IFileSearchProjection searchProjection,
+        ISearchIndexSignatureCalculator signatureCalculator)
+        : base(repository, clock, mapper, unitOfWork, projectionScope, searchProjection, signatureCalculator)
+    {
+    }
+
+    /// <inheritdoc />
+    public async Task<AppResult<Guid>> Handle(DeleteFileCommand request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var file = await Repository.GetAsync(request.FileId, cancellationToken).ConfigureAwait(false);
+            if (file is null)
+            {
+                return AppResult<Guid>.NotFound($"File '{request.FileId}' was not found.");
+            }
+
+            await DeleteAsync(file, cancellationToken).ConfigureAwait(false);
+            return AppResult<Guid>.Success(request.FileId);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            return AppResult<Guid>.FromException(ex, "Failed to delete file.");
+        }
+    }
+}

--- a/Veriado.Application/UseCases/Files/Validation/DeleteFileCommandValidator.cs
+++ b/Veriado.Application/UseCases/Files/Validation/DeleteFileCommandValidator.cs
@@ -1,0 +1,30 @@
+using Veriado.Appl.UseCases.Files.DeleteFile;
+
+namespace Veriado.Appl.UseCases.Files.Validation;
+
+/// <summary>
+/// Validates delete file commands.
+/// </summary>
+public sealed class DeleteFileCommandValidator : AbstractValidator<DeleteFileCommand>, IRequestValidator<DeleteFileCommand>
+{
+    private static readonly IReadOnlyCollection<string> NoErrors = Array.Empty<string>();
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DeleteFileCommandValidator"/> class.
+    /// </summary>
+    public DeleteFileCommandValidator()
+    {
+        RuleFor(command => command.FileId)
+            .NotEmpty();
+    }
+
+    async Task<IReadOnlyCollection<string>> IRequestValidator<DeleteFileCommand>.ValidateAsync(
+        DeleteFileCommand request,
+        CancellationToken cancellationToken)
+    {
+        var result = await ValidateAsync(request, cancellationToken).ConfigureAwait(false);
+        return result.IsValid
+            ? NoErrors
+            : result.Errors.Select(static failure => failure.ErrorMessage).ToArray();
+    }
+}

--- a/Veriado.Mapping/DependencyInjection/MappingServiceCollectionExtensions.cs
+++ b/Veriado.Mapping/DependencyInjection/MappingServiceCollectionExtensions.cs
@@ -6,8 +6,10 @@ using Microsoft.Extensions.Hosting;
 using Veriado.Appl.UseCases.Files.ApplySystemMetadata;
 using Veriado.Appl.UseCases.Files.ClearFileValidity;
 using Veriado.Appl.UseCases.Files.CreateFile;
+using Veriado.Appl.UseCases.Files.DeleteFile;
 using Veriado.Appl.UseCases.Files.RenameFile;
 using Veriado.Appl.UseCases.Files.ReplaceFileContent;
+using Veriado.Appl.UseCases.Files.SetFileReadOnly;
 using Veriado.Appl.UseCases.Files.Validation;
 using Veriado.Mapping.AC;
 using Veriado.Mapping.Profiles;
@@ -44,6 +46,7 @@ public static class MappingServiceCollectionExtensions
         services.AddTransient<IValidator<ClearFileValidityCommand>, ClearFileValidityCommandValidator>();
         services.AddTransient<IValidator<ApplySystemMetadataCommand>, ApplySystemMetadataCommandValidator>();
         services.AddTransient<IValidator<SetFileReadOnlyCommand>, SetFileReadOnlyCommandValidator>();
+        services.AddTransient<IValidator<DeleteFileCommand>, DeleteFileCommandValidator>();
 
         // tvoje pipeline (ponechávám dle tvého projektu)
         services.AddTransient<WriteMappingPipeline>();

--- a/Veriado.Services/Files/IFileOperationsService.cs
+++ b/Veriado.Services/Files/IFileOperationsService.cs
@@ -26,4 +26,6 @@ public interface IFileOperationsService
     Task<ApiResponse<Guid>> ReplaceContentAsync(Guid fileId, byte[] content, CancellationToken cancellationToken);
 
     Task<ApiResponse<Guid>> ApplySystemMetadataAsync(Guid fileId, FileSystemMetadataDto metadata, CancellationToken cancellationToken);
+
+    Task<ApiResponse<Guid>> DeleteAsync(Guid fileId, CancellationToken cancellationToken);
 }

--- a/Veriado.WinUI/Services/ExceptionHandler.cs
+++ b/Veriado.WinUI/Services/ExceptionHandler.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Logging;
 using Veriado.Appl.Common;
+using Veriado.Services.Files.Exceptions;
 
 namespace Veriado.WinUI.Services;
 
@@ -21,6 +22,18 @@ public sealed class ExceptionHandler : IExceptionHandler
             var message = BuildValidationMessage(validationException);
             _logger.LogWarning(exception, "Validation failure in view model execution.");
             return message;
+        }
+
+        if (exception is FileDetailNotFoundException notFound)
+        {
+            _logger.LogInformation(exception, "Requested file was not found.");
+            return notFound.Message;
+        }
+
+        if (exception is FileDetailServiceException serviceException)
+        {
+            _logger.LogError(exception, "File detail service operation failed.");
+            return serviceException.Message;
         }
 
         if (exception is OperationCanceledException)

--- a/Veriado.WinUI/Views/Files/FilesPage.xaml
+++ b/Veriado.WinUI/Views/Files/FilesPage.xaml
@@ -297,14 +297,23 @@
                                         </StackPanel>
                                     </Grid>
 
-                                    <Button
-                                        x:Uid="FilesPage_ItemDetailButton"
+                                    <StackPanel
                                         Grid.Column="1"
+                                        Orientation="Horizontal"
+                                        Spacing="8"
                                         HorizontalAlignment="Right"
-                                        VerticalAlignment="Center"
-                                        Content="Detail"
-                                        Command="{Binding DataContext.OpenDetailCommand, ElementName=PageRoot}"
-                                        CommandParameter="{x:Bind Dto}" />
+                                        VerticalAlignment="Center">
+                                        <Button
+                                            x:Uid="FilesPage_ItemDetailButton"
+                                            Content="Detail"
+                                            Command="{Binding DataContext.OpenDetailCommand, ElementName=PageRoot}"
+                                            CommandParameter="{x:Bind Dto}" />
+                                        <Button
+                                            x:Uid="FilesPage_ItemDeleteButton"
+                                            Content="Smazat"
+                                            Command="{Binding DataContext.DeleteFileCommand, ElementName=PageRoot}"
+                                            CommandParameter="{x:Bind Dto}" />
+                                    </StackPanel>
                                 </Grid>
                             </Border>
                         </DataTemplate>


### PR DESCRIPTION
## Summary
- add a dedicated DeleteFile command, handler, and validator in the application layer
- extend the repository, orchestration services, and WinUI exception handler to support deleting files
- surface a delete action in the Files page view model and XAML so users can remove files from the list

## Testing
- dotnet test *(fails: command not found)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910b5107b108326934d839351cd3b93)