### PR TITLE
Add configurable import performance profiles

### DIFF
--- a/Veriado.Application/Import/IFileImportWriter.cs
+++ b/Veriado.Application/Import/IFileImportWriter.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Veriado.Contracts.Import;
 
 namespace Veriado.Application.Import;
 
@@ -26,7 +27,12 @@ public sealed record ImportItem(
     DateTimeOffset? ModifiedUtc,
     object? Metadata);
 
-public sealed record ImportOptions(int BatchSize = 500, bool UpsertFts = true, bool DetachAfterBatch = true);
+public sealed record ImportOptions(
+    int BatchSize = 500,
+    bool UpsertFts = true,
+    bool DetachAfterBatch = true,
+    PerformanceProfile PerformanceProfile = PerformanceProfile.Normal,
+    int MaxDegreeOfParallelism = 1);
 
 public sealed record ImportResult(int Imported, int Skipped, int Updated);
 

--- a/Veriado.Contracts/Import/ImportFolderRequest.cs
+++ b/Veriado.Contracts/Import/ImportFolderRequest.cs
@@ -35,6 +35,24 @@ public sealed record class ImportFolderRequest
         = 4;
 
     /// <summary>
+    /// Gets or sets the maximum number of concurrently opened files.
+    /// </summary>
+    public int MaxConcurrentReads { get; init; }
+        = 2;
+
+    /// <summary>
+    /// Gets or sets the configured read buffer size in bytes.
+    /// </summary>
+    public int ReadBufferSize { get; init; }
+        = 128 * 1024;
+
+    /// <summary>
+    /// Gets or sets the maximum number of items in a database batch.
+    /// </summary>
+    public int BatchSize { get; init; }
+        = 200;
+
+    /// <summary>
     /// Gets or sets the search pattern applied when enumerating files.
     /// </summary>
     public string? SearchPattern { get; init; }
@@ -52,4 +70,10 @@ public sealed record class ImportFolderRequest
     /// </summary>
     public long? MaxFileSizeBytes { get; init; }
         = null;
+
+    /// <summary>
+    /// Gets or sets the desired performance profile.
+    /// </summary>
+    public PerformanceProfile PerformanceProfile { get; init; }
+        = PerformanceProfile.Normal;
 }

--- a/Veriado.Contracts/Import/ImportOptions.cs
+++ b/Veriado.Contracts/Import/ImportOptions.cs
@@ -20,11 +20,31 @@ public sealed record class ImportOptions
         = 1;
 
     /// <summary>
+    /// Gets or sets the maximum number of files that can be read concurrently from disk.
+    /// Values lower than one are normalized to one.
+    /// </summary>
+    public int MaxConcurrentReads { get; init; }
+        = 1;
+
+    /// <summary>
     /// Gets or sets the buffer size used while streaming file content from disk.
     /// Values lower than four kilobytes are normalized to four kilobytes.
     /// </summary>
-    public int BufferSize { get; init; }
+    public int ReadBufferSize { get; init; }
         = 64 * 1024;
+
+    /// <summary>
+    /// Gets or sets the maximum number of items persisted in a single database batch.
+    /// Values lower than one are normalized to one.
+    /// </summary>
+    public int BatchSize { get; init; }
+        = 200;
+
+    /// <summary>
+    /// Gets or sets the performance profile that influences normalization of other values.
+    /// </summary>
+    public PerformanceProfile PerformanceProfile { get; init; }
+        = PerformanceProfile.Normal;
 
     /// <summary>
     /// Gets or sets a value indicating whether the source file can be deleted by other processes while it is being imported.

--- a/Veriado.Contracts/Import/PerformanceProfile.cs
+++ b/Veriado.Contracts/Import/PerformanceProfile.cs
@@ -1,0 +1,12 @@
+namespace Veriado.Contracts.Import;
+
+/// <summary>
+/// Represents pre-defined performance presets for the import pipeline.
+/// </summary>
+public enum PerformanceProfile
+{
+    Low = 0,
+    Normal = 1,
+    High = 2,
+    Custom = 3,
+}

--- a/Veriado.Services/Import/Ingestion/FileOpener.cs
+++ b/Veriado.Services/Import/Ingestion/FileOpener.cs
@@ -21,7 +21,7 @@ internal static class FileOpener
         ArgumentException.ThrowIfNullOrEmpty(path);
         ArgumentNullException.ThrowIfNull(options);
 
-        var normalizedBufferSize = Math.Max(options.BufferSize, 4096);
+        var normalizedBufferSize = Math.Max(options.ReadBufferSize, 4096);
         var share = ResolveShare(options.SharePolicy);
         var attempts = 0;
         var delay = NormalizeDelay(options.RetryBaseDelay);

--- a/Veriado.Services/Import/Ingestion/ImportOptions.cs
+++ b/Veriado.Services/Import/Ingestion/ImportOptions.cs
@@ -10,7 +10,7 @@ public sealed record class ImportOptions
     /// <summary>
     /// Gets or sets the buffer size used while copying content between streams.
     /// </summary>
-    public int BufferSize { get; init; } = 128 * 1024;
+    public int ReadBufferSize { get; init; } = 128 * 1024;
 
     /// <summary>
     /// Gets or sets the maximum number of retries when the source file is temporarily unavailable.

--- a/Veriado.Services/Import/Ingestion/StreamingFileIngestor.cs
+++ b/Veriado.Services/Import/Ingestion/StreamingFileIngestor.cs
@@ -30,7 +30,7 @@ public sealed class StreamingFileIngestor : IFileIngestor
         cancellationToken.ThrowIfCancellationRequested();
 
         var options = request.Options ?? new ImportOptions();
-        var bufferSize = Math.Max(options.BufferSize, 16 * 1024);
+        var bufferSize = Math.Max(options.ReadBufferSize, 16 * 1024);
 
         var reservation = await _storage
             .ReservePathAsync(request.PreferredStoragePath, cancellationToken)

--- a/Veriado.WinUI/Views/Import/ImportPage.xaml
+++ b/Veriado.WinUI/Views/Import/ImportPage.xaml
@@ -9,6 +9,7 @@
     xmlns:datagrid="using:CommunityToolkit.WinUI.UI.Controls"
     xmlns:toolkit="using:CommunityToolkit.WinUI.Controls"
     xmlns:import="using:Veriado.WinUI.ViewModels.Import"
+    xmlns:contracts="using:Veriado.Contracts.Import"
     xmlns:converters="using:Veriado.WinUI.Converters"
     xmlns:animations="using:Microsoft.UI.Xaml.Media.Animation"
     d:DataContext="{d:DesignInstance Type=import:ImportPageViewModel}"
@@ -216,6 +217,22 @@
                         Content="Automaticky exportovat protokol po dokončení"
                         IsChecked="{Binding AutoExportLog, Mode=TwoWay}" />
                 </StackPanel>
+                <StackPanel Orientation="Vertical" Spacing="8" Width="220">
+                    <TextBlock Text="Výkonový profil" FontWeight="SemiBold" />
+                    <ComboBox
+                        ItemsSource="{Binding PerformanceProfiles}"
+                        SelectedItem="{Binding PerformanceProfile, Mode=TwoWay}">
+                        <ComboBox.ItemTemplate>
+                            <DataTemplate>
+                                <TextBlock Text="{Binding}" />
+                            </DataTemplate>
+                        </ComboBox.ItemTemplate>
+                    </ComboBox>
+                    <TextBlock
+                        FontSize="12"
+                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                        Text="Pro ruční ladění zvolte profil Custom." />
+                </StackPanel>
                 <StackPanel Orientation="Vertical" Spacing="8">
                     <CheckBox Content="Nastavit jen pro čtení" IsChecked="{Binding SetReadOnly, Mode=TwoWay}" />
                     <CheckBox Content="Paralelně" IsChecked="{Binding UseParallel, Mode=TwoWay}" />
@@ -223,9 +240,16 @@
                         Header="Max. paralelních vláken"
                         Minimum="1"
                         SpinButtonPlacementMode="Compact"
-                        IsEnabled="{Binding UseParallel}"
+                        IsEnabled="{Binding IsCustomProfile}"
                         ValidationMode="InvalidInputOverwritten"
                         Value="{Binding MaxDegreeOfParallelism, Mode=TwoWay, Converter={StaticResource NullableIntToDoubleConverter}, TargetNullValue=1}" />
+                    <NumberBox
+                        Header="Max. souběžných čtení"
+                        Minimum="1"
+                        SpinButtonPlacementMode="Compact"
+                        IsEnabled="{Binding IsCustomProfile}"
+                        ValidationMode="InvalidInputOverwritten"
+                        Value="{Binding MaxConcurrentReads, Mode=TwoWay, Converter={StaticResource NullableIntToDoubleConverter}, TargetNullValue=1}" />
                     <muxc:InfoBar
                         Margin="0,4,0,0"
                         IsOpen="{Binding HasParallelismError}"
@@ -233,12 +257,32 @@
                         Title="Neplatný počet vláken"
                         Message="Zadejte kladné celé číslo větší než nula."
                         IsClosable="False" />
+                    <muxc:InfoBar
+                        Margin="0,4,0,0"
+                        IsOpen="{Binding HasConcurrentReadError}"
+                        Severity="Error"
+                        Title="Neplatný počet čtení"
+                        Message="Zadejte kladné celé číslo pro souběžná čtení." />
                 </StackPanel>
                 <StackPanel Orientation="Vertical" Spacing="8" Width="200">
                     <TextBox
                         Header="Výchozí autor"
                         PlaceholderText="(nevyplněno)"
                         Text="{Binding DefaultAuthor, Mode=TwoWay}" />
+                    <NumberBox
+                        Header="Velikost čtecího bufferu (B)"
+                        Minimum="4096"
+                        SpinButtonPlacementMode="Compact"
+                        IsEnabled="{Binding IsCustomProfile}"
+                        ValidationMode="InvalidInputOverwritten"
+                        Value="{Binding ReadBufferSize, Mode=TwoWay, Converter={StaticResource NullableIntToDoubleConverter}, TargetNullValue=131072}" />
+                    <muxc:InfoBar
+                        Margin="0,4,0,0"
+                        IsOpen="{Binding HasBufferSizeError}"
+                        Severity="Error"
+                        Title="Neplatná velikost bufferu"
+                        Message="Použijte kladnou hodnotu v bajtech (min. 4096)."
+                        IsClosable="False" />
                     <NumberBox
                         Header="Max. velikost souboru (MB)"
                         Minimum="0"
@@ -256,6 +300,20 @@
                         FontSize="12"
                         Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                         Text="0 = bez limitu" />
+                    <NumberBox
+                        Header="Velikost batch (DB)"
+                        Minimum="1"
+                        SpinButtonPlacementMode="Compact"
+                        IsEnabled="{Binding IsCustomProfile}"
+                        ValidationMode="InvalidInputOverwritten"
+                        Value="{Binding BatchSize, Mode=TwoWay, Converter={StaticResource NullableIntToDoubleConverter}, TargetNullValue=200}" />
+                    <muxc:InfoBar
+                        Margin="0,4,0,0"
+                        IsOpen="{Binding HasBatchSizeError}"
+                        Severity="Error"
+                        Title="Neplatná velikost batch"
+                        Message="Zadejte kladné číslo (doporučeno 50–200)."
+                        IsClosable="False" />
                 </StackPanel>
             </StackPanel>
         </StackPanel>


### PR DESCRIPTION
## Summary
- add performance profiles and advanced concurrency/buffer settings to import contracts and UI
- enforce safer cancellation and channel consumption while limiting I/O concurrency in the import service
- propagate tuning parameters to ingestion and database import options for better scaling across hardware

## Testing
- ⚠️ `dotnet build Veriado.sln` (unavailable in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6926e263245c8326819f248083746075)