### PR TITLE
Add status warning support and fix import progress iterator

### DIFF
--- a/Veriado.Services/Import/ImportService.cs
+++ b/Veriado.Services/Import/ImportService.cs
@@ -972,16 +972,9 @@ public sealed class ImportService : IImportService
             }
         }
 
-        try
+        await foreach (var progress in channel.Reader.ReadAllAsync(CancellationToken.None).ConfigureAwait(false))
         {
-            await foreach (var progress in channel.Reader.ReadAllAsync(CancellationToken.None).ConfigureAwait(false))
-            {
-                yield return progress;
-            }
-        }
-        catch (OperationCanceledException)
-        {
-            // Channel consumption is shielded from external cancellation to keep teardown graceful.
+            yield return progress;
         }
 
         try

--- a/Veriado.WinUI/Services/Abstractions/IStatusService.cs
+++ b/Veriado.WinUI/Services/Abstractions/IStatusService.cs
@@ -4,6 +4,8 @@ public interface IStatusService
 {
     void Info(string? message);
 
+    void Warning(string? message);
+
     void Error(string? message);
 
     void Clear();

--- a/Veriado.WinUI/Services/StatusService.cs
+++ b/Veriado.WinUI/Services/StatusService.cs
@@ -22,6 +22,17 @@ public sealed class StatusService : IStatusService
         _messenger.Send(new StatusChangedMessage(false, message));
     }
 
+    public void Warning(string? message)
+    {
+        if (string.IsNullOrWhiteSpace(message))
+        {
+            Clear();
+            return;
+        }
+
+        _messenger.Send(new StatusChangedMessage(false, message));
+    }
+
     public void Error(string? message)
     {
         if (string.IsNullOrWhiteSpace(message))


### PR DESCRIPTION
## Summary
- adjust import progress enumeration to avoid yielding inside try/catch
- extend the status service interface and implementation with a warning message helper

## Testing
- dotnet build Veriado.sln *(fails: `dotnet` not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69288d1943ec8326b3d7e52da9fecbac)