### PR TITLE
Fix StorageManagementService verification mapping overload

### DIFF
--- a/Veriado.Services/Storage/StorageManagementService.cs
+++ b/Veriado.Services/Storage/StorageManagementService.cs
@@ -136,8 +136,13 @@ public sealed class StorageManagementService : IStorageManagementService
         };
     }
 
-    private static StorageVerificationOptions Map(StorageVerificationOptionsDto dto)
+    private static StorageVerificationOptions Map(StorageVerificationOptionsDto? dto)
     {
+        if (dto is null)
+        {
+            return new StorageVerificationOptions();
+        }
+
         return new StorageVerificationOptions
         {
             VerifyDatabaseHash = dto.VerifyDatabaseHash,
@@ -145,9 +150,6 @@ public sealed class StorageManagementService : IStorageManagementService
             VerifyFilesBySize = dto.VerifyFilesBySize,
         };
     }
-
-    private static StorageVerificationOptions Map(StorageVerificationOptionsDto? dto)
-        => dto is null ? new StorageVerificationOptions() : Map(dto);
 
     private static StorageOperationStatusDto Map(StorageOperationStatus status)
         => status switch


### PR DESCRIPTION
## Summary
- consolidate storage verification mapping into a single nullable-aware method to avoid overload ambiguity

## Testing
- not run (environment missing dotnet SDK)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928bed8c90483268fbb76dedf11c299)