### PR TITLE
Fix dialog service calls in FilesPageViewModel

### DIFF
--- a/Veriado.WinUI/ViewModels/Files/FilesPageViewModel.cs
+++ b/Veriado.WinUI/ViewModels/Files/FilesPageViewModel.cs
@@ -844,7 +844,9 @@ public partial class FilesPageViewModel : ViewModelBase
         {
             IsBusy = true;
             await _catalogMaintenanceService.ClearCatalogAsync(CancellationToken.None).ConfigureAwait(false);
-            await _dialogService.ShowInfoAsync("Databáze a katalog byly úspěšně smazány.");
+            await _dialogService.ShowInfoAsync(
+                "Smazání databáze",
+                "Databáze a katalog byly úspěšně smazány.");
         }
         catch (OperationCanceledException)
         {
@@ -852,7 +854,9 @@ public partial class FilesPageViewModel : ViewModelBase
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to clear catalog from UI.");
-            await _dialogService.ShowErrorAsync("Nepodařilo se smazat databázi. Podrobnosti jsou v logu.");
+            await _dialogService.ShowErrorAsync(
+                "Chyba mazání databáze",
+                "Nepodařilo se smazat databázi. Podrobnosti jsou v logu.");
             return;
         }
         finally


### PR DESCRIPTION
## Summary
- supply dialog titles and messages when showing info and error notifications after clearing the catalog

## Testing
- not run (dotnet CLI not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925f6a6bb5083268278fae5b99540e5)