### PR TITLE
Handle lifecycle cancellations and extend timeouts

### DIFF
--- a/Veriado.Infrastructure/Idempotency/IdempotencyCleanupWorker.cs
+++ b/Veriado.Infrastructure/Idempotency/IdempotencyCleanupWorker.cs
@@ -17,7 +17,7 @@ namespace Veriado.Infrastructure.Idempotency;
 /// </summary>
 internal sealed class IdempotencyCleanupWorker : BackgroundService
 {
-    private static readonly TimeSpan IterationTimeout = TimeSpan.FromMinutes(5);
+    private static readonly TimeSpan IterationTimeout = TimeSpan.FromMinutes(10);
     private const string MonitorServiceName = nameof(IdempotencyCleanupWorker);
 
     private readonly InfrastructureOptions _options;


### PR DESCRIPTION
## Summary
- extend the lifecycle service start/stop/pause/resume timeouts to better match long-running initialization and cleanup
- treat cancellation requests as non-error paths during lifecycle transitions, restoring pause/run tokens when a request is aborted
- give the idempotency cleanup worker a longer iteration timeout to avoid premature cancellation when purging keys

## Testing
- dotnet test *(fails: `dotnet` command not available in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914bd98def083268d47703eae25a7de)