### PR TITLE
Use delete-all to clear FTS index

### DIFF
--- a/Veriado.Services/Files/CatalogMaintenanceService.cs
+++ b/Veriado.Services/Files/CatalogMaintenanceService.cs
@@ -56,7 +56,8 @@ public sealed class CatalogMaintenanceService : ICatalogMaintenanceService
         db.ReindexQueue.RemoveRange(db.ReindexQueue);
         db.DomainEventLog.RemoveRange(db.DomainEventLog);
 
-        await db.Database.ExecuteSqlRawAsync("DELETE FROM search_document_fts;", cancellationToken).ConfigureAwait(false);
+        await db.Database.ExecuteSqlRawAsync("INSERT INTO search_document_fts(search_document_fts) VALUES ('delete-all');", cancellationToken)
+            .ConfigureAwait(false);
         await db.Database.ExecuteSqlRawAsync("DELETE FROM search_document;", cancellationToken).ConfigureAwait(false);
 
         await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
## Summary
- clear the contentless FTS table using the FTS5 delete-all command to avoid delete errors
- continue clearing the associated search_document table during catalog cleanup

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925df83304883268b2178ba831f4071)