### PR TITLE
Fix named argument casing for shutdown result

### DIFF
--- a/Veriado.WinUI/Services/Shutdown/ShutdownResult.cs
+++ b/Veriado.WinUI/Services/Shutdown/ShutdownResult.cs
@@ -62,7 +62,7 @@ public sealed record class ShutdownResult(
         new(ShutdownStatus.Success, duration, lifecycleStopped, host);
 
     public static ShutdownResult Canceled(TimeSpan duration) =>
-        new(ShutdownStatus.Canceled, duration, lifecycleStopped: false, host: default);
+        new(ShutdownStatus.Canceled, duration, LifecycleStopped: false, host: default);
 
     public static ShutdownResult Failed(
         ShutdownFailureDetail failure,


### PR DESCRIPTION
## Summary
- fix the casing of the named argument used when constructing a canceled shutdown result to match the record parameter

## Testing
- dotnet build Veriado.sln *(fails: command not found: dotnet)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914af9c8f948326b48ed133cee5cc2e)