### PR TITLE
Fix temp export filename compose

### DIFF
--- a/Veriado.Services/Files/FileContentService.cs
+++ b/Veriado.Services/Files/FileContentService.cs
@@ -114,8 +114,9 @@ public sealed class FileContentService : IFileContentService
             return null;
         }
 
-        var safeName = SanitizeFileName(resolution.Value.File.Name, fileId);
-        var extension = resolution.Value.File.Extension ?? string.Empty;
+        var safeName = SanitizeFileName(resolution.Value.File.Name.Value, fileId);
+        var extensionValue = resolution.Value.File.Extension.Value;
+        var extension = string.IsNullOrEmpty(extensionValue) ? string.Empty : $".{extensionValue}";
         var destination = Path.Combine(tempFolder, string.Concat(safeName, extension));
 
         try


### PR DESCRIPTION
## Summary
- use value object string values when sanitizing file names for temp export
- prefix file extensions with a dot before composing the temp destination path

## Testing
- dotnet --version *(fails: dotnet CLI not available in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921e68118fc8326b99a87d7c34d7488)