### PR TITLE
Update delete all button text and availability

### DIFF
--- a/Veriado.WinUI/ViewModels/Files/FilesPageViewModel.cs
+++ b/Veriado.WinUI/ViewModels/Files/FilesPageViewModel.cs
@@ -44,6 +44,7 @@ public partial class FilesPageViewModel : ViewModelBase
     
     private static readonly TimeSpan HealthPollingInterval = TimeSpan.FromSeconds(15);
     private CancellationTokenSource? _searchDebounceSource;
+    private readonly AsyncRelayCommand _deleteAllCommand;
     private readonly AsyncRelayCommand _nextPageCommand;
     private readonly AsyncRelayCommand _previousPageCommand;
     private readonly AsyncRelayCommand<FileSummaryDto?> _openDetailCommand;
@@ -88,7 +89,8 @@ public partial class FilesPageViewModel : ViewModelBase
 
         Items = new ObservableCollection<FileListItemModel>();
         RefreshCommand = new AsyncRelayCommand(RefreshAsync);
-        DeleteAllCommand = new AsyncRelayCommand(DeleteAllAsync);
+        _deleteAllCommand = new AsyncRelayCommand(DeleteAllAsync, CanDeleteAll);
+        DeleteAllCommand = _deleteAllCommand;
 
         _nextPageCommand = new AsyncRelayCommand(LoadNextPageAsync, CanLoadNextPage);
         _previousPageCommand = new AsyncRelayCommand(LoadPreviousPageAsync, CanLoadPreviousPage);
@@ -187,6 +189,11 @@ public partial class FilesPageViewModel : ViewModelBase
 
     [ObservableProperty]
     private int totalCount;
+
+    partial void OnTotalCountChanged(int value)
+    {
+        _deleteAllCommand.NotifyCanExecuteChanged();
+    }
 
     [ObservableProperty]
     private double targetPage;
@@ -705,6 +712,8 @@ public partial class FilesPageViewModel : ViewModelBase
 
     private static bool CanDeleteFile(FileSummaryDto? summary) => summary is not null;
 
+    private bool CanDeleteAll() => TotalCount > 0;
+
     private static string GenerateDeleteAllCode()
     {
         const string chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
@@ -731,7 +740,7 @@ public partial class FilesPageViewModel : ViewModelBase
             {
                 DataContext = this,
             },
-            PrimaryButtonText = "Smazat vše",
+            PrimaryButtonText = "Smazat databázi",
             CloseButtonText = "Zrušit",
             DefaultButton = ContentDialogButton.Close,
         };

--- a/Veriado.WinUI/Views/Files/FilesPage.xaml
+++ b/Veriado.WinUI/Views/Files/FilesPage.xaml
@@ -99,7 +99,7 @@
                         Command="{Binding DeleteAllCommand}">
                     <StackPanel Orientation="Horizontal" Spacing="4">
                         <FontIcon FontFamily="Segoe Fluent Icons" Glyph="&#xE74D;"/>
-                        <TextBlock Text="Smazat vše"/>
+                        <TextBlock Text="Smazat databázi"/>
                     </StackPanel>
                 </Button>
             </StackPanel>


### PR DESCRIPTION
## Summary
- rename the delete-all UI text to "Smazat databázi" for clarity and consistency with the dialog
- disable the delete database command when no items are present

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923f83b78448326b749538cb63c24af)