### PR TITLE
Expose SQLite exception extensions to other assemblies

### DIFF
--- a/Veriado.Infrastructure/Search/SqliteExceptionExtensions.cs
+++ b/Veriado.Infrastructure/Search/SqliteExceptionExtensions.cs
@@ -1,6 +1,6 @@
 namespace Veriado.Infrastructure.Search;
 
-internal static class SqliteExceptionExtensions
+public static class SqliteExceptionExtensions
 {
     private const int SqliteCorrupt = 11;
     private const int SqliteNotADatabase = 26;


### PR DESCRIPTION
## Summary
- Make SqliteExceptionExtensions public so extension methods like IndicatesDatabaseCorruption are visible to consuming projects

## Testing
- dotnet build Veriado.sln *(fails: dotnet command not found in container environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925e7907be48326a1d2735b76028f7c)