### PR TITLE
Fix catch clause ordering in shutdown orchestrator

### DIFF
--- a/Veriado.WinUI/Services/Shutdown/ShutdownOrchestrator.cs
+++ b/Veriado.WinUI/Services/Shutdown/ShutdownOrchestrator.cs
@@ -143,14 +143,14 @@ public sealed class ShutdownOrchestrator : IShutdownOrchestrator, IAsyncDisposab
         {
             _logger.LogWarning("Host stop operation timed out after {Timeout}.", StopTimeout);
         }
-        catch (InvalidOperationException ex)
-        {
-            _logger.LogDebug(ex, "Host stop operation skipped because the host was not initialized.");
-            return true;
-        }
         catch (ObjectDisposedException ex)
         {
             _logger.LogDebug(ex, "Host stop operation skipped because the host was already disposed.");
+            return true;
+        }
+        catch (InvalidOperationException ex)
+        {
+            _logger.LogDebug(ex, "Host stop operation skipped because the host was not initialized.");
             return true;
         }
         catch (Exception ex)
@@ -169,14 +169,14 @@ public sealed class ShutdownOrchestrator : IShutdownOrchestrator, IAsyncDisposab
             _logger.LogDebug("Host disposed successfully.");
             return true;
         }
-        catch (InvalidOperationException ex)
-        {
-            _logger.LogDebug(ex, "Host dispose operation skipped because the host was not initialized.");
-            return true;
-        }
         catch (ObjectDisposedException ex)
         {
             _logger.LogDebug(ex, "Host dispose operation skipped because the host was already disposed.");
+            return true;
+        }
+        catch (InvalidOperationException ex)
+        {
+            _logger.LogDebug(ex, "Host dispose operation skipped because the host was not initialized.");
             return true;
         }
         catch (Exception ex)


### PR DESCRIPTION
## Summary
- place more specific ObjectDisposedException catches before InvalidOperationException in the shutdown orchestrator
- ensure host stop and dispose routines compile without conflicting catch clauses

## Testing
- dotnet build Veriado.sln *(fails: command not found in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69139a7ca778832699f47ae81cac7e47)