### PR TITLE
Align file system state normalization

### DIFF
--- a/Veriado.Domain/FileSystem/FileSystemEntity.ImportFactory.cs
+++ b/Veriado.Domain/FileSystem/FileSystemEntity.ImportFactory.cs
@@ -27,34 +27,26 @@ public sealed partial class FileSystemEntity
         string? originalFilePath = null,
         FilePhysicalState physicalState = FilePhysicalState.Unknown)
     {
-        var entity = new FileSystemEntity(id)
-        {
-            Provider = provider,
-            RelativePath = relativePath,
-            Hash = hash,
-            Size = size,
-            Mime = mime,
-            Attributes = attributes,
-            OwnerSid = string.IsNullOrWhiteSpace(ownerSid) ? null : ownerSid.Trim(),
-            IsEncrypted = isEncrypted,
-            CreatedUtc = createdUtc,
-            LastWriteUtc = lastWriteUtc,
-            LastAccessUtc = lastAccessUtc,
-            ContentVersion = contentVersion,
-            IsMissing = isMissing || physicalState == FilePhysicalState.Missing,
-            MissingSinceUtc = (isMissing || physicalState == FilePhysicalState.Missing) ? missingSinceUtc : null,
-            LastLinkedUtc = lastLinkedUtc,
-            CurrentFilePath = currentFilePath ?? string.Empty,
-            OriginalFilePath = string.IsNullOrWhiteSpace(originalFilePath)
-                ? currentFilePath ?? string.Empty
-                : originalFilePath.Trim(),
-            PhysicalState = isMissing
-                ? FilePhysicalState.Missing
-                : physicalState == FilePhysicalState.Unknown
-                    ? FilePhysicalState.Healthy
-                    : physicalState,
-        };
-
-        return entity;
+        return CreateCore(
+            id,
+            provider,
+            relativePath,
+            hash,
+            size,
+            mime,
+            attributes,
+            ownerSid,
+            isEncrypted,
+            createdUtc,
+            lastWriteUtc,
+            lastAccessUtc,
+            contentVersion,
+            isMissing,
+            missingSinceUtc,
+            lastLinkedUtc,
+            currentFilePath,
+            originalFilePath,
+            physicalState,
+            raiseInitialEvents: true);
     }
 }

--- a/Veriado.Infrastructure/FileSystem/FilePathResolver.cs
+++ b/Veriado.Infrastructure/FileSystem/FilePathResolver.cs
@@ -51,6 +51,11 @@ public sealed class FilePathResolver : IFilePathResolver
         }
     }
 
+    public void InvalidateRootCache()
+    {
+        _cachedRoot = null;
+    }
+
     public string GetFullPath(string relativePath)
         => GetFullPath(relativePath, null);
 


### PR DESCRIPTION
## Summary
- unify FileSystemEntity import and creation flows through shared initialization and reconciliation
- validate physical paths and missing state normalization prior to persistence
- add storage root cache invalidation and refresh file watcher rename/change handling

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69204c53df308326b1655da607232e19)