### PR TITLE
Fix namespace conflicts and nullable hash handling

### DIFF
--- a/Veriado.Infrastructure/FileSystem/FileSystemHealthCheckWorker.cs
+++ b/Veriado.Infrastructure/FileSystem/FileSystemHealthCheckWorker.cs
@@ -12,7 +12,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Veriado.Appl.Abstractions;
 using Veriado.Application.Abstractions;
-using Veriado.Appl.FileSystem;
+using FileSystemSyncService = Veriado.Appl.FileSystem.IFileSystemSyncService;
 using Veriado.Domain.FileSystem;
 using Veriado.Domain.Primitives;
 using Veriado.Domain.ValueObjects;
@@ -28,14 +28,14 @@ internal sealed class FileSystemHealthCheckWorker : BackgroundService
     private readonly FileSystemHealthCheckOptions _options;
     private readonly IOperationalPauseCoordinator _pauseCoordinator;
     private readonly ILogger<FileSystemHealthCheckWorker> _logger;
-    private readonly IFileSystemSyncService _syncService;
+    private readonly FileSystemSyncService _syncService;
 
     public FileSystemHealthCheckWorker(
         IServiceScopeFactory scopeFactory,
         IFilePathResolver pathResolver,
         IOptions<FileSystemHealthCheckOptions> options,
         IOperationalPauseCoordinator pauseCoordinator,
-        IFileSystemSyncService syncService,
+        FileSystemSyncService syncService,
         ILogger<FileSystemHealthCheckWorker> logger)
     {
         _scopeFactory = scopeFactory ?? throw new ArgumentNullException(nameof(scopeFactory));

--- a/Veriado.Infrastructure/FileSystem/FileSystemMonitoringService.cs
+++ b/Veriado.Infrastructure/FileSystem/FileSystemMonitoringService.cs
@@ -9,7 +9,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Veriado.Appl.Abstractions;
-using Veriado.Appl.FileSystem;
+using FileSystemSyncService = Veriado.Appl.FileSystem.IFileSystemSyncService;
 using Veriado.Domain.FileSystem;
 using Veriado.Domain.Primitives;
 using Veriado.Domain.ValueObjects;
@@ -24,7 +24,7 @@ internal sealed class FileSystemMonitoringService : IFileSystemMonitoringService
     private readonly IFilePathResolver _pathResolver;
     private readonly IServiceScopeFactory _scopeFactory;
     private readonly IOperationalPauseCoordinator _pauseCoordinator;
-    private readonly IFileSystemSyncService _syncService;
+    private readonly FileSystemSyncService _syncService;
     private readonly ApplicationClock _clock;
     private readonly ILogger<FileSystemMonitoringService> _logger;
     private readonly Channel<FileSystemEvent> _eventChannel;
@@ -37,7 +37,7 @@ internal sealed class FileSystemMonitoringService : IFileSystemMonitoringService
         IFilePathResolver pathResolver,
         IServiceScopeFactory scopeFactory,
         IOperationalPauseCoordinator pauseCoordinator,
-        IFileSystemSyncService syncService,
+        FileSystemSyncService syncService,
         ApplicationClock clock,
         ILogger<FileSystemMonitoringService> logger)
     {
@@ -359,9 +359,9 @@ internal sealed class FileSystemMonitoringService : IFileSystemMonitoringService
 
         entity.MarkHealthy();
         entity.UpdatePath(fullPath);
-        if (hash is not null)
+        if (hash is FileHash computedHash)
         {
-            entity.ReplaceContent(entity.RelativePath, hash, size, entity.Mime, entity.IsEncrypted, observedUtc);
+            entity.ReplaceContent(entity.RelativePath, computedHash, size, entity.Mime, entity.IsEncrypted, observedUtc);
         }
         else if (entity.Size != size)
         {
@@ -527,9 +527,9 @@ internal sealed class FileSystemMonitoringService : IFileSystemMonitoringService
             }
         }
 
-        if (hash is not null)
+        if (hash is FileHash computedHash)
         {
-            entity.ReplaceContent(entity.RelativePath, hash, size, entity.Mime, entity.IsEncrypted, whenUtc);
+            entity.ReplaceContent(entity.RelativePath, computedHash, size, entity.Mime, entity.IsEncrypted, whenUtc);
             contentChanged = true;
         }
         else if (sizeChanged)

--- a/Veriado.Infrastructure/Storage/ImportPackageService.cs
+++ b/Veriado.Infrastructure/Storage/ImportPackageService.cs
@@ -9,6 +9,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Veriado.Appl.Abstractions;
 using Veriado.Application.Abstractions;
+using Veriado.Infrastructure.FileSystem;
 using Veriado.Infrastructure.Persistence;
 using Veriado.Infrastructure.Persistence.Connections;
 using Veriado.Infrastructure.Persistence.Entities;


### PR DESCRIPTION
## Summary
- alias the file system sync service interface in infrastructure workers to remove namespace ambiguity
- ensure file hash updates only use computed values after null checks
- include file path resolver namespace in import package service for cache overrides

## Testing
- dotnet build (fails: command not found in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69209786eafc832693f3eb9af73df40f)