### PR TITLE
Fix named argument casing for ShutdownResult.Canceled

### DIFF
--- a/Veriado.WinUI/Services/Shutdown/ShutdownResult.cs
+++ b/Veriado.WinUI/Services/Shutdown/ShutdownResult.cs
@@ -62,7 +62,7 @@ public sealed record class ShutdownResult(
         new(ShutdownStatus.Success, duration, lifecycleStopped, host);
 
     public static ShutdownResult Canceled(TimeSpan duration) =>
-        new(ShutdownStatus.Canceled, duration, LifecycleStopped: false, host: default);
+        new(ShutdownStatus.Canceled, duration, LifecycleStopped: false, Host: default);
 
     public static ShutdownResult Failed(
         ShutdownFailureDetail failure,


### PR DESCRIPTION
## Summary
- fix the named argument name for `ShutdownResult.Canceled` to match the record's constructor

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914b069ac8c8326ae7e0fb58a781d85)