### PR TITLE
Fix missing x:Name for FilesPage x:Load panels

### DIFF
--- a/Veriado.WinUI/Views/Files/FilesPage.xaml
+++ b/Veriado.WinUI/Views/Files/FilesPage.xaml
@@ -108,6 +108,7 @@
                             </ComboBox>
 
                             <StackPanel
+                                x:Name="ExpiringWithinPanel"
                                 Spacing="8"
                                 x:Load="{x:Bind ViewModel.IsExpiringWithinMode, Mode=OneWay}">
                                 <controls:NumberBox
@@ -132,6 +133,7 @@
                             </StackPanel>
 
                             <StackPanel
+                                x:Name="ExpiringRangePanel"
                                 Spacing="8"
                                 x:Load="{x:Bind ViewModel.IsExpiringRangeMode, Mode=OneWay}">
                                 <TextBlock Text="Expirace v rozsahu" />


### PR DESCRIPTION
## Summary
- add `x:Name` attributes to the FilesPage StackPanels that use `x:Load` so the WinUI analyzer no longer reports WMC0907

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919a3e2c85083268801d5a5e9af5ce6)