### PR TITLE
Improve WinUI async startup flow

### DIFF
--- a/Veriado.WinUI/Services/DispatcherService.cs
+++ b/Veriado.WinUI/Services/DispatcherService.cs
@@ -17,17 +17,7 @@ public sealed class DispatcherService : IDispatcherService
         get
         {
             var dispatcher = Volatile.Read(ref _dispatcher);
-            if (dispatcher is not null)
-            {
-                return dispatcher.HasThreadAccess;
-            }
-
-            if (_dispatcherReady.Task.IsCompletedSuccessfully)
-            {
-                return _dispatcherReady.Task.Result.HasThreadAccess;
-            }
-
-            return false;
+            return dispatcher?.HasThreadAccess ?? false;
         }
     }
 

--- a/Veriado.WinUI/Services/FilesSearchSuggestionsProvider.cs
+++ b/Veriado.WinUI/Services/FilesSearchSuggestionsProvider.cs
@@ -24,12 +24,12 @@ public sealed class FilesSearchSuggestionsProvider : IFilesSearchSuggestionsProv
 
         await Task.WhenAll(favoritesTask, historyTask).ConfigureAwait(false);
 
-        var favorites = favoritesTask.Result
+        var favorites = (await favoritesTask.ConfigureAwait(false))
             .Select(item => item.QueryText ?? item.MatchQuery)
             .Where(text => !string.IsNullOrWhiteSpace(text))
             .Select(text => text!.Trim());
 
-        var history = historyTask.Result
+        var history = (await historyTask.ConfigureAwait(false))
             .Select(item => item.QueryText ?? item.MatchQuery)
             .Where(text => !string.IsNullOrWhiteSpace(text))
             .Select(text => text!.Trim());


### PR DESCRIPTION
## Summary
- remove synchronous Task.Result usage when reading UI dispatcher availability and search suggestions
- allow AppHost.StartAsync to accept cancellation, acquire the global mutex without blocking the UI thread, and propagate the token when starting services

## Testing
- dotnet build Veriado.sln *(fails: `dotnet` not available in the execution environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69178d4fa9488326b5e95be90feddf4e)