### PR TITLE
Handle physical file issues on files page

### DIFF
--- a/Veriado.WinUI/ViewModels/Files/FileListItemModel.cs
+++ b/Veriado.WinUI/ViewModels/Files/FileListItemModel.cs
@@ -35,6 +35,9 @@ public sealed partial class FileListItemModel : ObservableObject
         ValidTo = to;
         _validityThresholds = thresholds;
         Validity = new ValidityInfo(ValidFrom, ValidTo, referenceTime, _validityThresholds);
+
+        PhysicalState = dto.PhysicalState;
+        PhysicalStatusMessage = dto.PhysicalStatusMessage;
     }
 
     public FileSummaryDto Dto { get; }
@@ -51,6 +54,16 @@ public sealed partial class FileListItemModel : ObservableObject
         private set => SetProperty(ref _validity, value);
     }
 
+    [ObservableProperty]
+    private string? physicalState;
+
+    [ObservableProperty]
+    private string? physicalStatusMessage;
+
+    public bool HasPhysicalIssue => !string.IsNullOrWhiteSpace(PhysicalStatusMessage);
+
+    public bool IsHealthy => string.Equals(PhysicalState, "Healthy", StringComparison.OrdinalIgnoreCase);
+
     public void RecomputeValidity(DateTimeOffset referenceTime, ValidityThresholds? thresholds = null)
     {
         if (thresholds.HasValue)
@@ -59,5 +72,21 @@ public sealed partial class FileListItemModel : ObservableObject
         }
 
         Validity = new ValidityInfo(ValidFrom, ValidTo, referenceTime, _validityThresholds);
+    }
+
+    public void UpdatePhysicalStatus(string? newState, string? statusMessage)
+    {
+        PhysicalState = newState;
+        PhysicalStatusMessage = statusMessage;
+    }
+
+    partial void OnPhysicalStateChanged(string? value)
+    {
+        OnPropertyChanged(nameof(IsHealthy));
+    }
+
+    partial void OnPhysicalStatusMessageChanged(string? value)
+    {
+        OnPropertyChanged(nameof(HasPhysicalIssue));
     }
 }

--- a/Veriado.WinUI/Views/Files/FilesPage.xaml
+++ b/Veriado.WinUI/Views/Files/FilesPage.xaml
@@ -167,6 +167,12 @@
                                             <TextBlock
                                                 Text="{x:Bind Dto.Size, Converter={StaticResource SizeToHumanConverter}}"
                                                 FontSize="12" />
+                                            <TextBlock
+                                                Text="{x:Bind PhysicalStatusMessage, Mode=OneWay}"
+                                                FontSize="12"
+                                                Foreground="Red"
+                                                TextWrapping="Wrap"
+                                                Visibility="{x:Bind HasPhysicalIssue, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}" />
                                         </StackPanel>
                                     </Grid>
 
@@ -186,6 +192,11 @@
                                             Content="Smazat"
                                             Command="{Binding DataContext.DeleteFileCommand, ElementName=PageRoot}"
                                             CommandParameter="{x:Bind Dto}" />
+                                        <Button
+                                            Content="Aktualizovat soubor"
+                                            Command="{Binding DataContext.UpdateFileCommand, ElementName=PageRoot}"
+                                            CommandParameter="{x:Bind}"
+                                            Visibility="{x:Bind HasPhysicalIssue, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}" />
                                     </StackPanel>
                                 </Grid>
                             </Border>


### PR DESCRIPTION
## Summary
- surface physical state messaging and remediation action in the files list template
- extend the file list item model with physical health fields and helper flags for binding
- add a command that picks a replacement file, computes its hash, and refreshes the UI after attempting to reattach

## Testing
- dotnet build Veriado.WinUI/Veriado.csproj *(fails: dotnet is not available in the container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691cb7bd87f483268023fc4e302bd664)