### PR TITLE
Disable unavailable file actions

### DIFF
--- a/Veriado.WinUI/ViewModels/Files/FileListItemModel.cs
+++ b/Veriado.WinUI/ViewModels/Files/FileListItemModel.cs
@@ -62,6 +62,8 @@ public sealed partial class FileListItemModel : ObservableObject
 
     public bool HasPhysicalIssue => !string.IsNullOrWhiteSpace(PhysicalStatusMessage);
 
+    public bool HasPhysicalFile => !string.Equals(PhysicalState, "Missing", StringComparison.OrdinalIgnoreCase);
+
     public bool IsHealthy => string.Equals(PhysicalState, "Healthy", StringComparison.OrdinalIgnoreCase);
 
     public void RecomputeValidity(DateTimeOffset referenceTime, ValidityThresholds? thresholds = null)
@@ -82,6 +84,7 @@ public sealed partial class FileListItemModel : ObservableObject
 
     partial void OnPhysicalStateChanged(string? value)
     {
+        OnPropertyChanged(nameof(HasPhysicalFile));
         OnPropertyChanged(nameof(IsHealthy));
     }
 

--- a/Veriado.WinUI/Views/Files/FilesPage.xaml
+++ b/Veriado.WinUI/Views/Files/FilesPage.xaml
@@ -185,11 +185,13 @@
                                         <Button
                                             x:Uid="FilesPage_ItemOpenButton"
                                             Content="Otevřít"
+                                            IsEnabled="{x:Bind HasPhysicalFile, Mode=OneWay}"
                                             Command="{Binding DataContext.OpenFileCommand, ElementName=PageRoot}"
                                             CommandParameter="{x:Bind}" />
                                         <Button
                                             x:Uid="FilesPage_ItemShowInFolderButton"
                                             Content="Ukázat ve složce"
+                                            IsEnabled="{x:Bind HasPhysicalFile, Mode=OneWay}"
                                             Command="{Binding DataContext.ShowInFolderCommand, ElementName=PageRoot}"
                                             CommandParameter="{x:Bind}" />
                                         <Button


### PR DESCRIPTION
## Summary
- add flag to list items indicating whether the physical file exists in storage
- disable the open and show-in-folder buttons when the physical file is missing

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69232a861a508326bcb07c6ccd0a0b45)