### PR TITLE
Fix Files page validity filter bindings

### DIFF
--- a/Veriado.WinUI/ViewModels/Files/FilesPageViewModel.cs
+++ b/Veriado.WinUI/ViewModels/Files/FilesPageViewModel.cs
@@ -43,6 +43,24 @@ public partial class FilesPageViewModel : ViewModelBase
     private readonly AsyncRelayCommand<FileSummaryDto?> _selectFileCommand;
     private readonly AsyncRelayCommand<FileSummaryDto?> _deleteFileCommand;
     private readonly IReadOnlyList<int> _pageSizeOptions = new[] { 25, 50, 100, 150, 200 };
+    private readonly IReadOnlyList<ValidityFilterModeOption> _validityFilterModeOptions = new[]
+    {
+        new ValidityFilterModeOption("Bez filtru", ValidityFilterMode.None),
+        new ValidityFilterModeOption("Má platnost", ValidityFilterMode.HasValidity),
+        new ValidityFilterModeOption("Nemá platnost", ValidityFilterMode.NoValidity),
+        new ValidityFilterModeOption("Aktuálně platné", ValidityFilterMode.CurrentlyValid),
+        new ValidityFilterModeOption("Po expiraci", ValidityFilterMode.Expired),
+        new ValidityFilterModeOption("Vyprší do", ValidityFilterMode.ExpiringWithin),
+        new ValidityFilterModeOption("Expirace v rozsahu", ValidityFilterMode.ExpiringRange),
+    };
+
+    private readonly IReadOnlyList<ValidityRelativeUnitOption> _validityRelativeUnitOptions = new[]
+    {
+        new ValidityRelativeUnitOption("dní", ValidityRelativeUnit.Days),
+        new ValidityRelativeUnitOption("týdnů", ValidityRelativeUnit.Weeks),
+        new ValidityRelativeUnitOption("měsíců", ValidityRelativeUnit.Months),
+        new ValidityRelativeUnitOption("let", ValidityRelativeUnit.Years),
+    };
     private bool _suppressTargetPageChange;
     private readonly object _detailLoadGate = new();
     private CancellationTokenSource? _detailLoadSource;
@@ -113,6 +131,10 @@ public partial class FilesPageViewModel : ViewModelBase
     public IAsyncRelayCommand<FileSummaryDto?> DeleteFileCommand => _deleteFileCommand;
 
     public IReadOnlyList<int> PageSizeOptions => _pageSizeOptions;
+
+    public IReadOnlyList<ValidityFilterModeOption> ValidityFilterModeOptions => _validityFilterModeOptions;
+
+    public IReadOnlyList<ValidityRelativeUnitOption> ValidityRelativeUnitOptions => _validityRelativeUnitOptions;
 
     [ObservableProperty]
     private string? searchText;
@@ -214,6 +236,10 @@ public partial class FilesPageViewModel : ViewModelBase
     private string? mimeFilterErrorMessage;
 
     public bool HasMimeFilterError => !string.IsNullOrEmpty(MimeFilterErrorMessage);
+
+    public bool IsExpiringWithinMode => ValidityFilterMode == ValidityFilterMode.ExpiringWithin;
+
+    public bool IsExpiringRangeMode => ValidityFilterMode == ValidityFilterMode.ExpiringRange;
 
     public double TargetPageMaximum
     {
@@ -349,6 +375,9 @@ public partial class FilesPageViewModel : ViewModelBase
 
     partial void OnValidityFilterModeChanged(ValidityFilterMode value)
     {
+        OnPropertyChanged(nameof(IsExpiringWithinMode));
+        OnPropertyChanged(nameof(IsExpiringRangeMode));
+
         switch (value)
         {
             case ValidityFilterMode.HasValidity:
@@ -978,3 +1007,7 @@ public partial class FilesPageViewModel : ViewModelBase
         source?.Dispose();
     }
 }
+
+public sealed record ValidityFilterModeOption(string DisplayName, ValidityFilterMode Mode);
+
+public sealed record ValidityRelativeUnitOption(string DisplayName, ValidityRelativeUnit Unit);

--- a/Veriado.WinUI/Views/Files/FilesPage.xaml
+++ b/Veriado.WinUI/Views/Files/FilesPage.xaml
@@ -9,7 +9,6 @@
     xmlns:views="using:Veriado.WinUI.Views.Files"
     xmlns:converters="using:Veriado.WinUI.Converters"
     xmlns:viewModels="using:Veriado.WinUI.ViewModels.Files"
-    xmlns:contracts="using:Veriado.Contracts.Files"
     mc:Ignorable="d">
     <Page.Resources>
         <converters:NullableIntToDoubleConverter x:Key="NullableIntToDoubleConverter" />
@@ -98,20 +97,19 @@
                             <ComboBox
                                 x:Uid="FilesPage_ValidityModeComboBox"
                                 Header="Filtr platnosti"
-                                SelectedValuePath="Tag"
+                                ItemsSource="{x:Bind ViewModel.ValidityFilterModeOptions, Mode=OneWay}"
+                                SelectedValuePath="Mode"
                                 SelectedValue="{x:Bind ViewModel.ValidityFilterMode, Mode=TwoWay}">
-                                <ComboBoxItem Content="Bez filtru" Tag="{x:Bind contracts:ValidityFilterMode.None, Mode=OneWay}" />
-                                <ComboBoxItem Content="Má platnost" Tag="{x:Bind contracts:ValidityFilterMode.HasValidity, Mode=OneWay}" />
-                                <ComboBoxItem Content="Nemá platnost" Tag="{x:Bind contracts:ValidityFilterMode.NoValidity, Mode=OneWay}" />
-                                <ComboBoxItem Content="Aktuálně platné" Tag="{x:Bind contracts:ValidityFilterMode.CurrentlyValid, Mode=OneWay}" />
-                                <ComboBoxItem Content="Po expiraci" Tag="{x:Bind contracts:ValidityFilterMode.Expired, Mode=OneWay}" />
-                                <ComboBoxItem Content="Vyprší do" Tag="{x:Bind contracts:ValidityFilterMode.ExpiringWithin, Mode=OneWay}" />
-                                <ComboBoxItem Content="Expirace v rozsahu" Tag="{x:Bind contracts:ValidityFilterMode.ExpiringRange, Mode=OneWay}" />
+                                <ComboBox.ItemTemplate>
+                                    <DataTemplate x:DataType="viewModels:ValidityFilterModeOption">
+                                        <TextBlock Text="{x:Bind DisplayName}" />
+                                    </DataTemplate>
+                                </ComboBox.ItemTemplate>
                             </ComboBox>
 
                             <StackPanel
                                 Spacing="8"
-                                x:Load="{x:Bind ViewModel.ValidityFilterMode == contracts:ValidityFilterMode.ExpiringWithin, Mode=OneWay}">
+                                x:Load="{x:Bind ViewModel.IsExpiringWithinMode, Mode=OneWay}">
                                 <controls:NumberBox
                                     x:Uid="FilesPage_ExpiringWithinNumberBox"
                                     Header="Vyprší do"
@@ -122,18 +120,20 @@
                                 <ComboBox
                                     x:Uid="FilesPage_ExpiringWithinUnitComboBox"
                                     Header="Jednotka"
-                                    SelectedValuePath="Tag"
+                                    ItemsSource="{x:Bind ViewModel.ValidityRelativeUnitOptions, Mode=OneWay}"
+                                    SelectedValuePath="Unit"
                                     SelectedValue="{x:Bind ViewModel.ValidityFilterUnit, Mode=TwoWay}">
-                                    <ComboBoxItem Content="dní" Tag="{x:Bind contracts:ValidityRelativeUnit.Days, Mode=OneWay}" />
-                                    <ComboBoxItem Content="týdnů" Tag="{x:Bind contracts:ValidityRelativeUnit.Weeks, Mode=OneWay}" />
-                                    <ComboBoxItem Content="měsíců" Tag="{x:Bind contracts:ValidityRelativeUnit.Months, Mode=OneWay}" />
-                                    <ComboBoxItem Content="let" Tag="{x:Bind contracts:ValidityRelativeUnit.Years, Mode=OneWay}" />
+                                    <ComboBox.ItemTemplate>
+                                        <DataTemplate x:DataType="viewModels:ValidityRelativeUnitOption">
+                                            <TextBlock Text="{x:Bind DisplayName}" />
+                                        </DataTemplate>
+                                    </ComboBox.ItemTemplate>
                                 </ComboBox>
                             </StackPanel>
 
                             <StackPanel
                                 Spacing="8"
-                                x:Load="{x:Bind ViewModel.ValidityFilterMode == contracts:ValidityFilterMode.ExpiringRange, Mode=OneWay}">
+                                x:Load="{x:Bind ViewModel.IsExpiringRangeMode, Mode=OneWay}">
                                 <TextBlock Text="Expirace v rozsahu" />
                                 <StackPanel Orientation="Horizontal" Spacing="8">
                                     <controls:NumberBox
@@ -155,12 +155,14 @@
                                     <ComboBox
                                         x:Uid="FilesPage_ValidityRangeUnitComboBox"
                                         Header="Jednotka"
-                                        SelectedValuePath="Tag"
+                                        ItemsSource="{x:Bind ViewModel.ValidityRelativeUnitOptions, Mode=OneWay}"
+                                        SelectedValuePath="Unit"
                                         SelectedValue="{x:Bind ViewModel.ValidityFilterUnit, Mode=TwoWay}">
-                                        <ComboBoxItem Content="dní" Tag="{x:Bind contracts:ValidityRelativeUnit.Days, Mode=OneWay}" />
-                                        <ComboBoxItem Content="týdnů" Tag="{x:Bind contracts:ValidityRelativeUnit.Weeks, Mode=OneWay}" />
-                                        <ComboBoxItem Content="měsíců" Tag="{x:Bind contracts:ValidityRelativeUnit.Months, Mode=OneWay}" />
-                                        <ComboBoxItem Content="let" Tag="{x:Bind contracts:ValidityRelativeUnit.Years, Mode=OneWay}" />
+                                        <ComboBox.ItemTemplate>
+                                            <DataTemplate x:DataType="viewModels:ValidityRelativeUnitOption">
+                                                <TextBlock Text="{x:Bind DisplayName}" />
+                                            </DataTemplate>
+                                        </ComboBox.ItemTemplate>
                                     </ComboBox>
                                 </StackPanel>
                             </StackPanel>


### PR DESCRIPTION
## Summary
- rework the validity-related ComboBoxes in `FilesPage.xaml` to bind against strongly typed option collections instead of hard-coded items, eliminating invalid `x:Bind` expressions
- expose the option collections and helper flags from `FilesPageViewModel` so the XAML can conditionally show the range inputs without referencing the contracts namespace

## Testing
- Not run (WinUI 3 application requires Windows to build and run)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919a111dcd48326a789e3bd82c8756d)