### PR TITLE
Add WinUI file content actions

### DIFF
--- a/Veriado.Services/Files/FileOperationsService.cs
+++ b/Veriado.Services/Files/FileOperationsService.cs
@@ -161,6 +161,14 @@ public sealed class FileOperationsService : IFileOperationsService
         return ToIdResponse(result);
     }
 
+    public Task<ApiResponse<FileSummaryDto>> ReplaceFileContentAsync(
+        Guid fileId,
+        string sourceFileFullPath,
+        CancellationToken cancellationToken)
+    {
+        return UpdateFileContentAsync(fileId, sourceFileFullPath, cancellationToken);
+    }
+
     public async Task<ApiResponse<FileSummaryDto>> UpdateFileContentAsync(
         Guid fileId,
         string sourceFileFullPath,

--- a/Veriado.Services/Files/IFileOperationsService.cs
+++ b/Veriado.Services/Files/IFileOperationsService.cs
@@ -25,6 +25,11 @@ public interface IFileOperationsService
 
     Task<ApiResponse<Guid>> ReplaceContentAsync(Guid fileId, byte[] content, CancellationToken cancellationToken);
 
+    Task<ApiResponse<FileSummaryDto>> ReplaceFileContentAsync(
+        Guid fileId,
+        string sourceFileFullPath,
+        CancellationToken cancellationToken);
+
     Task<ApiResponse<FileSummaryDto>> UpdateFileContentAsync(
         Guid fileId,
         string sourceFileFullPath,

--- a/Veriado.WinUI/Views/Files/FilesPage.xaml
+++ b/Veriado.WinUI/Views/Files/FilesPage.xaml
@@ -183,6 +183,21 @@
                                         HorizontalAlignment="Right"
                                         VerticalAlignment="Center">
                                         <Button
+                                            x:Uid="FilesPage_ItemOpenButton"
+                                            Content="Otevřít"
+                                            Command="{Binding DataContext.OpenFileCommand, ElementName=PageRoot}"
+                                            CommandParameter="{x:Bind}" />
+                                        <Button
+                                            x:Uid="FilesPage_ItemShowInFolderButton"
+                                            Content="Ukázat ve složce"
+                                            Command="{Binding DataContext.ShowInFolderCommand, ElementName=PageRoot}"
+                                            CommandParameter="{x:Bind}" />
+                                        <Button
+                                            x:Uid="FilesPage_ItemUpdateButton"
+                                            Content="Aktualizovat soubor"
+                                            Command="{Binding DataContext.UpdateFileContentCommand, ElementName=PageRoot}"
+                                            CommandParameter="{x:Bind}" />
+                                        <Button
                                             x:Uid="FilesPage_ItemDetailButton"
                                             Content="Detail"
                                             Command="{Binding DataContext.OpenDetailCommand, ElementName=PageRoot}"
@@ -192,11 +207,6 @@
                                             Content="Smazat"
                                             Command="{Binding DataContext.DeleteFileCommand, ElementName=PageRoot}"
                                             CommandParameter="{x:Bind Dto}" />
-                                        <Button
-                                            Content="Aktualizovat soubor"
-                                            Command="{Binding DataContext.UpdateFileCommand, ElementName=PageRoot}"
-                                            CommandParameter="{x:Bind}"
-                                            Visibility="{x:Bind HasPhysicalIssue, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}" />
                                     </StackPanel>
                                 </Grid>
                             </Border>


### PR DESCRIPTION
## Summary
- add WinUI commands for opening files, showing them in Explorer, and replacing their content
- validate picked files before calling the new ReplaceFileContentAsync service and refresh item state from returned summaries
- wire the new commands into the Files page item template for user access

## Testing
- dotnet build Veriado.sln *(fails: dotnet CLI not available in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921cc41af008326a5bd5dd135c3e901)