### PR TITLE
Unify storage root handling

### DIFF
--- a/Veriado.Infrastructure/FileSystem/StorageRootInitializer.cs
+++ b/Veriado.Infrastructure/FileSystem/StorageRootInitializer.cs
@@ -1,0 +1,62 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Veriado.Infrastructure.Persistence;
+using Veriado.Infrastructure.Persistence.Entities;
+using Veriado.Infrastructure.Persistence.Options;
+
+namespace Veriado.Infrastructure.FileSystem;
+
+/// <summary>
+/// Ensures that a storage root exists and is persisted in the database.
+/// </summary>
+internal static class StorageRootInitializer
+{
+    /// <summary>
+    /// Ensures that the storage root is present in the database and on disk.
+    /// </summary>
+    public static async Task EnsureStorageRootAsync(
+        AppDbContext dbContext,
+        InfrastructureOptions options,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(dbContext);
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        var existingRoot = await dbContext.StorageRoots
+            .SingleOrDefaultAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        if (existingRoot is not null)
+        {
+            var normalized = Path.GetFullPath(existingRoot.RootPath);
+            Directory.CreateDirectory(normalized);
+            logger.LogInformation("Using configured storage root {RootPath}.", normalized);
+            return;
+        }
+
+        string rootPath;
+        if (!string.IsNullOrWhiteSpace(options.StorageRootOverride))
+        {
+            rootPath = Path.GetFullPath(options.StorageRootOverride!);
+        }
+        else
+        {
+            var documents = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
+            rootPath = Path.Combine(documents, "Veriado");
+            rootPath = Path.GetFullPath(rootPath);
+        }
+
+        Directory.CreateDirectory(rootPath);
+
+        dbContext.StorageRoots.Add(new FileStorageRootEntity(rootPath));
+        await dbContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        logger.LogInformation("Initialized storage root at {RootPath}.", rootPath);
+    }
+}

--- a/Veriado.Infrastructure/Persistence/Options/InfrastructureOptions.cs
+++ b/Veriado.Infrastructure/Persistence/Options/InfrastructureOptions.cs
@@ -22,6 +22,12 @@ public sealed class InfrastructureOptions
     public string DbPath { get; set; } = string.Empty;
 
     /// <summary>
+    /// Gets or sets an optional override for the file storage root path.
+    /// </summary>
+    public string? StorageRootOverride { get; set; }
+        = null;
+
+    /// <summary>
     /// Gets or sets the optional maximum number of bytes allowed for stored file content.
     /// </summary>
     public int? MaxContentBytes { get; set; }

--- a/Veriado.Infrastructure/Storage/LocalFileStorage.cs
+++ b/Veriado.Infrastructure/Storage/LocalFileStorage.cs
@@ -5,38 +5,28 @@ using System.IO;
 using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Veriado.Appl.Abstractions;
 using Veriado.Domain.Metadata;
 using Veriado.Domain.ValueObjects;
+using Veriado.Infrastructure.FileSystem;
 
 namespace Veriado.Infrastructure.Storage;
 
 /// <summary>
-/// Provides a simple file-system based implementation of <see cref="IFileStorage"/> for local development scenarios.
+/// Provides a file-system based implementation of <see cref="IFileStorage"/> rooted at the configured storage root.
 /// </summary>
 internal sealed class LocalFileStorage : IFileStorage, IStorageWriter
 {
     private const string DefaultMimeType = "application/octet-stream";
-    private readonly string _rootPath;
     private readonly StorageProvider _provider = StorageProvider.Local;
+    private readonly IFilePathResolver _pathResolver;
+    private readonly ILogger<LocalFileStorage> _logger;
 
-    public LocalFileStorage(InfrastructureOptions options)
+    public LocalFileStorage(IFilePathResolver pathResolver, ILogger<LocalFileStorage> logger)
     {
-        ArgumentNullException.ThrowIfNull(options);
-
-        if (string.IsNullOrWhiteSpace(options.DbPath))
-        {
-            throw new ArgumentException("Infrastructure options must configure a database path to derive storage location.", nameof(options));
-        }
-
-        var baseDirectory = Path.GetDirectoryName(options.DbPath);
-        if (string.IsNullOrWhiteSpace(baseDirectory))
-        {
-            baseDirectory = AppContext.BaseDirectory;
-        }
-
-        _rootPath = Path.Combine(baseDirectory!, "storage");
-        Directory.CreateDirectory(_rootPath);
+        _pathResolver = pathResolver ?? throw new ArgumentNullException(nameof(pathResolver));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
     public ValueTask<StorageReservation> ReservePathAsync(string? preferredPath, CancellationToken cancellationToken)
@@ -44,7 +34,7 @@ internal sealed class LocalFileStorage : IFileStorage, IStorageWriter
         cancellationToken.ThrowIfCancellationRequested();
 
         var relativePath = string.IsNullOrWhiteSpace(preferredPath)
-            ? BuildRelativePath()
+            ? BuildTemporaryPath()
             : NormalizePath(preferredPath!.Trim());
 
         var storagePath = StoragePath.From(relativePath);
@@ -83,7 +73,17 @@ internal sealed class LocalFileStorage : IFileStorage, IStorageWriter
         cancellationToken.ThrowIfCancellationRequested();
 
         var hash = FileHash.From(context.Sha256);
-        var snapshot = CreateSnapshot(reservation.Path.Value, hash, context.Length);
+        var targetRelativePath = NormalizePath(BuildRelativePath(hash.Value));
+        var currentPhysical = ResolvePath(reservation.Path.Value);
+        var targetPhysical = ResolvePath(targetRelativePath);
+
+        if (!string.Equals(currentPhysical, targetPhysical, StringComparison.OrdinalIgnoreCase))
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(targetPhysical)!);
+            File.Move(currentPhysical, targetPhysical, overwrite: true);
+        }
+
+        var snapshot = CreateSnapshot(targetRelativePath, hash, context.Length);
         return ValueTask.FromResult(snapshot);
     }
 
@@ -212,17 +212,26 @@ internal sealed class LocalFileStorage : IFileStorage, IStorageWriter
             UtcTimestamp.From(info.LastAccessTimeUtc));
     }
 
-    private static string BuildRelativePath()
+    private static string BuildRelativePath(string sha256)
+    {
+        if (sha256.Length < 2)
+        {
+            return BuildTemporaryPath();
+        }
+
+        return Path.Combine(sha256[..2], sha256[2..]);
+    }
+
+    private static string BuildTemporaryPath()
     {
         var identifier = Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture);
-        return Path.Combine(identifier[..2], identifier[2..]);
+        return Path.Combine("tmp", identifier[..2], identifier[2..]);
     }
 
     private string ResolvePath(string relativePath)
     {
         ArgumentNullException.ThrowIfNull(relativePath);
 
-        var rootFullPath = Path.GetFullPath(_rootPath);
         var trimmedRelative = relativePath.Trim();
         if (trimmedRelative.Length == 0)
         {
@@ -233,60 +242,17 @@ internal sealed class LocalFileStorage : IFileStorage, IStorageWriter
             .Replace('\\', Path.DirectorySeparatorChar)
             .Replace('/', Path.DirectorySeparatorChar);
 
-        var fullPath = Path.GetFullPath(Path.Combine(rootFullPath, sanitizedRelative));
-
-        EnsureWithinRoot(rootFullPath, fullPath);
-
-        return fullPath;
-    }
-
-    private static void EnsureWithinRoot(string rootFullPath, string fullPath)
-    {
-        if (!fullPath.StartsWith(rootFullPath, StringComparison.OrdinalIgnoreCase))
+        try
         {
-            throw new StoragePathViolationException(rootFullPath, fullPath);
+            var fullPath = _pathResolver.GetFullPath(sanitizedRelative);
+            return fullPath;
         }
-
-        if (Path.EndsInDirectorySeparator(rootFullPath))
+        catch (Exception ex)
         {
-            return;
-        }
-
-        var normalizedRoot = TrimTrailingSeparators(rootFullPath);
-        if (!fullPath.StartsWith(normalizedRoot, StringComparison.OrdinalIgnoreCase))
-        {
-            throw new StoragePathViolationException(rootFullPath, fullPath);
-        }
-
-        if (fullPath.Length > normalizedRoot.Length)
-        {
-            var nextChar = fullPath[normalizedRoot.Length];
-            if (!IsDirectorySeparator(nextChar))
-            {
-                throw new StoragePathViolationException(rootFullPath, fullPath);
-            }
-        }
-
-        var relative = Path.GetRelativePath(rootFullPath, fullPath);
-        if (relative.StartsWith("..", StringComparison.Ordinal) || Path.IsPathRooted(relative))
-        {
-            throw new StoragePathViolationException(rootFullPath, fullPath);
+            _logger.LogError(ex, "Failed to resolve storage path for relative path {RelativePath}.", relativePath);
+            throw;
         }
     }
-
-    private static string TrimTrailingSeparators(string path)
-    {
-        if (string.IsNullOrEmpty(path))
-        {
-            return path;
-        }
-
-        var trimmed = path.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-        return trimmed.Length == 0 ? path : trimmed;
-    }
-
-    private static bool IsDirectorySeparator(char character)
-        => character == Path.DirectorySeparatorChar || character == Path.AltDirectorySeparatorChar;
 
     private static string NormalizePath(string relativePath)
     {


### PR DESCRIPTION
## Summary
- add storage root initializer that seeds a default Documents/Veriado root or applies configured overrides
- update path resolution and DI wiring to rely on the persisted storage root and scoped services
- refactor local file storage to write under the storage root using hash-based paths and the resolver

## Testing
- dotnet test Veriado.sln --no-build *(fails: dotnet not available in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69200da8d4bc8326abe40be48ac48f65)