### PR TITLE
Fix file storage path handling

### DIFF
--- a/Veriado.Application/UseCases/Files/CreateFileWithUpload/CreateFileWithUploadHandler.cs
+++ b/Veriado.Application/UseCases/Files/CreateFileWithUpload/CreateFileWithUploadHandler.cs
@@ -1,4 +1,5 @@
 using Veriado.Appl.Abstractions;
+using Veriado.Domain.ValueObjects;
 
 namespace Veriado.Appl.UseCases.Files.CreateFileWithUpload;
 
@@ -63,9 +64,10 @@ public sealed class CreateFileWithUploadHandler : FileWriteHandlerBase, IRequest
             }
 
             var createdAt = CurrentTimestamp();
+            var relativePath = RelativeFilePath.From(storageResult.Path.Value);
             var fileSystem = FileSystemEntity.CreateNew(
                 storageResult.Provider,
-                storageResult.Path,
+                relativePath,
                 storageResult.Hash,
                 storageResult.Size,
                 storageResult.Mime,

--- a/Veriado.Application/UseCases/Files/RelinkFileContent/RelinkFileContentHandler.cs
+++ b/Veriado.Application/UseCases/Files/RelinkFileContent/RelinkFileContentHandler.cs
@@ -1,4 +1,5 @@
 using Veriado.Appl.Abstractions;
+using Veriado.Domain.ValueObjects;
 
 namespace Veriado.Appl.UseCases.Files.RelinkFileContent;
 
@@ -72,9 +73,10 @@ public sealed class RelinkFileContentHandler : FileWriteHandlerBase, IRequestHan
                 throw new InvalidOperationException($"File system entity '{file.FileSystemId}' was not found.");
             }
 
+            var relativePath = RelativeFilePath.From(storageResult.Path.Value);
             var timestamp = CurrentTimestamp();
             fileSystem.ReplaceContent(
-                storageResult.Path,
+                relativePath,
                 storageResult.Hash,
                 storageResult.Size,
                 storageResult.Mime,

--- a/Veriado.Application/UseCases/Files/ReplaceFileContent/ReplaceFileContentHandler.cs
+++ b/Veriado.Application/UseCases/Files/ReplaceFileContent/ReplaceFileContentHandler.cs
@@ -59,7 +59,7 @@ public sealed class ReplaceFileContentHandler : FileWriteHandlerBase, IRequestHa
             var newSize = ByteSize.From(request.Content.LongLength);
 
             fileSystem.ReplaceContent(
-                fileSystem.Path,
+                fileSystem.RelativePath,
                 newHash,
                 newSize,
                 file.Mime,
@@ -68,7 +68,7 @@ public sealed class ReplaceFileContentHandler : FileWriteHandlerBase, IRequestHa
 
             var link = FileContentLink.Create(
                 fileSystem.Provider.ToString(),
-                fileSystem.Path.Value,
+                fileSystem.RelativePath.Value,
                 fileSystem.Hash,
                 fileSystem.Size,
                 fileSystem.ContentVersion,


### PR DESCRIPTION
## Summary
- normalize storage paths into relative file paths before creating or updating file system entities
- use relative path property when updating existing file links to match domain model

## Testing
- not run (dotnet CLI not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691cc31350288326b6eba9bb824dabcb)