### PR TITLE
Fix ByteSize and FileHash nullability handling in storage services

### DIFF
--- a/Veriado.Infrastructure/Storage/ExportPackageService.cs
+++ b/Veriado.Infrastructure/Storage/ExportPackageService.cs
@@ -81,7 +81,7 @@ public sealed class ExportPackageService : IExportPackageService
 
         var databaseSize = await _spaceAnalyzer.GetFileSizeAsync(_connectionStringProvider.DatabasePath, cancellationToken)
             .ConfigureAwait(false);
-        var totalSize = files.Sum(f => f.Size?.Value ?? 0) + databaseSize;
+        var totalSize = files.Sum(f => f.Size.Value) + databaseSize;
         var available = await _spaceAnalyzer.GetAvailableBytesAsync(normalizedPackageRoot, cancellationToken)
             .ConfigureAwait(false);
 

--- a/Veriado.Infrastructure/Storage/StorageMigrationService.cs
+++ b/Veriado.Infrastructure/Storage/StorageMigrationService.cs
@@ -78,7 +78,7 @@ public sealed class StorageMigrationService : IStorageMigrationService
                 .ToListAsync(cancellationToken)
                 .ConfigureAwait(false);
 
-            var totalSize = files.Sum(f => f.Size?.Value ?? 0);
+            var totalSize = files.Sum(f => f.Size.Value);
             var available = await _spaceAnalyzer.GetAvailableBytesAsync(normalizedTargetRoot, cancellationToken).ConfigureAwait(false);
             var required = (long)Math.Ceiling(totalSize * SafetyMargin);
             if (available < required)
@@ -146,14 +146,14 @@ public sealed class StorageMigrationService : IStorageMigrationService
                     }
 
                     var info = new FileInfo(destinationPath);
-                    if (options.Verification.VerifyFilesBySize && file.Size.HasValue && info.Length != file.Size.Value)
+                    if (options.Verification.VerifyFilesBySize && info.Length != file.Size.Value)
                     {
                         verificationFailures++;
                         errors.Add($"Size mismatch for {relativePath}: expected {file.Size.Value} bytes, found {info.Length} bytes.");
                         continue;
                     }
 
-                    if (options.Verification.VerifyFilesByHash && !string.IsNullOrWhiteSpace(file.Hash?.Value))
+                    if (options.Verification.VerifyFilesByHash && !string.IsNullOrWhiteSpace(file.Hash.Value))
                     {
                         var computedHash = await _hashCalculator
                             .ComputeSha256Async(destinationPath, cancellationToken)


### PR DESCRIPTION
## Summary
- update storage services to use non-nullable ByteSize and FileHash value properties when computing totals and verifications
- remove incorrect nullable checks to align with value object definitions

## Testing
- Not run (dotnet CLI unavailable in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928bf838cc48326a65800e6c04a8ba9)