### PR TITLE
Refine shutdown coordination and lifecycle handling

### DIFF
--- a/Veriado.Services/Import/ImportService.cs
+++ b/Veriado.Services/Import/ImportService.cs
@@ -747,9 +747,12 @@ public sealed class ImportService : IImportService
 
         try
         {
-            await foreach (var progress in channel.Reader.ReadAllAsync(cancellationToken).ConfigureAwait(false))
+            while (await channel.Reader.WaitToReadAsync(cancellationToken).ConfigureAwait(false))
             {
-                yield return progress;
+                while (channel.Reader.TryRead(out var progress))
+                {
+                    yield return progress;
+                }
             }
         }
         finally

--- a/Veriado.WinUI/Services/Abstractions/IHostShutdownService.cs
+++ b/Veriado.WinUI/Services/Abstractions/IHostShutdownService.cs
@@ -6,9 +6,12 @@ namespace Veriado.WinUI.Services.Abstractions;
 
 public interface IHostShutdownService
 {
-    Task<HostStopResult> StopAsync(TimeSpan timeout, CancellationToken cancellationToken);
+    Task<HostShutdownResult> StopAndDisposeAsync(
+        TimeSpan stopTimeout,
+        TimeSpan disposeTimeout,
+        CancellationToken cancellationToken);
 
-    ValueTask<HostDisposeResult> DisposeAsync();
+    Task WhenStopped { get; }
 }
 
 public enum HostStopState
@@ -57,4 +60,11 @@ public readonly record struct HostDisposeResult(HostDisposeState State, Exceptio
     public static HostDisposeResult NotInitialized(Exception? exception = null) => new(HostDisposeState.NotInitialized, exception);
 
     public static HostDisposeResult Failed(Exception exception) => new(HostDisposeState.Failed, exception);
+}
+
+public readonly record struct HostShutdownResult(HostStopResult Stop, HostDisposeResult Dispose)
+{
+    public bool IsCompleted => Stop.IsSuccess && Dispose.IsSuccess;
+
+    public static HostShutdownResult NotInitialized() => new(HostStopResult.NotInitialized(), HostDisposeResult.NotInitialized());
 }

--- a/Veriado.WinUI/Views/Files/FilesPage.xaml.cs
+++ b/Veriado.WinUI/Views/Files/FilesPage.xaml.cs
@@ -50,9 +50,9 @@ public sealed partial class FilesPage : Page
         RefreshValidityIndicators();
     }
 
-    private void OnUnloaded(object sender, RoutedEventArgs e)
+    private async void OnUnloaded(object sender, RoutedEventArgs e)
     {
-        ViewModel.StopHealthMonitoring();
+        await ViewModel.StopHealthMonitoringAsync().ConfigureAwait(true);
         CancelSuggestionRequest();
         if (_validityRefreshTimer.IsEnabled)
         {


### PR DESCRIPTION
## Summary
- add a centralized host shutdown coordinator and route AppHost/ShutdownOrchestrator through it with improved logging and idempotence
- harden WinUI shutdown flow to await confirmation, orchestrated stop/dispose, and health monitor tear-down
- make background services, import pipeline, and hot-state persistence cooperative with pause, cancellation, and deterministic cancellation

## Testing
- `dotnet build Veriado.sln` *(fails: command not found)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914557994f48326ba305de0eaf08a1b)