### PR TITLE
Handle cancellation gracefully in index audit service

### DIFF
--- a/Veriado.Infrastructure/Integrity/IndexAuditBackgroundService.cs
+++ b/Veriado.Infrastructure/Integrity/IndexAuditBackgroundService.cs
@@ -55,9 +55,10 @@ internal sealed class IndexAuditBackgroundService : BackgroundService
             {
                 break;
             }
-            catch (OperationCanceledException)
+            catch (OperationCanceledException ex)
             {
-                throw;
+                _logger.LogDebug(ex, "Index audit execution canceled.");
+                break;
             }
             catch (Exception ex)
             {
@@ -68,8 +69,9 @@ internal sealed class IndexAuditBackgroundService : BackgroundService
             {
                 await Task.Delay(interval, stoppingToken).ConfigureAwait(false);
             }
-            catch (OperationCanceledException)
+            catch (OperationCanceledException ex)
             {
+                _logger.LogDebug(ex, "Index audit delay canceled.");
                 break;
             }
         }


### PR DESCRIPTION
## Summary
- stop the index audit loop gracefully when audit or delay tasks are canceled
- log debug information instead of surfacing OperationCanceledException during shutdown

## Testing
- dotnet build *(fails: command not found in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914ed8eb560832689bbf4a3b49cf199)