### PR TITLE
Bootstrap storage root when missing

### DIFF
--- a/Veriado.Infrastructure/Persistence/Entities/FileStorageRootEntity.cs
+++ b/Veriado.Infrastructure/Persistence/Entities/FileStorageRootEntity.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Veriado.Infrastructure.Persistence.Entities;
 
 /// <summary>
@@ -5,6 +7,16 @@ namespace Veriado.Infrastructure.Persistence.Entities;
 /// </summary>
 public sealed class FileStorageRootEntity
 {
+    public FileStorageRootEntity(string rootPath)
+    {
+        RootPath = rootPath ?? throw new ArgumentNullException(nameof(rootPath));
+    }
+
+    // Required for EF Core
+    private FileStorageRootEntity()
+    {
+    }
+
     /// <summary>
     /// Gets the primary key. Only a single row is expected (Id = 1).
     /// </summary>


### PR DESCRIPTION
## Summary
- allow FileStorageRootEntity to be constructed with a specific root path
- bootstrap a default storage root during infrastructure initialization when the database has none

## Testing
- dotnet test *(fails: dotnet CLI not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f5a6d47ac8326a53c68053de6eaf9)