### PR TITLE
Use abstractions IFileSystemSyncService

### DIFF
--- a/Veriado.Infrastructure/FileSystem/FileSystemHealthCheckWorker.cs
+++ b/Veriado.Infrastructure/FileSystem/FileSystemHealthCheckWorker.cs
@@ -12,7 +12,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Veriado.Appl.Abstractions;
 using Veriado.Application.Abstractions;
-using FileSystemSyncService = Veriado.Appl.FileSystem.IFileSystemSyncService;
+using FileSystemSyncService = Veriado.Appl.Abstractions.IFileSystemSyncService;
 using Veriado.Domain.FileSystem;
 using Veriado.Domain.Primitives;
 using Veriado.Domain.ValueObjects;

--- a/Veriado.Services/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/Veriado.Services/DependencyInjection/ServiceCollectionExtensions.cs
@@ -1,7 +1,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using Veriado.Appl.DependencyInjection;
 using Veriado.Appl.Files;
-using Veriado.Appl.FileSystem;
+using ApplicationFileSystemSyncService = Veriado.Appl.Abstractions.IFileSystemSyncService;
 using Veriado.Contracts.Search.Abstractions;
 using Veriado.Services.Diagnostics;
 using Veriado.Services.FileSystem;
@@ -36,7 +36,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IMaintenanceService, MaintenanceService>();
         services.AddScoped<IHealthService, HealthService>();
         services.AddSingleton<ISearchFacade, SearchFacade>();
-        services.AddSingleton<IFileSystemSyncService, FileSystemSyncService>();
+        services.AddSingleton<ApplicationFileSystemSyncService, FileSystemSyncService>();
 
         return services;
     }

--- a/Veriado.Services/FileSystem/FileSystemSyncService.cs
+++ b/Veriado.Services/FileSystem/FileSystemSyncService.cs
@@ -1,6 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
-using Veriado.Appl.FileSystem;
+using ApplicationFileSystemSyncService = Veriado.Appl.Abstractions.IFileSystemSyncService;
 using Veriado.Domain.Files;
 using Veriado.Domain.ValueObjects;
 using Veriado.Infrastructure.Persistence;
@@ -11,7 +11,7 @@ namespace Veriado.Services.FileSystem;
 /// <summary>
 /// Coordinates logical file state in response to physical file system changes.
 /// </summary>
-public sealed class FileSystemSyncService : IFileSystemSyncService
+public sealed class FileSystemSyncService : ApplicationFileSystemSyncService
 {
     private readonly IDbContextFactory<AppDbContext> _dbContextFactory;
     private readonly ApplicationClock _clock;


### PR DESCRIPTION
## Summary
- resolve ambiguous IFileSystemSyncService references by using the abstractions interface
- update dependency registration and worker usage to the shared interface

## Testing
- Not run (dotnet CLI not available in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69209c3e07288326b887f71253994a8b)