### PR TITLE
Expose physical file state in file DTOs

### DIFF
--- a/Veriado.Application/Abstractions/IFileReadRepository.cs
+++ b/Veriado.Application/Abstractions/IFileReadRepository.cs
@@ -23,7 +23,8 @@ public sealed record FileListItemReadModel(
     bool IsReadOnly,
     DateTimeOffset CreatedUtc,
     DateTimeOffset LastModifiedUtc,
-    DateTimeOffset? ValidUntilUtc);
+    DateTimeOffset? ValidUntilUtc,
+    FilePhysicalState PhysicalState);
 
 public sealed record FileDocumentValidityReadModel(
     DateTimeOffset IssuedAtUtc,
@@ -44,4 +45,5 @@ public sealed record FileDetailReadModel(
     DateTimeOffset CreatedUtc,
     DateTimeOffset LastModifiedUtc,
     FileDocumentValidityReadModel? Validity,
-    FileSystemMetadata SystemMetadata);
+    FileSystemMetadata SystemMetadata,
+    FilePhysicalState PhysicalState);

--- a/Veriado.Contracts/Files/FileListItemDto.cs
+++ b/Veriado.Contracts/Files/FileListItemDto.cs
@@ -25,4 +25,6 @@ public sealed record FileListItemDto(
     bool IsReadOnly,
     DateTimeOffset CreatedUtc,
     DateTimeOffset LastModifiedUtc,
-    DateTimeOffset? ValidUntilUtc);
+    DateTimeOffset? ValidUntilUtc,
+    string? PhysicalState,
+    string? PhysicalStatusMessage);

--- a/Veriado.Contracts/Files/FileSummaryDto.cs
+++ b/Veriado.Contracts/Files/FileSummaryDto.cs
@@ -94,4 +94,15 @@ public sealed record FileSummaryDto
     /// Gets the optional relevance score returned from full-text search queries.
     /// </summary>
     public double? Score { get; init; }
+
+    /// <summary>
+    /// Stav fyzického souboru (např. Healthy, Missing, MovedOrRenamed, ContentChanged).
+    /// </summary>
+    public string? PhysicalState { get; init; }
+
+    /// <summary>
+    /// Lidsky čitelná hláška o fyzickém stavu souboru pro UI.
+    /// Např. "Soubor byl smazán z disku", "Soubor byl přejmenován nebo přesunut", "Soubor byl změněn mimo aplikaci".
+    /// </summary>
+    public string? PhysicalStatusMessage { get; init; }
 }

--- a/Veriado.Domain/Files/FileEntity.cs
+++ b/Veriado.Domain/Files/FileEntity.cs
@@ -1,4 +1,5 @@
 using Veriado.Domain.Files.Events;
+using Veriado.Domain.FileSystem;
 using Veriado.Domain.Metadata;
 using Veriado.Domain.Primitives;
 using Veriado.Domain.Search;
@@ -100,6 +101,11 @@ public sealed partial class FileEntity : AggregateRoot
     /// Gets the identifier of the linked file system content.
     /// </summary>
     public Guid FileSystemId { get; private set; }
+
+    /// <summary>
+    /// Gets the linked file system entity describing the physical file state.
+    /// </summary>
+    public FileSystemEntity? FileSystem { get; private set; }
 
     /// <summary>
     /// Gets the version of the currently linked content.

--- a/Veriado.Infrastructure/Persistence/Configurations/FileEntityConfiguration.cs
+++ b/Veriado.Infrastructure/Persistence/Configurations/FileEntityConfiguration.cs
@@ -132,7 +132,7 @@ internal sealed class FileEntityConfiguration : IEntityTypeConfiguration<FileEnt
         builder.HasIndex(file => file.Mime).HasDatabaseName("idx_files_mime");
         builder.HasIndex(file => file.FileSystemId).HasDatabaseName("ux_files_filesystem_id").IsUnique();
 
-        builder.HasOne<FileSystemEntity>()
+        builder.HasOne(file => file.FileSystem)
             .WithMany()
             .HasForeignKey(file => file.FileSystemId)
             .HasPrincipalKey(entity => entity.Id)


### PR DESCRIPTION
## Summary
- add physical state and status message fields to file list/detail DTOs used by the grid
- map physical state from file system entities with human-readable messaging
- extend read models and repository projections to join file system state for queries

## Testing
- dotnet build Veriado.sln *(fails: `dotnet` command not available in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691cb3f4c3408326a2842e3147bbad51)