### PR TITLE
Fix MarkMissing missing event path

### DIFF
--- a/Veriado.Domain/FileSystem/FileSystemEntity.cs
+++ b/Veriado.Domain/FileSystem/FileSystemEntity.cs
@@ -590,7 +590,7 @@ public sealed partial class FileSystemEntity : AggregateRoot
 
         SetPhysicalState(FilePhysicalState.Missing, whenUtc);
 
-        RaiseDomainEvent(new FileSystemMissingDetected(Id, Path, whenUtc, MissingSinceUtc));
+        RaiseDomainEvent(new FileSystemMissingDetected(Id, RelativePath, whenUtc, MissingSinceUtc));
     }
 
     public void MarkHealthy()


### PR DESCRIPTION
## Summary
- update FileSystemEntity.MarkMissing to emit FileSystemMissingDetected with the relative path

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691caac2ee2c8326a77172b698bffa0a)