### PR TITLE
Add storage settings management UI

### DIFF
--- a/Veriado.Infrastructure/FileSystem/FilePathResolver.cs
+++ b/Veriado.Infrastructure/FileSystem/FilePathResolver.cs
@@ -137,7 +137,7 @@ public sealed class FilePathResolver : IFilePathResolver
         }
     }
 
-    internal void OverrideCachedRoot(string normalizedRoot)
+    public void OverrideCachedRoot(string normalizedRoot)
     {
         if (string.IsNullOrWhiteSpace(normalizedRoot))
         {

--- a/Veriado.Infrastructure/Storage/StorageRootValidator.cs
+++ b/Veriado.Infrastructure/Storage/StorageRootValidator.cs
@@ -4,7 +4,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Veriado.Infrastructure.Storage;
 
-internal static class StorageRootValidator
+public static class StorageRootValidator
 {
     public static string ValidateWritableRoot(string proposedRoot, ILogger logger)
     {

--- a/Veriado.Services/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/Veriado.Services/DependencyInjection/ServiceCollectionExtensions.cs
@@ -39,6 +39,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IProcessLauncher, ProcessLauncher>();
         services.AddScoped<IMaintenanceService, MaintenanceService>();
         services.AddScoped<IHealthService, HealthService>();
+        services.AddScoped<IStorageSettingsService, StorageSettingsService>();
         services.AddScoped<IStorageManagementService, StorageManagementService>();
         services.AddSingleton<ISearchFacade, SearchFacade>();
         services.AddSingleton<ApplicationFileSystemSyncService, FileSystemSyncService>();

--- a/Veriado.Services/Storage/IStorageSettingsService.cs
+++ b/Veriado.Services/Storage/IStorageSettingsService.cs
@@ -1,0 +1,24 @@
+namespace Veriado.Services.Storage;
+
+public sealed class StorageSettingsDto
+{
+    public string? CurrentRootPath { get; init; }
+
+    public bool CanChangeRoot { get; init; }
+}
+
+public enum ChangeStorageRootResult
+{
+    Success,
+    CatalogNotEmpty,
+    InvalidPath,
+    IoError,
+    UnknownError,
+}
+
+public interface IStorageSettingsService
+{
+    Task<StorageSettingsDto> GetStorageSettingsAsync(CancellationToken cancellationToken = default);
+
+    Task<ChangeStorageRootResult> ChangeStorageRootAsync(string newRootPath, CancellationToken cancellationToken = default);
+}

--- a/Veriado.Services/Storage/StorageSettingsService.cs
+++ b/Veriado.Services/Storage/StorageSettingsService.cs
@@ -1,0 +1,155 @@
+using System.IO;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Veriado.Infrastructure.FileSystem;
+using Veriado.Infrastructure.Persistence;
+using Veriado.Infrastructure.Persistence.Entities;
+using Veriado.Infrastructure.Storage;
+
+namespace Veriado.Services.Storage;
+
+public sealed class StorageSettingsService : IStorageSettingsService
+{
+    private readonly IDbContextFactory<AppDbContext> _dbContextFactory;
+    private readonly IFilePathResolver _pathResolver;
+    private readonly ILogger<StorageSettingsService> _logger;
+
+    public StorageSettingsService(
+        IDbContextFactory<AppDbContext> dbContextFactory,
+        IFilePathResolver pathResolver,
+        ILogger<StorageSettingsService> logger)
+    {
+        _dbContextFactory = dbContextFactory ?? throw new ArgumentNullException(nameof(dbContextFactory));
+        _pathResolver = pathResolver ?? throw new ArgumentNullException(nameof(pathResolver));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<StorageSettingsDto> GetStorageSettingsAsync(CancellationToken cancellationToken = default)
+    {
+        await using var dbContext = await _dbContextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+        var root = await dbContext.StorageRoots
+            .AsNoTracking()
+            .SingleOrDefaultAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        var hasFiles = await dbContext.FileSystems
+            .AsNoTracking()
+            .AnyAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return new StorageSettingsDto
+        {
+            CurrentRootPath = root?.RootPath,
+            CanChangeRoot = !hasFiles,
+        };
+    }
+
+    public async Task<ChangeStorageRootResult> ChangeStorageRootAsync(string newRootPath, CancellationToken cancellationToken = default)
+    {
+        await using var dbContext = await _dbContextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+
+        var hasFiles = await dbContext.FileSystems
+            .AsNoTracking()
+            .AnyAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        if (hasFiles)
+        {
+            return ChangeStorageRootResult.CatalogNotEmpty;
+        }
+
+        if (string.IsNullOrWhiteSpace(newRootPath))
+        {
+            return ChangeStorageRootResult.InvalidPath;
+        }
+
+        string normalizedRoot;
+        try
+        {
+            normalizedRoot = StorageRootValidator.ValidateWritableRoot(newRootPath, _logger);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex) when (ex is ArgumentException or InvalidOperationException)
+        {
+            _logger.LogWarning(ex, "Invalid storage root path {RootPath}.", newRootPath);
+            return ChangeStorageRootResult.InvalidPath;
+        }
+        catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException)
+        {
+            _logger.LogError(ex, "I/O error while validating storage root {RootPath}.", newRootPath);
+            return ChangeStorageRootResult.IoError;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unexpected error while validating storage root {RootPath}.", newRootPath);
+            return ChangeStorageRootResult.UnknownError;
+        }
+
+        try
+        {
+            Directory.CreateDirectory(normalizedRoot);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException)
+        {
+            _logger.LogError(ex, "I/O error while ensuring storage root exists {RootPath}.", normalizedRoot);
+            return ChangeStorageRootResult.IoError;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unexpected error while creating storage root directory {RootPath}.", normalizedRoot);
+            return ChangeStorageRootResult.UnknownError;
+        }
+
+        try
+        {
+            var existing = await dbContext.StorageRoots
+                .SingleOrDefaultAsync(cancellationToken)
+                .ConfigureAwait(false);
+
+            if (existing is null)
+            {
+                await dbContext.StorageRoots
+                    .AddAsync(new FileStorageRootEntity(normalizedRoot), cancellationToken)
+                    .ConfigureAwait(false);
+            }
+            else
+            {
+                existing.UpdateRootPath(normalizedRoot);
+            }
+
+            await dbContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+            if (_pathResolver is FilePathResolver resolver)
+            {
+                resolver.OverrideCachedRoot(normalizedRoot);
+            }
+            else
+            {
+                _pathResolver.InvalidateRootCache();
+            }
+
+            return ChangeStorageRootResult.Success;
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException)
+        {
+            _logger.LogError(ex, "I/O error while persisting storage root {RootPath}.", normalizedRoot);
+            return ChangeStorageRootResult.IoError;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unexpected error while updating storage root {RootPath}.", normalizedRoot);
+            return ChangeStorageRootResult.UnknownError;
+        }
+    }
+}

--- a/Veriado.WinUI/ViewModels/Settings/SettingsPageViewModel.cs
+++ b/Veriado.WinUI/ViewModels/Settings/SettingsPageViewModel.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using Veriado.Contracts.Localization;
+using Veriado.Services.Storage;
 using Veriado.WinUI.Services.Abstractions;
 using Veriado.WinUI.ViewModels.Base;
 
@@ -7,11 +8,18 @@ namespace Veriado.WinUI.ViewModels.Settings;
 
 public partial class SettingsPageViewModel : ViewModelBase
 {
+    private readonly IStorageSettingsService _storageSettingsService;
+    private readonly IPickerService _pickerService;
     private readonly IHotStateService _hotStateService;
     private readonly IThemeService _themeService;
     private readonly AsyncRelayCommand _applyThemeCommand;
+    private readonly AsyncRelayCommand _loadStorageSettingsCommand;
+    private readonly AsyncRelayCommand _browseStorageRootCommand;
+    private readonly AsyncRelayCommand _saveStorageRootCommand;
 
     public SettingsPageViewModel(
+        IStorageSettingsService storageSettingsService,
+        IPickerService pickerService,
         IHotStateService hotStateService,
         IThemeService themeService,
         IMessenger messenger,
@@ -20,6 +28,8 @@ public partial class SettingsPageViewModel : ViewModelBase
         IExceptionHandler exceptionHandler)
         : base(messenger, statusService, dispatcher, exceptionHandler)
     {
+        _storageSettingsService = storageSettingsService ?? throw new ArgumentNullException(nameof(storageSettingsService));
+        _pickerService = pickerService ?? throw new ArgumentNullException(nameof(pickerService));
         _hotStateService = hotStateService ?? throw new ArgumentNullException(nameof(hotStateService));
         _themeService = themeService ?? throw new ArgumentNullException(nameof(themeService));
 
@@ -32,6 +42,9 @@ public partial class SettingsPageViewModel : ViewModelBase
 
         ThemeOptions = Array.AsReadOnly(Enum.GetValues<AppTheme>());
         _applyThemeCommand = new AsyncRelayCommand(ApplyThemeAsync);
+        _loadStorageSettingsCommand = new AsyncRelayCommand(LoadStorageSettingsAsync);
+        _browseStorageRootCommand = new AsyncRelayCommand(BrowseStorageRootAsync, () => CanChangeStorageRoot);
+        _saveStorageRootCommand = new AsyncRelayCommand(SaveStorageRootAsync, () => CanChangeStorageRoot);
         if (_hotStateService is INotifyPropertyChanged observable)
         {
             observable.PropertyChanged += OnHotStatePropertyChanged;
@@ -60,6 +73,102 @@ public partial class SettingsPageViewModel : ViewModelBase
 
     public IAsyncRelayCommand ApplyThemeCommand => _applyThemeCommand;
 
+    [ObservableProperty]
+    private string? currentStorageRoot;
+
+    [ObservableProperty]
+    private bool canChangeStorageRoot;
+
+    [ObservableProperty]
+    private string? newStorageRootCandidate;
+
+    [ObservableProperty]
+    private string? storageChangeMessage;
+
+    public IAsyncRelayCommand LoadStorageSettingsCommand => _loadStorageSettingsCommand;
+
+    public IAsyncRelayCommand BrowseStorageRootCommand => _browseStorageRootCommand;
+
+    public IAsyncRelayCommand SaveStorageRootCommand => _saveStorageRootCommand;
+
+    private Task LoadStorageSettingsAsync()
+    {
+        return SafeExecuteAsync(async cancellationToken =>
+        {
+            var dto = await _storageSettingsService
+                .GetStorageSettingsAsync(cancellationToken)
+                .ConfigureAwait(false);
+
+            CurrentStorageRoot = dto.CurrentRootPath;
+            CanChangeStorageRoot = dto.CanChangeRoot;
+            NewStorageRootCandidate = dto.CurrentRootPath;
+
+            StorageChangeMessage = dto.CanChangeRoot
+                ? null
+                : "Pro změnu úložiště je nutná migrace.";
+        });
+    }
+
+    private Task BrowseStorageRootAsync()
+    {
+        if (!CanChangeStorageRoot)
+        {
+            return Task.CompletedTask;
+        }
+
+        return SafeExecuteAsync(async _ =>
+        {
+            var folder = await _pickerService.PickFolderAsync().ConfigureAwait(false);
+            if (!string.IsNullOrWhiteSpace(folder))
+            {
+                NewStorageRootCandidate = folder;
+            }
+        });
+    }
+
+    private Task SaveStorageRootAsync()
+    {
+        if (!CanChangeStorageRoot || string.IsNullOrWhiteSpace(NewStorageRootCandidate))
+        {
+            return Task.CompletedTask;
+        }
+
+        return SafeExecuteAsync(async cancellationToken =>
+        {
+            var result = await _storageSettingsService
+                .ChangeStorageRootAsync(NewStorageRootCandidate!, cancellationToken)
+                .ConfigureAwait(false);
+
+            switch (result)
+            {
+                case ChangeStorageRootResult.Success:
+                    StorageChangeMessage = "Složka úložiště byla úspěšně změněna.";
+                    CurrentStorageRoot = NewStorageRootCandidate;
+                    break;
+
+                case ChangeStorageRootResult.CatalogNotEmpty:
+                    StorageChangeMessage = "Pro změnu úložiště je nutná migrace.";
+                    CanChangeStorageRoot = false;
+                    break;
+
+                case ChangeStorageRootResult.InvalidPath:
+                    StorageChangeMessage = "Neplatná cesta k úložišti. Zkontrolujte prosím složku.";
+                    break;
+
+                case ChangeStorageRootResult.IoError:
+                    StorageChangeMessage = "Složku úložiště nelze použít kvůli chybě při přístupu na disk.";
+                    break;
+
+                default:
+                    StorageChangeMessage = "Došlo k neočekávané chybě při změně úložiště.";
+                    break;
+            }
+
+            _browseStorageRootCommand.NotifyCanExecuteChanged();
+            _saveStorageRootCommand.NotifyCanExecuteChanged();
+        });
+    }
+
     private Task ApplyThemeAsync()
     {
         return SafeExecuteAsync(async cancellationToken =>
@@ -67,6 +176,12 @@ public partial class SettingsPageViewModel : ViewModelBase
             await _themeService.SetThemeAsync(ThemeMode, cancellationToken).ConfigureAwait(false);
             StatusService.Info("Motiv byl použit.");
         });
+    }
+
+    partial void OnCanChangeStorageRootChanged(bool value)
+    {
+        _browseStorageRootCommand.NotifyCanExecuteChanged();
+        _saveStorageRootCommand.NotifyCanExecuteChanged();
     }
 
     partial void OnPageSizeChanged(int value)

--- a/Veriado.WinUI/Views/Settings/SettingsPage.xaml
+++ b/Veriado.WinUI/Views/Settings/SettingsPage.xaml
@@ -48,6 +48,38 @@
             SpinButtonPlacementMode="Compact"
             Value="{Binding ValidityGreenThreshold, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
 
+        <StackPanel Orientation="Vertical" Spacing="12">
+            <TextBlock Text="Uložiště dokumentů"
+                       FontSize="20"
+                       FontWeight="SemiBold"
+                       Margin="0,16,0,4" />
+
+            <TextBlock Text="Aktuální složka úložiště:"
+                       FontWeight="SemiBold" />
+            <TextBlock Text="{Binding CurrentStorageRoot}"
+                       TextTrimming="CharacterEllipsis"
+                       MaxWidth="600" />
+
+            <StackPanel Orientation="Horizontal" Spacing="8" Margin="0,8,0,0">
+                <TextBox Width="400"
+                         IsReadOnly="True"
+                         Text="{Binding NewStorageRootCandidate, Mode=OneWay}" />
+
+                <Button Content="Změnit složku"
+                        Command="{Binding BrowseStorageRootCommand}"
+                        IsEnabled="{Binding CanChangeStorageRoot}" />
+
+                <Button Content="Uložit"
+                        Command="{Binding SaveStorageRootCommand}"
+                        IsEnabled="{Binding CanChangeStorageRoot}" />
+            </StackPanel>
+
+            <TextBlock Text="{Binding StorageChangeMessage}"
+                       TextWrapping="Wrap"
+                       Foreground="{ThemeResource SystemControlForegroundBaseMediumBrush}"
+                       Margin="0,4,0,0" />
+        </StackPanel>
+
         <Button Content="Použít motiv" Command="{Binding ApplyThemeCommand}" />
     </StackPanel>
 </Page>

--- a/Veriado.WinUI/Views/Settings/SettingsPage.xaml.cs
+++ b/Veriado.WinUI/Views/Settings/SettingsPage.xaml.cs
@@ -5,5 +5,15 @@ public sealed partial class SettingsPage : Page
     public SettingsPage()
     {
         InitializeComponent();
+        Loaded += OnLoaded;
+    }
+
+    private async void OnLoaded(object sender, RoutedEventArgs e)
+    {
+        Loaded -= OnLoaded;
+        if (DataContext is ViewModels.Settings.SettingsPageViewModel viewModel)
+        {
+            await viewModel.LoadStorageSettingsCommand.ExecuteAsync(null);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add a storage settings service that only updates the storage root when the catalog is empty and refreshes the path resolver cache
- expose storage root helper APIs and register the new service in DI for consumption
- extend the settings view model and page with storage root bindings, messaging, and folder picker workflow

## Testing
- dotnet build Veriado.sln *(fails: `dotnet` CLI not available in container environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692408bfb274832681e609a8d923d65d)