### PR TITLE
Adjust list validity thresholds to match badge ranges

### DIFF
--- a/Veriado.WinUI/Helpers/ValidityHelper.cs
+++ b/Veriado.WinUI/Helpers/ValidityHelper.cs
@@ -31,12 +31,12 @@ public static class ValidityHelper
             return ValidityStatus.Expired;
         }
 
-        if (days <= thresholds.RedDays)
+        if (days <= thresholds.OrangeDays)
         {
             return ValidityStatus.Soon;
         }
 
-        if (days <= thresholds.OrangeDays)
+        if (days <= thresholds.GreenDays)
         {
             return ValidityStatus.Upcoming;
         }


### PR DESCRIPTION
## Summary
- align list validity status thresholds with the configured orange and green cut-offs to restore the "Soon" classification

## Testing
- not run (not supported in environment)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912236aa0bc8326a3d75e8cd262740d)