### PR TITLE
Add temp export for opening files with original names

### DIFF
--- a/Veriado.Services/Files/IFileContentService.cs
+++ b/Veriado.Services/Files/IFileContentService.cs
@@ -14,6 +14,8 @@ public interface IFileContentService
 
     Task<AppResult<Guid>> ExportContentAsync(Guid fileId, string targetPath, CancellationToken cancellationToken = default);
 
+    Task<string?> ExportToTempWithOriginalNameAsync(Guid fileId, CancellationToken cancellationToken = default);
+
     Task OpenInDefaultAppAsync(Guid fileId, CancellationToken cancellationToken = default);
 
     Task ShowInFolderAsync(Guid fileId, CancellationToken cancellationToken = default);


### PR DESCRIPTION
## Summary
- add a temp export helper that restores the original filename for stored files
- update file opening and explorer actions to use the temp copy and sanitize names

## Testing
- dotnet build Veriado.sln -v minimal *(fails: dotnet CLI not available in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921e3ea89f48326bc200c1ccd8adeab)