### PR TITLE
Add day noun to validity badge countdown

### DIFF
--- a/Veriado.WinUI/ViewModels/Files/ValidityInfo.cs
+++ b/Veriado.WinUI/ViewModels/Files/ValidityInfo.cs
@@ -18,6 +18,9 @@ public sealed class ValidityInfo
     {
         HasValidity = validFrom.HasValue && validTo.HasValue;
         DaysRemaining = HasValidity ? ValidityHelper.ComputeDaysRemaining(referenceTime, validTo) : null;
+        DaysRemainingDisplay = DaysRemaining.HasValue
+            ? CzechPluralization.FormatDays(DaysRemaining.Value)
+            : null;
         Status = ValidityHelper.ComputeStatus(DaysRemaining);
         Tooltip = ValidityHelper.BuildTooltip(validFrom, validTo, DaysRemaining);
     }
@@ -25,6 +28,8 @@ public sealed class ValidityInfo
     public bool HasValidity { get; }
 
     public int? DaysRemaining { get; }
+
+    public string? DaysRemainingDisplay { get; }
 
     public ValidityStatus Status { get; }
 

--- a/Veriado.WinUI/Views/Files/FilesPage.xaml
+++ b/Veriado.WinUI/Views/Files/FilesPage.xaml
@@ -264,19 +264,22 @@
 
                                         <Border
                                             Grid.Column="0"
-                                            Width="36"
-                                            Height="36"
+                                            MinWidth="36"
+                                            MinHeight="36"
+                                            Padding="4"
                                             CornerRadius="8"
                                             Background="{x:Bind Validity.Status, Mode=OneWay, Converter={StaticResource StatusToBrush}}"
                                             Visibility="{x:Bind Validity.DaysRemaining, Mode=OneWay, Converter={StaticResource NullToCollapsed}}"
                                             ToolTipService.ToolTip="{x:Bind Validity.Tooltip, Mode=OneWay}"
                                             AutomationProperties.Name="{x:Bind Validity.Tooltip, Mode=OneWay}">
                                             <TextBlock
-                                                Text="{x:Bind Validity.DaysRemaining}"
+                                                Text="{x:Bind Validity.DaysRemainingDisplay}"
                                                 VerticalAlignment="Center"
                                                 HorizontalAlignment="Center"
+                                                TextAlignment="Center"
+                                                TextWrapping="WrapWholeWords"
                                                 FontWeight="SemiBold"
-                                                FontSize="14"
+                                                FontSize="12"
                                                 Foreground="White" />
                                         </Border>
 


### PR DESCRIPTION
## Summary
- compute a localized day label for validity countdowns
- show the formatted day text inside the validity badge and adjust its layout to fit the label

## Testing
- dotnet build Veriado.sln *(fails: command not found: dotnet)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910fbe4694c83268d68ab3aacc1f716)