### PR TITLE
Fix EF Core file grid filters

### DIFF
--- a/Veriado.Infrastructure/Search/FacetService.cs
+++ b/Veriado.Infrastructure/Search/FacetService.cs
@@ -1,6 +1,7 @@
 namespace Veriado.Infrastructure.Search;
 
 using System.Diagnostics;
+using Microsoft.EntityFrameworkCore;
 
 /// <summary>
 /// Implements aggregation-based facets using SQLite group by projections.
@@ -156,12 +157,14 @@ internal sealed class FacetService : IFacetService
     {
         if (TryConvertLong(from, out var lower))
         {
-            query = query.Where(file => file.Size.Value >= lower);
+            query = query.Where(file =>
+                EF.Property<long?>(file, "Content_Size") >= lower);
         }
 
         if (TryConvertLong(to, out var upper))
         {
-            query = query.Where(file => file.Size.Value <= upper);
+            query = query.Where(file =>
+                EF.Property<long?>(file, "Content_Size") <= upper);
         }
 
         return query;
@@ -247,7 +250,7 @@ internal sealed class FacetService : IFacetService
         }
 
         var buckets = await query
-            .Select(file => file.Size.Value)
+            .Select(file => EF.Property<long?>(file, "Content_Size") ?? 0L)
             .GroupBy(size => size < TenMegabytes
                 ? "0-10MB"
                 : size < HundredMegabytes


### PR DESCRIPTION
## Summary
- update file grid filters to reference scalar shadow properties for index, validity, size, and timestamp checks so EF Core can translate them
- fix repository projections and ordering to rely on EF scalar columns and client-side timestamp parsing
- update the facet service size filters and buckets to read the content size shadow property

## Testing
- Not run (dotnet CLI not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919ab77db608326b701fe55d18bddd7)