### PR TITLE
Ensure dispatcher enqueued tasks are awaited

### DIFF
--- a/Veriado.WinUI/Services/DispatcherService.cs
+++ b/Veriado.WinUI/Services/DispatcherService.cs
@@ -157,14 +157,14 @@ public sealed class DispatcherService : IDispatcherService
         }
     }
 
-    private static void ExecuteAsync(Func<Task> action, TaskCompletionSource<object?> completion)
+    private static async void ExecuteAsync(Func<Task> action, TaskCompletionSource<object?> completion)
     {
-        _ = ExecuteAsyncCore(action, completion);
+        await ExecuteAsyncCore(action, completion).ConfigureAwait(true);
     }
 
-    private static void ExecuteAsync<T>(Func<Task<T>> action, TaskCompletionSource<T> completion)
+    private static async void ExecuteAsync<T>(Func<Task<T>> action, TaskCompletionSource<T> completion)
     {
-        _ = ExecuteAsyncCore(action, completion);
+        await ExecuteAsyncCore(action, completion).ConfigureAwait(true);
     }
 
     private static async Task ExecuteAsyncCore(Func<Task> action, TaskCompletionSource<object?> completion)


### PR DESCRIPTION
## Summary
- ensure dispatcher async execution helpers await their inner tasks to avoid unobserved failures

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925b56e1d0c8326891f50198b09f231)