### PR TITLE
Expose physical file operations via content service

### DIFF
--- a/Veriado.Contracts/Files/FileContentLocationDto.cs
+++ b/Veriado.Contracts/Files/FileContentLocationDto.cs
@@ -1,0 +1,62 @@
+namespace Veriado.Contracts.Files;
+
+/// <summary>
+/// Represents the physical location and metadata of stored file content.
+/// </summary>
+public sealed record FileContentLocationDto
+{
+    /// <summary>
+    /// Gets the identifier of the logical file.
+    /// </summary>
+    public Guid FileId { get; init; }
+
+    /// <summary>
+    /// Gets the absolute path to the stored content.
+    /// </summary>
+    public string FullPath { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets the MIME type associated with the stored content, if known.
+    /// </summary>
+    public string? Mime { get; init; }
+
+    /// <summary>
+    /// Gets the size of the stored content in bytes.
+    /// </summary>
+    public long SizeBytes { get; init; }
+
+    /// <summary>
+    /// Gets the creation timestamp of the stored content in UTC, if available.
+    /// </summary>
+    public DateTimeOffset? CreatedUtc { get; init; }
+
+    /// <summary>
+    /// Gets the last write timestamp of the stored content in UTC, if available.
+    /// </summary>
+    public DateTimeOffset? LastWriteUtc { get; init; }
+
+    /// <summary>
+    /// Gets the last access timestamp of the stored content in UTC, if available.
+    /// </summary>
+    public DateTimeOffset? LastAccessUtc { get; init; }
+
+    /// <summary>
+    /// Gets the hash of the stored content, if known.
+    /// </summary>
+    public string? Hash { get; init; }
+
+    /// <summary>
+    /// Gets the storage provider hosting the content.
+    /// </summary>
+    public string? StorageProvider { get; init; }
+
+    /// <summary>
+    /// Gets the current physical health state of the content, if tracked.
+    /// </summary>
+    public string? PhysicalState { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether the content is encrypted at rest.
+    /// </summary>
+    public bool IsEncrypted { get; init; }
+}

--- a/Veriado.Services/Files/FileContentService.cs
+++ b/Veriado.Services/Files/FileContentService.cs
@@ -1,6 +1,9 @@
 // File: Veriado.Services/Files/FileContentService.cs
+using System.Diagnostics;
 using System.IO;
 using AutoMapper;
+using Veriado.Domain.Files;
+using Veriado.Domain.FileSystem;
 
 namespace Veriado.Services.Files;
 
@@ -20,56 +23,46 @@ public sealed class FileContentService : IFileContentService
         _mapper = mapper ?? throw new ArgumentNullException(nameof(mapper));
     }
 
-    public async Task<FileContentResponseDto?> GetContentAsync(Guid fileId, CancellationToken cancellationToken)
+    public async Task<FileContentResponseDto?> GetContentAsync(Guid fileId, CancellationToken cancellationToken = default)
     {
-        var file = await _repository.GetAsync(fileId, cancellationToken).ConfigureAwait(false);
-        if (file is null)
+        var resolution = await ResolvePhysicalFileAsync(fileId, cancellationToken).ConfigureAwait(false);
+        if (resolution.IsFailure)
         {
             return null;
         }
 
-        var fileSystem = await _repository.GetFileSystemAsync(file.FileSystemId, cancellationToken)
-            .ConfigureAwait(false);
-        if (fileSystem is null)
-        {
-            return null;
-        }
-
-        var absolutePath = _pathResolver.GetFullPath(fileSystem.RelativePath.Value);
-        if (!File.Exists(absolutePath))
-        {
-            return null;
-        }
-
-        var bytes = await File.ReadAllBytesAsync(absolutePath, cancellationToken).ConfigureAwait(false);
-        var dto = _mapper.Map<FileContentResponseDto>(file);
+        var bytes = await File.ReadAllBytesAsync(resolution.Value.FullPath, cancellationToken).ConfigureAwait(false);
+        var dto = _mapper.Map<FileContentResponseDto>(resolution.Value.File);
         return dto with { Content = bytes };
     }
 
-    public async Task<AppResult<Guid>> SaveContentToDiskAsync(Guid fileId, string targetPath, CancellationToken cancellationToken)
+    public async Task<FileContentLocationDto?> GetContentLocationAsync(
+        Guid fileId,
+        CancellationToken cancellationToken = default)
+    {
+        var resolution = await ResolvePhysicalFileAsync(fileId, cancellationToken).ConfigureAwait(false);
+        if (resolution.IsFailure)
+        {
+            return null;
+        }
+
+        return CreateLocationDto(resolution.Value);
+    }
+
+    public async Task<AppResult<Guid>> SaveContentToDiskAsync(
+        Guid fileId,
+        string targetPath,
+        CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrWhiteSpace(targetPath))
         {
             return AppResult<Guid>.Validation(new[] { "Target path is required." });
         }
 
-        var file = await _repository.GetAsync(fileId, cancellationToken).ConfigureAwait(false);
-        if (file is null)
+        var resolution = await ResolvePhysicalFileAsync(fileId, cancellationToken).ConfigureAwait(false);
+        if (resolution.IsFailure)
         {
-            return AppResult<Guid>.NotFound($"File '{fileId}' was not found.");
-        }
-
-        var fileSystem = await _repository.GetFileSystemAsync(file.FileSystemId, cancellationToken)
-            .ConfigureAwait(false);
-        if (fileSystem is null)
-        {
-            return AppResult<Guid>.NotFound($"File system entry for '{fileId}' was not found.");
-        }
-
-        var sourcePath = _pathResolver.GetFullPath(fileSystem.RelativePath.Value);
-        if (!File.Exists(sourcePath))
-        {
-            return AppResult<Guid>.NotFound($"Physical file for '{fileId}' was not found at '{sourcePath}'.");
+            return AppResult<Guid>.Failure(resolution.Error);
         }
 
         var targetDirectory = Path.GetDirectoryName(targetPath);
@@ -78,7 +71,126 @@ public sealed class FileContentService : IFileContentService
             Directory.CreateDirectory(targetDirectory!);
         }
 
-        File.Copy(sourcePath, targetPath, overwrite: true);
+        File.Copy(resolution.Value.FullPath, targetPath, overwrite: true);
         return AppResult<Guid>.Success(fileId);
     }
+
+    public Task<AppResult<Guid>> ExportContentAsync(
+        Guid fileId,
+        string targetPath,
+        CancellationToken cancellationToken = default) =>
+        SaveContentToDiskAsync(fileId, targetPath, cancellationToken);
+
+    public async Task<AppResult<Guid>> OpenInDefaultAppAsync(
+        Guid fileId,
+        CancellationToken cancellationToken = default)
+    {
+        var resolution = await ResolvePhysicalFileAsync(fileId, cancellationToken).ConfigureAwait(false);
+        if (resolution.IsFailure)
+        {
+            return AppResult<Guid>.Failure(resolution.Error);
+        }
+
+        try
+        {
+            var startInfo = new ProcessStartInfo
+            {
+                FileName = resolution.Value.FullPath,
+                UseShellExecute = true,
+            };
+
+            _ = Process.Start(startInfo);
+            return AppResult<Guid>.Success(fileId);
+        }
+        catch (Exception ex)
+        {
+            return AppResult<Guid>.FromException(ex, "Unable to open the file in the default application.");
+        }
+    }
+
+    public async Task<AppResult<Guid>> ShowInFileExplorerAsync(
+        Guid fileId,
+        CancellationToken cancellationToken = default)
+    {
+        var resolution = await ResolvePhysicalFileAsync(fileId, cancellationToken).ConfigureAwait(false);
+        if (resolution.IsFailure)
+        {
+            return AppResult<Guid>.Failure(resolution.Error);
+        }
+
+        try
+        {
+            var startInfo = new ProcessStartInfo
+            {
+                FileName = "explorer.exe",
+                Arguments = $"/select,\"{resolution.Value.FullPath}\"",
+                UseShellExecute = true,
+            };
+
+            _ = Process.Start(startInfo);
+            return AppResult<Guid>.Success(fileId);
+        }
+        catch (Exception ex)
+        {
+            return AppResult<Guid>.FromException(ex, "Unable to show the file in File Explorer.");
+        }
+    }
+
+    private static FileContentLocationDto CreateLocationDto(ResolvedContentLocation resolved)
+    {
+        var fileInfo = new FileInfo(resolved.FullPath);
+        var createdUtc = fileInfo.Exists
+            ? new DateTimeOffset(fileInfo.CreationTimeUtc, TimeSpan.Zero)
+            : resolved.FileSystem.CreatedUtc.ToDateTimeOffset();
+        var lastWriteUtc = fileInfo.Exists
+            ? new DateTimeOffset(fileInfo.LastWriteTimeUtc, TimeSpan.Zero)
+            : resolved.FileSystem.LastWriteUtc.ToDateTimeOffset();
+        var lastAccessUtc = fileInfo.Exists
+            ? new DateTimeOffset(fileInfo.LastAccessTimeUtc, TimeSpan.Zero)
+            : resolved.FileSystem.LastAccessUtc.ToDateTimeOffset();
+
+        return new FileContentLocationDto
+        {
+            FileId = resolved.File.Id,
+            FullPath = resolved.FullPath,
+            Mime = resolved.FileSystem.Mime.Value,
+            SizeBytes = fileInfo.Exists ? fileInfo.Length : resolved.FileSystem.Size.Value,
+            CreatedUtc = createdUtc,
+            LastWriteUtc = lastWriteUtc,
+            LastAccessUtc = lastAccessUtc,
+            Hash = resolved.FileSystem.Hash.Value,
+            StorageProvider = resolved.FileSystem.Provider.ToString(),
+            PhysicalState = resolved.FileSystem.PhysicalState.ToString(),
+            IsEncrypted = resolved.FileSystem.IsEncrypted,
+        };
+    }
+
+    private async Task<AppResult<ResolvedContentLocation>> ResolvePhysicalFileAsync(
+        Guid fileId,
+        CancellationToken cancellationToken)
+    {
+        var file = await _repository.GetAsync(fileId, cancellationToken).ConfigureAwait(false);
+        if (file is null)
+        {
+            return AppResult<ResolvedContentLocation>.NotFound($"File '{fileId}' was not found.");
+        }
+
+        var fileSystem = await _repository.GetFileSystemAsync(file.FileSystemId, cancellationToken)
+            .ConfigureAwait(false);
+        if (fileSystem is null)
+        {
+            return AppResult<ResolvedContentLocation>.NotFound($"File system entry for '{fileId}' was not found.");
+        }
+
+        var fullPath = _pathResolver.GetFullPath(fileSystem.RelativePath.Value);
+        if (!File.Exists(fullPath))
+        {
+            return AppResult<ResolvedContentLocation>.NotFound(
+                $"Physical file for '{fileId}' was not found at '{fullPath}'.");
+        }
+
+        return AppResult<ResolvedContentLocation>.Success(new ResolvedContentLocation(file, fileSystem, fullPath));
+    }
+
+    private sealed record ResolvedContentLocation(FileEntity File, FileSystemEntity FileSystem, string FullPath);
 }

--- a/Veriado.Services/Files/IFileContentService.cs
+++ b/Veriado.Services/Files/IFileContentService.cs
@@ -6,7 +6,15 @@ namespace Veriado.Services.Files;
 /// </summary>
 public interface IFileContentService
 {
-    Task<FileContentResponseDto?> GetContentAsync(Guid fileId, CancellationToken cancellationToken);
+    Task<FileContentResponseDto?> GetContentAsync(Guid fileId, CancellationToken cancellationToken = default);
 
-    Task<AppResult<Guid>> SaveContentToDiskAsync(Guid fileId, string targetPath, CancellationToken cancellationToken);
+    Task<FileContentLocationDto?> GetContentLocationAsync(Guid fileId, CancellationToken cancellationToken = default);
+
+    Task<AppResult<Guid>> SaveContentToDiskAsync(Guid fileId, string targetPath, CancellationToken cancellationToken = default);
+
+    Task<AppResult<Guid>> ExportContentAsync(Guid fileId, string targetPath, CancellationToken cancellationToken = default);
+
+    Task<AppResult<Guid>> OpenInDefaultAppAsync(Guid fileId, CancellationToken cancellationToken = default);
+
+    Task<AppResult<Guid>> ShowInFileExplorerAsync(Guid fileId, CancellationToken cancellationToken = default);
 }


### PR DESCRIPTION
## Summary
- add a FileContentLocationDto contract to expose physical file metadata
- extend the file content service to resolve stored files and surface location/export/open helpers
- update the content service interface to provide physical file operations

## Testing
- dotnet test *(fails: dotnet CLI is not available in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921c8d5990c83269987c3b802f6a526)