### PR TITLE
Add physical file path state tracking

### DIFF
--- a/Veriado.Application.Tests/Domain/FileSystem/FileSystemEntityTests.cs
+++ b/Veriado.Application.Tests/Domain/FileSystem/FileSystemEntityTests.cs
@@ -2,6 +2,7 @@ using System;
 using Veriado.Domain.FileSystem;
 using Veriado.Domain.FileSystem.Events;
 using Veriado.Domain.Metadata;
+using Veriado.Domain.Primitives;
 using Veriado.Domain.ValueObjects;
 using Xunit;
 
@@ -68,7 +69,7 @@ public class FileSystemEntityTests
         entity.ClearDomainEvents();
 
         var firstDetection = UtcTimestamp.From(new DateTimeOffset(2024, 4, 1, 0, 0, 0, TimeSpan.Zero));
-        entity.MarkMissing(firstDetection);
+        entity.MarkMissing(new StaticClock(firstDetection.ToDateTimeOffset()));
 
         var evt = Assert.IsType<FileSystemMissingDetected>(Assert.Single(entity.DomainEvents));
         Assert.Equal(firstDetection, entity.MissingSinceUtc);
@@ -76,10 +77,20 @@ public class FileSystemEntityTests
         Assert.True(entity.IsMissing);
 
         var laterDetection = UtcTimestamp.From(new DateTimeOffset(2024, 4, 2, 0, 0, 0, TimeSpan.Zero));
-        entity.MarkMissing(laterDetection);
+        entity.MarkMissing(new StaticClock(laterDetection.ToDateTimeOffset()));
 
         Assert.Single(entity.DomainEvents);
         Assert.Equal(firstDetection, entity.MissingSinceUtc);
         Assert.True(entity.IsMissing);
     }
+}
+
+file class StaticClock : IClock
+{
+    public StaticClock(DateTimeOffset utcNow)
+    {
+        UtcNow = utcNow;
+    }
+
+    public DateTimeOffset UtcNow { get; }
 }

--- a/Veriado.Domain/FileSystem/FilePhysicalState.cs
+++ b/Veriado.Domain/FileSystem/FilePhysicalState.cs
@@ -1,0 +1,13 @@
+namespace Veriado.Domain.FileSystem;
+
+/// <summary>
+/// Describes the observed physical health of a file on disk.
+/// </summary>
+public enum FilePhysicalState
+{
+    Unknown = 0,
+    Healthy = 1,
+    Missing = 2,
+    MovedOrRenamed = 3,
+    ContentChanged = 4,
+}

--- a/Veriado.Domain/FileSystem/FileSystemEntity.ImportFactory.cs
+++ b/Veriado.Domain/FileSystem/FileSystemEntity.ImportFactory.cs
@@ -22,7 +22,10 @@ public sealed partial class FileSystemEntity
         ContentVersion contentVersion,
         bool isMissing,
         UtcTimestamp? missingSinceUtc,
-        UtcTimestamp? lastLinkedUtc)
+        UtcTimestamp? lastLinkedUtc,
+        string? currentFilePath = null,
+        string? originalFilePath = null,
+        FilePhysicalState physicalState = FilePhysicalState.Unknown)
     {
         var entity = new FileSystemEntity(id)
         {
@@ -38,9 +41,18 @@ public sealed partial class FileSystemEntity
             LastWriteUtc = lastWriteUtc,
             LastAccessUtc = lastAccessUtc,
             ContentVersion = contentVersion,
-            IsMissing = isMissing,
-            MissingSinceUtc = missingSinceUtc,
+            IsMissing = isMissing || physicalState == FilePhysicalState.Missing,
+            MissingSinceUtc = (isMissing || physicalState == FilePhysicalState.Missing) ? missingSinceUtc : null,
             LastLinkedUtc = lastLinkedUtc,
+            CurrentFilePath = currentFilePath ?? string.Empty,
+            OriginalFilePath = string.IsNullOrWhiteSpace(originalFilePath)
+                ? currentFilePath ?? string.Empty
+                : originalFilePath.Trim(),
+            PhysicalState = isMissing
+                ? FilePhysicalState.Missing
+                : physicalState == FilePhysicalState.Unknown
+                    ? FilePhysicalState.Healthy
+                    : physicalState,
         };
 
         return entity;

--- a/Veriado.Infrastructure/Persistence/Configurations/FileSystemEntityConfiguration.cs
+++ b/Veriado.Infrastructure/Persistence/Configurations/FileSystemEntityConfiguration.cs
@@ -1,3 +1,5 @@
+using Veriado.Domain.FileSystem;
+
 namespace Veriado.Infrastructure.Persistence.Configurations;
 
 /// <summary>
@@ -78,10 +80,28 @@ internal sealed class FileSystemEntityConfiguration : IEntityTypeConfiguration<F
             .HasColumnType("INTEGER")
             .IsRequired();
 
+        // Legacy missing flags retained for compatibility alongside PhysicalState.
         builder.Property(entity => entity.MissingSinceUtc)
             .HasColumnName("missing_since_utc")
             .HasColumnType("TEXT")
             .HasConversion(Converters.NullableUtcTimestampToString);
+
+        builder.Property(entity => entity.CurrentFilePath)
+            .HasColumnName("current_file_path")
+            .HasColumnType("TEXT")
+            .HasMaxLength(2048);
+
+        builder.Property(entity => entity.OriginalFilePath)
+            .HasColumnName("original_file_path")
+            .HasColumnType("TEXT")
+            .HasMaxLength(2048);
+
+        builder.Property(entity => entity.PhysicalState)
+            .HasColumnName("physical_state")
+            .HasColumnType("INTEGER")
+            .HasConversion<int>()
+            .HasDefaultValue((int)FilePhysicalState.Unknown)
+            .IsRequired();
 
         builder.Property(entity => entity.ContentVersion)
             .HasColumnName("content_version")
@@ -111,6 +131,7 @@ internal sealed class FileSystemEntityConfiguration : IEntityTypeConfiguration<F
             .HasColumnName("last_linked_utc")
             .HasColumnType("TEXT")
             .HasConversion(Converters.NullableUtcTimestampToString);
+
 
         builder.Ignore(entity => entity.DomainEvents);
 


### PR DESCRIPTION
## Summary
- add FilePhysicalState enum and extend FileSystemEntity with physical path tracking and state transitions
- update import factory and EF Core configuration to persist new path and physical state fields
- refresh domain tests for new clock-based missing detection API

## Testing
- dotnet test (fails: dotnet CLI not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b73546c80832699a9f318d14144ec)