### PR TITLE
Add file system monitoring service

### DIFF
--- a/Veriado.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/Veriado.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
@@ -196,6 +196,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IFileStorage>(sp => sp.GetRequiredService<LocalFileStorage>());
         services.AddSingleton<IStorageWriter>(sp => sp.GetRequiredService<LocalFileStorage>());
         services.AddScoped<IFilePathResolver, FilePathResolver>();
+        services.AddSingleton<IFileSystemMonitoringService, FileSystemMonitoringService>();
 
         services.AddSingleton<ISearchQueryService, SqliteFts5QueryService>();
         services.AddSingleton<ISearchHistoryService, SearchHistoryService>();
@@ -223,6 +224,7 @@ public static class ServiceCollectionExtensions
         services.AddHostedService<IdempotencyCleanupWorker>();
         services.AddHostedService<IndexAuditBackgroundService>();
         services.AddHostedService<FileSystemHealthCheckWorker>();
+        services.AddHostedService<FileSystemMonitoringHostedService>();
 
         return services;
     }

--- a/Veriado.Infrastructure/FileSystem/FileSystemMonitoringHostedService.cs
+++ b/Veriado.Infrastructure/FileSystem/FileSystemMonitoringHostedService.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
+
+namespace Veriado.Infrastructure.FileSystem;
+
+internal sealed class FileSystemMonitoringHostedService : BackgroundService
+{
+    private readonly IFileSystemMonitoringService _monitoringService;
+
+    public FileSystemMonitoringHostedService(IFileSystemMonitoringService monitoringService)
+    {
+        _monitoringService = monitoringService ?? throw new ArgumentNullException(nameof(monitoringService));
+    }
+
+    protected override Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _monitoringService.Start(stoppingToken);
+        return Task.CompletedTask;
+    }
+
+    public override void Dispose()
+    {
+        _monitoringService.Dispose();
+        base.Dispose();
+    }
+}

--- a/Veriado.Infrastructure/FileSystem/FileSystemMonitoringService.cs
+++ b/Veriado.Infrastructure/FileSystem/FileSystemMonitoringService.cs
@@ -1,0 +1,251 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Veriado.Domain.Primitives;
+using Veriado.Domain.ValueObjects;
+using Veriado.Infrastructure.Persistence;
+
+namespace Veriado.Infrastructure.FileSystem;
+
+internal sealed class FileSystemMonitoringService : IFileSystemMonitoringService
+{
+    private readonly IFilePathResolver _pathResolver;
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ILogger<FileSystemMonitoringService> _logger;
+    private FileSystemWatcher? _watcher;
+    private CancellationToken _cancellationToken;
+
+    public FileSystemMonitoringService(
+        IFilePathResolver pathResolver,
+        IServiceScopeFactory scopeFactory,
+        ILogger<FileSystemMonitoringService> logger)
+    {
+        _pathResolver = pathResolver ?? throw new ArgumentNullException(nameof(pathResolver));
+        _scopeFactory = scopeFactory ?? throw new ArgumentNullException(nameof(scopeFactory));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public void Start(CancellationToken cancellationToken)
+    {
+        if (_watcher is not null)
+        {
+            _logger.LogDebug("File system monitoring already started.");
+            return;
+        }
+
+        _cancellationToken = cancellationToken;
+
+        string root;
+        try
+        {
+            root = _pathResolver.GetStorageRoot();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to resolve storage root for monitoring.");
+            return;
+        }
+
+        _watcher = new FileSystemWatcher(root)
+        {
+            IncludeSubdirectories = true,
+            NotifyFilter = NotifyFilters.FileName | NotifyFilters.DirectoryName | NotifyFilters.Size | NotifyFilters.LastWrite,
+        };
+
+        _watcher.Created += OnCreated;
+        _watcher.Deleted += OnDeleted;
+        _watcher.Renamed += OnRenamed;
+        _watcher.Changed += OnChanged;
+        _watcher.EnableRaisingEvents = true;
+
+        _logger.LogInformation("File system monitoring started for root {Root}.", root);
+    }
+
+    public void Dispose()
+    {
+        if (_watcher is null)
+        {
+            return;
+        }
+
+        _watcher.EnableRaisingEvents = false;
+        _watcher.Created -= OnCreated;
+        _watcher.Deleted -= OnDeleted;
+        _watcher.Renamed -= OnRenamed;
+        _watcher.Changed -= OnChanged;
+        _watcher.Dispose();
+        _watcher = null;
+    }
+
+    private void OnCreated(object sender, FileSystemEventArgs e)
+    {
+        QueueHandling(() => HandleCreatedAsync(e.FullPath, _cancellationToken));
+    }
+
+    private void OnDeleted(object sender, FileSystemEventArgs e)
+    {
+        QueueHandling(() => HandleDeletedAsync(e.FullPath, _cancellationToken));
+    }
+
+    private void OnRenamed(object sender, RenamedEventArgs e)
+    {
+        QueueHandling(() => HandleRenamedAsync(e.OldFullPath, e.FullPath, _cancellationToken));
+    }
+
+    private void OnChanged(object sender, FileSystemEventArgs e)
+    {
+        QueueHandling(() => HandleChangedAsync(e.FullPath, _cancellationToken));
+    }
+
+    private void QueueHandling(Func<Task> handler)
+    {
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                await handler().ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (_cancellationToken.IsCancellationRequested)
+            {
+                _logger.LogDebug("File system monitoring operation canceled.");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Unhandled error while processing file system event.");
+            }
+        }, _cancellationToken);
+    }
+
+    private async Task HandleCreatedAsync(string fullPath, CancellationToken cancellationToken)
+    {
+        if (!TryGetRelativePath(fullPath, out var relativePath))
+        {
+            return;
+        }
+
+        await using var scope = _scopeFactory.CreateAsyncScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        var clock = scope.ServiceProvider.GetRequiredService<IClock>();
+
+        var entity = await dbContext.FileSystems
+            .SingleOrDefaultAsync(f => f.RelativePath.Value == relativePath, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (entity is null)
+        {
+            _logger.LogInformation(
+                "Detected creation for {RelativePath} but no matching file system entity exists (future import may handle).",
+                relativePath);
+            return;
+        }
+
+        entity.MarkHealthy();
+        entity.UpdatePath(fullPath);
+        entity.UpdateTimestamps(null, UtcTimestamp.From(clock.UtcNow), null, UtcTimestamp.From(clock.UtcNow));
+
+        await dbContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task HandleDeletedAsync(string fullPath, CancellationToken cancellationToken)
+    {
+        if (!TryGetRelativePath(fullPath, out var relativePath))
+        {
+            return;
+        }
+
+        await using var scope = _scopeFactory.CreateAsyncScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        var clock = scope.ServiceProvider.GetRequiredService<IClock>();
+
+        var entity = await dbContext.FileSystems
+            .SingleOrDefaultAsync(f => f.RelativePath.Value == relativePath, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (entity is null)
+        {
+            _logger.LogDebug("No tracked file system entity found for deleted path {RelativePath}.", relativePath);
+            return;
+        }
+
+        entity.MarkMissing(clock);
+        await dbContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task HandleRenamedAsync(string oldFullPath, string newFullPath, CancellationToken cancellationToken)
+    {
+        if (!TryGetRelativePath(oldFullPath, out var oldRelativePath) ||
+            !TryGetRelativePath(newFullPath, out var newRelativePath))
+        {
+            return;
+        }
+
+        await using var scope = _scopeFactory.CreateAsyncScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        var clock = scope.ServiceProvider.GetRequiredService<IClock>();
+
+        var entity = await dbContext.FileSystems
+            .SingleOrDefaultAsync(f => f.RelativePath.Value == oldRelativePath, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (entity is null)
+        {
+            _logger.LogDebug(
+                "No tracked file system entity found for rename from {OldRelativePath} to {NewRelativePath}.",
+                oldRelativePath,
+                newRelativePath);
+            return;
+        }
+
+        var whenUtc = UtcTimestamp.From(clock.UtcNow);
+        entity.MoveTo(RelativeFilePath.From(newRelativePath), whenUtc);
+        entity.MarkMovedOrRenamed(newFullPath);
+
+        await dbContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task HandleChangedAsync(string fullPath, CancellationToken cancellationToken)
+    {
+        if (!TryGetRelativePath(fullPath, out var relativePath))
+        {
+            return;
+        }
+
+        await using var scope = _scopeFactory.CreateAsyncScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+
+        var entity = await dbContext.FileSystems
+            .SingleOrDefaultAsync(f => f.RelativePath.Value == relativePath, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (entity is null)
+        {
+            _logger.LogDebug("Change notification ignored; no file system entity found for {RelativePath}.", relativePath);
+            return;
+        }
+
+        entity.MarkContentChanged();
+        entity.UpdatePath(fullPath);
+
+        await dbContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private bool TryGetRelativePath(string fullPath, out string? relativePath)
+    {
+        relativePath = null;
+
+        try
+        {
+            relativePath = _pathResolver.GetRelativePath(fullPath);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Unable to resolve relative path for {FullPath}; ignoring watcher event.", fullPath);
+            return false;
+        }
+    }
+}

--- a/Veriado.Infrastructure/FileSystem/IFileSystemMonitoringService.cs
+++ b/Veriado.Infrastructure/FileSystem/IFileSystemMonitoringService.cs
@@ -1,0 +1,9 @@
+using System;
+using System.Threading;
+
+namespace Veriado.Infrastructure.FileSystem;
+
+public interface IFileSystemMonitoringService : IDisposable
+{
+    void Start(CancellationToken cancellationToken);
+}


### PR DESCRIPTION
## Summary
- add a file system monitoring service that watches the storage root and updates tracked FileSystemEntity records
- register the monitoring hosted service within dependency injection to start at application boot

## Testing
- dotnet test *(fails: dotnet CLI not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691caf81d9f88326aaa0261f4af9c5cf)