### PR TITLE
Add configurable file system health check worker

### DIFF
--- a/Veriado.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/Veriado.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
@@ -196,6 +196,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IFileStorage>(sp => sp.GetRequiredService<LocalFileStorage>());
         services.AddSingleton<IStorageWriter>(sp => sp.GetRequiredService<LocalFileStorage>());
         services.AddScoped<IFilePathResolver, FilePathResolver>();
+        services.AddSingleton<IFileHashCalculator, FileHashCalculator>();
         services.AddSingleton<IFileSystemMonitoringService, FileSystemMonitoringService>();
 
         services.AddSingleton<ISearchQueryService, SqliteFts5QueryService>();

--- a/Veriado.Infrastructure/FileSystem/FileHashCalculator.cs
+++ b/Veriado.Infrastructure/FileSystem/FileHashCalculator.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Buffers;
+using System.IO;
+using System.Security.Cryptography;
+using System.Threading;
+using System.Threading.Tasks;
+using Veriado.Domain.ValueObjects;
+
+namespace Veriado.Infrastructure.FileSystem;
+
+internal sealed class FileHashCalculator : IFileHashCalculator
+{
+    public async Task<FileHash> ComputeSha256Async(string filePath, CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(filePath);
+
+        await using var stream = new FileStream(
+            filePath,
+            FileMode.Open,
+            FileAccess.Read,
+            FileShare.ReadWrite,
+            81920,
+            FileOptions.Asynchronous | FileOptions.SequentialScan);
+
+        using var hash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+        var buffer = ArrayPool<byte>.Shared.Rent(81920);
+
+        try
+        {
+            while (true)
+            {
+                var read = await stream.ReadAsync(buffer.AsMemory(0, buffer.Length), cancellationToken)
+                    .ConfigureAwait(false);
+                if (read == 0)
+                {
+                    break;
+                }
+
+                hash.AppendData(buffer, 0, read);
+            }
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+
+        var hex = Convert.ToHexString(hash.GetHashAndReset());
+        return FileHash.From(hex);
+    }
+}

--- a/Veriado.Infrastructure/FileSystem/FileSystemHealthCheckOptions.cs
+++ b/Veriado.Infrastructure/FileSystem/FileSystemHealthCheckOptions.cs
@@ -16,4 +16,14 @@ public sealed class FileSystemHealthCheckOptions
     /// Gets or sets the number of files processed per batch.
     /// </summary>
     public int BatchSize { get; set; } = 200;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether file checks should run in parallel.
+    /// </summary>
+    public bool EnableParallelChecks { get; set; }
+
+    /// <summary>
+    /// Gets or sets the maximum degree of parallelism when parallel checks are enabled.
+    /// </summary>
+    public int MaxDegreeOfParallelism { get; set; } = 4;
 }

--- a/Veriado.Infrastructure/FileSystem/IFileHashCalculator.cs
+++ b/Veriado.Infrastructure/FileSystem/IFileHashCalculator.cs
@@ -1,0 +1,19 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Veriado.Domain.ValueObjects;
+
+namespace Veriado.Infrastructure.FileSystem;
+
+/// <summary>
+/// Computes hashes for files stored on disk.
+/// </summary>
+public interface IFileHashCalculator
+{
+    /// <summary>
+    /// Computes the SHA-256 hash for a file at the specified path.
+    /// </summary>
+    /// <param name="filePath">The full path of the file to hash.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The computed <see cref="FileHash"/>.</returns>
+    Task<FileHash> ComputeSha256Async(string filePath, CancellationToken cancellationToken);
+}


### PR DESCRIPTION
## Summary
- expand file system health check options with batching, interval, and parallel execution controls
- rework the file system health check worker to resolve full paths, batch iteration, and domain state updates using shared hashing services
- add a reusable file hash calculator and register supporting services in dependency injection

## Testing
- dotnet test Veriado.sln --nologo *(fails: dotnet not installed in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691cb13cb04483268bcb0b8ef8e5bfa9)