### PR TITLE
Introduce VPF models and two-phase import scaffolding

### DIFF
--- a/Veriado.Application/Abstractions/IStorageMigrationService.cs
+++ b/Veriado.Application/Abstractions/IStorageMigrationService.cs
@@ -52,6 +52,15 @@ public interface IImportPackageService
         string targetStorageRoot,
         StorageImportOptions? options,
         CancellationToken cancellationToken);
+
+    Task<ImportValidationResult> ValidateLogicalPackageAsync(
+        ImportRequest request,
+        CancellationToken cancellationToken);
+
+    Task<ImportCommitResult> CommitLogicalPackageAsync(
+        ImportRequest request,
+        ImportConflictStrategy conflictStrategy,
+        CancellationToken cancellationToken);
 }
 
 /// <summary>Options controlling verification of storage operations.</summary>
@@ -86,6 +95,15 @@ public sealed record StorageExportOptions
 
     /// <summary>Verification configuration for exported assets.</summary>
     public StorageVerificationOptions Verification { get; init; } = new();
+
+    /// <summary>Defines the logical export mode used for the package.</summary>
+    public StorageExportMode ExportMode { get; init; } = StorageExportMode.PhysicalWithDatabase;
+}
+
+public enum StorageExportMode
+{
+    PhysicalWithDatabase,
+    LogicalPerFile,
 }
 
 /// <summary>Options controlling import behaviour.</summary>

--- a/Veriado.Application/Abstractions/ImportModels.cs
+++ b/Veriado.Application/Abstractions/ImportModels.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Collections.Generic;
+
+namespace Veriado.Application.Abstractions;
+
+/// <summary>
+/// Two-phase import request information.
+/// </summary>
+public sealed record ImportRequest
+{
+    public string PackagePath { get; init; } = string.Empty;
+
+    /// <summary>Optional filter (tags, subfolder, etc.) reserved for future extension.</summary>
+    public string? ScopeFilter { get; init; }
+        = null;
+
+    /// <summary>Optional explicit target storage root for commit stage.</summary>
+    public string? TargetStorageRoot { get; init; }
+        = null;
+}
+
+public enum ImportConflictStrategy
+{
+    SkipExisting,
+    Overwrite,
+    Duplicate,
+}
+
+public enum ImportIssueType
+{
+    PackageMissing,
+    ManifestMissing,
+    ManifestUnsupported,
+    MetadataMissing,
+    MetadataUnsupported,
+    FilesRootMissing,
+    MissingDescriptor,
+    MissingFile,
+    SizeMismatch,
+    HashMismatch,
+    SchemaUnsupported,
+    FileCountMismatch,
+    FileBytesMismatch,
+    ConflictExistingFile,
+}
+
+public enum ImportIssueSeverity
+{
+    Warning,
+    Error,
+}
+
+public sealed record ImportValidationIssue(
+    ImportIssueType Type,
+    ImportIssueSeverity Severity,
+    string? RelativePath,
+    string Message);
+
+public sealed record ImportValidationResult(
+    bool IsValid,
+    IReadOnlyList<ImportValidationIssue> Issues,
+    int DiscoveredFiles,
+    int DiscoveredDescriptors,
+    long TotalBytes)
+{
+    public static ImportValidationResult FromIssues(IReadOnlyList<ImportValidationIssue> issues)
+        => new(issues.Count == 0, issues, 0, 0, 0);
+}
+
+public enum ImportCommitStatus
+{
+    Success,
+    PartialSuccess,
+    Failed,
+}
+
+public sealed record ImportCommitResult(
+    ImportCommitStatus Status,
+    int ImportedFiles,
+    int SkippedFiles,
+    int ConflictedFiles,
+    IReadOnlyList<ImportValidationIssue> Issues);

--- a/Veriado.Contracts/Storage/ImportContracts.cs
+++ b/Veriado.Contracts/Storage/ImportContracts.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+using Veriado.Application.Abstractions;
+
+namespace Veriado.Contracts.Storage;
+
+public sealed record ImportRequestDto
+{
+    public string PackagePath { get; init; } = string.Empty;
+    public string? ScopeFilter { get; init; }
+        = null;
+    public string? TargetStorageRoot { get; init; }
+        = null;
+}
+
+public sealed record ImportValidationIssueDto
+{
+    public ImportIssueType Type { get; init; }
+    public ImportIssueSeverity Severity { get; init; }
+    public string? RelativePath { get; init; }
+    public string Message { get; init; } = string.Empty;
+}
+
+public sealed record ImportValidationResultDto
+{
+    public bool IsValid { get; init; }
+    public IReadOnlyList<ImportValidationIssueDto> Issues { get; init; } = Array.Empty<ImportValidationIssueDto>();
+    public int DiscoveredFiles { get; init; }
+    public int DiscoveredDescriptors { get; init; }
+    public long TotalBytes { get; init; }
+}
+
+public sealed record ImportCommitResultDto
+{
+    public ImportCommitStatus Status { get; init; }
+    public int ImportedFiles { get; init; }
+    public int SkippedFiles { get; init; }
+    public int ConflictedFiles { get; init; }
+    public IReadOnlyList<ImportValidationIssueDto> Issues { get; init; } = Array.Empty<ImportValidationIssueDto>();
+}

--- a/Veriado.Contracts/Storage/StorageExportOptionsDto.cs
+++ b/Veriado.Contracts/Storage/StorageExportOptionsDto.cs
@@ -1,4 +1,6 @@
 // File: Veriado.Contracts/Storage/StorageExportOptionsDto.cs
+using Veriado.Application.Abstractions;
+
 namespace Veriado.Contracts.Storage;
 
 /// <summary>
@@ -11,6 +13,10 @@ public sealed record StorageExportOptionsDto
 
     /// <summary>Gets a value indicating whether file hashes should be included in the package.</summary>
     public bool IncludeFileHashes { get; init; }
+
+    /// <summary>Defines the logical export mode used for the package.</summary>
+    public StorageExportMode ExportMode { get; init; }
+        = StorageExportMode.PhysicalWithDatabase;
 
     public StorageVerificationOptionsDto Verification { get; init; } = new();
 }

--- a/Veriado.Infrastructure/Storage/ExportPackageService.cs
+++ b/Veriado.Infrastructure/Storage/ExportPackageService.cs
@@ -12,6 +12,7 @@ using Veriado.Appl.Abstractions;
 using Veriado.Application.Abstractions;
 using Veriado.Infrastructure.Persistence;
 using Veriado.Infrastructure.Persistence.Connections;
+using Veriado.Infrastructure.Storage.Vpf;
 
 namespace Veriado.Infrastructure.Storage;
 
@@ -48,6 +49,12 @@ public sealed class ExportPackageService : IExportPackageService
         CancellationToken cancellationToken)
     {
         options ??= new StorageExportOptions();
+
+        if (options.ExportMode == StorageExportMode.LogicalPerFile)
+        {
+            return await ExportLogicalPackageAsync(packageRoot, options, cancellationToken).ConfigureAwait(false);
+        }
+
         var normalizedPackageRoot = Path.GetFullPath(packageRoot);
         PreparePackageDirectory(normalizedPackageRoot, options.OverwriteExisting);
 
@@ -185,6 +192,161 @@ public sealed class ExportPackageService : IExportPackageService
             DatabaseHashMatched = metadata.DatabaseSha256 != null,
             Message = missingFiles.Count == 0 ? "Export completed." : "Export completed with missing files.",
         };
+    }
+
+    private async Task<StorageOperationResult> ExportLogicalPackageAsync(
+        string packageRoot,
+        StorageExportOptions options,
+        CancellationToken cancellationToken)
+    {
+        var normalizedPackageRoot = Path.GetFullPath(packageRoot);
+        PreparePackageDirectory(normalizedPackageRoot, options.OverwriteExisting);
+
+        await using var dbContext = await _dbContextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+        var pendingMigrations = await dbContext.Database
+            .GetPendingMigrationsAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        if (pendingMigrations.Any())
+        {
+            return new StorageOperationResult
+            {
+                Status = StorageOperationStatus.PendingMigrations,
+                Message = "Cannot export while database migrations are pending. Please update the database first.",
+                PackageRoot = normalizedPackageRoot,
+            };
+        }
+
+        var storageRoot = await dbContext.StorageRoots
+            .AsNoTracking()
+            .SingleOrDefaultAsync(cancellationToken)
+            .ConfigureAwait(false)
+            ?? throw new InvalidOperationException("Storage root is not configured.");
+
+        var normalizedRoot = SafePathUtilities.NormalizeAndValidateRoot(storageRoot.RootPath, _logger);
+        var files = await dbContext.FileSystems
+            .AsNoTracking()
+            .Select(f => new
+            {
+                f.Id,
+                f.RelativePath,
+                f.Size,
+                f.Hash,
+                f.Mime,
+                f.CreatedUtc,
+                f.LastWriteUtc,
+            })
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        var totalBytes = files.Sum(f => f.Size.Value);
+        var available = await _spaceAnalyzer.GetAvailableBytesAsync(normalizedPackageRoot, cancellationToken)
+            .ConfigureAwait(false);
+        var required = (long)Math.Ceiling(totalBytes * SafetyMargin);
+        if (available < required)
+        {
+            return new StorageOperationResult
+            {
+                Status = StorageOperationStatus.InsufficientSpace,
+                Message = $"Insufficient disk space for export. Required {required} bytes, available {available} bytes.",
+                RequiredBytes = required,
+                AvailableBytes = available,
+                PackageRoot = normalizedPackageRoot,
+            };
+        }
+
+        var filesRoot = Path.Combine(normalizedPackageRoot, VpfPackagePaths.FilesDirectory);
+        Directory.CreateDirectory(filesRoot);
+
+        var missingFiles = new List<string>();
+        var exportedFiles = 0;
+
+        foreach (var file in files)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var relativePath = SafePathUtilities.NormalizeRelative(file.RelativePath.Value, _logger);
+            var sourcePath = Path.Combine(normalizedRoot, relativePath);
+            var destinationPath = Path.Combine(filesRoot, relativePath);
+            SafePathUtilities.EnsureDirectoryForFile(destinationPath);
+
+            try
+            {
+                await AtomicFileOperations.CopyAsync(sourcePath, destinationPath, overwrite: true, cancellationToken)
+                    .ConfigureAwait(false);
+                exportedFiles++;
+
+                var hash = await _hashCalculator.ComputeSha256Async(sourcePath, cancellationToken).ConfigureAwait(false);
+                var descriptor = new VpfFileDescriptor
+                {
+                    FileId = file.Id,
+                    OriginalInstanceId = Guid.Empty,
+                    RelativePath = Path.GetDirectoryName(relativePath)?.Replace('\\', '/') ?? string.Empty,
+                    FileName = Path.GetFileName(relativePath),
+                    ContentHash = hash.Value,
+                    SizeBytes = file.Size.Value,
+                    MimeType = file.Mime.Value,
+                    CreatedAtUtc = file.CreatedUtc.ToDateTimeOffset(),
+                    LastModifiedAtUtc = file.LastWriteUtc.ToDateTimeOffset(),
+                };
+
+                await WriteJsonAsync(destinationPath + ".json", descriptor, cancellationToken).ConfigureAwait(false);
+            }
+            catch (FileNotFoundException)
+            {
+                missingFiles.Add(relativePath);
+                _logger.LogWarning("Source file {SourcePath} missing during logical export.", sourcePath);
+            }
+            catch (Exception ex)
+            {
+                missingFiles.Add(relativePath);
+                _logger.LogError(ex, "Failed to export {RelativePath}.", relativePath);
+            }
+        }
+
+        var manifest = new VpfPackageManifest
+        {
+            PackageId = Guid.NewGuid(),
+            CreatedAtUtc = DateTimeOffset.UtcNow,
+            CreatedBy = Environment.UserName,
+            ExportMode = "LogicalPerFile",
+        };
+
+        var metadata = new VpfTechnicalMetadata
+        {
+            FormatVersion = 1,
+            ApplicationVersion = Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "unknown",
+            DatabaseSchemaVersion = (await dbContext.Database.GetAppliedMigrationsAsync(cancellationToken).ConfigureAwait(false)).LastOrDefault(),
+            ExportMode = "LogicalPerFile",
+            OriginalStorageRootPath = normalizedRoot,
+            TotalFilesCount = files.Count,
+            TotalFilesBytes = totalBytes,
+            HashAlgorithm = "SHA256",
+            FileDescriptorSchemaVersion = 1,
+        };
+
+        await WriteJsonAsync(Path.Combine(normalizedPackageRoot, VpfPackagePaths.PackageManifestFile), manifest, cancellationToken).ConfigureAwait(false);
+        await WriteJsonAsync(Path.Combine(normalizedPackageRoot, VpfPackagePaths.MetadataFile), metadata, cancellationToken).ConfigureAwait(false);
+
+        _logger.LogInformation(
+            "Logical export completed to {PackageRoot}. Files exported: {ExportedFiles}, missing: {MissingFiles}.",
+            normalizedPackageRoot,
+            exportedFiles,
+            missingFiles.Count);
+
+        return new StorageOperationResult
+        {
+            Status = missingFiles.Count == 0 ? StorageOperationStatus.Success : StorageOperationStatus.PartialSuccess,
+            PackageRoot = normalizedPackageRoot,
+            AffectedFiles = exportedFiles,
+            MissingFiles = missingFiles,
+            Message = missingFiles.Count == 0 ? "Export completed." : "Export completed with missing files.",
+        };
+    }
+
+    private static async Task WriteJsonAsync<T>(string path, T payload, CancellationToken cancellationToken)
+    {
+        await using var stream = File.Create(path);
+        await JsonSerializer.SerializeAsync(stream, payload, VpfSerialization.Options, cancellationToken).ConfigureAwait(false);
     }
 
     private static void PreparePackageDirectory(string packageRoot, bool overwriteExisting)

--- a/Veriado.Infrastructure/Storage/Vpf/VpfPackageModels.cs
+++ b/Veriado.Infrastructure/Storage/Vpf/VpfPackageModels.cs
@@ -1,0 +1,177 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Veriado.Infrastructure.Storage.Vpf;
+
+/// <summary>
+/// Root manifest describing the portable package for user-facing presentation.
+/// </summary>
+public sealed record VpfPackageManifest
+{
+    public const string ExpectedSpec = "Veriado.Package";
+    public const string ExpectedSpecVersion = "1.0";
+
+    [JsonPropertyName("spec")]
+    public string Spec { get; init; } = ExpectedSpec;
+
+    [JsonPropertyName("specVersion")]
+    public string SpecVersion { get; init; } = ExpectedSpecVersion;
+
+    [JsonPropertyName("packageId")]
+    public Guid PackageId { get; init; }
+        = Guid.NewGuid();
+
+    [JsonPropertyName("name")]
+    public string? Name { get; init; }
+        = "Veriado Package";
+
+    [JsonPropertyName("description")]
+    public string? Description { get; init; }
+        = string.Empty;
+
+    [JsonPropertyName("createdAtUtc")]
+    public DateTimeOffset CreatedAtUtc { get; init; }
+        = DateTimeOffset.UtcNow;
+
+    [JsonPropertyName("createdBy")]
+    public string? CreatedBy { get; init; }
+        = Environment.UserName;
+
+    [JsonPropertyName("sourceInstanceId")]
+    public Guid SourceInstanceId { get; init; }
+        = Guid.Empty;
+
+    [JsonPropertyName("sourceInstanceName")]
+    public string? SourceInstanceName { get; init; }
+        = string.Empty;
+
+    [JsonPropertyName("exportMode")]
+    public string ExportMode { get; init; } = "LogicalPerFile";
+}
+
+/// <summary>
+/// Technical metadata describing application and schema versions captured during export.
+/// </summary>
+public sealed record VpfTechnicalMetadata
+{
+    [JsonPropertyName("formatVersion")]
+    public int FormatVersion { get; init; } = 1;
+
+    [JsonPropertyName("applicationVersion")]
+    public string ApplicationVersion { get; init; } = string.Empty;
+
+    [JsonPropertyName("databaseSchemaVersion")]
+    public string? DatabaseSchemaVersion { get; init; }
+        = string.Empty;
+
+    [JsonPropertyName("exportMode")]
+    public string ExportMode { get; init; } = "LogicalPerFile";
+
+    [JsonPropertyName("originalStorageRootPath")]
+    public string OriginalStorageRootPath { get; init; } = string.Empty;
+
+    [JsonPropertyName("totalFilesCount")]
+    public int TotalFilesCount { get; init; }
+        = 0;
+
+    [JsonPropertyName("totalFilesBytes")]
+    public long TotalFilesBytes { get; init; }
+        = 0;
+
+    [JsonPropertyName("hashAlgorithm")]
+    public string HashAlgorithm { get; init; } = "SHA256";
+
+    [JsonPropertyName("fileDescriptorSchemaVersion")]
+    public int FileDescriptorSchemaVersion { get; init; } = 1;
+
+    [JsonPropertyName("extensions")]
+    public IReadOnlyList<string> Extensions { get; init; } = Array.Empty<string>();
+}
+
+/// <summary>
+/// Descriptor persisted next to every file inside <c>files/</c>.
+/// </summary>
+public sealed record VpfFileDescriptor
+{
+    [JsonPropertyName("schema")]
+    public string Schema { get; init; } = "Veriado.FileDescriptor";
+
+    [JsonPropertyName("schemaVersion")]
+    public int SchemaVersion { get; init; } = 1;
+
+    [JsonPropertyName("fileId")]
+    public Guid FileId { get; init; }
+        = Guid.Empty;
+
+    [JsonPropertyName("originalInstanceId")]
+    public Guid OriginalInstanceId { get; init; }
+        = Guid.Empty;
+
+    [JsonPropertyName("relativePath")]
+    public string RelativePath { get; init; } = string.Empty;
+
+    [JsonPropertyName("fileName")]
+    public string FileName { get; init; } = string.Empty;
+
+    [JsonPropertyName("contentHash")]
+    public string ContentHash { get; init; } = string.Empty;
+
+    [JsonPropertyName("sizeBytes")]
+    public long SizeBytes { get; init; }
+        = 0;
+
+    [JsonPropertyName("mimeType")]
+    public string? MimeType { get; init; }
+        = string.Empty;
+
+    [JsonPropertyName("createdAtUtc")]
+    public DateTimeOffset CreatedAtUtc { get; init; }
+        = DateTimeOffset.MinValue;
+
+    [JsonPropertyName("createdBy")]
+    public string? CreatedBy { get; init; }
+        = string.Empty;
+
+    [JsonPropertyName("lastModifiedAtUtc")]
+    public DateTimeOffset LastModifiedAtUtc { get; init; }
+        = DateTimeOffset.MinValue;
+
+    [JsonPropertyName("lastModifiedBy")]
+    public string? LastModifiedBy { get; init; }
+        = string.Empty;
+
+    [JsonPropertyName("isReadOnly")]
+    public bool IsReadOnly { get; init; }
+        = false;
+
+    [JsonPropertyName("labels")]
+    public IReadOnlyList<string> Labels { get; init; } = Array.Empty<string>();
+
+    [JsonPropertyName("customMetadata")]
+    public IDictionary<string, object?> CustomMetadata { get; init; }
+        = new Dictionary<string, object?>();
+
+    [JsonPropertyName("extensions")]
+    public IDictionary<string, object?> Extensions { get; init; }
+        = new Dictionary<string, object?>();
+}
+
+public static class VpfPackagePaths
+{
+    public const string PackageManifestFile = "package.json";
+    public const string MetadataFile = "metadata.json";
+    public const string FilesDirectory = "files";
+    public const string ExtraDirectory = "extra";
+}
+
+public static class VpfSerialization
+{
+    public static readonly JsonSerializerOptions Options = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+}

--- a/Veriado.Infrastructure/Storage/Vpf/VpfPackageValidator.cs
+++ b/Veriado.Infrastructure/Storage/Vpf/VpfPackageValidator.cs
@@ -1,0 +1,236 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Veriado.Application.Abstractions;
+
+namespace Veriado.Infrastructure.Storage.Vpf;
+
+/// <summary>
+/// Performs structural and integrity validation of a VPF package prior to import.
+/// </summary>
+public sealed class VpfPackageValidator
+{
+    private readonly IFileHashCalculator _hashCalculator;
+
+    public VpfPackageValidator(IFileHashCalculator hashCalculator)
+    {
+        _hashCalculator = hashCalculator ?? throw new ArgumentNullException(nameof(hashCalculator));
+    }
+
+    public async Task<ImportValidationResult> ValidateAsync(string packageRoot, CancellationToken cancellationToken)
+    {
+        var issues = new List<ImportValidationIssue>();
+        var normalized = Path.GetFullPath(packageRoot);
+        if (!Directory.Exists(normalized))
+        {
+            issues.Add(new ImportValidationIssue(
+                ImportIssueType.PackageMissing,
+                ImportIssueSeverity.Error,
+                null,
+                $"Package directory '{normalized}' does not exist."));
+
+            return ImportValidationResult.FromIssues(issues);
+        }
+
+        var manifestPath = Path.Combine(normalized, VpfPackagePaths.PackageManifestFile);
+        var metadataPath = Path.Combine(normalized, VpfPackagePaths.MetadataFile);
+        if (!File.Exists(manifestPath))
+        {
+            issues.Add(new ImportValidationIssue(
+                ImportIssueType.ManifestMissing,
+                ImportIssueSeverity.Error,
+                null,
+                "Package is missing package.json."));
+        }
+
+        if (!File.Exists(metadataPath))
+        {
+            issues.Add(new ImportValidationIssue(
+                ImportIssueType.MetadataMissing,
+                ImportIssueSeverity.Error,
+                null,
+                "Package is missing metadata.json."));
+        }
+
+        VpfPackageManifest? manifest = null;
+        VpfTechnicalMetadata? metadata = null;
+
+        if (File.Exists(manifestPath))
+        {
+            manifest = await DeserializeAsync<VpfPackageManifest>(manifestPath, cancellationToken).ConfigureAwait(false);
+            if (!string.Equals(manifest.Spec, VpfPackageManifest.ExpectedSpec, StringComparison.Ordinal))
+            {
+                issues.Add(new ImportValidationIssue(
+                    ImportIssueType.ManifestUnsupported,
+                    ImportIssueSeverity.Error,
+                    null,
+                    $"Unsupported manifest spec '{manifest.Spec}'."));
+            }
+
+            if (!string.Equals(manifest.SpecVersion, VpfPackageManifest.ExpectedSpecVersion, StringComparison.Ordinal))
+            {
+                issues.Add(new ImportValidationIssue(
+                    ImportIssueType.ManifestUnsupported,
+                    ImportIssueSeverity.Error,
+                    null,
+                    $"Unsupported manifest specVersion '{manifest.SpecVersion}'."));
+            }
+        }
+
+        if (File.Exists(metadataPath))
+        {
+            metadata = await DeserializeAsync<VpfTechnicalMetadata>(metadataPath, cancellationToken).ConfigureAwait(false);
+            if (metadata.FormatVersion != 1)
+            {
+                issues.Add(new ImportValidationIssue(
+                    ImportIssueType.MetadataUnsupported,
+                    ImportIssueSeverity.Error,
+                    null,
+                    $"Unsupported metadata format version '{metadata.FormatVersion}'."));
+            }
+
+            if (!string.Equals(metadata.HashAlgorithm, "SHA256", StringComparison.OrdinalIgnoreCase))
+            {
+                issues.Add(new ImportValidationIssue(
+                    ImportIssueType.MetadataUnsupported,
+                    ImportIssueSeverity.Error,
+                    null,
+                    "Only SHA256 hashAlgorithm is supported."));
+            }
+        }
+
+        var filesRoot = Path.Combine(normalized, VpfPackagePaths.FilesDirectory);
+        if (!Directory.Exists(filesRoot))
+        {
+            issues.Add(new ImportValidationIssue(
+                ImportIssueType.FilesRootMissing,
+                ImportIssueSeverity.Error,
+                null,
+                "Package does not contain a files directory."));
+
+            return new ImportValidationResult(false, issues, 0, 0, 0);
+        }
+
+        var totalFiles = 0;
+        var totalBytes = 0L;
+        var descriptorCount = 0;
+
+        foreach (var filePath in Directory.EnumerateFiles(filesRoot, "*", SearchOption.AllDirectories))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (filePath.EndsWith(".json", StringComparison.OrdinalIgnoreCase))
+            {
+                continue; // descriptors are validated alongside their sibling files
+            }
+
+            var relativePath = Path.GetRelativePath(filesRoot, filePath);
+            var descriptorPath = filePath + ".json";
+            totalFiles++;
+            totalBytes += new FileInfo(filePath).Length;
+
+            if (!File.Exists(descriptorPath))
+            {
+                issues.Add(new ImportValidationIssue(
+                    ImportIssueType.MissingDescriptor,
+                    ImportIssueSeverity.Error,
+                    relativePath,
+                    "Descriptor JSON is missing for file."));
+                continue;
+            }
+
+            descriptorCount++;
+            var descriptor = await DeserializeAsync<VpfFileDescriptor>(descriptorPath, cancellationToken).ConfigureAwait(false);
+
+            if (!string.Equals(descriptor.Schema, "Veriado.FileDescriptor", StringComparison.Ordinal))
+            {
+                issues.Add(new ImportValidationIssue(
+                    ImportIssueType.SchemaUnsupported,
+                    ImportIssueSeverity.Error,
+                    relativePath,
+                    $"Unsupported descriptor schema '{descriptor.Schema}'."));
+            }
+
+            if (descriptor.SchemaVersion != 1)
+            {
+                issues.Add(new ImportValidationIssue(
+                    ImportIssueType.SchemaUnsupported,
+                    ImportIssueSeverity.Error,
+                    relativePath,
+                    $"Unsupported descriptor schemaVersion '{descriptor.SchemaVersion}'."));
+            }
+
+            var size = new FileInfo(filePath).Length;
+            if (descriptor.SizeBytes != size)
+            {
+                issues.Add(new ImportValidationIssue(
+                    ImportIssueType.SizeMismatch,
+                    ImportIssueSeverity.Error,
+                    relativePath,
+                    $"Descriptor sizeBytes {descriptor.SizeBytes} does not match file size {size}."));
+            }
+
+            if (metadata is not null && metadata.HashAlgorithm.Equals("SHA256", StringComparison.OrdinalIgnoreCase))
+            {
+                var hash = await _hashCalculator.ComputeSha256Async(filePath, cancellationToken).ConfigureAwait(false);
+                if (!string.Equals(hash.Value, descriptor.ContentHash, StringComparison.OrdinalIgnoreCase))
+                {
+                    issues.Add(new ImportValidationIssue(
+                        ImportIssueType.HashMismatch,
+                        ImportIssueSeverity.Error,
+                        relativePath,
+                        "Content hash does not match descriptor."));
+                }
+            }
+        }
+
+        if (metadata is not null)
+        {
+            if (metadata.TotalFilesCount != 0 && metadata.TotalFilesCount != totalFiles)
+            {
+                issues.Add(new ImportValidationIssue(
+                    ImportIssueType.FileCountMismatch,
+                    ImportIssueSeverity.Error,
+                    null,
+                    $"metadata.json totalFilesCount={metadata.TotalFilesCount} differs from detected {totalFiles}."));
+            }
+
+            if (metadata.TotalFilesBytes != 0 && metadata.TotalFilesBytes != totalBytes)
+            {
+                issues.Add(new ImportValidationIssue(
+                    ImportIssueType.FileBytesMismatch,
+                    ImportIssueSeverity.Error,
+                    null,
+                    $"metadata.json totalFilesBytes={metadata.TotalFilesBytes} differs from detected {totalBytes}."));
+            }
+
+            if (metadata.FileDescriptorSchemaVersion != 1)
+            {
+                issues.Add(new ImportValidationIssue(
+                    ImportIssueType.SchemaUnsupported,
+                    ImportIssueSeverity.Error,
+                    null,
+                    $"Unsupported fileDescriptorSchemaVersion '{metadata.FileDescriptorSchemaVersion}'."));
+            }
+        }
+
+        return new ImportValidationResult(issues.Count == 0, issues, totalFiles, descriptorCount, totalBytes);
+    }
+
+    private static async Task<T> DeserializeAsync<T>(string path, CancellationToken cancellationToken)
+    {
+        await using var stream = File.OpenRead(path);
+        var model = await JsonSerializer.DeserializeAsync<T>(stream, VpfSerialization.Options, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (model is null)
+        {
+            throw new InvalidOperationException($"Failed to deserialize {typeof(T).Name} from '{path}'.");
+        }
+
+        return model;
+    }
+}

--- a/Veriado.Services/Storage/IStorageManagementService.cs
+++ b/Veriado.Services/Storage/IStorageManagementService.cs
@@ -1,4 +1,5 @@
 // File: Veriado.Services/Storage/IStorageManagementService.cs
+using Veriado.Application.Abstractions;
 using Veriado.Contracts.Storage;
 
 namespace Veriado.Services.Storage;
@@ -28,5 +29,14 @@ public interface IStorageManagementService
         string packageRoot,
         string targetStorageRoot,
         StorageImportOptionsDto? options,
+        CancellationToken cancellationToken);
+
+    Task<ImportValidationResultDto> ValidateImportAsync(
+        ImportRequestDto request,
+        CancellationToken cancellationToken);
+
+    Task<ImportCommitResultDto> CommitImportAsync(
+        ImportRequestDto request,
+        ImportConflictStrategy conflictStrategy,
         CancellationToken cancellationToken);
 }


### PR DESCRIPTION
## Summary
- add VPF manifest, metadata, and descriptor models with validation helper
- extend storage export options to support logical per-file VPF packages and generate package/json descriptors
- introduce two-phase import contracts and service methods for validation and commit orchestration

## Testing
- ⚠️ `dotnet build -nologo` (dotnet CLI not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69294e9ac0088326a96ac261fddf8a6b)