### PR TITLE
Enhance validity filters

### DIFF
--- a/Veriado.Application/UseCases/Queries/FileGrid/FileGridQueryHandler.cs
+++ b/Veriado.Application/UseCases/Queries/FileGrid/FileGridQueryHandler.cs
@@ -53,7 +53,7 @@ public sealed class FileGridQueryHandler : IRequestHandler<FileGridQuery, PageRe
         var dto = request.Parameters;
         var pageNumber = Math.Max(dto.Page, 1);
         var pageSize = Math.Clamp(dto.PageSize, 1, _options.MaxPageSize);
-        var today = DateOnly.FromDateTime(_clock.UtcNow.UtcDateTime);
+        var referenceTime = _clock.UtcNow;
 
         SearchFavoriteItem? favorite = null;
         if (!string.IsNullOrWhiteSpace(dto.SavedQueryKey))
@@ -81,7 +81,7 @@ public sealed class FileGridQueryHandler : IRequestHandler<FileGridQuery, PageRe
         await using var context = await _contextFactory.CreateAsync(cancellationToken).ConfigureAwait(false);
         var filesQuery = context.Files;
 
-        var filteredQuery = QueryableFilters.ApplyFilters(filesQuery, dto, today);
+        var filteredQuery = QueryableFilters.ApplyFilters(filesQuery, dto, referenceTime);
         var sortSpecifications = dto.Sort ?? new List<FileSortSpecDto>();
         bool sortByScore = sortSpecifications.Count > 0
             && string.Equals(sortSpecifications[0].Field, "score", StringComparison.OrdinalIgnoreCase);

--- a/Veriado.Application/UseCases/Queries/FileGrid/FileGridQueryValidator.cs
+++ b/Veriado.Application/UseCases/Queries/FileGrid/FileGridQueryValidator.cs
@@ -1,3 +1,5 @@
+using Veriado.Contracts.Files;
+
 namespace Veriado.Appl.UseCases.Queries.FileGrid;
 
 /// <summary>
@@ -55,6 +57,42 @@ public sealed class FileGridQueryValidator : AbstractValidator<FileGridQueryDto>
         RuleFor(dto => dto.ExpiringInDays)
             .Must(value => !value.HasValue || value.Value >= 0)
             .WithMessage("ExpiringInDays must be non-negative.");
+
+        RuleFor(dto => dto.ValidityFilterValue)
+            .Must(value => !value.HasValue || value.Value >= 0)
+            .WithMessage("ValidityFilterValue must be non-negative.");
+
+        RuleFor(dto => dto.ValidityFilterRangeFrom)
+            .Must(value => !value.HasValue || value.Value >= 0)
+            .WithMessage("ValidityFilterRangeFrom must be non-negative.");
+
+        RuleFor(dto => dto.ValidityFilterRangeTo)
+            .Must(value => !value.HasValue || value.Value >= 0)
+            .WithMessage("ValidityFilterRangeTo must be non-negative.");
+
+        RuleFor(dto => dto.ValidityFilterRangeTo)
+            .Must((dto, to) => !to.HasValue
+                || !dto.ValidityFilterRangeFrom.HasValue
+                || dto.ValidityFilterRangeFrom.Value <= to.Value)
+            .WithMessage("ValidityFilterRangeTo must be greater than or equal to ValidityFilterRangeFrom.");
+
+        When(dto => dto.ValidityFilterMode == ValidityFilterMode.ExpiringWithin, () =>
+        {
+            RuleFor(dto => dto.ValidityFilterValue)
+                .NotNull()
+                .WithMessage("ValidityFilterValue is required for ExpiringWithin mode.");
+        });
+
+        When(dto => dto.ValidityFilterMode == ValidityFilterMode.ExpiringRange, () =>
+        {
+            RuleFor(dto => dto.ValidityFilterRangeFrom)
+                .NotNull()
+                .WithMessage("ValidityFilterRangeFrom is required for ExpiringRange mode.");
+
+            RuleFor(dto => dto.ValidityFilterRangeTo)
+                .NotNull()
+                .WithMessage("ValidityFilterRangeTo is required for ExpiringRange mode.");
+        });
 
         RuleForEach(dto => dto.Sort)
             .SetValidator(new SortSpecValidator());

--- a/Veriado.Contracts/Files/FileGridQueryDto.cs
+++ b/Veriado.Contracts/Files/FileGridQueryDto.cs
@@ -84,6 +84,36 @@ public sealed record FileGridQueryDto
         = null;
 
     /// <summary>
+    /// Gets or sets the high-level validity filter mode.
+    /// </summary>
+    public ValidityFilterMode ValidityFilterMode { get; init; }
+        = ValidityFilterMode.None;
+
+    /// <summary>
+    /// Gets or sets the unit used by relative validity filters.
+    /// </summary>
+    public ValidityRelativeUnit ValidityFilterUnit { get; init; }
+        = ValidityRelativeUnit.Days;
+
+    /// <summary>
+    /// Gets or sets the single relative value (for expiring-within scenarios).
+    /// </summary>
+    public int? ValidityFilterValue { get; init; }
+        = null;
+
+    /// <summary>
+    /// Gets or sets the lower bound of the relative validity range.
+    /// </summary>
+    public int? ValidityFilterRangeFrom { get; init; }
+        = null;
+
+    /// <summary>
+    /// Gets or sets the upper bound of the relative validity range.
+    /// </summary>
+    public int? ValidityFilterRangeTo { get; init; }
+        = null;
+
+    /// <summary>
     /// Gets or sets the minimum file size in bytes.
     /// </summary>
     public long? SizeMin { get; init; }

--- a/Veriado.Contracts/Files/ValidityFilterMode.cs
+++ b/Veriado.Contracts/Files/ValidityFilterMode.cs
@@ -1,0 +1,15 @@
+namespace Veriado.Contracts.Files;
+
+/// <summary>
+/// Describes the available high-level validity filter modes.
+/// </summary>
+public enum ValidityFilterMode
+{
+    None = 0,
+    HasValidity,
+    NoValidity,
+    CurrentlyValid,
+    Expired,
+    ExpiringWithin,
+    ExpiringRange,
+}

--- a/Veriado.Contracts/Files/ValidityRelativeUnit.cs
+++ b/Veriado.Contracts/Files/ValidityRelativeUnit.cs
@@ -1,0 +1,12 @@
+namespace Veriado.Contracts.Files;
+
+/// <summary>
+/// Represents the supported units for relative validity filters.
+/// </summary>
+public enum ValidityRelativeUnit
+{
+    Days = 0,
+    Weeks,
+    Months,
+    Years,
+}

--- a/Veriado.WinUI/Views/Files/FilesPage.xaml
+++ b/Veriado.WinUI/Views/Files/FilesPage.xaml
@@ -9,6 +9,7 @@
     xmlns:views="using:Veriado.WinUI.Views.Files"
     xmlns:converters="using:Veriado.WinUI.Converters"
     xmlns:viewModels="using:Veriado.WinUI.ViewModels.Files"
+    xmlns:contracts="using:Veriado.Contracts.Files"
     mc:Ignorable="d">
     <Page.Resources>
         <converters:NullableIntToDoubleConverter x:Key="NullableIntToDoubleConverter" />
@@ -94,23 +95,75 @@
                                 Content="Neaktuální index"
                                 IsThreeState="True"
                                 IsChecked="{x:Bind ViewModel.IsIndexStaleFilter, Mode=TwoWay}" />
-                            <CheckBox
-                                x:Uid="FilesPage_HasValidityCheckBox"
-                                Content="Má platnost"
-                                IsThreeState="True"
-                                IsChecked="{x:Bind ViewModel.HasValidityFilter, Mode=TwoWay}" />
-                            <CheckBox
-                                x:Uid="FilesPage_CurrentlyValidCheckBox"
-                                Content="Aktuálně platné"
-                                IsThreeState="True"
-                                IsChecked="{x:Bind ViewModel.CurrentlyValidFilter, Mode=TwoWay}" />
-                            <controls:NumberBox
-                                x:Uid="FilesPage_ExpiringNumberBox"
-                                Header="Vyprší za (dní)"
-                                Minimum="0"
-                                SmallChange="1"
-                                SpinButtonPlacementMode="Compact"
-                                Value="{x:Bind ViewModel.ExpiringInDaysFilter, Mode=TwoWay, Converter={StaticResource NullableIntToDoubleConverter}}" />
+                            <ComboBox
+                                x:Uid="FilesPage_ValidityModeComboBox"
+                                Header="Filtr platnosti"
+                                SelectedValuePath="Tag"
+                                SelectedValue="{x:Bind ViewModel.ValidityFilterMode, Mode=TwoWay}">
+                                <ComboBoxItem Content="Bez filtru" Tag="{x:Bind contracts:ValidityFilterMode.None, Mode=OneWay}" />
+                                <ComboBoxItem Content="Má platnost" Tag="{x:Bind contracts:ValidityFilterMode.HasValidity, Mode=OneWay}" />
+                                <ComboBoxItem Content="Nemá platnost" Tag="{x:Bind contracts:ValidityFilterMode.NoValidity, Mode=OneWay}" />
+                                <ComboBoxItem Content="Aktuálně platné" Tag="{x:Bind contracts:ValidityFilterMode.CurrentlyValid, Mode=OneWay}" />
+                                <ComboBoxItem Content="Po expiraci" Tag="{x:Bind contracts:ValidityFilterMode.Expired, Mode=OneWay}" />
+                                <ComboBoxItem Content="Vyprší do" Tag="{x:Bind contracts:ValidityFilterMode.ExpiringWithin, Mode=OneWay}" />
+                                <ComboBoxItem Content="Expirace v rozsahu" Tag="{x:Bind contracts:ValidityFilterMode.ExpiringRange, Mode=OneWay}" />
+                            </ComboBox>
+
+                            <StackPanel
+                                Spacing="8"
+                                x:Load="{x:Bind ViewModel.ValidityFilterMode == contracts:ValidityFilterMode.ExpiringWithin, Mode=OneWay}">
+                                <controls:NumberBox
+                                    x:Uid="FilesPage_ExpiringWithinNumberBox"
+                                    Header="Vyprší do"
+                                    Minimum="0"
+                                    SmallChange="1"
+                                    SpinButtonPlacementMode="Compact"
+                                    Value="{x:Bind ViewModel.ExpiringInDaysFilter, Mode=TwoWay, Converter={StaticResource NullableIntToDoubleConverter}}" />
+                                <ComboBox
+                                    x:Uid="FilesPage_ExpiringWithinUnitComboBox"
+                                    Header="Jednotka"
+                                    SelectedValuePath="Tag"
+                                    SelectedValue="{x:Bind ViewModel.ValidityFilterUnit, Mode=TwoWay}">
+                                    <ComboBoxItem Content="dní" Tag="{x:Bind contracts:ValidityRelativeUnit.Days, Mode=OneWay}" />
+                                    <ComboBoxItem Content="týdnů" Tag="{x:Bind contracts:ValidityRelativeUnit.Weeks, Mode=OneWay}" />
+                                    <ComboBoxItem Content="měsíců" Tag="{x:Bind contracts:ValidityRelativeUnit.Months, Mode=OneWay}" />
+                                    <ComboBoxItem Content="let" Tag="{x:Bind contracts:ValidityRelativeUnit.Years, Mode=OneWay}" />
+                                </ComboBox>
+                            </StackPanel>
+
+                            <StackPanel
+                                Spacing="8"
+                                x:Load="{x:Bind ViewModel.ValidityFilterMode == contracts:ValidityFilterMode.ExpiringRange, Mode=OneWay}">
+                                <TextBlock Text="Expirace v rozsahu" />
+                                <StackPanel Orientation="Horizontal" Spacing="8">
+                                    <controls:NumberBox
+                                        x:Uid="FilesPage_ValidityRangeFromNumberBox"
+                                        Width="120"
+                                        Header="Od"
+                                        Minimum="0"
+                                        SmallChange="1"
+                                        SpinButtonPlacementMode="Compact"
+                                        Value="{x:Bind ViewModel.ExpiringFromInDaysFilter, Mode=TwoWay, Converter={StaticResource NullableIntToDoubleConverter}}" />
+                                    <controls:NumberBox
+                                        x:Uid="FilesPage_ValidityRangeToNumberBox"
+                                        Width="120"
+                                        Header="Do"
+                                        Minimum="0"
+                                        SmallChange="1"
+                                        SpinButtonPlacementMode="Compact"
+                                        Value="{x:Bind ViewModel.ExpiringInDaysFilter, Mode=TwoWay, Converter={StaticResource NullableIntToDoubleConverter}}" />
+                                    <ComboBox
+                                        x:Uid="FilesPage_ValidityRangeUnitComboBox"
+                                        Header="Jednotka"
+                                        SelectedValuePath="Tag"
+                                        SelectedValue="{x:Bind ViewModel.ValidityFilterUnit, Mode=TwoWay}">
+                                        <ComboBoxItem Content="dní" Tag="{x:Bind contracts:ValidityRelativeUnit.Days, Mode=OneWay}" />
+                                        <ComboBoxItem Content="týdnů" Tag="{x:Bind contracts:ValidityRelativeUnit.Weeks, Mode=OneWay}" />
+                                        <ComboBoxItem Content="měsíců" Tag="{x:Bind contracts:ValidityRelativeUnit.Months, Mode=OneWay}" />
+                                        <ComboBoxItem Content="let" Tag="{x:Bind contracts:ValidityRelativeUnit.Years, Mode=OneWay}" />
+                                    </ComboBox>
+                                </StackPanel>
+                            </StackPanel>
                         </StackPanel>
                     </controls:Expander>
 


### PR DESCRIPTION
## Summary
- replace the validity filter section on FilesPage with a single selector that surfaces the requested scenarios (has/has not validity, expiring within, expired, range) including number/units inputs for the relative cases
- extend FilesPageViewModel plus FileGridQueryDto with validity filter mode and unit fields so that advanced filters can be mapped into the query payload alongside the existing flags
- update the validator and EF filter builder to consume the new contract, rely on the server clock for time-based calculations, and validate the incoming relative ranges

## Testing
- `dotnet test Veriado.sln` *(fails: dotnet CLI is not available in the execution environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919993737308326bd50b23356ea74fb)