### PR TITLE
Resolve file system sync service ambiguity

### DIFF
--- a/Veriado.Infrastructure/FileSystem/FileSystemHealthCheckWorker.cs
+++ b/Veriado.Infrastructure/FileSystem/FileSystemHealthCheckWorker.cs
@@ -12,12 +12,12 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Veriado.Appl.Abstractions;
 using Veriado.Application.Abstractions;
-using Veriado.Appl.FileSystem;
 using Veriado.Domain.FileSystem;
 using Veriado.Domain.Primitives;
 using Veriado.Domain.ValueObjects;
 using Veriado.Infrastructure.Persistence;
 using DomainClock = Veriado.Domain.Primitives.IClock;
+using IFileSystemSyncService = Veriado.Appl.FileSystem.IFileSystemSyncService;
 
 namespace Veriado.Infrastructure.FileSystem;
 

--- a/Veriado.Infrastructure/FileSystem/FileSystemMonitoringService.cs
+++ b/Veriado.Infrastructure/FileSystem/FileSystemMonitoringService.cs
@@ -9,13 +9,13 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Veriado.Appl.Abstractions;
-using Veriado.Appl.FileSystem;
 using Veriado.Domain.FileSystem;
 using Veriado.Domain.Primitives;
 using Veriado.Domain.ValueObjects;
 using Veriado.Infrastructure.Persistence;
 using ApplicationClock = Veriado.Appl.Abstractions.IClock;
 using DomainClock = Veriado.Domain.Primitives.IClock;
+using IFileSystemSyncService = Veriado.Appl.FileSystem.IFileSystemSyncService;
 
 namespace Veriado.Infrastructure.FileSystem;
 
@@ -361,7 +361,7 @@ internal sealed class FileSystemMonitoringService : IFileSystemMonitoringService
         entity.UpdatePath(fullPath);
         if (hash is not null)
         {
-            entity.ReplaceContent(entity.RelativePath, hash, size, entity.Mime, entity.IsEncrypted, observedUtc);
+            entity.ReplaceContent(entity.RelativePath, hash.Value, size, entity.Mime, entity.IsEncrypted, observedUtc);
         }
         else if (entity.Size != size)
         {
@@ -529,7 +529,7 @@ internal sealed class FileSystemMonitoringService : IFileSystemMonitoringService
 
         if (hash is not null)
         {
-            entity.ReplaceContent(entity.RelativePath, hash, size, entity.Mime, entity.IsEncrypted, whenUtc);
+            entity.ReplaceContent(entity.RelativePath, hash.Value, size, entity.Mime, entity.IsEncrypted, whenUtc);
             contentChanged = true;
         }
         else if (sizeChanged)

--- a/Veriado.Infrastructure/Storage/ImportPackageService.cs
+++ b/Veriado.Infrastructure/Storage/ImportPackageService.cs
@@ -9,6 +9,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Veriado.Appl.Abstractions;
 using Veriado.Application.Abstractions;
+using Veriado.Infrastructure.FileSystem;
 using Veriado.Infrastructure.Persistence;
 using Veriado.Infrastructure.Persistence.Connections;
 using Veriado.Infrastructure.Persistence.Entities;


### PR DESCRIPTION
## Summary
- reference the application file system sync service via aliases to avoid namespace collisions
- dereference computed hashes before replacing file content when monitoring file system changes
- import the infrastructure file path resolver so cached roots can be updated during package import

## Testing
- dotnet build *(fails: dotnet CLI is unavailable in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692097b421e4832683e43381b6159b82)