### PR TITLE
Improve async handling and cancellation safety

### DIFF
--- a/Veriado.Infrastructure/FileSystem/FileSystemMonitoringHostedService.cs
+++ b/Veriado.Infrastructure/FileSystem/FileSystemMonitoringHostedService.cs
@@ -25,4 +25,10 @@ internal sealed class FileSystemMonitoringHostedService : BackgroundService
         _monitoringService.Dispose();
         base.Dispose();
     }
+
+    public override async ValueTask DisposeAsync()
+    {
+        await _monitoringService.DisposeAsync().ConfigureAwait(false);
+        await base.DisposeAsync().ConfigureAwait(false);
+    }
 }

--- a/Veriado.Infrastructure/FileSystem/IFileSystemMonitoringService.cs
+++ b/Veriado.Infrastructure/FileSystem/IFileSystemMonitoringService.cs
@@ -3,7 +3,7 @@ using System.Threading;
 
 namespace Veriado.Infrastructure.FileSystem;
 
-public interface IFileSystemMonitoringService : IDisposable
+public interface IFileSystemMonitoringService : IDisposable, IAsyncDisposable
 {
     void Start(CancellationToken cancellationToken);
 }

--- a/Veriado.WinUI/Services/HotStateService.cs
+++ b/Veriado.WinUI/Services/HotStateService.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Veriado.Contracts.Files;
 using Veriado.WinUI.Services.Abstractions;
@@ -209,7 +210,17 @@ public sealed partial class HotStateService : ObservableObject, IHotStateService
             return;
         }
 
-        _ = PersistStateAsync();
+        _ = PersistStateAsync().ContinueWith(
+            t =>
+            {
+                if (t.Exception is not null)
+                {
+                    _logger.LogError(t.Exception, "Failed to persist hot state.");
+                }
+            },
+            CancellationToken.None,
+            TaskContinuationOptions.OnlyOnFaulted,
+            TaskScheduler.Default);
     }
 
     private async Task PersistStateAsync()


### PR DESCRIPTION
## Summary
- handle hot state persistence fire-and-forget operations with fault logging to avoid unobserved exceptions
- convert file system monitoring disposal to asynchronous flow and ensure watcher event handling logs failures
- update hosted service to support asynchronous disposal

## Testing
- dotnet build Veriado.sln *(fails: dotnet command not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925ad12e7a88326a4a4ba13eb9f3806)