### PR TITLE
Add search icon to files page search box

### DIFF
--- a/Veriado.WinUI/Views/Files/FilesPage.xaml
+++ b/Veriado.WinUI/Views/Files/FilesPage.xaml
@@ -31,7 +31,11 @@
                     PlaceholderText="Hledat soubory"
                     Text="{x:Bind ViewModel.SearchText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                     QuerySubmitted="OnSearchQuerySubmitted"
-                    TextChanged="OnSearchTextChanged" />
+                    TextChanged="OnSearchTextChanged">
+                    <AutoSuggestBox.QueryIcon>
+                        <FontIcon FontFamily="Segoe Fluent Icons" Glyph="&#xE721;" />
+                    </AutoSuggestBox.QueryIcon>
+                </AutoSuggestBox>
             </Grid>
 
             <StackPanel Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">


### PR DESCRIPTION
## Summary
- add magnifying glass query icon to the files page search AutoSuggestBox
- preserve existing bindings and handlers while enabling visual search cue

## Testing
- not run (UI change only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69234a45de3c8326b8089b0533542fa4)