### PR TITLE
Fix delete all dialog continuation on UI thread

### DIFF
--- a/Veriado.WinUI/ViewModels/Files/FilesPageViewModel.cs
+++ b/Veriado.WinUI/ViewModels/Files/FilesPageViewModel.cs
@@ -824,7 +824,7 @@ public partial class FilesPageViewModel : ViewModelBase
         ContentDialogResult result;
         try
         {
-            result = await _dialogService.ShowDialogAsync(dialog).ConfigureAwait(false);
+            result = await _dialogService.ShowDialogAsync(dialog);
         }
         finally
         {


### PR DESCRIPTION
## Summary
- keep DeleteAll dialog flow on the UI thread to avoid WinRT activation errors

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925e1ae7bd48326b758ae261be46c25)