### PR TITLE
Improve shutdown flow and pause responsiveness

### DIFF
--- a/Veriado.Infrastructure/Idempotency/IdempotencyCleanupWorker.cs
+++ b/Veriado.Infrastructure/Idempotency/IdempotencyCleanupWorker.cs
@@ -94,7 +94,7 @@ internal sealed class IdempotencyCleanupWorker : BackgroundService
 
             try
             {
-                await Task.Delay(delay, iterationToken).ConfigureAwait(false);
+                await PauseResponsiveDelay.DelayAsync(delay, _lifecycleService.PauseToken, iterationToken).ConfigureAwait(false);
             }
             catch (OperationCanceledException) when (iterationToken.IsCancellationRequested)
             {

--- a/Veriado.Infrastructure/Integrity/IndexAuditBackgroundService.cs
+++ b/Veriado.Infrastructure/Integrity/IndexAuditBackgroundService.cs
@@ -125,7 +125,7 @@ internal sealed class IndexAuditBackgroundService : BackgroundService
 
                 try
                 {
-                    await Task.Delay(delay, effectiveToken).ConfigureAwait(false);
+                    await PauseResponsiveDelay.DelayAsync(delay, _lifecycleService.PauseToken, effectiveToken).ConfigureAwait(false);
                 }
                 catch (OperationCanceledException) when (effectiveToken.IsCancellationRequested)
                 {
@@ -157,7 +157,7 @@ internal sealed class IndexAuditBackgroundService : BackgroundService
         var delay = RandomUpTo(jitter);
         if (delay > TimeSpan.Zero)
         {
-            await Task.Delay(delay, ct).ConfigureAwait(false);
+            await PauseResponsiveDelay.DelayAsync(delay, _lifecycleService.PauseToken, ct).ConfigureAwait(false);
         }
     }
 

--- a/Veriado.Infrastructure/Lifecycle/IAppLifecycleService.cs
+++ b/Veriado.Infrastructure/Lifecycle/IAppLifecycleService.cs
@@ -30,7 +30,7 @@ public interface IAppLifecycleService
 
     Task StopAsync(CancellationToken ct = default);
 
-    Task PauseAsync(CancellationToken ct = default);
+    Task<PauseResult> PauseAsync(CancellationToken ct = default);
 
     Task ResumeAsync(CancellationToken ct = default);
 

--- a/Veriado.Infrastructure/Lifecycle/PauseResponsiveDelay.cs
+++ b/Veriado.Infrastructure/Lifecycle/PauseResponsiveDelay.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Veriado.Infrastructure.Lifecycle;
+
+public static class PauseResponsiveDelay
+{
+    public static async Task DelayAsync(TimeSpan delay, PauseToken pauseToken, CancellationToken cancellationToken)
+    {
+        if (delay <= TimeSpan.Zero)
+        {
+            return;
+        }
+
+        if (pauseToken.IsPaused)
+        {
+            await pauseToken.WaitIfPausedAsync(cancellationToken).ConfigureAwait(false);
+            return;
+        }
+
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        var delayTask = Task.Delay(delay, linkedCts.Token);
+
+        if (!pauseToken.IsPaused)
+        {
+            Task pauseTask;
+            try
+            {
+                pauseTask = pauseToken.WhenPausedAsync(cancellationToken);
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+
+            var completed = await Task.WhenAny(delayTask, pauseTask).ConfigureAwait(false);
+            if (completed == pauseTask)
+            {
+                linkedCts.Cancel();
+                await pauseToken.WaitIfPausedAsync(cancellationToken).ConfigureAwait(false);
+                return;
+            }
+        }
+
+        await delayTask.ConfigureAwait(false);
+    }
+}

--- a/Veriado.Infrastructure/Lifecycle/PauseResult.cs
+++ b/Veriado.Infrastructure/Lifecycle/PauseResult.cs
@@ -1,0 +1,26 @@
+using System;
+
+namespace Veriado.Infrastructure.Lifecycle;
+
+public enum PauseStatus
+{
+    Succeeded,
+    RetryableFailure,
+    NotSupported,
+}
+
+public readonly record struct PauseResult(
+    PauseStatus Status,
+    TimeSpan Duration,
+    Exception? Exception = null)
+{
+    public bool IsSuccess => Status == PauseStatus.Succeeded;
+
+    public static PauseResult Success(TimeSpan duration) => new(PauseStatus.Succeeded, duration);
+
+    public static PauseResult RetryableFailure(Exception? exception = null) =>
+        new(PauseStatus.RetryableFailure, TimeSpan.Zero, exception);
+
+    public static PauseResult NotSupported(Exception? exception = null) =>
+        new(PauseStatus.NotSupported, TimeSpan.Zero, exception);
+}

--- a/Veriado.Infrastructure/Lifecycle/PauseToken.cs
+++ b/Veriado.Infrastructure/Lifecycle/PauseToken.cs
@@ -15,16 +15,22 @@ public readonly struct PauseToken
 
     public bool IsPaused => _source?.IsPaused ?? false;
 
-    public Task WaitIfPausedAsync(CancellationToken cancellationToken = default)
-    {
-        return _source?.WaitIfPausedAsync(cancellationToken) ?? Task.CompletedTask;
-    }
+    public Task WaitIfPausedAsync(CancellationToken cancellationToken = default) =>
+        _source?.WaitIfPausedAsync(cancellationToken) ?? Task.CompletedTask;
+
+    public Task WhenPausedAsync(CancellationToken cancellationToken = default) =>
+        _source?.WhenPausedAsync(cancellationToken) ?? Task.CompletedTask;
+
+    public Task WhenResumedAsync(CancellationToken cancellationToken = default) =>
+        _source?.WhenResumedAsync(cancellationToken) ?? Task.CompletedTask;
 }
 
 public sealed class PauseTokenSource
 {
     private readonly object _sync = new();
     private TaskCompletionSource<bool>? _pauseCompletion;
+    private TaskCompletionSource<bool> _pauseSignal = CreateSignal();
+    private TaskCompletionSource<bool> _resumeSignal = CreateSignal(completed: true);
 
     public bool IsPaused { get; private set; }
 
@@ -32,6 +38,7 @@ public sealed class PauseTokenSource
 
     public bool TryPause()
     {
+        TaskCompletionSource<bool> pauseSignal;
         lock (_sync)
         {
             if (IsPaused)
@@ -39,15 +46,21 @@ public sealed class PauseTokenSource
                 return false;
             }
 
+            pauseSignal = _pauseSignal;
+            _pauseSignal = CreateSignal();
+            _resumeSignal = CreateSignal();
             _pauseCompletion = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             IsPaused = true;
-            return true;
         }
+
+        pauseSignal.TrySetResult(true);
+        return true;
     }
 
     public bool TryResume()
     {
         TaskCompletionSource<bool>? completion;
+        TaskCompletionSource<bool> resumeSignal;
         lock (_sync)
         {
             if (!IsPaused)
@@ -58,9 +71,13 @@ public sealed class PauseTokenSource
             IsPaused = false;
             completion = _pauseCompletion;
             _pauseCompletion = null;
+            resumeSignal = _resumeSignal;
+            _resumeSignal = CreateSignal(completed: true);
+            _pauseSignal = CreateSignal();
         }
 
         completion?.TrySetResult(true);
+        resumeSignal.TrySetResult(true);
         return true;
     }
 
@@ -78,6 +95,38 @@ public sealed class PauseTokenSource
         }
 
         return WaitInternalAsync(completion.Task, cancellationToken);
+    }
+
+    internal Task WhenPausedAsync(CancellationToken cancellationToken)
+    {
+        Task task;
+        lock (_sync)
+        {
+            if (IsPaused)
+            {
+                return Task.CompletedTask;
+            }
+
+            task = _pauseSignal.Task;
+        }
+
+        return WaitInternalAsync(task, cancellationToken);
+    }
+
+    internal Task WhenResumedAsync(CancellationToken cancellationToken)
+    {
+        Task task;
+        lock (_sync)
+        {
+            if (!IsPaused)
+            {
+                return Task.CompletedTask;
+            }
+
+            task = _resumeSignal.Task;
+        }
+
+        return WaitInternalAsync(task, cancellationToken);
     }
 
     private static async Task WaitInternalAsync(Task pauseTask, CancellationToken cancellationToken)
@@ -108,5 +157,16 @@ public sealed class PauseTokenSource
         }
 
         cancellationToken.ThrowIfCancellationRequested();
+    }
+
+    private static TaskCompletionSource<bool> CreateSignal(bool completed = false)
+    {
+        var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        if (completed)
+        {
+            tcs.TrySetResult(true);
+        }
+
+        return tcs;
     }
 }

--- a/Veriado.WinUI/Services/Abstractions/IShutdownOrchestrator.cs
+++ b/Veriado.WinUI/Services/Abstractions/IShutdownOrchestrator.cs
@@ -1,3 +1,5 @@
+using Veriado.WinUI.Services.Shutdown;
+
 namespace Veriado.WinUI.Services.Abstractions;
 
 public interface IShutdownOrchestrator

--- a/Veriado.WinUI/Services/Shutdown/ShutdownResult.cs
+++ b/Veriado.WinUI/Services/Shutdown/ShutdownResult.cs
@@ -1,8 +1,73 @@
-namespace Veriado.WinUI.Services.Abstractions;
+using System;
+using Veriado.WinUI.Services.Abstractions;
 
-public readonly record struct ShutdownResult(bool IsAllowed)
+namespace Veriado.WinUI.Services.Shutdown;
+
+public enum ShutdownStatus
 {
-    public static ShutdownResult Allow() => new(true);
+    Success,
+    Canceled,
+    Failed,
+}
 
-    public static ShutdownResult Cancel() => new(false);
+public enum ShutdownFailurePhase
+{
+    None,
+    LifecycleStop,
+    HostStop,
+    HostDispose,
+}
+
+public enum ShutdownFailureReason
+{
+    None,
+    Timeout,
+    Canceled,
+    Exception,
+    NotSupported,
+    Unknown,
+}
+
+public sealed record class ShutdownFailureDetail(
+    ShutdownFailurePhase Phase,
+    ShutdownFailureReason Reason,
+    Exception? Exception = null)
+{
+    public static ShutdownFailureDetail Timeout(ShutdownFailurePhase phase, Exception? exception = null) =>
+        new(phase, ShutdownFailureReason.Timeout, exception);
+
+    public static ShutdownFailureDetail Canceled(ShutdownFailurePhase phase, Exception? exception = null) =>
+        new(phase, ShutdownFailureReason.Canceled, exception);
+
+    public static ShutdownFailureDetail Error(ShutdownFailurePhase phase, Exception? exception = null) =>
+        new(phase, ShutdownFailureReason.Exception, exception);
+
+    public static ShutdownFailureDetail NotSupported(ShutdownFailurePhase phase) =>
+        new(phase, ShutdownFailureReason.NotSupported);
+
+    public static ShutdownFailureDetail Unknown(ShutdownFailurePhase phase, Exception? exception = null) =>
+        new(phase, ShutdownFailureReason.Unknown, exception);
+}
+
+public sealed record class ShutdownResult(
+    ShutdownStatus Status,
+    TimeSpan Duration,
+    bool LifecycleStopped,
+    HostShutdownResult Host,
+    ShutdownFailureDetail? Failure = null)
+{
+    public bool IsAllowed => Status == ShutdownStatus.Success;
+
+    public static ShutdownResult Success(TimeSpan duration, bool lifecycleStopped, HostShutdownResult host) =>
+        new(ShutdownStatus.Success, duration, lifecycleStopped, host);
+
+    public static ShutdownResult Canceled(TimeSpan duration) =>
+        new(ShutdownStatus.Canceled, duration, lifecycleStopped: false, host: default);
+
+    public static ShutdownResult Failure(
+        ShutdownFailureDetail failure,
+        TimeSpan duration,
+        bool lifecycleStopped,
+        HostShutdownResult host) =>
+        new(ShutdownStatus.Failed, duration, lifecycleStopped, host, failure);
 }


### PR DESCRIPTION
## Summary
- introduce granular shutdown results with UI feedback and central exception handling in the WinUI app
- harden import pause behavior with retries, channel monitoring, and responsive throttling
- add pause-aware delay utilities and apply them across lifecycle/background services

## Testing
- `dotnet build` *(fails: dotnet command not available in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691469e6e9f0832693c52deb3fbe5e1e)