### PR TITLE
Add confirmation helper before deleting files

### DIFF
--- a/Veriado.WinUI/ViewModels/Files/FilesPageViewModel.cs
+++ b/Veriado.WinUI/ViewModels/Files/FilesPageViewModel.cs
@@ -693,13 +693,7 @@ public partial class FilesPageViewModel : ViewModelBase
             return;
         }
 
-        var confirmed = await _dialogService
-            .ConfirmAsync(
-                "Smazat soubor",
-                $"Opravdu chcete smazat soubor \"{summary.Name}\"?",
-                "Smazat",
-                "Zrušit")
-            .ConfigureAwait(false);
+        var confirmed = await ConfirmFileDeletionAsync(summary).ConfigureAwait(false);
 
         if (!confirmed)
         {
@@ -723,6 +717,19 @@ public partial class FilesPageViewModel : ViewModelBase
 
         await Dispatcher.Enqueue(() => ClearDetailState()).ConfigureAwait(false);
         await RefreshCommand.ExecuteAsync(null);
+    }
+
+    private Task<bool> ConfirmFileDeletionAsync(FileSummaryDto summary)
+    {
+        var fileDisplayName = string.IsNullOrWhiteSpace(summary.Extension)
+            ? summary.Name
+            : $"{summary.Name}.{summary.Extension}";
+
+        return _dialogService.ConfirmAsync(
+            "Smazat soubor",
+            $"Opravdu chcete smazat soubor \"{fileDisplayName}\"?",
+            "Smazat",
+            "Zrušit");
     }
 
     private async Task ExecuteSelectFileAsync(FileSummaryDto? summary)


### PR DESCRIPTION
## Summary
- reuse a dedicated helper to confirm deletions before invoking the service
- show the full file name with extension in the confirmation dialog text

## Testing
- dotnet build *(fails: command not found)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910bc025ffc83269ee58f4745210033)