### PR TITLE
Fix Czech day pluralization for compound numerals

### DIFF
--- a/Veriado.WinUI/Helpers/CzechPluralization.cs
+++ b/Veriado.WinUI/Helpers/CzechPluralization.cs
@@ -14,6 +14,11 @@ internal static class CzechPluralization
         var absoluteValue = Math.Abs(days);
         var remainder100 = absoluteValue % 100;
 
+        if (absoluteValue == 1)
+        {
+            return "den";
+        }
+
         if (remainder100 is >= 11 and <= 14)
         {
             return "dní";
@@ -21,7 +26,6 @@ internal static class CzechPluralization
 
         return (absoluteValue % 10) switch
         {
-            1 => "den",
             2 or 3 or 4 => "dny",
             _ => "dní",
         };


### PR DESCRIPTION
## Summary
- ensure Czech day pluralization uses the singular form only for the value 1
- return the genitive plural form for compound numerals ending with 1 (e.g., 61)

## Testing
- dotnet test *(fails: `dotnet` command not available in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69123a57a6088326832d9ebda6423cff)