### PR TITLE
Improve shutdown orchestration and confirmation handling

### DIFF
--- a/Veriado.WinUI/Services/Shutdown/ShutdownOrchestrator.cs
+++ b/Veriado.WinUI/Services/Shutdown/ShutdownOrchestrator.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Threading;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Veriado.WinUI.Services.Abstractions;
@@ -14,7 +16,8 @@ public sealed class ShutdownOrchestrator : IShutdownOrchestrator, IAsyncDisposab
     private readonly ILogger<ShutdownOrchestrator> _logger;
     private readonly SemaphoreSlim _gate = new(1, 1);
 
-    private bool _completed;
+    private bool _stopCompleted;
+    private bool _disposeCompleted;
 
     public ShutdownOrchestrator(
         IConfirmService confirmService,
@@ -36,7 +39,7 @@ public sealed class ShutdownOrchestrator : IShutdownOrchestrator, IAsyncDisposab
 
         try
         {
-            if (_completed)
+            if (_stopCompleted && _disposeCompleted)
             {
                 _logger.LogDebug("Shutdown has already completed. Allowing close.");
                 return ShutdownResult.Allow();
@@ -53,11 +56,30 @@ public sealed class ShutdownOrchestrator : IShutdownOrchestrator, IAsyncDisposab
 
             ExecuteStopApplication();
 
-            await StopHostAsync(cancellationToken).ConfigureAwait(false);
-            await DisposeHostAsync().ConfigureAwait(false);
+            var stopCompleted = _stopCompleted;
+            if (!stopCompleted)
+            {
+                stopCompleted = await StopHostAsync(cancellationToken).ConfigureAwait(false);
+                _stopCompleted = stopCompleted;
+            }
 
-            _completed = true;
-            _logger.LogInformation("Shutdown sequence finished.");
+            var disposeCompleted = _disposeCompleted;
+            if (!disposeCompleted)
+            {
+                disposeCompleted = await DisposeHostAsync().ConfigureAwait(false);
+                _disposeCompleted = disposeCompleted;
+            }
+
+            if (stopCompleted && disposeCompleted)
+            {
+                _logger.LogInformation("Shutdown sequence finished.");
+                return ShutdownResult.Allow();
+            }
+
+            _logger.LogWarning(
+                "Shutdown sequence incomplete. Stop completed: {StopCompleted}, dispose completed: {DisposeCompleted}.",
+                stopCompleted,
+                disposeCompleted);
             return ShutdownResult.Allow();
         }
         catch (Exception ex)
@@ -102,7 +124,7 @@ public sealed class ShutdownOrchestrator : IShutdownOrchestrator, IAsyncDisposab
         }
     }
 
-    private async Task StopHostAsync(CancellationToken cancellationToken)
+    private async Task<bool> StopHostAsync(CancellationToken cancellationToken)
     {
         try
         {
@@ -111,27 +133,57 @@ public sealed class ShutdownOrchestrator : IShutdownOrchestrator, IAsyncDisposab
 
             await _hostShutdownService.StopAsync(stopCts.Token).ConfigureAwait(false);
             _logger.LogDebug("Host stopped successfully.");
+            return true;
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            _logger.LogInformation("Host stop operation canceled via caller token.");
         }
         catch (OperationCanceledException)
         {
             _logger.LogWarning("Host stop operation timed out after {Timeout}.", StopTimeout);
         }
+        catch (InvalidOperationException ex)
+        {
+            _logger.LogDebug(ex, "Host stop operation skipped because the host was not initialized.");
+            return true;
+        }
+        catch (ObjectDisposedException ex)
+        {
+            _logger.LogDebug(ex, "Host stop operation skipped because the host was already disposed.");
+            return true;
+        }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Host stop operation failed.");
         }
+
+        return false;
     }
 
-    private async Task DisposeHostAsync()
+    private async Task<bool> DisposeHostAsync()
     {
         try
         {
             await _hostShutdownService.DisposeAsync().ConfigureAwait(false);
             _logger.LogDebug("Host disposed successfully.");
+            return true;
+        }
+        catch (InvalidOperationException ex)
+        {
+            _logger.LogDebug(ex, "Host dispose operation skipped because the host was not initialized.");
+            return true;
+        }
+        catch (ObjectDisposedException ex)
+        {
+            _logger.LogDebug(ex, "Host dispose operation skipped because the host was already disposed.");
+            return true;
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Host dispose operation failed.");
         }
+
+        return false;
     }
 }


### PR DESCRIPTION
## Summary
- tighten shutdown orchestration to respect cancellation timeouts, capture completion state, and improve logging
- harden HostShutdownService and AppHost disposal to avoid double shutdown attempts and surface failures
- make confirmation dialogs default to staying open when unavailable, failing, or timing out and extend the timeout window

## Testing
- `dotnet test` *(fails: dotnet CLI not available in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691396a15e9c83268dfbb52098ae13b7)