### PR TITLE
Fix async usage and cancellation handling

### DIFF
--- a/Veriado.Infrastructure/FileSystem/FileSystemMonitoringHostedService.cs
+++ b/Veriado.Infrastructure/FileSystem/FileSystemMonitoringHostedService.cs
@@ -5,7 +5,7 @@ using Microsoft.Extensions.Hosting;
 
 namespace Veriado.Infrastructure.FileSystem;
 
-internal sealed class FileSystemMonitoringHostedService : BackgroundService
+internal sealed class FileSystemMonitoringHostedService : BackgroundService, IAsyncDisposable
 {
     private readonly IFileSystemMonitoringService _monitoringService;
 
@@ -26,9 +26,9 @@ internal sealed class FileSystemMonitoringHostedService : BackgroundService
         base.Dispose();
     }
 
-    public override async ValueTask DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
         await _monitoringService.DisposeAsync().ConfigureAwait(false);
-        await base.DisposeAsync().ConfigureAwait(false);
+        Dispose();
     }
 }

--- a/Veriado.WinUI/Services/HotStateService.cs
+++ b/Veriado.WinUI/Services/HotStateService.cs
@@ -131,17 +131,7 @@ public sealed partial class HotStateService : ObservableObject, IHotStateService
 
     partial void OnLastFolderChanged(string? value) => SchedulePersistAsync();
 
-    partial void OnPageSizeChanged(int value)
-    {
-        if (value <= 0)
-        {
-            pageSize = AppSettings.DefaultPageSize;
-            OnPropertyChanged(nameof(PageSize));
-        }
-
-        SchedulePersistAsync(cancellationToken);
-        await _persistTask.ConfigureAwait(false);
-    }
+    partial void OnPageSizeChanged(int value) => _ = OnPageSizeChangedAsync(value);
 
     partial void OnImportRecursiveChanged(bool value) => SchedulePersistAsync();
 
@@ -214,6 +204,18 @@ public sealed partial class HotStateService : ObservableObject, IHotStateService
         }
 
         return PersistStateAsync(cancellationToken);
+    }
+
+    private async Task OnPageSizeChangedAsync(int value)
+    {
+        if (value <= 0)
+        {
+            pageSize = AppSettings.DefaultPageSize;
+            OnPropertyChanged(nameof(PageSize));
+        }
+
+        SchedulePersistAsync();
+        await _persistTask.ConfigureAwait(false);
     }
 
     private void SchedulePersistAsync(CancellationToken cancellationToken = default)


### PR DESCRIPTION
## Summary
- prevent unobserved async calls in HotStateService and fix invalid cancellation token usage
- ensure page size persistence is awaited through an async helper
- implement IAsyncDisposable for FileSystemMonitoringHostedService without invalid override

## Testing
- dotnet build (fails: dotnet CLI not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925dca1541083269d56fa13f72f2275)