### PR TITLE
Add process launcher support for opening files

### DIFF
--- a/Veriado.Services/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/Veriado.Services/DependencyInjection/ServiceCollectionExtensions.cs
@@ -35,6 +35,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IFileOperationsService, FileOperationsService>();
         services.AddScoped<IFileService, FileService>();
         services.AddScoped<IFileContentService, FileContentService>();
+        services.AddScoped<IProcessLauncher, ProcessLauncher>();
         services.AddScoped<IMaintenanceService, MaintenanceService>();
         services.AddScoped<IHealthService, HealthService>();
         services.AddScoped<IStorageManagementService, StorageManagementService>();

--- a/Veriado.Services/Files/IFileContentService.cs
+++ b/Veriado.Services/Files/IFileContentService.cs
@@ -14,7 +14,7 @@ public interface IFileContentService
 
     Task<AppResult<Guid>> ExportContentAsync(Guid fileId, string targetPath, CancellationToken cancellationToken = default);
 
-    Task<AppResult<Guid>> OpenInDefaultAppAsync(Guid fileId, CancellationToken cancellationToken = default);
+    Task OpenInDefaultAppAsync(Guid fileId, CancellationToken cancellationToken = default);
 
-    Task<AppResult<Guid>> ShowInFileExplorerAsync(Guid fileId, CancellationToken cancellationToken = default);
+    Task ShowInFolderAsync(Guid fileId, CancellationToken cancellationToken = default);
 }

--- a/Veriado.Services/Files/IProcessLauncher.cs
+++ b/Veriado.Services/Files/IProcessLauncher.cs
@@ -1,0 +1,16 @@
+using System.Diagnostics;
+
+namespace Veriado.Services.Files;
+
+/// <summary>
+/// Provides a testable abstraction for starting external processes.
+/// </summary>
+public interface IProcessLauncher
+{
+    /// <summary>
+    /// Attempts to start a process using the provided <see cref="ProcessStartInfo"/>.
+    /// </summary>
+    /// <param name="startInfo">The process start information.</param>
+    /// <returns><c>true</c> if the process was started; otherwise <c>false</c>.</returns>
+    bool TryStart(ProcessStartInfo startInfo);
+}

--- a/Veriado.Services/Files/ProcessLauncher.cs
+++ b/Veriado.Services/Files/ProcessLauncher.cs
@@ -1,0 +1,33 @@
+using System.Diagnostics;
+using Microsoft.Extensions.Logging;
+
+namespace Veriado.Services.Files;
+
+/// <summary>
+/// Default implementation of <see cref="IProcessLauncher"/> using <see cref="Process.Start(ProcessStartInfo)"/>.
+/// </summary>
+public sealed class ProcessLauncher : IProcessLauncher
+{
+    private readonly ILogger<ProcessLauncher> _logger;
+
+    public ProcessLauncher(ILogger<ProcessLauncher> logger)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public bool TryStart(ProcessStartInfo startInfo)
+    {
+        ArgumentNullException.ThrowIfNull(startInfo);
+
+        try
+        {
+            var process = Process.Start(startInfo);
+            return process is not null;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to start process {FileName}.", startInfo.FileName);
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a process launcher abstraction for starting shell processes
- update file content helper methods to use content location resolution with graceful logging and Windows-only guards
- register the new launcher in dependency injection

## Testing
- dotnet build *(fails: `dotnet` CLI unavailable in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921cb559f508326a3951ced3362a729)