### PR TITLE
Set main shell window title to Veriado

### DIFF
--- a/Veriado.WinUI/Views/Shell/MainShell.xaml
+++ b/Veriado.WinUI/Views/Shell/MainShell.xaml
@@ -1,5 +1,6 @@
 <Window
     x:Class="Veriado.WinUI.Views.Shell.MainShell"
+    Title="Veriado"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"


### PR DESCRIPTION
## Summary
- set the main shell window title in XAML so the app displays "Veriado" instead of the WinUI default

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910c4aa27708326befa18c5d5c3b8dc)