### PR TITLE
Refine FileSystemEntity initialization and state transitions

### DIFF
--- a/Veriado.Domain/FileSystem/FileSystemEntity.ImportFactory.cs
+++ b/Veriado.Domain/FileSystem/FileSystemEntity.ImportFactory.cs
@@ -47,6 +47,6 @@ public sealed partial class FileSystemEntity
             currentFilePath,
             originalFilePath,
             physicalState,
-            raiseInitialEvents: true);
+            raiseInitialEvents: false);
     }
 }


### PR DESCRIPTION
## Summary
- centralize FileSystemEntity construction logic to ensure consistent initialization for new and imported entities
- add validation for physical file paths and align physical state/missing flags through dedicated transition methods
- adjust import and rehydrate paths to avoid emitting creation events while keeping state normalization intact

## Testing
- dotnet build Veriado.Domain/Veriado.Domain.csproj -nologo (fails: dotnet not installed in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69208c20d6648326a903c56b44d2eb74)