### PR TITLE
Add concurrency token to file content revision

### DIFF
--- a/Veriado.Infrastructure/Persistence/Configurations/FileEntityConfiguration.cs
+++ b/Veriado.Infrastructure/Persistence/Configurations/FileEntityConfiguration.cs
@@ -64,7 +64,8 @@ internal sealed class FileEntityConfiguration : IEntityTypeConfiguration<FileEnt
 
         builder.Property(file => file.ContentRevision)
             .HasColumnName("content_revision")
-            .IsRequired();
+            .IsRequired()
+            .IsConcurrencyToken();
 
         builder.OwnsOne(file => file.Content, owned =>
         {


### PR DESCRIPTION
## Summary
- mark the file content revision column as a concurrency token to enforce optimistic concurrency checks during updates

## Testing
- dotnet test (fails: dotnet not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925848c72ac8326915914d94d159222)