### PR TITLE
Handle dispatcher async callbacks safely

### DIFF
--- a/Veriado.WinUI/Services/DispatcherService.cs
+++ b/Veriado.WinUI/Services/DispatcherService.cs
@@ -1,4 +1,5 @@
 using Microsoft.UI.Dispatching;
+using System.Threading.Tasks;
 
 namespace Veriado.WinUI.Services;
 
@@ -156,7 +157,17 @@ public sealed class DispatcherService : IDispatcherService
         }
     }
 
-    private static async void ExecuteAsync(Func<Task> action, TaskCompletionSource<object?> completion)
+    private static void ExecuteAsync(Func<Task> action, TaskCompletionSource<object?> completion)
+    {
+        _ = ExecuteAsyncCore(action, completion);
+    }
+
+    private static void ExecuteAsync<T>(Func<Task<T>> action, TaskCompletionSource<T> completion)
+    {
+        _ = ExecuteAsyncCore(action, completion);
+    }
+
+    private static async Task ExecuteAsyncCore(Func<Task> action, TaskCompletionSource<object?> completion)
     {
         try
         {
@@ -176,7 +187,7 @@ public sealed class DispatcherService : IDispatcherService
         }
     }
 
-    private static async void ExecuteAsync<T>(Func<Task<T>> action, TaskCompletionSource<T> completion)
+    private static async Task ExecuteAsyncCore<T>(Func<Task<T>> action, TaskCompletionSource<T> completion)
     {
         try
         {


### PR DESCRIPTION
## Summary
- replace dispatcher async void helpers with task-returning implementations to surface exceptions via completion sources
- add explicit task using directive for dispatcher service

## Testing
- dotnet build Veriado.sln *(fails: dotnet CLI not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925b2c56a0c83269269fd97a44f9ca7)