### PR TITLE
Fix monitoring clock resolution and mapping expressions

### DIFF
--- a/Veriado.Infrastructure/FileSystem/FileSystemMonitoringService.cs
+++ b/Veriado.Infrastructure/FileSystem/FileSystemMonitoringService.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Veriado.Domain.Primitives;
 using Veriado.Domain.ValueObjects;
+using DomainClock = Veriado.Domain.Primitives.IClock;
 using Veriado.Infrastructure.Persistence;
 
 namespace Veriado.Infrastructure.FileSystem;
@@ -129,7 +130,7 @@ internal sealed class FileSystemMonitoringService : IFileSystemMonitoringService
 
         await using var scope = _scopeFactory.CreateAsyncScope();
         var dbContext = scope.ServiceProvider.GetRequiredService<AppDbContext>();
-        var clock = scope.ServiceProvider.GetRequiredService<IClock>();
+        var clock = scope.ServiceProvider.GetRequiredService<DomainClock>();
 
         var entity = await dbContext.FileSystems
             .SingleOrDefaultAsync(f => f.RelativePath.Value == relativePath, cancellationToken)
@@ -159,7 +160,7 @@ internal sealed class FileSystemMonitoringService : IFileSystemMonitoringService
 
         await using var scope = _scopeFactory.CreateAsyncScope();
         var dbContext = scope.ServiceProvider.GetRequiredService<AppDbContext>();
-        var clock = scope.ServiceProvider.GetRequiredService<IClock>();
+        var clock = scope.ServiceProvider.GetRequiredService<DomainClock>();
 
         var entity = await dbContext.FileSystems
             .SingleOrDefaultAsync(f => f.RelativePath.Value == relativePath, cancellationToken)
@@ -185,7 +186,7 @@ internal sealed class FileSystemMonitoringService : IFileSystemMonitoringService
 
         await using var scope = _scopeFactory.CreateAsyncScope();
         var dbContext = scope.ServiceProvider.GetRequiredService<AppDbContext>();
-        var clock = scope.ServiceProvider.GetRequiredService<IClock>();
+        var clock = scope.ServiceProvider.GetRequiredService<DomainClock>();
 
         var entity = await dbContext.FileSystems
             .SingleOrDefaultAsync(f => f.RelativePath.Value == oldRelativePath, cancellationToken)

--- a/Veriado.Mapping/Profiles/FileReadProfiles.cs
+++ b/Veriado.Mapping/Profiles/FileReadProfiles.cs
@@ -66,7 +66,8 @@ public sealed class FileReadProfiles : Profile
             .ForMember(dest => dest.PhysicalState, opt =>
                 opt.MapFrom(static src => src.FileSystem != null ? src.FileSystem.PhysicalState.ToString() : null))
             .ForMember(dest => dest.PhysicalStatusMessage, opt =>
-                opt.MapFrom(static src => GetPhysicalStatusMessage(src.FileSystem?.PhysicalState)))
+                opt.MapFrom(static src => GetPhysicalStatusMessage(
+                    src.FileSystem != null ? src.FileSystem.PhysicalState : (FilePhysicalState?)null)))
             .ForMember(dest => dest.IsIndexStale, ConfigureSearchIndexMember<FileSummaryDto, bool>(static state => state.IsStale))
             .ForMember(dest => dest.LastIndexedUtc, ConfigureSearchIndexMember<FileSummaryDto, DateTimeOffset?>(static state => state.LastIndexedUtc))
             .ForMember(dest => dest.IndexedTitle, ConfigureSearchIndexMember<FileSummaryDto, string?>(static state => state.IndexedTitle))


### PR DESCRIPTION
## Summary
- resolve the IClock ambiguity in `FileSystemMonitoringService` by explicitly requesting the domain clock implementation
- adjust the physical status mapping to avoid the null-propagation operator inside AutoMapper expression trees

## Testing
- Not run (dotnet CLI not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ded481dac83269669cbe6d45fe944)