### PR TITLE
Restore pause coordinator import for monitoring service

### DIFF
--- a/Veriado.Infrastructure/FileSystem/FileSystemMonitoringService.cs
+++ b/Veriado.Infrastructure/FileSystem/FileSystemMonitoringService.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Veriado.Application.Abstractions;
 using Veriado.Domain.FileSystem;
 using Veriado.Domain.Primitives;
 using Veriado.Domain.ValueObjects;


### PR DESCRIPTION
## Summary
- restore Veriado.Application.Abstractions using so FileSystemMonitoringService can resolve IOperationalPauseCoordinator

## Testing
- not run (dotnet CLI not available in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692090926b248326902bc5ad3cf7c82e)