### PR TITLE
Allow configuring validity badge thresholds via settings

### DIFF
--- a/Veriado.WinUI/Helpers/FileValidityHelper.cs
+++ b/Veriado.WinUI/Helpers/FileValidityHelper.cs
@@ -2,6 +2,7 @@ using System;
 using Microsoft.UI.Xaml.Media;
 using Veriado.Contracts.Files;
 using Veriado.WinUI.Resources;
+using Veriado.WinUI.Services.Abstractions;
 
 namespace Veriado.WinUI.Helpers;
 
@@ -19,6 +20,23 @@ public static class FileValidityHelper
     /// <returns><see langword="true"/> if the badge represents a valid window; otherwise <see langword="false"/>.</returns>
     public static bool TryGetBadge(FileValidityDto? validity, DateTimeOffset referenceTime, out FileValidityBadge badge)
     {
+        return TryGetBadge(validity, referenceTime, ValidityThresholds.Default, out badge);
+    }
+
+    /// <summary>
+    /// Attempts to build a validity badge for the supplied validity window.
+    /// </summary>
+    /// <param name="validity">The validity window to evaluate.</param>
+    /// <param name="referenceTime">The reference timestamp used for calculations.</param>
+    /// <param name="thresholds">The configured badge thresholds.</param>
+    /// <param name="badge">The resulting badge metadata.</param>
+    /// <returns><see langword="true"/> if the badge represents a valid window; otherwise <see langword="false"/>.</returns>
+    public static bool TryGetBadge(
+        FileValidityDto? validity,
+        DateTimeOffset referenceTime,
+        ValidityThresholds thresholds,
+        out FileValidityBadge badge)
+    {
         if (validity is null
             || validity.ValidUntil < validity.IssuedAt)
         {
@@ -29,10 +47,10 @@ public static class FileValidityHelper
         var referenceDate = referenceTime.ToLocalTime().Date;
         var validUntilDate = validity.ValidUntil.ToLocalTime().Date;
         var daysRemaining = (validUntilDate - referenceDate).Days;
-        var status = DetermineStatus(daysRemaining);
+        var status = DetermineStatus(daysRemaining, thresholds);
         var text = CreateText(status, daysRemaining);
-        var background = SelectBackground(status);
-        var foreground = SelectForeground(status);
+        var background = SelectBackground(status, daysRemaining, thresholds);
+        var foreground = SelectForeground(status, daysRemaining, thresholds);
 
         badge = new FileValidityBadge(status, daysRemaining, text, background, foreground);
         return true;
@@ -46,28 +64,43 @@ public static class FileValidityHelper
     /// <returns>The computed badge metadata.</returns>
     public static FileValidityBadge GetBadge(FileValidityDto? validity, DateTimeOffset referenceTime)
     {
-        TryGetBadge(validity, referenceTime, out var badge);
+        return GetBadge(validity, referenceTime, ValidityThresholds.Default);
+    }
+
+    /// <summary>
+    /// Gets a validity badge for the supplied validity window or a default placeholder when unavailable.
+    /// </summary>
+    /// <param name="validity">The validity window to evaluate.</param>
+    /// <param name="referenceTime">The reference timestamp used for calculations.</param>
+    /// <param name="thresholds">The configured badge thresholds.</param>
+    /// <returns>The computed badge metadata.</returns>
+    public static FileValidityBadge GetBadge(
+        FileValidityDto? validity,
+        DateTimeOffset referenceTime,
+        ValidityThresholds thresholds)
+    {
+        TryGetBadge(validity, referenceTime, thresholds, out var badge);
         return badge;
     }
 
-    private static FileValidityStatus DetermineStatus(int daysRemaining)
+    private static FileValidityStatus DetermineStatus(int daysRemaining, ValidityThresholds thresholds)
     {
         if (daysRemaining < 0)
         {
             return FileValidityStatus.Expired;
         }
 
-        if (daysRemaining == 0)
+        if (daysRemaining <= thresholds.RedDays)
         {
             return FileValidityStatus.ExpiringToday;
         }
 
-        if (daysRemaining <= 7)
+        if (daysRemaining <= thresholds.OrangeDays)
         {
             return FileValidityStatus.ExpiringSoon;
         }
 
-        if (daysRemaining <= 30)
+        if (daysRemaining <= thresholds.GreenDays)
         {
             return FileValidityStatus.ExpiringLater;
         }
@@ -77,21 +110,35 @@ public static class FileValidityHelper
 
     private static string CreateText(FileValidityStatus status, int daysRemaining)
     {
+        if (status == FileValidityStatus.None)
+        {
+            return string.Empty;
+        }
+
+        if (daysRemaining < 0)
+        {
+            return "Platnost skončila";
+        }
+
+        if (daysRemaining == 0)
+        {
+            return "Dnes končí";
+        }
+
         return status switch
         {
-            FileValidityStatus.None => string.Empty,
-            FileValidityStatus.Expired => "Platnost skončila",
-            FileValidityStatus.ExpiringToday => "Dnes končí",
             _ => $"Zbývá {CzechPluralization.FormatDays(daysRemaining)}",
         };
     }
 
-    private static Brush SelectBackground(FileValidityStatus status)
+    private static Brush SelectBackground(FileValidityStatus status, int daysRemaining, ValidityThresholds thresholds)
     {
         return status switch
         {
             FileValidityStatus.Expired => AppColorPalette.ValidityExpiredBackgroundBrush,
             FileValidityStatus.ExpiringToday => AppColorPalette.ValidityExpiredBackgroundBrush,
+            FileValidityStatus.ExpiringSoon when daysRemaining <= thresholds.RedDays
+                => AppColorPalette.ValidityExpiredBackgroundBrush,
             FileValidityStatus.ExpiringSoon => AppColorPalette.ValidityExpiringSoonBackgroundBrush,
             FileValidityStatus.ExpiringLater => AppColorPalette.ValidityExpiringLaterBackgroundBrush,
             FileValidityStatus.LongTerm => AppColorPalette.ValidityLongTermBackgroundBrush,
@@ -99,12 +146,14 @@ public static class FileValidityHelper
         };
     }
 
-    private static Brush SelectForeground(FileValidityStatus status)
+    private static Brush SelectForeground(FileValidityStatus status, int daysRemaining, ValidityThresholds thresholds)
     {
         return status switch
         {
             FileValidityStatus.Expired => AppColorPalette.ValidityLightForegroundBrush,
             FileValidityStatus.ExpiringToday => AppColorPalette.ValidityLightForegroundBrush,
+            FileValidityStatus.ExpiringSoon when daysRemaining <= thresholds.RedDays
+                => AppColorPalette.ValidityLightForegroundBrush,
             FileValidityStatus.ExpiringSoon => AppColorPalette.ValidityLightForegroundBrush,
             _ => AppColorPalette.ValidityDarkForegroundBrush,
         };
@@ -158,22 +207,22 @@ public enum FileValidityStatus
     Expired,
 
     /// <summary>
-    /// The document expires on the current day.
+    /// The document expires within the configured red threshold.
     /// </summary>
     ExpiringToday,
 
     /// <summary>
-    /// The document expires within seven days.
+    /// The document expires within the configured orange threshold.
     /// </summary>
     ExpiringSoon,
 
     /// <summary>
-    /// The document expires within thirty days.
+    /// The document expires within the configured green threshold.
     /// </summary>
     ExpiringLater,
 
     /// <summary>
-    /// The document validity extends beyond thirty days.
+    /// The document validity extends beyond the configured green threshold.
     /// </summary>
     LongTerm,
 }

--- a/Veriado.WinUI/Helpers/ValidityHelper.cs
+++ b/Veriado.WinUI/Helpers/ValidityHelper.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Globalization;
+using Veriado.WinUI.Services.Abstractions;
 using Veriado.WinUI.ViewModels.Files;
 
 namespace Veriado.WinUI.Helpers;
@@ -16,17 +17,31 @@ public static class ValidityHelper
         return (validTo.Value.Date - now.Date).Days;
     }
 
-    public static ValidityStatus ComputeStatus(int? daysRemaining)
+    public static ValidityStatus ComputeStatus(int? daysRemaining, ValidityThresholds thresholds)
     {
         if (!daysRemaining.HasValue)
         {
             return ValidityStatus.None;
         }
 
-        return daysRemaining.Value <= 0 ? ValidityStatus.Expired
-            : daysRemaining.Value <= 7 ? ValidityStatus.Soon
-            : daysRemaining.Value <= 30 ? ValidityStatus.Upcoming
-            : ValidityStatus.Ok;
+        var days = daysRemaining.Value;
+
+        if (days <= 0)
+        {
+            return ValidityStatus.Expired;
+        }
+
+        if (days <= thresholds.RedDays)
+        {
+            return ValidityStatus.Soon;
+        }
+
+        if (days <= thresholds.OrangeDays)
+        {
+            return ValidityStatus.Upcoming;
+        }
+
+        return ValidityStatus.Ok;
     }
 
     public static string? BuildTooltip(DateTimeOffset? from, DateTimeOffset? to, int? days)

--- a/Veriado.WinUI/Services/Abstractions/IHotStateService.cs
+++ b/Veriado.WinUI/Services/Abstractions/IHotStateService.cs
@@ -24,5 +24,13 @@ public interface IHotStateService
 
     bool ImportAutoExportLog { get; set; }
 
+    ValidityThresholds ValidityThresholds { get; }
+
+    int ValidityRedThresholdDays { get; set; }
+
+    int ValidityOrangeThresholdDays { get; set; }
+
+    int ValidityGreenThresholdDays { get; set; }
+
     Task InitializeAsync(CancellationToken cancellationToken = default);
 }

--- a/Veriado.WinUI/Services/Abstractions/ISettingsService.cs
+++ b/Veriado.WinUI/Services/Abstractions/ISettingsService.cs
@@ -12,6 +12,9 @@ public interface ISettingsService
 public sealed class AppSettings
 {
     public const int DefaultPageSize = 50;
+    public const int DefaultValidityRedThresholdDays = 0;
+    public const int DefaultValidityOrangeThresholdDays = 7;
+    public const int DefaultValidityGreenThresholdDays = 30;
 
     public AppTheme Theme { get; set; } = AppTheme.Default;
 
@@ -24,6 +27,8 @@ public sealed class AppSettings
         = null;
 
     public ImportPreferences Import { get; set; } = new();
+
+    public ValidityPreferences Validity { get; set; } = new();
 }
 
 public sealed class ImportPreferences
@@ -50,5 +55,17 @@ public sealed class ImportPreferences
         = null;
 
     public bool? AutoExportLog { get; set; }
+        = null;
+}
+
+public sealed class ValidityPreferences
+{
+    public int? RedThresholdDays { get; set; }
+        = null;
+
+    public int? OrangeThresholdDays { get; set; }
+        = null;
+
+    public int? GreenThresholdDays { get; set; }
         = null;
 }

--- a/Veriado.WinUI/Services/Abstractions/ValidityThresholds.cs
+++ b/Veriado.WinUI/Services/Abstractions/ValidityThresholds.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace Veriado.WinUI.Services.Abstractions;
+
+public readonly record struct ValidityThresholds(int RedDays, int OrangeDays, int GreenDays)
+{
+    public static ValidityThresholds Default { get; } = new(
+        AppSettings.DefaultValidityRedThresholdDays,
+        AppSettings.DefaultValidityOrangeThresholdDays,
+        AppSettings.DefaultValidityGreenThresholdDays);
+
+    public static ValidityThresholds Normalize(int redDays, int orangeDays, int greenDays)
+    {
+        var normalizedRed = Math.Max(0, redDays);
+        var normalizedOrange = Math.Max(normalizedRed, orangeDays);
+        var normalizedGreen = Math.Max(normalizedOrange, greenDays);
+        return new ValidityThresholds(normalizedRed, normalizedOrange, normalizedGreen);
+    }
+}

--- a/Veriado.WinUI/ViewModels/Files/FileListItemModel.cs
+++ b/Veriado.WinUI/ViewModels/Files/FileListItemModel.cs
@@ -1,11 +1,14 @@
 using System;
 using CommunityToolkit.Mvvm.ComponentModel;
 using Veriado.Contracts.Files;
+using Veriado.WinUI.Services.Abstractions;
 
 namespace Veriado.WinUI.ViewModels.Files;
 
 public sealed partial class FileListItemModel : ObservableObject
 {
+    private ValidityThresholds _validityThresholds;
+
     private static (DateTimeOffset? from, DateTimeOffset? to) NormalizeValidity(FileValidityDto? validity)
     {
         if (validity is null)
@@ -24,13 +27,14 @@ public sealed partial class FileListItemModel : ObservableObject
         return (validFrom, validTo);
     }
 
-    public FileListItemModel(FileSummaryDto dto, DateTimeOffset referenceTime)
+    public FileListItemModel(FileSummaryDto dto, DateTimeOffset referenceTime, ValidityThresholds thresholds)
     {
         Dto = dto ?? throw new ArgumentNullException(nameof(dto));
         var (from, to) = NormalizeValidity(dto.Validity);
         ValidFrom = from;
         ValidTo = to;
-        Validity = new ValidityInfo(ValidFrom, ValidTo, referenceTime);
+        _validityThresholds = thresholds;
+        Validity = new ValidityInfo(ValidFrom, ValidTo, referenceTime, _validityThresholds);
     }
 
     public FileSummaryDto Dto { get; }
@@ -47,8 +51,13 @@ public sealed partial class FileListItemModel : ObservableObject
         private set => SetProperty(ref _validity, value);
     }
 
-    public void RecomputeValidity(DateTimeOffset referenceTime)
+    public void RecomputeValidity(DateTimeOffset referenceTime, ValidityThresholds? thresholds = null)
     {
-        Validity = new ValidityInfo(ValidFrom, ValidTo, referenceTime);
+        if (thresholds.HasValue)
+        {
+            _validityThresholds = thresholds.Value;
+        }
+
+        Validity = new ValidityInfo(ValidFrom, ValidTo, referenceTime, _validityThresholds);
     }
 }

--- a/Veriado.WinUI/ViewModels/Files/ValidityInfo.cs
+++ b/Veriado.WinUI/ViewModels/Files/ValidityInfo.cs
@@ -1,5 +1,6 @@
 using System;
 using Veriado.WinUI.Helpers;
+using Veriado.WinUI.Services.Abstractions;
 
 namespace Veriado.WinUI.ViewModels.Files;
 
@@ -14,14 +15,18 @@ public enum ValidityStatus
 
 public sealed class ValidityInfo
 {
-    public ValidityInfo(DateTimeOffset? validFrom, DateTimeOffset? validTo, DateTimeOffset referenceTime)
+    public ValidityInfo(
+        DateTimeOffset? validFrom,
+        DateTimeOffset? validTo,
+        DateTimeOffset referenceTime,
+        ValidityThresholds thresholds)
     {
         HasValidity = validFrom.HasValue && validTo.HasValue;
         DaysRemaining = HasValidity ? ValidityHelper.ComputeDaysRemaining(referenceTime, validTo) : null;
         DaysRemainingDisplay = DaysRemaining.HasValue
             ? CzechPluralization.FormatDays(DaysRemaining.Value)
             : null;
-        Status = ValidityHelper.ComputeStatus(DaysRemaining);
+        Status = ValidityHelper.ComputeStatus(DaysRemaining, thresholds);
         Tooltip = ValidityHelper.BuildTooltip(validFrom, validTo, DaysRemaining);
     }
 

--- a/Veriado.WinUI/Views/Files/FilesPage.xaml.cs
+++ b/Veriado.WinUI/Views/Files/FilesPage.xaml.cs
@@ -194,7 +194,7 @@ public sealed partial class FilesPage : Page
         var now = _serverClock.NowLocal;
         foreach (var item in e.NewItems.OfType<FileListItemModel>())
         {
-            item.RecomputeValidity(now);
+            item.RecomputeValidity(now, ViewModel.ValidityThresholds);
         }
     }
 }

--- a/Veriado.WinUI/Views/Settings/SettingsPage.xaml
+++ b/Veriado.WinUI/Views/Settings/SettingsPage.xaml
@@ -25,6 +25,29 @@
             PlaceholderText="Cesta ke složce"
             Text="{Binding LastFolder, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
 
+        <TextBlock Text="Platnost dokumentů" FontSize="16" FontWeight="SemiBold" Margin="0,12,0,0" />
+
+        <controls:NumberBox
+            Header="Červený odznak (dní)"
+            Minimum="0"
+            SmallChange="1"
+            SpinButtonPlacementMode="Compact"
+            Value="{Binding ValidityRedThreshold, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+
+        <controls:NumberBox
+            Header="Oranžový odznak (dní)"
+            Minimum="0"
+            SmallChange="1"
+            SpinButtonPlacementMode="Compact"
+            Value="{Binding ValidityOrangeThreshold, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+
+        <controls:NumberBox
+            Header="Zelený odznak (dní)"
+            Minimum="0"
+            SmallChange="1"
+            SpinButtonPlacementMode="Compact"
+            Value="{Binding ValidityGreenThreshold, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+
         <Button Content="Použít motiv" Command="{Binding ApplyThemeCommand}" />
     </StackPanel>
 </Page>


### PR DESCRIPTION
## Summary
- add persisted validity threshold settings with defaults and normalization
- expose threshold controls on the settings page and update in-memory state when they change
- apply configured thresholds when computing validity badges and list indicators

## Testing
- `dotnet build Veriado.sln` *(fails: command not found in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691217c6add0832690899e3116a86e5b)