### PR TITLE
Handle fatal SQLite fulltext errors during catalog clear

### DIFF
--- a/Veriado.Services/Files/CatalogMaintenanceService.cs
+++ b/Veriado.Services/Files/CatalogMaintenanceService.cs
@@ -95,7 +95,7 @@ public sealed class CatalogMaintenanceService : ICatalogMaintenanceService
                 .ConfigureAwait(false);
             await db.Database.ExecuteSqlRawAsync("DELETE FROM search_document;", cancellationToken).ConfigureAwait(false);
         }
-        catch (SqliteException ex)
+        catch (SqliteException ex) when (!ex.IndicatesFatalFulltextFailure())
         {
             rebuildFulltext = true;
             _logger.LogWarning(ex, "Failed to clear full-text catalog; forcing full rebuild.");


### PR DESCRIPTION
## Summary
- allow fatal full-text SQLite failures to propagate so catalog recreation can run
- limit full-text rebuilds to non-fatal SQLite errors during catalog clearing

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925ed6da06c8326b1ce9537226534fe)