### PR TITLE
Improve async task handling

### DIFF
--- a/Veriado.WinUI/ViewModels/Files/FileDetailDialogViewModel.cs
+++ b/Veriado.WinUI/ViewModels/Files/FileDetailDialogViewModel.cs
@@ -286,7 +286,7 @@ public sealed partial class FileDetailDialogViewModel : ObservableObject, IDialo
 
     private async Task ExecuteSaveCommandAsync()
     {
-        _ = await ExecuteSaveAsync().ConfigureAwait(false);
+        await ExecuteSaveAsync().ConfigureAwait(false);
     }
 
     private void ExecuteCancel()

--- a/Veriado.WinUI/Views/Files/FilesPage.xaml.cs
+++ b/Veriado.WinUI/Views/Files/FilesPage.xaml.cs
@@ -45,14 +45,14 @@ public sealed partial class FilesPage : Page
         Loaded -= OnLoaded;
         _validityRefreshTimer.Start();
         RefreshValidityIndicators();
-        ViewModel.StartHealthMonitoring();
+        await ViewModel.StartHealthMonitoringAsync().ConfigureAwait(true);
         await ExecuteInitialRefreshAsync().ConfigureAwait(true);
         RefreshValidityIndicators();
     }
 
-    private void OnUnloaded(object sender, RoutedEventArgs e)
+    private async void OnUnloaded(object sender, RoutedEventArgs e)
     {
-        ViewModel.StopHealthMonitoring();
+        await ViewModel.StopHealthMonitoringAsync().ConfigureAwait(true);
         CancelSuggestionRequest();
         if (_validityRefreshTimer.IsEnabled)
         {


### PR DESCRIPTION
## Summary
- convert import page stop/clear commands to async and await status updates instead of fire-and-forget
- ensure file detail dialog save command awaits save execution
- add observed background task handling and awaited health monitoring lifecycle on files page

## Testing
- dotnet build Veriado.sln *(fails: `dotnet` command not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925a5a5f6b88326a945e71900c3bb4b)