### PR TITLE
Avoid blocking FilesPage initial refresh during health monitoring

### DIFF
--- a/Veriado.WinUI/Views/Files/FilesPage.xaml.cs
+++ b/Veriado.WinUI/Views/Files/FilesPage.xaml.cs
@@ -45,7 +45,7 @@ public sealed partial class FilesPage : Page
         Loaded -= OnLoaded;
         _validityRefreshTimer.Start();
         RefreshValidityIndicators();
-        await ViewModel.StartHealthMonitoringAsync().ConfigureAwait(true);
+        _ = ViewModel.StartHealthMonitoringAsync();
         await ExecuteInitialRefreshAsync().ConfigureAwait(true);
         RefreshValidityIndicators();
     }


### PR DESCRIPTION
## Summary
- start FilesPage health monitoring without awaiting the long-running loop to allow initial refresh

## Testing
- not run (dotnet not available in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925a8b1f4a48326881d30795c55e1fb)