### PR TITLE
Remove legacy file filters

### DIFF
--- a/Veriado.WinUI/Views/Files/FilesPage.xaml
+++ b/Veriado.WinUI/Views/Files/FilesPage.xaml
@@ -11,8 +11,6 @@
     xmlns:viewModels="using:Veriado.WinUI.ViewModels.Files"
     mc:Ignorable="d">
     <Page.Resources>
-        <converters:NullableIntToDoubleConverter x:Key="NullableIntToDoubleConverter" />
-        <converters:NullableLongToDoubleConverter x:Key="NullableLongToDoubleConverter" />
         <converters:SizeToHumanConverter x:Key="SizeToHumanConverter" />
         <converters:ValidityStatusToBrushConverter x:Key="StatusToBrush" />
         <converters:ValidityStatusToForegroundBrushConverter x:Key="StatusToForegroundBrush" />
@@ -25,19 +23,8 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
-        <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="320" />
-            <ColumnDefinition Width="*" />
-        </Grid.ColumnDefinitions>
-
-        <Grid Grid.Column="0" Grid.RowSpan="2" RowSpacing="12">
-            <Grid.RowDefinitions>
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="*" />
-                <RowDefinition Height="Auto" />
-            </Grid.RowDefinitions>
-
-            <Grid x:Uid="FilesPage_SearchRow" Grid.Row="0">
+        <StackPanel Grid.Row="0" Orientation="Vertical" Spacing="12">
+            <Grid x:Uid="FilesPage_SearchRow">
                 <AutoSuggestBox
                     x:Name="SearchAutoSuggestBox"
                     x:Uid="FilesPage_SearchBox"
@@ -47,190 +34,7 @@
                     TextChanged="OnSearchTextChanged" />
             </Grid>
 
-            <ScrollViewer
-                x:Uid="FilesPage_FilterScrollViewer"
-                Grid.Row="1"
-                HorizontalScrollMode="Disabled"
-                HorizontalScrollBarVisibility="Hidden"
-                VerticalScrollMode="Auto"
-                VerticalScrollBarVisibility="Auto">
-                <StackPanel Spacing="12">
-                    <controls:Expander x:Uid="FilesPage_AttributesExpander" Header="Atributy" IsExpanded="True">
-                        <StackPanel Spacing="8">
-                            <TextBox
-                                x:Uid="FilesPage_ExtensionTextBox"
-                                PlaceholderText="Přípona"
-                                MaxLength="16"
-                                Text="{x:Bind ViewModel.ExtensionFilter, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-                            <TextBox
-                                x:Uid="FilesPage_MimeTextBox"
-                                PlaceholderText="MIME"
-                                Text="{x:Bind ViewModel.MimeFilter, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-                            <controls:InfoBar
-                                IsClosable="False"
-                                IsOpen="{x:Bind ViewModel.HasMimeFilterError, Mode=OneWay}"
-                                Message="{x:Bind ViewModel.MimeFilterErrorMessage, Mode=OneWay}"
-                                Severity="Error" />
-                            <TextBox
-                                x:Uid="FilesPage_AuthorTextBox"
-                                PlaceholderText="Autor"
-                                Text="{x:Bind ViewModel.AuthorFilter, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-                            <TextBox
-                                x:Uid="FilesPage_VersionTextBox"
-                                PlaceholderText="Verze"
-                                Text="{x:Bind ViewModel.VersionFilter, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-                        </StackPanel>
-                    </controls:Expander>
-
-                    <controls:Expander x:Uid="FilesPage_ValidityExpander" Header="Platnost" IsExpanded="True">
-                        <StackPanel Spacing="8">
-                            <CheckBox
-                                x:Uid="FilesPage_ReadOnlyCheckBox"
-                                Content="Jen pro čtení"
-                                IsThreeState="True"
-                                IsChecked="{x:Bind ViewModel.ReadOnlyFilter, Mode=TwoWay}" />
-                            <CheckBox
-                                x:Uid="FilesPage_IndexStaleCheckBox"
-                                Content="Neaktuální index"
-                                IsThreeState="True"
-                                IsChecked="{x:Bind ViewModel.IsIndexStaleFilter, Mode=TwoWay}" />
-                            <ComboBox
-                                x:Uid="FilesPage_ValidityModeComboBox"
-                                Header="Filtr platnosti"
-                                ItemsSource="{x:Bind ViewModel.ValidityFilterModeOptions, Mode=OneWay}"
-                                SelectedValuePath="Mode"
-                                SelectedValue="{x:Bind ViewModel.ValidityFilterMode, Mode=TwoWay}">
-                                <ComboBox.ItemTemplate>
-                                    <DataTemplate x:DataType="viewModels:ValidityFilterModeOption">
-                                        <TextBlock Text="{x:Bind DisplayName}" />
-                                    </DataTemplate>
-                                </ComboBox.ItemTemplate>
-                            </ComboBox>
-
-                            <StackPanel
-                                x:Name="ExpiringWithinPanel"
-                                Spacing="8"
-                                x:Load="{x:Bind ViewModel.IsExpiringWithinMode, Mode=OneWay}">
-                                <controls:NumberBox
-                                    x:Uid="FilesPage_ExpiringWithinNumberBox"
-                                    Header="Vyprší do"
-                                    Minimum="0"
-                                    SmallChange="1"
-                                    SpinButtonPlacementMode="Compact"
-                                    Value="{x:Bind ViewModel.ExpiringInDaysFilter, Mode=TwoWay, Converter={StaticResource NullableIntToDoubleConverter}}" />
-                                <ComboBox
-                                    x:Uid="FilesPage_ExpiringWithinUnitComboBox"
-                                    Header="Jednotka"
-                                    ItemsSource="{x:Bind ViewModel.ValidityRelativeUnitOptions, Mode=OneWay}"
-                                    SelectedValuePath="Unit"
-                                    SelectedValue="{x:Bind ViewModel.ValidityFilterUnit, Mode=TwoWay}">
-                                    <ComboBox.ItemTemplate>
-                                        <DataTemplate x:DataType="viewModels:ValidityRelativeUnitOption">
-                                            <TextBlock Text="{x:Bind DisplayName}" />
-                                        </DataTemplate>
-                                    </ComboBox.ItemTemplate>
-                                </ComboBox>
-                            </StackPanel>
-
-                            <StackPanel
-                                x:Name="ExpiringRangePanel"
-                                Spacing="8"
-                                x:Load="{x:Bind ViewModel.IsExpiringRangeMode, Mode=OneWay}">
-                                <TextBlock Text="Expirace v rozsahu" />
-                                <StackPanel Orientation="Horizontal" Spacing="8">
-                                    <controls:NumberBox
-                                        x:Uid="FilesPage_ValidityRangeFromNumberBox"
-                                        Width="120"
-                                        Header="Od"
-                                        Minimum="0"
-                                        SmallChange="1"
-                                        SpinButtonPlacementMode="Compact"
-                                        Value="{x:Bind ViewModel.ExpiringFromInDaysFilter, Mode=TwoWay, Converter={StaticResource NullableIntToDoubleConverter}}" />
-                                    <controls:NumberBox
-                                        x:Uid="FilesPage_ValidityRangeToNumberBox"
-                                        Width="120"
-                                        Header="Do"
-                                        Minimum="0"
-                                        SmallChange="1"
-                                        SpinButtonPlacementMode="Compact"
-                                        Value="{x:Bind ViewModel.ExpiringInDaysFilter, Mode=TwoWay, Converter={StaticResource NullableIntToDoubleConverter}}" />
-                                    <ComboBox
-                                        x:Uid="FilesPage_ValidityRangeUnitComboBox"
-                                        Header="Jednotka"
-                                        ItemsSource="{x:Bind ViewModel.ValidityRelativeUnitOptions, Mode=OneWay}"
-                                        SelectedValuePath="Unit"
-                                        SelectedValue="{x:Bind ViewModel.ValidityFilterUnit, Mode=TwoWay}">
-                                        <ComboBox.ItemTemplate>
-                                            <DataTemplate x:DataType="viewModels:ValidityRelativeUnitOption">
-                                                <TextBlock Text="{x:Bind DisplayName}" />
-                                            </DataTemplate>
-                                        </ComboBox.ItemTemplate>
-                                    </ComboBox>
-                                </StackPanel>
-                            </StackPanel>
-                        </StackPanel>
-                    </controls:Expander>
-
-                    <controls:Expander x:Uid="FilesPage_DatesExpander" Header="Data" IsExpanded="False">
-                        <StackPanel Spacing="8">
-                            <CalendarDatePicker
-                                x:Uid="FilesPage_CreatedFromPicker"
-                                PlaceholderText="Vytvořeno od"
-                                Date="{x:Bind ViewModel.CreatedFromFilter, Mode=TwoWay}" />
-                            <CalendarDatePicker
-                                x:Uid="FilesPage_CreatedToPicker"
-                                PlaceholderText="Vytvořeno do"
-                                Date="{x:Bind ViewModel.CreatedToFilter, Mode=TwoWay}" />
-                            <CalendarDatePicker
-                                x:Uid="FilesPage_ModifiedFromPicker"
-                                PlaceholderText="Upraveno od"
-                                Date="{x:Bind ViewModel.ModifiedFromFilter, Mode=TwoWay}" />
-                            <CalendarDatePicker
-                                x:Uid="FilesPage_ModifiedToPicker"
-                                PlaceholderText="Upraveno do"
-                                Date="{x:Bind ViewModel.ModifiedToFilter, Mode=TwoWay}" />
-                        </StackPanel>
-                    </controls:Expander>
-
-                    <controls:Expander x:Uid="FilesPage_SizeExpander" Header="Velikost" IsExpanded="False">
-                        <StackPanel Spacing="8">
-                            <controls:NumberBox
-                                x:Uid="FilesPage_SizeMinNumberBox"
-                                Header="Minimální velikost (B)"
-                                Minimum="0"
-                                SpinButtonPlacementMode="Compact"
-                                Value="{x:Bind ViewModel.SizeMinFilter, Mode=TwoWay, Converter={StaticResource NullableLongToDoubleConverter}}" />
-                            <controls:NumberBox
-                                x:Uid="FilesPage_SizeMaxNumberBox"
-                                Header="Maximální velikost (B)"
-                                Minimum="0"
-                                SpinButtonPlacementMode="Compact"
-                                Value="{x:Bind ViewModel.SizeMaxFilter, Mode=TwoWay, Converter={StaticResource NullableLongToDoubleConverter}}" />
-                        </StackPanel>
-                    </controls:Expander>
-                </StackPanel>
-            </ScrollViewer>
-
-            <Grid Grid.Row="2" ColumnSpacing="12">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="*" />
-                    <ColumnDefinition Width="*" />
-                </Grid.ColumnDefinitions>
-                <Button
-                    x:Uid="FilesPage_ApplyButton"
-                    Grid.Column="0"
-                    Content="Použít"
-                    Command="{x:Bind ViewModel.RefreshCommand}" />
-                <Button
-                    x:Uid="FilesPage_ClearButton"
-                    Grid.Column="1"
-                    Content="Vyčistit"
-                    Command="{x:Bind ViewModel.ClearFiltersCommand}" />
-            </Grid>
-        </Grid>
-
-        <StackPanel Grid.Row="0" Grid.Column="1" Orientation="Vertical" Spacing="8">
-            <StackPanel Orientation="Horizontal" Spacing="12" VerticalAlignment="Center">
+            <StackPanel Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
                 <ProgressRing Width="20" Height="20" IsActive="{x:Bind ViewModel.IsBusy}" />
                 <TextBlock
                     x:Uid="FilesPage_StatusText"
@@ -284,7 +88,7 @@
                 Message="Nepodařilo se načíst výsledky." />
         </StackPanel>
 
-        <controls:ItemsRepeaterScrollHost Grid.Row="1" Grid.Column="1">
+        <controls:ItemsRepeaterScrollHost Grid.Row="1">
             <controls:ScrollViewer
         x:Name="FilesScrollViewer"
         HorizontalScrollMode="Disabled"


### PR DESCRIPTION
## Summary
- remove the attribute/validity/date/size filter panels from the Files page and simplify the layout so the search box and pagination controls remain at the top of the view
- streamline `FilesPageViewModel` by deleting the unused filter properties/commands and sending only the search text and paging data to the query service

## Testing
- `dotnet build Veriado.sln` *(fails: `dotnet` command is unavailable in the container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919c33d6b3083268316dddaf8e5ce76)