### PR TITLE
Allow directory separators in path validation

### DIFF
--- a/Veriado.Infrastructure/Storage/SafePathUtilities.cs
+++ b/Veriado.Infrastructure/Storage/SafePathUtilities.cs
@@ -66,7 +66,11 @@ internal static class SafePathUtilities
 
     private static void ValidatePathCharacters(string relativePath, ILogger logger)
     {
-        var invalidChars = Path.GetInvalidPathChars().Concat(Path.GetInvalidFileNameChars()).Distinct().ToArray();
+        var invalidChars = Path.GetInvalidPathChars()
+            .Concat(Path.GetInvalidFileNameChars())
+            .Where(c => c != Path.DirectorySeparatorChar && c != Path.AltDirectorySeparatorChar)
+            .Distinct()
+            .ToArray();
         if (relativePath.IndexOfAny(invalidChars) >= 0)
         {
             logger.LogWarning("Relative path {RelativePath} contains invalid characters.", relativePath);


### PR DESCRIPTION
## Summary
- exclude path separators from the invalid character set when validating relative paths

## Testing
- dotnet test *(fails: dotnet not installed in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920a2d615d08326a466138576410b49)