### PR TITLE
Fix temp export file name construction

### DIFF
--- a/Veriado.Services/Files/FileContentService.cs
+++ b/Veriado.Services/Files/FileContentService.cs
@@ -114,9 +114,12 @@ public sealed class FileContentService : IFileContentService
             return null;
         }
 
-        var safeName = SanitizeFileName(resolution.Value.File.Name, fileId);
-        var extension = resolution.Value.File.Extension ?? string.Empty;
-        var destination = Path.Combine(tempFolder, string.Concat(safeName, extension));
+        var safeName = SanitizeFileName(resolution.Value.File.Name.Value, fileId);
+        var extension = resolution.Value.File.Extension.Value;
+        var destinationFileName = string.IsNullOrEmpty(extension)
+            ? safeName
+            : string.Concat(safeName, ".", extension);
+        var destination = Path.Combine(tempFolder, destinationFileName);
 
         try
         {


### PR DESCRIPTION
## Summary
- use underlying value strings when building exported temp file names
- ensure extensions are combined with a separating dot and fallback safely

## Testing
- dotnet build (fails: dotnet not installed)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921e78da9148326b9ba0144df684fe8)