### PR TITLE
Fix storage option parameters and extension normalization

### DIFF
--- a/Veriado.Application/UseCases/Files/UpdateFileContent/UpdateFileContentCommandHandler.cs
+++ b/Veriado.Application/UseCases/Files/UpdateFileContent/UpdateFileContentCommandHandler.cs
@@ -153,7 +153,7 @@ public sealed class UpdateFileContentCommandHandler
             bufferSize: 81920,
             useAsync: true);
         var extension = Path.GetExtension(sourceFullPath);
-        var storageOptions = new StorageSaveOptions(extension, mime: null, originalFileName: Path.GetFileName(sourceFullPath));
+        var storageOptions = new StorageSaveOptions(extension, Mime: null, OriginalFileName: Path.GetFileName(sourceFullPath));
         var storageResult = await _fileStorage.SaveAsync(stream, storageOptions, cancellationToken).ConfigureAwait(false);
 
         if (storageResult.Hash != expectedHash)

--- a/Veriado.Infrastructure/Storage/LocalFileStorage.cs
+++ b/Veriado.Infrastructure/Storage/LocalFileStorage.cs
@@ -330,7 +330,7 @@ internal sealed class LocalFileStorage : IFileStorage, IStorageWriter
         }
 
         var trimmed = extension.Trim();
-        if (!trimmed.StartsWith('.', StringComparison.Ordinal))
+        if (!trimmed.StartsWith(".", StringComparison.Ordinal))
         {
             trimmed = $".{trimmed}";
         }


### PR DESCRIPTION
## Summary
- fix named parameters when constructing StorageSaveOptions to use proper casing
- adjust extension normalization to use string-based StartsWith overload

## Testing
- dotnet build *(fails: dotnet CLI not available in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922d978e5c48326bd8c16dd24fd2a9e)