### PR TITLE
Add storage root settings service

### DIFF
--- a/Veriado.Application/Abstractions/IStorageRootSettingsService.cs
+++ b/Veriado.Application/Abstractions/IStorageRootSettingsService.cs
@@ -1,0 +1,11 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Veriado.Application.Abstractions;
+
+public interface IStorageRootSettingsService
+{
+    Task<string> GetCurrentRootAsync(CancellationToken cancellationToken);
+    Task<string> GetEffectiveRootAsync(CancellationToken cancellationToken);
+    Task ChangeRootAsync(string newRoot, CancellationToken cancellationToken);
+}

--- a/Veriado.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/Veriado.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
@@ -200,6 +200,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IStorageWriter>(sp => sp.GetRequiredService<LocalFileStorage>());
         services.AddSingleton<IOperationalPauseCoordinator, OperationalPauseCoordinator>();
         services.AddScoped<IFilePathResolver, FilePathResolver>();
+        services.AddScoped<IStorageRootSettingsService, StorageRootSettingsService>();
         services.AddScoped<IStorageMigrationService, StorageMigrationService>();
         services.AddScoped<IExportPackageService, ExportPackageService>();
         services.AddScoped<IImportPackageService, ImportPackageService>();

--- a/Veriado.Infrastructure/Storage/StorageRootSettingsService.cs
+++ b/Veriado.Infrastructure/Storage/StorageRootSettingsService.cs
@@ -1,0 +1,106 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Veriado.Application.Abstractions;
+using Veriado.Infrastructure.FileSystem;
+using Veriado.Infrastructure.Persistence;
+using Veriado.Infrastructure.Persistence.Entities;
+
+namespace Veriado.Infrastructure.Storage;
+
+public sealed class StorageRootSettingsService : IStorageRootSettingsService
+{
+    private const string DefaultFolderName = "Veriado";
+
+    private readonly IDbContextFactory<AppDbContext> _dbContextFactory;
+    private readonly IFilePathResolver _filePathResolver;
+    private readonly ILogger<StorageRootSettingsService> _logger;
+
+    public StorageRootSettingsService(
+        IDbContextFactory<AppDbContext> dbContextFactory,
+        IFilePathResolver filePathResolver,
+        ILogger<StorageRootSettingsService> logger)
+    {
+        _dbContextFactory = dbContextFactory ?? throw new ArgumentNullException(nameof(dbContextFactory));
+        _filePathResolver = filePathResolver ?? throw new ArgumentNullException(nameof(filePathResolver));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<string> GetCurrentRootAsync(CancellationToken cancellationToken)
+    {
+        await using var dbContext = await _dbContextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+        var root = await dbContext.StorageRoots
+            .AsNoTracking()
+            .SingleOrDefaultAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return root?.RootPath ?? string.Empty;
+    }
+
+    public async Task<string> GetEffectiveRootAsync(CancellationToken cancellationToken)
+    {
+        var current = await GetCurrentRootAsync(cancellationToken).ConfigureAwait(false);
+        if (!string.IsNullOrWhiteSpace(current))
+        {
+            return current;
+        }
+
+        var defaultRoot = GetDefaultRootPath();
+        var normalizedDefault = StorageRootValidator.ValidateWritableRoot(defaultRoot, _logger);
+        await PersistRootIfMissingAsync(normalizedDefault, cancellationToken).ConfigureAwait(false);
+        return normalizedDefault;
+    }
+
+    public async Task ChangeRootAsync(string newRoot, CancellationToken cancellationToken)
+    {
+        var normalizedRoot = StorageRootValidator.ValidateWritableRoot(newRoot, _logger);
+
+        await using var dbContext = await _dbContextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+        var existing = await dbContext.StorageRoots
+            .SingleOrDefaultAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        if (existing is null)
+        {
+            await dbContext.StorageRoots.AddAsync(new FileStorageRootEntity(normalizedRoot), cancellationToken)
+                .ConfigureAwait(false);
+        }
+        else
+        {
+            existing.UpdateRootPath(normalizedRoot);
+        }
+
+        await dbContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        _filePathResolver.InvalidateRootCache();
+    }
+
+    private static string GetDefaultRootPath()
+    {
+        var documents = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
+        if (string.IsNullOrWhiteSpace(documents))
+        {
+            documents = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        }
+
+        return Path.Combine(documents, DefaultFolderName);
+    }
+
+    private async Task PersistRootIfMissingAsync(string normalizedRoot, CancellationToken cancellationToken)
+    {
+        await using var dbContext = await _dbContextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+        var existing = await dbContext.StorageRoots
+            .SingleOrDefaultAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        if (existing is null)
+        {
+            await dbContext.StorageRoots.AddAsync(new FileStorageRootEntity(normalizedRoot), cancellationToken)
+                .ConfigureAwait(false);
+            await dbContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            _filePathResolver.InvalidateRootCache();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add IStorageRootSettingsService abstraction to manage configured storage roots
- implement storage root settings service with default document folder fallback and validation
- register the service for dependency injection

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69209374f2c48326917f1cfe873f2ed8)