### PR TITLE
Fix nullable index statistics handling in FilesPageViewModel

### DIFF
--- a/Veriado.WinUI/ViewModels/Files/FilesPageViewModel.cs
+++ b/Veriado.WinUI/ViewModels/Files/FilesPageViewModel.cs
@@ -608,7 +608,7 @@ public partial class FilesPageViewModel : ViewModelBase
             }
 
             var staleDocuments = 0;
-            if (indexResult.TryGetValue(out var indexStatistics))
+            if (indexResult.Value.TryGetValue(out var indexStatistics))
             {
                 staleDocuments = Math.Max(indexStatistics.StaleDocuments, 0);
             }


### PR DESCRIPTION
## Summary
- ensure the index statistics polling path handles nullable results returned when cancellation occurs
- access the AppResult value safely before reading indexing statistics

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914cbeaf83883269cf481484d38d8e9)