### PR TITLE
Fix file system monitoring path queries for EF translation

### DIFF
--- a/Veriado.Infrastructure/FileSystem/FileSystemMonitoringService.cs
+++ b/Veriado.Infrastructure/FileSystem/FileSystemMonitoringService.cs
@@ -132,8 +132,10 @@ internal sealed class FileSystemMonitoringService : IFileSystemMonitoringService
         var dbContext = scope.ServiceProvider.GetRequiredService<AppDbContext>();
         var clock = scope.ServiceProvider.GetRequiredService<DomainClock>();
 
+        var relativeFilePath = RelativeFilePath.From(relativePath);
+
         var entity = await dbContext.FileSystems
-            .SingleOrDefaultAsync(f => f.RelativePath.Value == relativePath, cancellationToken)
+            .SingleOrDefaultAsync(f => f.RelativePath == relativeFilePath, cancellationToken)
             .ConfigureAwait(false);
 
         if (entity is null)
@@ -162,8 +164,10 @@ internal sealed class FileSystemMonitoringService : IFileSystemMonitoringService
         var dbContext = scope.ServiceProvider.GetRequiredService<AppDbContext>();
         var clock = scope.ServiceProvider.GetRequiredService<DomainClock>();
 
+        var relativeFilePath = RelativeFilePath.From(relativePath);
+
         var entity = await dbContext.FileSystems
-            .SingleOrDefaultAsync(f => f.RelativePath.Value == relativePath, cancellationToken)
+            .SingleOrDefaultAsync(f => f.RelativePath == relativeFilePath, cancellationToken)
             .ConfigureAwait(false);
 
         if (entity is null)
@@ -188,8 +192,10 @@ internal sealed class FileSystemMonitoringService : IFileSystemMonitoringService
         var dbContext = scope.ServiceProvider.GetRequiredService<AppDbContext>();
         var clock = scope.ServiceProvider.GetRequiredService<DomainClock>();
 
+        var oldRelativeFilePath = RelativeFilePath.From(oldRelativePath);
+
         var entity = await dbContext.FileSystems
-            .SingleOrDefaultAsync(f => f.RelativePath.Value == oldRelativePath, cancellationToken)
+            .SingleOrDefaultAsync(f => f.RelativePath == oldRelativeFilePath, cancellationToken)
             .ConfigureAwait(false);
 
         if (entity is null)
@@ -218,8 +224,10 @@ internal sealed class FileSystemMonitoringService : IFileSystemMonitoringService
         await using var scope = _scopeFactory.CreateAsyncScope();
         var dbContext = scope.ServiceProvider.GetRequiredService<AppDbContext>();
 
+        var relativeFilePath = RelativeFilePath.From(relativePath);
+
         var entity = await dbContext.FileSystems
-            .SingleOrDefaultAsync(f => f.RelativePath.Value == relativePath, cancellationToken)
+            .SingleOrDefaultAsync(f => f.RelativePath == relativeFilePath, cancellationToken)
             .ConfigureAwait(false);
 
         if (entity is null)


### PR DESCRIPTION
## Summary
- create RelativeFilePath instances before querying for file system entities to leverage value conversions
- update file watcher handlers to compare value objects instead of raw string properties, enabling EF translation

## Testing
- dotnet test *(fails: dotnet not installed in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f6481e7308326bc086396f90b0305)