### PR TITLE
Fix accessibility and shutdown coordination build errors

### DIFF
--- a/Veriado.Infrastructure/Common/SqliteRetry.cs
+++ b/Veriado.Infrastructure/Common/SqliteRetry.cs
@@ -5,7 +5,7 @@ namespace Veriado.Infrastructure.Common;
 /// <summary>
 /// Provides a unified retry helper for operations that may encounter SQLITE_BUSY.
 /// </summary>
-internal static class SqliteRetry
+public static class SqliteRetry
 {
     private const int SqliteBusyErrorCode = 5;
     private const int MaxAttempts = 5;

--- a/Veriado.Infrastructure/Search/SearchIndexCoordinator.cs
+++ b/Veriado.Infrastructure/Search/SearchIndexCoordinator.cs
@@ -1,7 +1,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
-using Veriado.Appl.Abstractions;
+using ApplicationClock = Veriado.Appl.Abstractions.IClock;
 using Veriado.Appl.Common.Exceptions;
 using Veriado.Appl.Search;
 using Veriado.Domain.Primitives;
@@ -19,7 +19,7 @@ internal sealed class SearchIndexCoordinator : ISearchIndexCoordinator
     private readonly IAnalyzerFactory _analyzerFactory;
     private readonly ISearchIndexSignatureCalculator _signatureCalculator;
     private readonly ILogger<SearchProjectionService> _projectionLogger;
-    private readonly IClock _clock;
+    private readonly ApplicationClock _clock;
     private readonly ISearchTelemetry? _telemetry;
 
     public SearchIndexCoordinator(
@@ -29,7 +29,7 @@ internal sealed class SearchIndexCoordinator : ISearchIndexCoordinator
         IAnalyzerFactory analyzerFactory,
         ISearchIndexSignatureCalculator signatureCalculator,
         ILogger<SearchProjectionService> projectionLogger,
-        IClock clock,
+        ApplicationClock clock,
         ISearchTelemetry? telemetry = null)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));

--- a/Veriado.WinUI/App.xaml.cs
+++ b/Veriado.WinUI/App.xaml.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Veriado.WinUI.Helpers;
+using Veriado.WinUI.Services;
 using Veriado.WinUI.Services.Abstractions;
 using Veriado.WinUI.Services.Shutdown;
 using Veriado.WinUI.ViewModels.Startup;
@@ -242,8 +243,7 @@ public partial class App : WinUIApplication
         }
 
         args.Cancel = true;
-        var deferral = args.GetDeferral();
-        ObserveTask(HandleCloseAsync(deferral), "window closing");
+        ObserveTask(HandleCloseAsync(), "window closing");
     }
 
     private void OnWindowClosed(object sender, WindowEventArgs e)
@@ -272,7 +272,7 @@ public partial class App : WinUIApplication
         MainWindow = null;
     }
 
-    private async Task HandleCloseAsync(AppWindowClosingDeferral? deferral)
+    private async Task HandleCloseAsync()
     {
         var forceExit = false;
 
@@ -366,8 +366,6 @@ public partial class App : WinUIApplication
         }
         finally
         {
-            deferral?.Complete();
-
             if (forceExit)
             {
                 Environment.ExitCode = 1;
@@ -591,7 +589,7 @@ public partial class App : WinUIApplication
         e.SetObserved();
     }
 
-    private void OnDomainUnhandledException(object? sender, UnhandledExceptionEventArgs e)
+    private void OnDomainUnhandledException(object? sender, global::System.UnhandledExceptionEventArgs e)
     {
         var logger = GetLogger();
         if (e.ExceptionObject is Exception exception)

--- a/Veriado.WinUI/Services/Shutdown/HostShutdownCoordinator.cs
+++ b/Veriado.WinUI/Services/Shutdown/HostShutdownCoordinator.cs
@@ -7,7 +7,7 @@ using Veriado.WinUI.Services.Abstractions;
 
 namespace Veriado.WinUI.Services.Shutdown;
 
-internal interface IHostShutdownCoordinator
+public interface IHostShutdownCoordinator
 {
     void Initialize(IHost host);
 

--- a/Veriado.WinUI/Services/Shutdown/ShutdownResult.cs
+++ b/Veriado.WinUI/Services/Shutdown/ShutdownResult.cs
@@ -64,7 +64,7 @@ public sealed record class ShutdownResult(
     public static ShutdownResult Canceled(TimeSpan duration) =>
         new(ShutdownStatus.Canceled, duration, lifecycleStopped: false, host: default);
 
-    public static ShutdownResult Failure(
+    public static ShutdownResult Failed(
         ShutdownFailureDetail failure,
         TimeSpan duration,
         bool lifecycleStopped,


### PR DESCRIPTION
## Summary
- expose the shared SqliteRetry helper and disambiguate the clock dependency used by the search index coordinator
- resolve shutdown orchestration naming collisions by renaming factory helpers and adjusting logging
- remove unsupported AppWindow closing deferral usage while wiring the confirm dialog options and unhandled exception handler

## Testing
- `dotnet build Veriado.sln` *(fails: dotnet CLI not available in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914adc3e5d08326925ff196a6df7509)