### PR TITLE
Coordinate maintenance during database reset

### DIFF
--- a/Veriado.Application/Abstractions/IApplicationMaintenanceCoordinator.cs
+++ b/Veriado.Application/Abstractions/IApplicationMaintenanceCoordinator.cs
@@ -1,0 +1,13 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Veriado.Appl.Abstractions;
+
+public interface IApplicationMaintenanceCoordinator
+{
+    Task PauseBackgroundWorkAsync(CancellationToken cancellationToken = default);
+
+    Task ResumeBackgroundWorkAsync(CancellationToken cancellationToken = default);
+
+    Task WaitForResumeAsync(CancellationToken cancellationToken = default);
+}

--- a/Veriado.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/Veriado.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
@@ -218,6 +218,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<INeedsReindexEvaluator, NeedsReindexEvaluator>();
         services.AddSingleton<AuditEventProjector>();
         services.AddSingleton<IIdempotencyStore, SqliteIdempotencyStore>();
+        services.AddSingleton<IApplicationMaintenanceCoordinator, ApplicationMaintenanceCoordinator>();
 
         services.AddScoped<ISearchProjectionScope, SearchProjectionScopeEf>();
         services.AddScoped<IFileSearchProjection, SearchProjectionService>();

--- a/Veriado.Infrastructure/FileSystem/FileSystemMonitoringService.cs
+++ b/Veriado.Infrastructure/FileSystem/FileSystemMonitoringService.cs
@@ -25,6 +25,7 @@ internal sealed class FileSystemMonitoringService : IFileSystemMonitoringService
     private readonly IFilePathResolver _pathResolver;
     private readonly IServiceScopeFactory _scopeFactory;
     private readonly IOperationalPauseCoordinator _pauseCoordinator;
+    private readonly IApplicationMaintenanceCoordinator _maintenanceCoordinator;
     private readonly ApplicationFileSystemSyncService _syncService;
     private readonly ApplicationClock _clock;
     private readonly ILogger<FileSystemMonitoringService> _logger;
@@ -38,6 +39,7 @@ internal sealed class FileSystemMonitoringService : IFileSystemMonitoringService
         IFilePathResolver pathResolver,
         IServiceScopeFactory scopeFactory,
         IOperationalPauseCoordinator pauseCoordinator,
+        IApplicationMaintenanceCoordinator maintenanceCoordinator,
         ApplicationFileSystemSyncService syncService,
         ApplicationClock clock,
         ILogger<FileSystemMonitoringService> logger)
@@ -45,6 +47,8 @@ internal sealed class FileSystemMonitoringService : IFileSystemMonitoringService
         _pathResolver = pathResolver ?? throw new ArgumentNullException(nameof(pathResolver));
         _scopeFactory = scopeFactory ?? throw new ArgumentNullException(nameof(scopeFactory));
         _pauseCoordinator = pauseCoordinator ?? throw new ArgumentNullException(nameof(pauseCoordinator));
+        _maintenanceCoordinator = maintenanceCoordinator
+            ?? throw new ArgumentNullException(nameof(maintenanceCoordinator));
         _syncService = syncService ?? throw new ArgumentNullException(nameof(syncService));
         _clock = clock ?? throw new ArgumentNullException(nameof(clock));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
@@ -228,6 +232,7 @@ internal sealed class FileSystemMonitoringService : IFileSystemMonitoringService
         {
             try
             {
+                await _maintenanceCoordinator.WaitForResumeAsync(cancellationToken).ConfigureAwait(false);
                 await _pauseCoordinator.WaitIfPausedAsync(cancellationToken).ConfigureAwait(false);
 
                 var initialEvent = await _eventChannel.Reader.ReadAsync(cancellationToken).ConfigureAwait(false);

--- a/Veriado.Infrastructure/Maintenance/ApplicationMaintenanceCoordinator.cs
+++ b/Veriado.Infrastructure/Maintenance/ApplicationMaintenanceCoordinator.cs
@@ -1,0 +1,27 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Veriado.Appl.Abstractions;
+
+namespace Veriado.Infrastructure.Maintenance;
+
+public sealed class ApplicationMaintenanceCoordinator : IApplicationMaintenanceCoordinator
+{
+    private readonly SemaphoreSlim _gate = new(1, 1);
+
+    public async Task PauseBackgroundWorkAsync(CancellationToken cancellationToken = default)
+    {
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    public Task ResumeBackgroundWorkAsync(CancellationToken cancellationToken = default)
+    {
+        _gate.Release();
+        return Task.CompletedTask;
+    }
+
+    public async Task WaitForResumeAsync(CancellationToken cancellationToken = default)
+    {
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        _gate.Release();
+    }
+}


### PR DESCRIPTION
## Summary
- add an application-wide maintenance coordinator abstraction and register its implementation
- pause background workers that touch the SQLite database and harden catalog recreation with pooled connection cleanup and retrying deletes
- refresh the files UI after database deletion with appropriate user messaging

## Testing
- `dotnet build Veriado.sln` *(fails: .NET SDK not installed in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925f47c3e248326912a9ddf7b8480f7)