### PR TITLE
Update validity expiration text handling

### DIFF
--- a/Veriado.Application.Tests/Files/ValidityComputationTests.cs
+++ b/Veriado.Application.Tests/Files/ValidityComputationTests.cs
@@ -84,7 +84,7 @@ public class ValidityComputationTests
     [InlineData(2, "2 dny")]
     [InlineData(5, "5 dní")]
     [InlineData(11, "11 dní")]
-    [InlineData(-3, "-3 dny")]
+    [InlineData(-3, "3 dny")]
     public void CzechPluralization_FormatsDays(int value, string expected)
     {
         Assert.Equal(expected, CzechPluralization.FormatDays(value));
@@ -94,7 +94,7 @@ public class ValidityComputationTests
     [InlineData(1, "1 týden")]
     [InlineData(4, "4 týdny")]
     [InlineData(6, "6 týdnů")]
-    [InlineData(-2, "-2 týdny")]
+    [InlineData(-2, "2 týdny")]
     public void CzechPluralization_FormatsWeeks(int value, string expected)
     {
         Assert.Equal(expected, CzechPluralization.FormatWeeks(value));
@@ -104,7 +104,7 @@ public class ValidityComputationTests
     [InlineData(1, "1 měsíc")]
     [InlineData(3, "3 měsíce")]
     [InlineData(8, "8 měsíců")]
-    [InlineData(-5, "-5 měsíců")]
+    [InlineData(-5, "5 měsíců")]
     public void CzechPluralization_FormatsMonths(int value, string expected)
     {
         Assert.Equal(expected, CzechPluralization.FormatMonths(value));
@@ -114,7 +114,7 @@ public class ValidityComputationTests
     [InlineData(1, "1 rok")]
     [InlineData(2, "2 roky")]
     [InlineData(5, "5 let")]
-    [InlineData(-7, "-7 let")]
+    [InlineData(-7, "7 let")]
     public void CzechPluralization_FormatsYears(int value, string expected)
     {
         Assert.Equal(expected, CzechPluralization.FormatYears(value));
@@ -154,5 +154,70 @@ public class ValidityComputationTests
 
         var formatted = ValidityRelativeFormatter.FormatAfterExpiration(countdown);
         Assert.Equal("1 rok", formatted);
+    }
+
+    [Theory]
+    [InlineData(5, 5, 0, 0, 0, 0, 0, 0, 0, "5 dní do expirace")]
+    [InlineData(1, 1, 0, 0, 0, 0, 0, 0, 0, "1 den do expirace")]
+    [InlineData(10, 10, 0, 1, 0, 0, 0, 0, 0, "1 týden do expirace")]
+    [InlineData(45, 45, 0, 6, 0, 1, 0, 0, 0, "1 měsíc do expirace")]
+    [InlineData(500, 500, 0, 71, 0, 16, 0, 1, 0, "1 rok do expirace")]
+    public void ValidityRelativeFormatter_BuildsBeforeExpirationPhrase(
+        int totalDays,
+        int daysRemaining,
+        int daysAfterExpiration,
+        int weeksRemaining,
+        int weeksAfterExpiration,
+        int monthsRemaining,
+        int monthsAfterExpiration,
+        int yearsRemaining,
+        int yearsAfterExpiration,
+        string expected)
+    {
+        var countdown = new ValidityCountdown(
+            totalDays,
+            daysRemaining,
+            daysAfterExpiration,
+            weeksRemaining,
+            weeksAfterExpiration,
+            monthsRemaining,
+            monthsAfterExpiration,
+            yearsRemaining,
+            yearsAfterExpiration);
+
+        var phrase = ValidityRelativeFormatter.FormatBeforeExpirationPhrase(countdown);
+        Assert.Equal(expected, phrase);
+    }
+
+    [Theory]
+    [InlineData(-1, 0, 1, 0, 0, 0, 0, 0, 0, "1 den po expiraci")]
+    [InlineData(-10, 0, 10, 0, 1, 0, 0, 0, 0, "1 týden po expiraci")]
+    [InlineData(-40, 0, 40, 0, 5, 0, 1, 0, 0, "1 měsíc po expiraci")]
+    [InlineData(-800, 0, 800, 0, 114, 0, 26, 0, 2, "2 roky po expiraci")]
+    public void ValidityRelativeFormatter_BuildsAfterExpirationPhrase(
+        int totalDays,
+        int daysRemaining,
+        int daysAfterExpiration,
+        int weeksRemaining,
+        int weeksAfterExpiration,
+        int monthsRemaining,
+        int monthsAfterExpiration,
+        int yearsRemaining,
+        int yearsAfterExpiration,
+        string expected)
+    {
+        var countdown = new ValidityCountdown(
+            totalDays,
+            daysRemaining,
+            daysAfterExpiration,
+            weeksRemaining,
+            weeksAfterExpiration,
+            monthsRemaining,
+            monthsAfterExpiration,
+            yearsRemaining,
+            yearsAfterExpiration);
+
+        var phrase = ValidityRelativeFormatter.FormatAfterExpirationPhrase(countdown);
+        Assert.Equal(expected, phrase);
     }
 }

--- a/Veriado.Contracts/Files/ValidityRelativeFormatter.cs
+++ b/Veriado.Contracts/Files/ValidityRelativeFormatter.cs
@@ -46,4 +46,14 @@ public static class ValidityRelativeFormatter
 
         return CzechPluralization.FormatDays(countdown.DaysAfterExpiration);
     }
+
+    public static string FormatBeforeExpirationPhrase(ValidityCountdown countdown)
+    {
+        return $"{FormatRemaining(countdown)} do expirace";
+    }
+
+    public static string FormatAfterExpirationPhrase(ValidityCountdown countdown)
+    {
+        return $"{FormatAfterExpiration(countdown)} po expiraci";
+    }
 }

--- a/Veriado.Contracts/Localization/CzechPluralization.cs
+++ b/Veriado.Contracts/Localization/CzechPluralization.cs
@@ -7,32 +7,56 @@ namespace Veriado.Contracts.Localization;
 /// </summary>
 public static class CzechPluralization
 {
-    public static string FormatDays(int days) => $"{days} {GetDayNoun(days)}";
+    public static string FormatDays(int days)
+    {
+        var absolute = Math.Abs(days);
+        return $"{absolute} {DayWord(absolute)}";
+    }
+
+    public static string DayWord(int days) => SelectNoun(Math.Abs(days), "den", "dny", "dní");
 
     public static string GetDayNoun(int days)
     {
-        return SelectNoun(days, "den", "dny", "dní");
+        return DayWord(Math.Abs(days));
     }
 
-    public static string FormatWeeks(int weeks) => $"{weeks} {GetWeekNoun(weeks)}";
+    public static string FormatWeeks(int weeks)
+    {
+        var absolute = Math.Abs(weeks);
+        return $"{absolute} {WeekWord(absolute)}";
+    }
+
+    public static string WeekWord(int weeks) => SelectNoun(Math.Abs(weeks), "týden", "týdny", "týdnů");
 
     public static string GetWeekNoun(int weeks)
     {
-        return SelectNoun(weeks, "týden", "týdny", "týdnů");
+        return WeekWord(Math.Abs(weeks));
     }
 
-    public static string FormatMonths(int months) => $"{months} {GetMonthNoun(months)}";
+    public static string FormatMonths(int months)
+    {
+        var absolute = Math.Abs(months);
+        return $"{absolute} {MonthWord(absolute)}";
+    }
+
+    public static string MonthWord(int months) => SelectNoun(Math.Abs(months), "měsíc", "měsíce", "měsíců");
 
     public static string GetMonthNoun(int months)
     {
-        return SelectNoun(months, "měsíc", "měsíce", "měsíců");
+        return MonthWord(Math.Abs(months));
     }
 
-    public static string FormatYears(int years) => $"{years} {GetYearNoun(years)}";
+    public static string FormatYears(int years)
+    {
+        var absolute = Math.Abs(years);
+        return $"{absolute} {YearWord(absolute)}";
+    }
+
+    public static string YearWord(int years) => SelectNoun(Math.Abs(years), "rok", "roky", "let");
 
     public static string GetYearNoun(int years)
     {
-        return SelectNoun(years, "rok", "roky", "let");
+        return YearWord(Math.Abs(years));
     }
 
     private static string SelectNoun(int value, string singular, string paucal, string plural)

--- a/Veriado.WinUI/Helpers/ValidityDisplayFormatter.cs
+++ b/Veriado.WinUI/Helpers/ValidityDisplayFormatter.cs
@@ -15,22 +15,17 @@ internal static class ValidityDisplayFormatter
 
         var metrics = countdown.Value;
 
-        if (status == ValidityStatus.Expired)
+        if (metrics.TotalDays == 0)
         {
-            if (metrics.DaysAfterExpiration == 0)
-            {
-                return "Platnost skončila";
-            }
-
-            return $"{ValidityRelativeFormatter.FormatAfterExpiration(metrics)} po expiraci";
+            return "Expirace dnes";
         }
 
-        if (metrics.ExpiresToday)
+        if (metrics.TotalDays < 0)
         {
-            return "Dnes končí";
+            return ValidityRelativeFormatter.FormatAfterExpirationPhrase(metrics);
         }
 
-        return $"Za {ValidityRelativeFormatter.FormatRemaining(metrics)}";
+        return ValidityRelativeFormatter.FormatBeforeExpirationPhrase(metrics);
     }
 
     public static string? BuildTooltip(
@@ -48,22 +43,30 @@ internal static class ValidityDisplayFormatter
         var toText = to.Value.ToString(DateFormats.ShortDate, CultureInfo.CurrentCulture);
         var rangeText = string.Format(CultureInfo.CurrentCulture, "Platné: {0} – {1}", fromText, toText);
 
-        return status switch
+        var metrics = countdown.Value;
+
+        if (metrics.TotalDays < 0)
         {
-            ValidityStatus.Expired => string.Format(
+            return string.Format(
                 CultureInfo.CurrentCulture,
                 "{0} (Platnost skončila před {1})",
                 rangeText,
-                ValidityRelativeFormatter.FormatAfterExpiration(countdown.Value)),
-            ValidityStatus.ExpiringToday => string.Format(
+                ValidityRelativeFormatter.FormatAfterExpiration(metrics));
+        }
+
+        if (metrics.TotalDays == 0)
+        {
+            return string.Format(
                 CultureInfo.CurrentCulture,
-                "{0} (Končí dnes)",
-                rangeText),
-            _ => string.Format(
-                CultureInfo.CurrentCulture,
-                "{0} (zbývá {1})",
+                "{0} (Platnost končí dnes: {1})",
                 rangeText,
-                ValidityRelativeFormatter.FormatRemaining(countdown.Value)),
-        };
+                toText);
+        }
+
+        return string.Format(
+            CultureInfo.CurrentCulture,
+            "{0} ({1})",
+            rangeText,
+            ValidityRelativeFormatter.FormatBeforeExpirationPhrase(metrics));
     }
 }


### PR DESCRIPTION
## Summary
- adjust badge and tooltip formatting to show "do expirace" / "po expiraci" strings and hide negative day counts
- add phrase helpers and absolute pluralization handling for days, weeks, months, and years
- extend unit tests to cover new pluralization outputs and phrase building scenarios

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918c00ee0e0832691b8448607e1b4f8)