### PR TITLE
Implement resilient shutdown orchestration

### DIFF
--- a/Veriado.WinUI/Helpers/WindowExtensions.cs
+++ b/Veriado.WinUI/Helpers/WindowExtensions.cs
@@ -1,0 +1,24 @@
+using Microsoft.UI.Windowing;
+using Microsoft.UI.Xaml;
+using WinRT.Interop;
+
+namespace Veriado.WinUI.Helpers;
+
+public static class WindowExtensions
+{
+    public static AppWindow? TryGetAppWindow(this Window window)
+    {
+        ArgumentNullException.ThrowIfNull(window);
+
+        try
+        {
+            var hwnd = WindowNative.GetWindowHandle(window);
+            var windowId = Win32Interop.GetWindowIdFromWindow(hwnd);
+            return AppWindow.GetFromWindowId(windowId);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+}

--- a/Veriado.WinUI/Services/Abstractions/IConfirmService.cs
+++ b/Veriado.WinUI/Services/Abstractions/IConfirmService.cs
@@ -1,0 +1,11 @@
+namespace Veriado.WinUI.Services.Abstractions;
+
+public interface IConfirmService
+{
+    Task<bool> TryConfirmAsync(
+        string title,
+        string message,
+        string confirmText,
+        string cancelText,
+        CancellationToken cancellationToken = default);
+}

--- a/Veriado.WinUI/Services/Abstractions/IHostShutdownService.cs
+++ b/Veriado.WinUI/Services/Abstractions/IHostShutdownService.cs
@@ -1,0 +1,8 @@
+namespace Veriado.WinUI.Services.Abstractions;
+
+public interface IHostShutdownService
+{
+    Task StopAsync(CancellationToken cancellationToken);
+
+    ValueTask DisposeAsync();
+}

--- a/Veriado.WinUI/Services/Abstractions/IShutdownOrchestrator.cs
+++ b/Veriado.WinUI/Services/Abstractions/IShutdownOrchestrator.cs
@@ -1,0 +1,8 @@
+namespace Veriado.WinUI.Services.Abstractions;
+
+public interface IShutdownOrchestrator
+{
+    Task<ShutdownResult> RequestAppShutdownAsync(
+        ShutdownReason reason,
+        CancellationToken cancellationToken = default);
+}

--- a/Veriado.WinUI/Services/ConfirmService.cs
+++ b/Veriado.WinUI/Services/ConfirmService.cs
@@ -1,0 +1,111 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Veriado.WinUI.Services.Abstractions;
+
+namespace Veriado.WinUI.Services;
+
+public sealed class ConfirmService : IConfirmService
+{
+    private static readonly TimeSpan DialogTimeout = TimeSpan.FromSeconds(8);
+
+    private readonly IWindowProvider _windowProvider;
+    private readonly ILogger<ConfirmService> _logger;
+
+    public ConfirmService(IWindowProvider windowProvider, ILogger<ConfirmService> logger)
+    {
+        _windowProvider = windowProvider ?? throw new ArgumentNullException(nameof(windowProvider));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<bool> TryConfirmAsync(
+        string title,
+        string message,
+        string confirmText,
+        string cancelText,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            if (!_windowProvider.TryGetWindow(out var window) || window?.Content is not FrameworkElement root)
+            {
+                _logger.LogDebug("Confirmation dialog skipped because no active window content is available.");
+                return true;
+            }
+
+            var xamlRoot = root.XamlRoot;
+            if (xamlRoot is null)
+            {
+                _logger.LogWarning("Confirmation dialog skipped because XamlRoot is not available.");
+                return true;
+            }
+
+            var dialog = new ContentDialog
+            {
+                Title = title,
+                Content = message,
+                PrimaryButtonText = confirmText,
+                CloseButtonText = string.IsNullOrWhiteSpace(cancelText) ? null : cancelText,
+                DefaultButton = ContentDialogButton.Primary,
+                XamlRoot = xamlRoot,
+                RequestedTheme = root.ActualTheme,
+            };
+
+            using var timeoutCts = new CancellationTokenSource(DialogTimeout);
+            using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(timeoutCts.Token, cancellationToken);
+
+            try
+            {
+                var result = await ShowDialogAsync(dialog, linkedCts.Token).ConfigureAwait(true);
+                return result;
+            }
+            catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested)
+            {
+                _logger.LogWarning("Confirmation dialog timed out after {Timeout}.", DialogTimeout);
+                return true;
+            }
+            catch (OperationCanceledException)
+            {
+                _logger.LogInformation("Confirmation dialog canceled via token; allowing shutdown to proceed.");
+                return true;
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Confirmation dialog failed. Proceeding with shutdown.");
+            return true;
+        }
+    }
+
+    private static async Task<bool> ShowDialogAsync(ContentDialog dialog, CancellationToken cancellationToken)
+    {
+        using var registration = cancellationToken.Register(() =>
+        {
+            if (dialog.DispatcherQueue.HasThreadAccess)
+            {
+                if (dialog.IsLoaded)
+                {
+                    dialog.Hide();
+                }
+            }
+            else
+            {
+                _ = dialog.DispatcherQueue.TryEnqueue(() =>
+                {
+                    if (dialog.IsLoaded)
+                    {
+                        dialog.Hide();
+                    }
+                });
+            }
+        });
+
+        var result = await dialog.ShowAsync().AsTask().ConfigureAwait(true);
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return true;
+        }
+
+        return result == ContentDialogResult.Primary;
+    }
+}

--- a/Veriado.WinUI/Services/HostShutdownService.cs
+++ b/Veriado.WinUI/Services/HostShutdownService.cs
@@ -1,0 +1,51 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Veriado.WinUI.Services.Abstractions;
+
+namespace Veriado.WinUI.Services;
+
+internal sealed class HostShutdownService : IHostShutdownService
+{
+    private readonly ILogger<HostShutdownService> _logger;
+    private IHost? _host;
+
+    public HostShutdownService(ILogger<HostShutdownService> logger)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public void Initialize(IHost host)
+    {
+        ArgumentNullException.ThrowIfNull(host);
+
+        if (Interlocked.CompareExchange(ref _host, host, null) is not null)
+        {
+            throw new InvalidOperationException("The host has already been initialized.");
+        }
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        var host = _host ?? throw new InvalidOperationException("The host has not been initialized.");
+        return host.StopAsync(cancellationToken);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        var host = _host;
+        if (host is null)
+        {
+            _logger.LogDebug("DisposeAsync called without an initialized host.");
+            return;
+        }
+
+        if (host is IAsyncDisposable asyncDisposable)
+        {
+            await asyncDisposable.DisposeAsync().ConfigureAwait(false);
+        }
+        else
+        {
+            host.Dispose();
+        }
+    }
+}

--- a/Veriado.WinUI/Services/Shutdown/ShutdownOrchestrator.cs
+++ b/Veriado.WinUI/Services/Shutdown/ShutdownOrchestrator.cs
@@ -1,0 +1,137 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Veriado.WinUI.Services.Abstractions;
+
+namespace Veriado.WinUI.Services.Shutdown;
+
+public sealed class ShutdownOrchestrator : IShutdownOrchestrator, IAsyncDisposable
+{
+    private static readonly TimeSpan StopTimeout = TimeSpan.FromSeconds(10);
+
+    private readonly IConfirmService _confirmService;
+    private readonly IHostApplicationLifetime _applicationLifetime;
+    private readonly IHostShutdownService _hostShutdownService;
+    private readonly ILogger<ShutdownOrchestrator> _logger;
+    private readonly SemaphoreSlim _gate = new(1, 1);
+
+    private bool _completed;
+
+    public ShutdownOrchestrator(
+        IConfirmService confirmService,
+        IHostApplicationLifetime applicationLifetime,
+        IHostShutdownService hostShutdownService,
+        ILogger<ShutdownOrchestrator> logger)
+    {
+        _confirmService = confirmService ?? throw new ArgumentNullException(nameof(confirmService));
+        _applicationLifetime = applicationLifetime ?? throw new ArgumentNullException(nameof(applicationLifetime));
+        _hostShutdownService = hostShutdownService ?? throw new ArgumentNullException(nameof(hostShutdownService));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<ShutdownResult> RequestAppShutdownAsync(
+        ShutdownReason reason,
+        CancellationToken cancellationToken = default)
+    {
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+
+        try
+        {
+            if (_completed)
+            {
+                _logger.LogDebug("Shutdown has already completed. Allowing close.");
+                return ShutdownResult.Allow();
+            }
+
+            _logger.LogInformation("Shutdown requested with reason {Reason}.", reason);
+
+            var confirmed = await ConfirmShutdownAsync(reason, cancellationToken).ConfigureAwait(true);
+            if (!confirmed)
+            {
+                _logger.LogInformation("Shutdown canceled by user confirmation.");
+                return ShutdownResult.Cancel();
+            }
+
+            ExecuteStopApplication();
+
+            await StopHostAsync(cancellationToken).ConfigureAwait(false);
+            await DisposeHostAsync().ConfigureAwait(false);
+
+            _completed = true;
+            _logger.LogInformation("Shutdown sequence finished.");
+            return ShutdownResult.Allow();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unexpected shutdown failure. Allowing window to close to avoid trapping the user.");
+            return ShutdownResult.Allow();
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        _gate.Dispose();
+        return ValueTask.CompletedTask;
+    }
+
+    private async Task<bool> ConfirmShutdownAsync(ShutdownReason reason, CancellationToken cancellationToken)
+    {
+        if (reason != ShutdownReason.AppWindowClosing)
+        {
+            return true;
+        }
+
+        return await _confirmService
+            .TryConfirmAsync("Ukončit aplikaci?", "Opravdu si přejete ukončit aplikaci?", "Ukončit", "Zůstat", cancellationToken)
+            .ConfigureAwait(true);
+    }
+
+    private void ExecuteStopApplication()
+    {
+        try
+        {
+            _applicationLifetime.StopApplication();
+            _logger.LogDebug("Signaled host application lifetime to stop.");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to signal application lifetime stop.");
+        }
+    }
+
+    private async Task StopHostAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            using var stopCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            stopCts.CancelAfter(StopTimeout);
+
+            await _hostShutdownService.StopAsync(stopCts.Token).ConfigureAwait(false);
+            _logger.LogDebug("Host stopped successfully.");
+        }
+        catch (OperationCanceledException)
+        {
+            _logger.LogWarning("Host stop operation timed out after {Timeout}.", StopTimeout);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Host stop operation failed.");
+        }
+    }
+
+    private async Task DisposeHostAsync()
+    {
+        try
+        {
+            await _hostShutdownService.DisposeAsync().ConfigureAwait(false);
+            _logger.LogDebug("Host disposed successfully.");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Host dispose operation failed.");
+        }
+    }
+}

--- a/Veriado.WinUI/Services/Shutdown/ShutdownReason.cs
+++ b/Veriado.WinUI/Services/Shutdown/ShutdownReason.cs
@@ -1,0 +1,8 @@
+namespace Veriado.WinUI.Services.Abstractions;
+
+public enum ShutdownReason
+{
+    AppWindowClosing,
+    ApplicationRequest,
+    UnexpectedTermination,
+}

--- a/Veriado.WinUI/Services/Shutdown/ShutdownResult.cs
+++ b/Veriado.WinUI/Services/Shutdown/ShutdownResult.cs
@@ -1,0 +1,8 @@
+namespace Veriado.WinUI.Services.Abstractions;
+
+public readonly record struct ShutdownResult(bool IsAllowed)
+{
+    public static ShutdownResult Allow() => new(true);
+
+    public static ShutdownResult Cancel() => new(false);
+}

--- a/Veriado.WinUI/Views/Shell/MainShell.xaml.cs
+++ b/Veriado.WinUI/Views/Shell/MainShell.xaml.cs
@@ -1,10 +1,8 @@
 using System.ComponentModel;
 using System.Linq;
-using Microsoft.UI.Windowing;
 using Veriado.WinUI.Navigation;
 using Veriado.WinUI.Services.Abstractions;
 using Veriado.WinUI.ViewModels.Shell;
-using WinRT.Interop;
 
 namespace Veriado.WinUI.Views.Shell;
 
@@ -12,8 +10,6 @@ public sealed partial class MainShell : Window, INavigationHost
 {
     private readonly MainShellViewModel _viewModel;
     private readonly INavigationService _navigationService;
-    private readonly IDialogService _dialogService;
-    private AppWindow? _appWindow;
 
     public MainShell(MainShellViewModel viewModel, INavigationService navigationService, IDialogService dialogService)
     {
@@ -21,12 +17,10 @@ public sealed partial class MainShell : Window, INavigationHost
 
         _viewModel = viewModel ?? throw new ArgumentNullException(nameof(viewModel));
         _navigationService = navigationService ?? throw new ArgumentNullException(nameof(navigationService));
-        _dialogService = dialogService ?? throw new ArgumentNullException(nameof(dialogService));
+        _ = dialogService ?? throw new ArgumentNullException(nameof(dialogService));
 
         RootNavigation.DataContext = _viewModel;
         _navigationService.AttachHost(this);
-
-        InitializeWindowing();
 
         _viewModel.PropertyChanged += OnViewModelPropertyChanged;
         RootNavigation.Loaded += OnLoaded;
@@ -44,68 +38,18 @@ public sealed partial class MainShell : Window, INavigationHost
         RootNavigation.Loaded -= OnLoaded;
         _viewModel.Initialize();
         UpdateNavigationSelection(_viewModel.CurrentPage);
-
-        if (_appWindow is null)
-        {
-            InitializeWindowing();
-        }
     }
 
     private void OnClosed(object sender, WindowEventArgs e)
     {
         Closed -= OnClosed;
         _viewModel.PropertyChanged -= OnViewModelPropertyChanged;
-
-        if (_appWindow is not null)
-        {
-            _appWindow.Closing -= OnAppWindowClosing;
-            _appWindow = null;
-        }
     }
 
     private void OnNavigationViewItemInvoked(NavigationView sender, NavigationViewItemInvokedEventArgs args)
     {
         var tag = args.InvokedItemContainer?.Tag as string;
         _viewModel.NavigateToTag(tag);
-    }
-
-    private void InitializeWindowing()
-    {
-        try
-        {
-            var hwnd = WindowNative.GetWindowHandle(this);
-            var windowId = Microsoft.UI.Win32Interop.GetWindowIdFromWindow(hwnd);
-            _appWindow = AppWindow.GetFromWindowId(windowId);
-            _appWindow.Closing += OnAppWindowClosing;
-        }
-        catch
-        {
-            _appWindow = null;
-        }
-    }
-
-    private async void OnAppWindowClosing(AppWindow sender, AppWindowClosingEventArgs args)
-    {
-        args.Cancel = true;
-
-        if (_appWindow is null)
-        {
-            return;
-        }
-
-        _appWindow.Closing -= OnAppWindowClosing;
-
-        var confirmed = await _dialogService
-            .ConfirmAsync("Ukončit aplikaci?", "Opravdu si přejete ukončit aplikaci?", "Ukončit", "Zůstat")
-            .ConfigureAwait(true);
-
-        if (confirmed)
-        {
-            Close();
-            return;
-        }
-
-        _appWindow.Closing += OnAppWindowClosing;
     }
 
     private void OnViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)


### PR DESCRIPTION
## Summary
- add a shutdown orchestrator and supporting services to drive confirmation, host stop and disposal with timeouts
- move AppWindow closing handling into App.xaml.cs with deferral-based orchestration and fail-open behavior
- register new services in the host, update the shell to drop inline confirmation logic, and add helper utilities for window access

## Testing
- not run (dotnet CLI not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69124b3c63a08326a75ef708d0879d17)