### PR TITLE
Add storage management UI for migration/export/import operations

### DIFF
--- a/Veriado.WinUI/AppHost.cs
+++ b/Veriado.WinUI/AppHost.cs
@@ -14,6 +14,7 @@ using Veriado.WinUI.Services.Abstractions;
 using Veriado.WinUI.Services.DialogFactories;
 using Veriado.WinUI.ViewModels.Files;
 using Veriado.WinUI.ViewModels.Import;
+using Veriado.WinUI.ViewModels.Storage;
 using Veriado.WinUI.ViewModels.Settings;
 using Veriado.WinUI.ViewModels.Shell;
 using Veriado.WinUI.Views.Files;
@@ -64,6 +65,7 @@ internal sealed class AppHost : IAsyncDisposable
                 services.AddTransient<FileDetailDialogViewModel>();
                 services.AddTransient<FilesPageViewModel>();
                 services.AddTransient<ImportPageViewModel>();
+                services.AddTransient<StorageManagementPageViewModel>();
                 services.AddTransient<SettingsPageViewModel>();
 
                 services.AddTransient<FileDetailDialog>();

--- a/Veriado.WinUI/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/Veriado.WinUI/DependencyInjection/ServiceCollectionExtensions.cs
@@ -17,6 +17,7 @@ public static class ServiceCollectionExtensions
         services.AddTransient<Views.Shell.MainShell>();
         services.AddTransient<Views.Files.FilesPage>();
         services.AddTransient<Views.Import.ImportPage>();
+        services.AddTransient<Views.Storage.StorageManagementPage>();
         services.AddTransient<Views.Settings.SettingsPage>();
 
         return services;

--- a/Veriado.WinUI/Navigation/PageId.cs
+++ b/Veriado.WinUI/Navigation/PageId.cs
@@ -4,5 +4,6 @@ public enum PageId
 {
     Files,
     Import,
+    Storage,
     Settings,
 }

--- a/Veriado.WinUI/Services/NavigationService.cs
+++ b/Veriado.WinUI/Services/NavigationService.cs
@@ -2,9 +2,11 @@ using Microsoft.Extensions.DependencyInjection;
 using Veriado.WinUI.Navigation;
 using Veriado.WinUI.ViewModels.Files;
 using Veriado.WinUI.ViewModels.Import;
+using Veriado.WinUI.ViewModels.Storage;
 using Veriado.WinUI.ViewModels.Settings;
 using Veriado.WinUI.Views.Files;
 using Veriado.WinUI.Views.Import;
+using Veriado.WinUI.Views.Storage;
 using Veriado.WinUI.Views.Settings;
 
 namespace Veriado.WinUI.Services;
@@ -18,10 +20,11 @@ public sealed class NavigationService : INavigationService
     public NavigationService(IServiceProvider serviceProvider)
     {
         _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
-        _registrations = new Dictionary<PageId, NavigationRegistration>
+            _registrations = new Dictionary<PageId, NavigationRegistration>
         {
             [PageId.Files] = new NavigationRegistration(typeof(FilesPage), typeof(FilesPageViewModel)),
             [PageId.Import] = new NavigationRegistration(typeof(ImportPage), typeof(ImportPageViewModel)),
+            [PageId.Storage] = new NavigationRegistration(typeof(StorageManagementPage), typeof(StorageManagementPageViewModel)),
             [PageId.Settings] = new NavigationRegistration(typeof(SettingsPage), typeof(SettingsPageViewModel)),
         };
     }

--- a/Veriado.WinUI/ViewModels/Shell/MainShellViewModel.cs
+++ b/Veriado.WinUI/ViewModels/Shell/MainShellViewModel.cs
@@ -42,6 +42,7 @@ public partial class MainShellViewModel : ObservableObject
         {
             "files" => PageId.Files,
             "import" => PageId.Import,
+            "storage" => PageId.Storage,
             "settings" => PageId.Settings,
             _ => CurrentPage,
         };

--- a/Veriado.WinUI/ViewModels/Storage/StorageManagementPageViewModel.cs
+++ b/Veriado.WinUI/ViewModels/Storage/StorageManagementPageViewModel.cs
@@ -1,0 +1,286 @@
+using Veriado.Contracts.Storage;
+using Veriado.Services.Storage;
+using Veriado.WinUI.ViewModels.Base;
+
+namespace Veriado.WinUI.ViewModels.Storage;
+
+public partial class StorageManagementPageViewModel : ViewModelBase
+{
+    private readonly IStorageManagementService _storageService;
+    private readonly IPickerService _pickerService;
+
+    private readonly AsyncRelayCommand _refreshCommand;
+    private readonly AsyncRelayCommand _runMigrationCommand;
+    private readonly AsyncRelayCommand _runExportCommand;
+    private readonly AsyncRelayCommand _runImportCommand;
+    private readonly AsyncRelayCommand _pickMigrationTargetCommand;
+    private readonly AsyncRelayCommand _pickExportRootCommand;
+    private readonly AsyncRelayCommand _pickImportPackageRootCommand;
+    private readonly AsyncRelayCommand _pickImportTargetRootCommand;
+
+    public StorageManagementPageViewModel(
+        IStorageManagementService storageService,
+        IPickerService pickerService,
+        IMessenger messenger,
+        IStatusService statusService,
+        IDispatcherService dispatcher,
+        IExceptionHandler exceptionHandler)
+        : base(messenger, statusService, dispatcher, exceptionHandler)
+    {
+        _storageService = storageService ?? throw new ArgumentNullException(nameof(storageService));
+        _pickerService = pickerService ?? throw new ArgumentNullException(nameof(pickerService));
+
+        _refreshCommand = new AsyncRelayCommand(RefreshAsync, CanExecuteWhenIdle);
+        _runMigrationCommand = new AsyncRelayCommand(RunMigrationAsync, CanRunMigration);
+        _runExportCommand = new AsyncRelayCommand(RunExportAsync, CanRunExport);
+        _runImportCommand = new AsyncRelayCommand(RunImportAsync, CanRunImport);
+        _pickMigrationTargetCommand = new AsyncRelayCommand(PickMigrationTargetAsync, CanExecuteWhenIdle);
+        _pickExportRootCommand = new AsyncRelayCommand(PickExportRootAsync, CanExecuteWhenIdle);
+        _pickImportPackageRootCommand = new AsyncRelayCommand(PickImportPackageRootAsync, CanExecuteWhenIdle);
+        _pickImportTargetRootCommand = new AsyncRelayCommand(PickImportTargetRootAsync, CanExecuteWhenIdle);
+    }
+
+    [ObservableProperty]
+    private string? currentRoot;
+
+    [ObservableProperty]
+    private string? effectiveRoot;
+
+    [ObservableProperty]
+    private string? migrationTargetRoot;
+
+    [ObservableProperty]
+    private bool deleteSourceAfterCopy;
+
+    [ObservableProperty]
+    private bool verifyHashes;
+
+    [ObservableProperty]
+    private string? exportPackageRoot;
+
+    [ObservableProperty]
+    private bool exportOverwriteExisting;
+
+    [ObservableProperty]
+    private string? importPackageRoot;
+
+    [ObservableProperty]
+    private string? importTargetRoot;
+
+    [ObservableProperty]
+    private bool importOverwriteExisting;
+
+    [ObservableProperty]
+    private bool importVerifyAfterCopy;
+
+    public IAsyncRelayCommand RefreshCommand => _refreshCommand;
+
+    public IAsyncRelayCommand RunMigrationCommand => _runMigrationCommand;
+
+    public IAsyncRelayCommand RunExportCommand => _runExportCommand;
+
+    public IAsyncRelayCommand RunImportCommand => _runImportCommand;
+
+    public IAsyncRelayCommand PickMigrationTargetCommand => _pickMigrationTargetCommand;
+
+    public IAsyncRelayCommand PickExportRootCommand => _pickExportRootCommand;
+
+    public IAsyncRelayCommand PickImportPackageRootCommand => _pickImportPackageRootCommand;
+
+    public IAsyncRelayCommand PickImportTargetRootCommand => _pickImportTargetRootCommand;
+
+    [RelayCommand]
+    private void Cancel()
+    {
+        TryCancelRunning();
+    }
+
+    private Task RefreshAsync()
+    {
+        return SafeExecuteAsync(async cancellationToken =>
+        {
+            var current = await _storageService.GetCurrentRootAsync(cancellationToken).ConfigureAwait(false);
+            var effective = await _storageService.GetEffectiveRootAsync(cancellationToken).ConfigureAwait(false);
+
+            await Dispatcher.Enqueue(() =>
+            {
+                CurrentRoot = current;
+                EffectiveRoot = effective;
+            });
+        }, "Načítám stav úložiště...");
+    }
+
+    private Task RunMigrationAsync()
+    {
+        return SafeExecuteAsync(async cancellationToken =>
+        {
+            if (string.IsNullOrWhiteSpace(MigrationTargetRoot))
+            {
+                StatusService.Error("Vyberte cílovou složku pro migraci.");
+                return;
+            }
+
+            var options = new StorageMigrationOptionsDto
+            {
+                DeleteSourceAfterCopy = DeleteSourceAfterCopy,
+                VerifyHashes = VerifyHashes,
+            };
+
+            var result = await _storageService
+                .MigrateRootAsync(MigrationTargetRoot, options, cancellationToken)
+                .ConfigureAwait(false);
+
+            await Dispatcher.Enqueue(() =>
+            {
+                CurrentRoot = result.NewRoot;
+                EffectiveRoot = result.NewRoot;
+            });
+
+            StatusService.Info($"Migrace dokončena. Přeneseno {result.MigratedFiles} souborů.");
+        }, "Provádím migraci úložiště...");
+    }
+
+    private Task RunExportAsync()
+    {
+        return SafeExecuteAsync(async cancellationToken =>
+        {
+            if (string.IsNullOrWhiteSpace(ExportPackageRoot))
+            {
+                StatusService.Error("Vyberte cílovou složku pro export balíčku.");
+                return;
+            }
+
+            var options = new StorageExportOptionsDto
+            {
+                OverwriteExisting = ExportOverwriteExisting,
+            };
+
+            var result = await _storageService
+                .ExportAsync(ExportPackageRoot, options, cancellationToken)
+                .ConfigureAwait(false);
+
+            StatusService.Info($"Export dokončen. Databáze: {result.DatabasePath}.");
+        }, "Exportuji databázi a dokumenty...");
+    }
+
+    private Task RunImportAsync()
+    {
+        return SafeExecuteAsync(async cancellationToken =>
+        {
+            if (string.IsNullOrWhiteSpace(ImportPackageRoot))
+            {
+                StatusService.Error("Vyberte složku s exportovaným balíčkem.");
+                return;
+            }
+
+            if (string.IsNullOrWhiteSpace(ImportTargetRoot))
+            {
+                StatusService.Error("Vyberte cílovou složku pro import dat.");
+                return;
+            }
+
+            var options = new StorageImportOptionsDto
+            {
+                OverwriteExisting = ImportOverwriteExisting,
+                VerifyAfterCopy = ImportVerifyAfterCopy,
+            };
+
+            var result = await _storageService
+                .ImportAsync(ImportPackageRoot, ImportTargetRoot, options, cancellationToken)
+                .ConfigureAwait(false);
+
+            await Dispatcher.Enqueue(() =>
+            {
+                CurrentRoot = result.TargetStorageRoot;
+                EffectiveRoot = result.TargetStorageRoot;
+            });
+
+            StatusService.Info($"Import dokončen. Načteno {result.ImportedFiles} souborů.");
+        }, "Importuji databázi a dokumenty...");
+    }
+
+    private Task PickMigrationTargetAsync()
+    {
+        return PickFolderAsync(value => MigrationTargetRoot = value);
+    }
+
+    private Task PickExportRootAsync()
+    {
+        return PickFolderAsync(value => ExportPackageRoot = value);
+    }
+
+    private Task PickImportPackageRootAsync()
+    {
+        return PickFolderAsync(value => ImportPackageRoot = value);
+    }
+
+    private Task PickImportTargetRootAsync()
+    {
+        return PickFolderAsync(value => ImportTargetRoot = value);
+    }
+
+    private Task PickFolderAsync(Action<string?> setter)
+    {
+        return SafeExecuteAsync(async cancellationToken =>
+        {
+            var folder = await _pickerService.PickFolderAsync().ConfigureAwait(false);
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return;
+            }
+
+            await Dispatcher.Enqueue(() => setter(folder));
+        }, cancellationToken: CancellationToken.None);
+    }
+
+    private bool CanExecuteWhenIdle()
+        => !IsBusy;
+
+    private bool CanRunMigration()
+        => !IsBusy && !string.IsNullOrWhiteSpace(MigrationTargetRoot);
+
+    private bool CanRunExport()
+        => !IsBusy && !string.IsNullOrWhiteSpace(ExportPackageRoot);
+
+    private bool CanRunImport()
+        => !IsBusy
+            && !string.IsNullOrWhiteSpace(ImportPackageRoot)
+            && !string.IsNullOrWhiteSpace(ImportTargetRoot);
+
+    partial void OnIsBusyChanged(bool value)
+    {
+        NotifyCommandStates();
+    }
+
+    partial void OnMigrationTargetRootChanged(string? value)
+    {
+        _runMigrationCommand.NotifyCanExecuteChanged();
+    }
+
+    partial void OnExportPackageRootChanged(string? value)
+    {
+        _runExportCommand.NotifyCanExecuteChanged();
+    }
+
+    partial void OnImportPackageRootChanged(string? value)
+    {
+        _runImportCommand.NotifyCanExecuteChanged();
+    }
+
+    partial void OnImportTargetRootChanged(string? value)
+    {
+        _runImportCommand.NotifyCanExecuteChanged();
+    }
+
+    private void NotifyCommandStates()
+    {
+        _refreshCommand.NotifyCanExecuteChanged();
+        _runMigrationCommand.NotifyCanExecuteChanged();
+        _runExportCommand.NotifyCanExecuteChanged();
+        _runImportCommand.NotifyCanExecuteChanged();
+        _pickMigrationTargetCommand.NotifyCanExecuteChanged();
+        _pickExportRootCommand.NotifyCanExecuteChanged();
+        _pickImportPackageRootCommand.NotifyCanExecuteChanged();
+        _pickImportTargetRootCommand.NotifyCanExecuteChanged();
+    }
+}

--- a/Veriado.WinUI/Views/Shell/MainShell.xaml
+++ b/Veriado.WinUI/Views/Shell/MainShell.xaml
@@ -44,6 +44,7 @@
         <controls:NavigationView.MenuItems>
             <controls:NavigationViewItem Tag="files" Content="Správa souborů" Icon="Document" />
             <controls:NavigationViewItem Tag="import" Content="Import souborů" Icon="OpenFile" />
+            <controls:NavigationViewItem Tag="storage" Content="Migrace a balíčky" Icon="Sync" />
             <controls:NavigationViewItem Tag="settings" Content="Nastavení" Icon="Setting" />
         </controls:NavigationView.MenuItems>
         <controls:NavigationView.Content>

--- a/Veriado.WinUI/Views/Storage/StorageManagementPage.xaml
+++ b/Veriado.WinUI/Views/Storage/StorageManagementPage.xaml
@@ -1,0 +1,153 @@
+<Page
+    x:Class="Veriado.WinUI.Views.Storage.StorageManagementPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+    mc:Ignorable="d">
+
+    <ScrollViewer>
+        <StackPanel Padding="24" Spacing="16">
+            <StackPanel Orientation="Horizontal" Spacing="12" VerticalAlignment="Center">
+                <TextBlock Text="Migrace, export a import" FontSize="28" FontWeight="SemiBold" />
+                <muxc:ProgressRing Width="28" Height="28" IsActive="{Binding IsBusy}" />
+                <Button Content="Zrušit" Command="{Binding CancelCommand}" />
+            </StackPanel>
+
+            <TextBlock
+                Text="Spravujte přesun úložiště a přípravu balíčků databáze a dokumentů."
+                Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+
+            <muxc:InfoBar
+                IsOpen="{Binding HasError}"
+                Severity="Error"
+                IsClosable="False"
+                Title="Došlo k chybě"
+                Message="Detail najdete v oznamovací liště nebo protokolu." />
+
+            <StackPanel Spacing="8">
+                <TextBlock Text="Aktuální stav" FontSize="20" FontWeight="SemiBold" />
+                <Grid ColumnSpacing="12" RowSpacing="8">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+
+                    <TextBlock Grid.Row="0" Grid.Column="0" Text="Aktuální kořen" VerticalAlignment="Center" />
+                    <TextBox
+                        Grid.Row="0"
+                        Grid.Column="1"
+                        IsReadOnly="True"
+                        Text="{Binding CurrentRoot}" />
+                    <Button Grid.Row="0" Grid.Column="2" Content="Načíst" Command="{Binding RefreshCommand}" />
+
+                    <TextBlock Grid.Row="1" Grid.Column="0" Text="Efektivní kořen" VerticalAlignment="Center" />
+                    <TextBox
+                        Grid.Row="1"
+                        Grid.Column="1"
+                        IsReadOnly="True"
+                        Text="{Binding EffectiveRoot}" />
+                </Grid>
+            </StackPanel>
+
+            <muxc:Expander IsExpanded="True">
+                <muxc:Expander.Header>
+                    <StackPanel Orientation="Horizontal" Spacing="8">
+                        <TextBlock Text="Migrace úložiště" FontSize="18" FontWeight="SemiBold" />
+                        <TextBlock Text="Přesun dat na nové umístění" Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                    </StackPanel>
+                </muxc:Expander.Header>
+                <StackPanel Spacing="12" Margin="0,8,0,0">
+                    <Grid ColumnSpacing="12">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+                        <TextBlock VerticalAlignment="Center" Text="Cílový kořen" />
+                        <TextBox Grid.Column="1" MinWidth="360" Text="{Binding MigrationTargetRoot, Mode=TwoWay}" />
+                        <Button Grid.Column="2" Content="Vybrat složku" Command="{Binding PickMigrationTargetCommand}" />
+                    </Grid>
+
+                    <StackPanel Orientation="Horizontal" Spacing="20">
+                        <CheckBox Content="Smazat zdroj po kopii" IsChecked="{Binding DeleteSourceAfterCopy, Mode=TwoWay}" />
+                        <CheckBox Content="Ověřit hashe" IsChecked="{Binding VerifyHashes, Mode=TwoWay}" />
+                    </StackPanel>
+
+                    <StackPanel Orientation="Horizontal" Spacing="12">
+                        <Button Content="Spustit migraci" Command="{Binding RunMigrationCommand}" />
+                        <TextBlock VerticalAlignment="Center" Foreground="{ThemeResource TextFillColorSecondaryBrush}" Text="Použije se pro přesun databáze i dokumentů." />
+                    </StackPanel>
+                </StackPanel>
+            </muxc:Expander>
+
+            <muxc:Expander IsExpanded="True">
+                <muxc:Expander.Header>
+                    <StackPanel Orientation="Horizontal" Spacing="8">
+                        <TextBlock Text="Export balíčku" FontSize="18" FontWeight="SemiBold" />
+                        <TextBlock Text="Příprava pro přesun nebo zálohu" Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                    </StackPanel>
+                </muxc:Expander.Header>
+                <StackPanel Spacing="12" Margin="0,8,0,0">
+                    <Grid ColumnSpacing="12">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+                        <TextBlock VerticalAlignment="Center" Text="Složka balíčku" />
+                        <TextBox Grid.Column="1" MinWidth="360" Text="{Binding ExportPackageRoot, Mode=TwoWay}" />
+                        <Button Grid.Column="2" Content="Vybrat složku" Command="{Binding PickExportRootCommand}" />
+                    </Grid>
+
+                    <CheckBox Content="Přepsat existující soubory" IsChecked="{Binding ExportOverwriteExisting, Mode=TwoWay}" />
+
+                    <Button Content="Exportovat databázi a dokumenty" Command="{Binding RunExportCommand}" />
+                </StackPanel>
+            </muxc:Expander>
+
+            <muxc:Expander IsExpanded="True">
+                <muxc:Expander.Header>
+                    <StackPanel Orientation="Horizontal" Spacing="8">
+                        <TextBlock Text="Import balíčku" FontSize="18" FontWeight="SemiBold" />
+                        <TextBlock Text="Načtení exportovaných dat" Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                    </StackPanel>
+                </muxc:Expander.Header>
+                <StackPanel Spacing="12" Margin="0,8,0,0">
+                    <Grid ColumnSpacing="12" RowSpacing="8">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                        </Grid.RowDefinitions>
+
+                        <TextBlock Grid.Row="0" Grid.Column="0" VerticalAlignment="Center" Text="Složka balíčku" />
+                        <TextBox Grid.Row="0" Grid.Column="1" MinWidth="360" Text="{Binding ImportPackageRoot, Mode=TwoWay}" />
+                        <Button Grid.Row="0" Grid.Column="2" Content="Vybrat složku" Command="{Binding PickImportPackageRootCommand}" />
+
+                        <TextBlock Grid.Row="1" Grid.Column="0" VerticalAlignment="Center" Text="Cílový kořen" />
+                        <TextBox Grid.Row="1" Grid.Column="1" MinWidth="360" Text="{Binding ImportTargetRoot, Mode=TwoWay}" />
+                        <Button Grid.Row="1" Grid.Column="2" Content="Vybrat složku" Command="{Binding PickImportTargetRootCommand}" />
+                    </Grid>
+
+                    <StackPanel Orientation="Horizontal" Spacing="20">
+                        <CheckBox Content="Přepsat existující soubory" IsChecked="{Binding ImportOverwriteExisting, Mode=TwoWay}" />
+                        <CheckBox Content="Ověřit po kopii" IsChecked="{Binding ImportVerifyAfterCopy, Mode=TwoWay}" />
+                    </StackPanel>
+
+                    <Button Content="Spustit import" Command="{Binding RunImportCommand}" />
+                </StackPanel>
+            </muxc:Expander>
+        </StackPanel>
+    </ScrollViewer>
+</Page>

--- a/Veriado.WinUI/Views/Storage/StorageManagementPage.xaml.cs
+++ b/Veriado.WinUI/Views/Storage/StorageManagementPage.xaml.cs
@@ -1,0 +1,19 @@
+namespace Veriado.WinUI.Views.Storage;
+
+public sealed partial class StorageManagementPage : Page
+{
+    public StorageManagementPage()
+    {
+        InitializeComponent();
+        Loaded += OnLoaded;
+    }
+
+    private async void OnLoaded(object sender, RoutedEventArgs e)
+    {
+        Loaded -= OnLoaded;
+        if (DataContext is ViewModels.Storage.StorageManagementPageViewModel viewModel)
+        {
+            await viewModel.RefreshCommand.ExecuteAsync(null);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add navigation registration and DI wiring for a new storage management page
- implement UI and view model to trigger migration, export, and import operations against the storage services

## Testing
- dotnet build (fails: `dotnet` not available in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920d272e55c832688c669cfe53159fa)