### PR TITLE
Ensure physical state drives missing metadata

### DIFF
--- a/Veriado.Domain/FileSystem/FileSystemEntity.cs
+++ b/Veriado.Domain/FileSystem/FileSystemEntity.cs
@@ -51,8 +51,7 @@ public sealed partial class FileSystemEntity : AggregateRoot
         ContentVersion = contentVersion;
         PhysicalState = NormalizePhysicalState(physicalState, isMissing);
         InitializePaths(currentFilePath, originalFilePath);
-        IsMissing = PhysicalState == FilePhysicalState.Missing || isMissing;
-        MissingSinceUtc = IsMissing ? missingSinceUtc : null;
+        SetPhysicalState(PhysicalState, missingSinceUtc);
         LastLinkedUtc = lastLinkedUtc;
     }
 
@@ -119,6 +118,9 @@ public sealed partial class FileSystemEntity : AggregateRoot
     /// <summary>
     /// Gets a value indicating whether the content is currently missing.
     /// </summary>
+    /// <remarks>
+    /// Maintained for legacy compatibility and kept in sync with <see cref="PhysicalState"/>.
+    /// </remarks>
     public bool IsMissing { get; private set; }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- normalize FileSystemEntity missing flags through SetPhysicalState to keep legacy fields in sync
- document the IsMissing flag as a compatibility helper alongside PhysicalState

## Testing
- Not run (dotnet CLI not available in the environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b763b2f1c8326ad5bb264eac44513)