### PR TITLE
Fix FileSystemMissingDetected event argument

### DIFF
--- a/Veriado.Domain/FileSystem/FileSystemEntity.cs
+++ b/Veriado.Domain/FileSystem/FileSystemEntity.cs
@@ -590,7 +590,7 @@ public sealed partial class FileSystemEntity : AggregateRoot
 
         SetPhysicalState(FilePhysicalState.Missing, whenUtc);
 
-        RaiseDomainEvent(new FileSystemMissingDetected(Id, Path, whenUtc, MissingSinceUtc));
+        RaiseDomainEvent(new FileSystemMissingDetected(Id, RelativePath, whenUtc, MissingSinceUtc));
     }
 
     public void MarkHealthy()


### PR DESCRIPTION
## Summary
- pass the relative path when raising FileSystemMissingDetected from MarkMissing

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691cc2241e28832698232e00e019d368)