### PR TITLE
Fix shutdown flow to close main window

### DIFF
--- a/Veriado.WinUI/App.xaml.cs
+++ b/Veriado.WinUI/App.xaml.cs
@@ -185,14 +185,14 @@ public partial class App : WinUIApplication
                 if (result.IsAllowed)
                 {
                     _isAppWindowShutdownInProgress = true;
-                    window.Close();
+                    MainWindow?.Close();
                 }
             }
             catch (Exception ex)
             {
                 BootstrapLogger.LogError(ex, "Shutdown orchestrator failed during AppWindow closing. Allowing close.");
                 _isAppWindowShutdownInProgress = true;
-                window.Close();
+                MainWindow?.Close();
             }
         }
     }


### PR DESCRIPTION
## Summary
- ensure the shutdown orchestrator closes the XAML main window instead of the AppWindow instance
- keep the shutdown flag logic intact so the window can exit when allowed

## Testing
- not run (Windows-specific project)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69124e84be008326a50f767e4865d479)