### PR TITLE
Handle file-system cleanup when deleting files

### DIFF
--- a/Veriado.Application/Abstractions/IFileRepository.cs
+++ b/Veriado.Application/Abstractions/IFileRepository.cs
@@ -83,4 +83,11 @@ public interface IFileRepository
     /// <param name="cancellationToken">The cancellation token.</param>
     Task DeleteAsync(Guid id, CancellationToken cancellationToken);
 
+    /// <summary>
+    /// Deletes the file-system aggregate with the provided identifier.
+    /// </summary>
+    /// <param name="id">The identifier of the file-system entity to delete.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    Task DeleteFileSystemAsync(Guid id, CancellationToken cancellationToken);
+
 }

--- a/Veriado.Application/UseCases/Files/Common/FileWriteHandlerBase.cs
+++ b/Veriado.Application/UseCases/Files/Common/FileWriteHandlerBase.cs
@@ -61,11 +61,16 @@ public abstract class FileWriteHandlerBase
         CancellationToken cancellationToken)
         => PersistInternalAsync(file, fileSystem, addFirst: false, options, cancellationToken);
 
-    protected async Task DeleteAsync(FileEntity file, CancellationToken cancellationToken)
+    protected async Task DeleteAsync(FileEntity file, FileSystemEntity? fileSystem, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(file);
 
         await _repository.DeleteAsync(file.Id, cancellationToken).ConfigureAwait(false);
+        if (fileSystem is not null)
+        {
+            await _repository.DeleteFileSystemAsync(fileSystem.Id, cancellationToken).ConfigureAwait(false);
+        }
+
         await CommitAsync(file, fileSystem: null, requiresProjection: true, deleteFromProjection: true, cancellationToken)
             .ConfigureAwait(false);
     }

--- a/Veriado.Application/UseCases/Files/DeleteFile/DeleteFileHandler.cs
+++ b/Veriado.Application/UseCases/Files/DeleteFile/DeleteFileHandler.cs
@@ -33,7 +33,15 @@ public sealed class DeleteFileHandler : FileWriteHandlerBase, IRequestHandler<De
                 return AppResult<Guid>.NotFound($"File '{request.FileId}' was not found.");
             }
 
-            await DeleteAsync(file, cancellationToken).ConfigureAwait(false);
+            var fileSystem = await Repository
+                .GetFileSystemAsync(file.FileSystemId, cancellationToken)
+                .ConfigureAwait(false);
+            if (fileSystem is null)
+            {
+                throw new InvalidOperationException($"File system entity '{file.FileSystemId}' was not found.");
+            }
+
+            await DeleteAsync(file, fileSystem, cancellationToken).ConfigureAwait(false);
             return AppResult<Guid>.Success(request.FileId);
         }
         catch (OperationCanceledException)

--- a/Veriado.Infrastructure/Repositories/FileRepository.cs
+++ b/Veriado.Infrastructure/Repositories/FileRepository.cs
@@ -293,6 +293,24 @@ internal sealed partial class FileRepository : IFileRepository
         }
     }
 
+    public async Task DeleteFileSystemAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var entity = await _db.FileSystems.FirstOrDefaultAsync(f => f.Id == id, cancellationToken).ConfigureAwait(false);
+            if (entity is null)
+            {
+                return;
+            }
+
+            WithChangeTrackerLock(() => _db.FileSystems.Remove(entity));
+        }
+        catch (DbUpdateConcurrencyException ex)
+        {
+            throw CreateConcurrencyException("deleting file system metadata for", ex);
+        }
+    }
+
 }
 
 partial class FileRepository


### PR DESCRIPTION
## Summary
- load the backing file-system entity in the delete handler and require it before deleting
- teach the shared persistence helper and repository to remove associated file-system records alongside files

## Testing
- dotnet test *(fails: command not found)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691223a5f5c88326b46cabb81e8c92e2)