### PR TITLE
Introduce relative file paths for file system entities

### DIFF
--- a/Veriado.Domain/FileSystem/Events/FileSystemEvents.cs
+++ b/Veriado.Domain/FileSystem/Events/FileSystemEvents.cs
@@ -15,7 +15,7 @@ public sealed class FileSystemContentChanged : IDomainEvent
     public FileSystemContentChanged(
         Guid fileSystemId,
         StorageProvider provider,
-        StoragePath path,
+        RelativeFilePath path,
         FileHash hash,
         ByteSize size,
         MimeType mime,
@@ -46,9 +46,9 @@ public sealed class FileSystemContentChanged : IDomainEvent
     public StorageProvider Provider { get; }
 
     /// <summary>
-    /// Gets the path referencing the content.
+    /// Gets the relative path referencing the content within the storage root.
     /// </summary>
-    public StoragePath Path { get; }
+    public RelativeFilePath Path { get; }
 
     /// <summary>
     /// Gets the hash of the content.
@@ -93,8 +93,8 @@ public sealed class FileSystemMoved : IDomainEvent
     public FileSystemMoved(
         Guid fileSystemId,
         StorageProvider provider,
-        StoragePath previousPath,
-        StoragePath newPath,
+        RelativeFilePath previousPath,
+        RelativeFilePath newPath,
         UtcTimestamp occurredUtc)
     {
         FileSystemId = fileSystemId;
@@ -116,14 +116,14 @@ public sealed class FileSystemMoved : IDomainEvent
     public StorageProvider Provider { get; }
 
     /// <summary>
-    /// Gets the previous storage path.
+    /// Gets the previous relative storage path.
     /// </summary>
-    public StoragePath PreviousPath { get; }
+    public RelativeFilePath PreviousPath { get; }
 
     /// <summary>
-    /// Gets the new storage path.
+    /// Gets the new relative storage path.
     /// </summary>
-    public StoragePath NewPath { get; }
+    public RelativeFilePath NewPath { get; }
 
     /// <inheritdoc />
     public Guid EventId { get; }
@@ -258,7 +258,7 @@ public sealed class FileSystemMissingDetected : IDomainEvent
     /// </summary>
     public FileSystemMissingDetected(
         Guid fileSystemId,
-        StoragePath path,
+        RelativeFilePath path,
         UtcTimestamp occurredUtc,
         UtcTimestamp? missingSinceUtc)
     {
@@ -275,9 +275,9 @@ public sealed class FileSystemMissingDetected : IDomainEvent
     public Guid FileSystemId { get; }
 
     /// <summary>
-    /// Gets the path that was probed.
+    /// Gets the relative path that was probed.
     /// </summary>
-    public StoragePath Path { get; }
+    public RelativeFilePath Path { get; }
 
     /// <summary>
     /// Gets the timestamp when the content was first observed missing, if known.
@@ -302,7 +302,7 @@ public sealed class FileSystemRehydrated : IDomainEvent
     public FileSystemRehydrated(
         Guid fileSystemId,
         StorageProvider provider,
-        StoragePath path,
+        RelativeFilePath path,
         bool wasMissing,
         UtcTimestamp? missingSinceUtc,
         UtcTimestamp occurredUtc)
@@ -327,9 +327,9 @@ public sealed class FileSystemRehydrated : IDomainEvent
     public StorageProvider Provider { get; }
 
     /// <summary>
-    /// Gets the path referencing the rehydrated content.
+    /// Gets the relative path referencing the rehydrated content.
     /// </summary>
-    public StoragePath Path { get; }
+    public RelativeFilePath Path { get; }
 
     /// <summary>
     /// Gets a value indicating whether the content had been missing prior to rehydration.

--- a/Veriado.Domain/FileSystem/FileSystemEntity.ImportFactory.cs
+++ b/Veriado.Domain/FileSystem/FileSystemEntity.ImportFactory.cs
@@ -9,7 +9,7 @@ public sealed partial class FileSystemEntity
     internal static FileSystemEntity CreateForImport(
         Guid id,
         StorageProvider provider,
-        StoragePath path,
+        RelativeFilePath relativePath,
         FileHash hash,
         ByteSize size,
         MimeType mime,
@@ -30,7 +30,7 @@ public sealed partial class FileSystemEntity
         var entity = new FileSystemEntity(id)
         {
             Provider = provider,
-            Path = path,
+            RelativePath = relativePath,
             Hash = hash,
             Size = size,
             Mime = mime,

--- a/Veriado.Domain/ValueObjects/RelativeFilePath.cs
+++ b/Veriado.Domain/ValueObjects/RelativeFilePath.cs
@@ -1,0 +1,91 @@
+using System.Collections.Generic;
+using System.IO;
+
+namespace Veriado.Domain.ValueObjects;
+
+/// <summary>
+/// Represents a normalized, relative path within the configured storage root.
+/// </summary>
+public sealed class RelativeFilePath : IEquatable<RelativeFilePath>
+{
+    private const int MaxLength = 2048;
+
+    private RelativeFilePath(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// Gets the normalized relative path value.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Creates a <see cref="RelativeFilePath"/> from the provided raw path.
+    /// </summary>
+    /// <param name="value">The relative path within the storage root.</param>
+    /// <returns>The created value object.</returns>
+    /// <exception cref="ArgumentException">Thrown when the value is null, empty, rooted, or exceeds the maximum length.</exception>
+    public static RelativeFilePath From(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            throw new ArgumentException("Relative path cannot be null or whitespace.", nameof(value));
+        }
+
+        var trimmed = value.Trim();
+        if (Path.IsPathRooted(trimmed))
+        {
+            throw new ArgumentException("Relative path must not be rooted.", nameof(value));
+        }
+
+        var segments = NormalizeSegments(trimmed);
+        var normalized = string.Join('/', segments);
+
+        if (normalized.Length == 0)
+        {
+            throw new ArgumentException("Relative path cannot be empty.", nameof(value));
+        }
+
+        if (normalized.Length > MaxLength)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(value),
+                normalized.Length,
+                $"Relative path exceeds the maximum allowed length of {MaxLength} characters.");
+        }
+
+        return new RelativeFilePath(normalized);
+    }
+
+    private static IEnumerable<string> NormalizeSegments(string path)
+    {
+        var segments = path
+            .Replace('\\', '/')
+            .Split('/', StringSplitOptions.RemoveEmptyEntries);
+
+        foreach (var segment in segments)
+        {
+            if (segment == "." || segment == "..")
+            {
+                throw new ArgumentException("Relative path cannot contain navigation segments.", nameof(path));
+            }
+
+            yield return segment;
+        }
+    }
+
+    /// <inheritdoc />
+    public override string ToString() => Value;
+
+    /// <inheritdoc />
+    public bool Equals(RelativeFilePath? other)
+        => other is not null && string.Equals(Value, other.Value, StringComparison.Ordinal);
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj)
+        => obj is RelativeFilePath other && Equals(other);
+
+    /// <inheritdoc />
+    public override int GetHashCode() => StringComparer.Ordinal.GetHashCode(Value);
+}


### PR DESCRIPTION
## Summary
- add a RelativeFilePath value object to capture normalized relative storage paths
- update FileSystemEntity to store and manipulate relative paths and emit updated events
- adjust file system domain events to carry relative paths for move, content, and missing scenarios

## Testing
- ⚠️ `dotnet build Veriado.Domain/Veriado.Domain.csproj` (not run: dotnet CLI unavailable in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ca5c779908326b0e1057aa655d14f)