### PR TITLE
Add file system health check background worker

### DIFF
--- a/Veriado.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/Veriado.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
@@ -16,6 +16,7 @@ using Veriado.Application.Import;
 using Veriado.Infrastructure.Events;
 using Veriado.Infrastructure.Events.Handlers;
 using Veriado.Infrastructure.Hosting;
+using Veriado.Infrastructure.FileSystem;
 using Veriado.Infrastructure.Import;
 using Veriado.Infrastructure.Idempotency;
 using Veriado.Infrastructure.Integrity;
@@ -139,6 +140,16 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IOptions<AnalyzerOptions>>(sp => Options.Create(sp.GetRequiredService<SearchOptions>().Analyzer));
         services.AddSingleton<IOptions<SearchScoreOptions>>(sp => Options.Create(sp.GetRequiredService<SearchOptions>().Score));
 
+        var fileSystemHealthOptions = services.AddOptions<FileSystemHealthCheckOptions>();
+        if (configuration is not null)
+        {
+            fileSystemHealthOptions.Bind(configuration.GetSection("FileSystemHealthCheck"));
+        }
+        else
+        {
+            fileSystemHealthOptions.Configure(_ => { });
+        }
+
         services.AddSingleton<IAnalyzerFactory, AnalyzerFactory>();
 
         services.AddSingleton<IDomainEventDispatcher, DomainEventDispatcher>();
@@ -210,6 +221,7 @@ public static class ServiceCollectionExtensions
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IHostedService, InfrastructureInitializationHostedService>());
         services.AddHostedService<IdempotencyCleanupWorker>();
         services.AddHostedService<IndexAuditBackgroundService>();
+        services.AddHostedService<FileSystemHealthCheckWorker>();
 
         return services;
     }

--- a/Veriado.Infrastructure/FileSystem/FileSystemHealthCheckOptions.cs
+++ b/Veriado.Infrastructure/FileSystem/FileSystemHealthCheckOptions.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace Veriado.Infrastructure.FileSystem;
+
+/// <summary>
+/// Configures the background health check of physical file system entities.
+/// </summary>
+public sealed class FileSystemHealthCheckOptions
+{
+    /// <summary>
+    /// Gets or sets the interval between health check iterations.
+    /// </summary>
+    public TimeSpan Interval { get; set; } = TimeSpan.FromHours(1);
+
+    /// <summary>
+    /// Gets or sets the number of files processed per batch.
+    /// </summary>
+    public int BatchSize { get; set; } = 200;
+}

--- a/Veriado.Infrastructure/FileSystem/FileSystemHealthCheckWorker.cs
+++ b/Veriado.Infrastructure/FileSystem/FileSystemHealthCheckWorker.cs
@@ -1,0 +1,182 @@
+using System;
+using System.Buffers;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Veriado.Domain.FileSystem;
+using Veriado.Domain.Primitives;
+using Veriado.Domain.ValueObjects;
+using Veriado.Infrastructure.Persistence;
+
+namespace Veriado.Infrastructure.FileSystem;
+
+internal sealed class FileSystemHealthCheckWorker : BackgroundService
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly IClock _clock;
+    private readonly ILogger<FileSystemHealthCheckWorker> _logger;
+    private readonly FileSystemHealthCheckOptions _options;
+
+    public FileSystemHealthCheckWorker(
+        IServiceScopeFactory scopeFactory,
+        IClock clock,
+        IOptions<FileSystemHealthCheckOptions> options,
+        ILogger<FileSystemHealthCheckWorker> logger)
+    {
+        _scopeFactory = scopeFactory ?? throw new ArgumentNullException(nameof(scopeFactory));
+        _clock = clock ?? throw new ArgumentNullException(nameof(clock));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _options = options?.Value ?? throw new ArgumentNullException(nameof(options));
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation(
+            "{WorkerName} started with interval {Interval} and batch size {BatchSize}.",
+            nameof(FileSystemHealthCheckWorker),
+            _options.Interval,
+            _options.BatchSize);
+
+        try
+        {
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                await RunHealthCheckAsync(stoppingToken).ConfigureAwait(false);
+                await Task.Delay(_options.Interval, stoppingToken).ConfigureAwait(false);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            _logger.LogInformation("{WorkerName} is stopping (canceled).", nameof(FileSystemHealthCheckWorker));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unexpected error in {WorkerName}.", nameof(FileSystemHealthCheckWorker));
+        }
+        finally
+        {
+            _logger.LogInformation("{WorkerName} stopped.", nameof(FileSystemHealthCheckWorker));
+        }
+    }
+
+    private async Task RunHealthCheckAsync(CancellationToken cancellationToken)
+    {
+        await using var scope = _scopeFactory.CreateAsyncScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+
+        var offset = 0;
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            var batch = await dbContext.FileSystems
+                .AsTracking()
+                .OrderBy(file => file.Id)
+                .Skip(offset)
+                .Take(_options.BatchSize)
+                .ToListAsync(cancellationToken)
+                .ConfigureAwait(false);
+
+            if (batch.Count == 0)
+            {
+                return;
+            }
+
+            foreach (var file in batch)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                await EvaluateFileAsync(file, cancellationToken).ConfigureAwait(false);
+            }
+
+            await dbContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            dbContext.ChangeTracker.Clear();
+
+            offset += batch.Count;
+        }
+    }
+
+    private async Task EvaluateFileAsync(FileSystemEntity file, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(file.CurrentFilePath))
+        {
+            _logger.LogDebug("Skipping file system entity {FileId} because no current path is set.", file.Id);
+            return;
+        }
+
+        var info = new FileInfo(file.CurrentFilePath);
+        if (!info.Exists)
+        {
+            file.MarkMissing(_clock);
+            return;
+        }
+
+        var size = ByteSize.From(info.Length);
+        var created = UtcTimestamp.From(info.CreationTimeUtc);
+        var lastWrite = UtcTimestamp.From(info.LastWriteTimeUtc);
+        var lastAccess = UtcTimestamp.From(info.LastAccessTimeUtc);
+
+        var sizeChanged = file.Size != size;
+        var timestampsChanged = file.CreatedUtc != created
+            || file.LastWriteUtc != lastWrite
+            || file.LastAccessUtc != lastAccess;
+
+        if (!sizeChanged && !timestampsChanged)
+        {
+            file.MarkHealthy();
+            return;
+        }
+
+        var hash = await ComputeHashAsync(info.FullName, cancellationToken).ConfigureAwait(false);
+        if (hash == file.Hash)
+        {
+            file.UpdateTimestamps(created, lastWrite, lastAccess, UtcTimestamp.From(_clock.UtcNow));
+            file.MarkHealthy();
+            return;
+        }
+
+        file.ReplaceContent(file.Path, hash, size, file.Mime, file.IsEncrypted, lastWrite);
+        file.UpdateTimestamps(created, lastWrite, lastAccess, UtcTimestamp.From(_clock.UtcNow));
+        file.MarkContentChanged();
+    }
+
+    private static async Task<FileHash> ComputeHashAsync(string filePath, CancellationToken cancellationToken)
+    {
+        await using var stream = new FileStream(
+            filePath,
+            FileMode.Open,
+            FileAccess.Read,
+            FileShare.ReadWrite,
+            81920,
+            FileOptions.Asynchronous | FileOptions.SequentialScan);
+
+        using var hash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+        var buffer = ArrayPool<byte>.Shared.Rent(81920);
+
+        try
+        {
+            while (true)
+            {
+                var read = await stream.ReadAsync(buffer.AsMemory(0, buffer.Length), cancellationToken)
+                    .ConfigureAwait(false);
+                if (read == 0)
+                {
+                    break;
+                }
+
+                hash.AppendData(buffer, 0, read);
+            }
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+
+        var hex = Convert.ToHexString(hash.GetHashAndReset());
+        return FileHash.From(hex);
+    }
+}

--- a/Veriado.Infrastructure/Persistence/Configurations/FileSystemEntityConfiguration.cs
+++ b/Veriado.Infrastructure/Persistence/Configurations/FileSystemEntityConfiguration.cs
@@ -89,12 +89,12 @@ internal sealed class FileSystemEntityConfiguration : IEntityTypeConfiguration<F
         builder.Property(entity => entity.CurrentFilePath)
             .HasColumnName("current_file_path")
             .HasColumnType("TEXT")
-            .HasMaxLength(2048);
+            .HasMaxLength(1024);
 
         builder.Property(entity => entity.OriginalFilePath)
             .HasColumnName("original_file_path")
             .HasColumnType("TEXT")
-            .HasMaxLength(2048);
+            .HasMaxLength(1024);
 
         builder.Property(entity => entity.PhysicalState)
             .HasColumnName("physical_state")

--- a/Veriado.Infrastructure/Persistence/Migrations/20251101090000_AddFileSystemPhysicalHealthColumns.cs
+++ b/Veriado.Infrastructure/Persistence/Migrations/20251101090000_AddFileSystemPhysicalHealthColumns.cs
@@ -1,0 +1,51 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Veriado.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddFileSystemPhysicalHealthColumns : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "current_file_path",
+                table: "filesystem_entities",
+                type: "TEXT",
+                maxLength: 1024,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "original_file_path",
+                table: "filesystem_entities",
+                type: "TEXT",
+                maxLength: 1024,
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "physical_state",
+                table: "filesystem_entities",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "current_file_path",
+                table: "filesystem_entities");
+
+            migrationBuilder.DropColumn(
+                name: "original_file_path",
+                table: "filesystem_entities");
+
+            migrationBuilder.DropColumn(
+                name: "physical_state",
+                table: "filesystem_entities");
+        }
+    }
+}

--- a/Veriado.Infrastructure/Persistence/Migrations/AppDbContextModelSnapshot.cs
+++ b/Veriado.Infrastructure/Persistence/Migrations/AppDbContextModelSnapshot.cs
@@ -36,6 +36,11 @@ namespace Veriado.Infrastructure.Persistence.Migrations
                         .HasColumnType("TEXT")
                         .HasColumnName("created_utc");
 
+                    b.Property<string>("CurrentFilePath")
+                        .HasMaxLength(1024)
+                        .HasColumnType("TEXT")
+                        .HasColumnName("current_file_path");
+
                     b.Property<string>("Hash")
                         .IsRequired()
                         .HasMaxLength(64)
@@ -74,6 +79,11 @@ namespace Veriado.Infrastructure.Persistence.Migrations
                         .HasColumnType("TEXT")
                         .HasColumnName("missing_since_utc");
 
+                    b.Property<string>("OriginalFilePath")
+                        .HasMaxLength(1024)
+                        .HasColumnType("TEXT")
+                        .HasColumnName("original_file_path");
+
                     b.Property<string>("OwnerSid")
                         .HasMaxLength(256)
                         .HasColumnType("TEXT")
@@ -83,6 +93,12 @@ namespace Veriado.Infrastructure.Persistence.Migrations
                         .IsRequired()
                         .HasColumnType("TEXT")
                         .HasColumnName("path");
+
+                    b.Property<int>("PhysicalState")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("INTEGER")
+                        .HasColumnName("physical_state")
+                        .HasDefaultValue(0);
 
                     b.Property<int>("Provider")
                         .HasColumnType("INTEGER")


### PR DESCRIPTION
## Summary
- add EF mapping for filesystem paths and physical state with migration
- introduce background health check worker with configurable options
- register health check options and hosted service in DI

## Testing
- (not run) dotnet build Veriado.sln (dotnet CLI unavailable in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b7c0e475c832696a4eec5d14e886b)