### PR TITLE
Fix duplicate content assignment on delete all button

### DIFF
--- a/Veriado.WinUI/Views/Files/FilesPage.xaml
+++ b/Veriado.WinUI/Views/Files/FilesPage.xaml
@@ -94,8 +94,7 @@
                         ItemsSource="{x:Bind ViewModel.PageSizeOptions, Mode=OneWay}"
                         SelectedItem="{x:Bind ViewModel.PageSize, Mode=TwoWay}" />
                 </StackPanel>
-                <Button Content="Smazat vše"
-                        HorizontalAlignment="Right"
+                <Button HorizontalAlignment="Right"
                         Margin="8,0,0,0"
                         Command="{Binding DeleteAllCommand}">
                     <StackPanel Orientation="Horizontal" Spacing="4">


### PR DESCRIPTION
## Summary
- remove redundant Content attribute from the delete-all button to resolve duplicate assignment errors

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923636ea7708326a1db0d7473f79848)