### PR TITLE
Handle failures during catalog clearing

### DIFF
--- a/Veriado.Services/Files/CatalogMaintenanceService.cs
+++ b/Veriado.Services/Files/CatalogMaintenanceService.cs
@@ -43,6 +43,15 @@ public sealed class CatalogMaintenanceService : ICatalogMaintenanceService
             _logger.LogWarning(ex, "Database corruption detected while clearing catalog; recreating database file.");
             await RecreateDatabaseAsync(cancellationToken).ConfigureAwait(false);
         }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Unexpected failure while clearing catalog; recreating database file.");
+            await RecreateDatabaseAsync(cancellationToken).ConfigureAwait(false);
+        }
     }
 
     private async Task ClearCatalogInternalAsync(CancellationToken cancellationToken)


### PR DESCRIPTION
## Summary
- recreate the database file when catalog deletion fails unexpectedly
- preserve cancellation behavior while logging unexpected cleanup errors

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925e86be3488326bca11bf1d45d73df)