### PR TITLE
Fix path conflict detection for import validation

### DIFF
--- a/Veriado.Infrastructure/Storage/ImportPackageService.cs
+++ b/Veriado.Infrastructure/Storage/ImportPackageService.cs
@@ -465,9 +465,9 @@ public sealed class ImportPackageService : IImportPackageService
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            var pathKey = string.IsNullOrWhiteSpace(file.RelativePath)
+            var pathKey = (string.IsNullOrWhiteSpace(file.RelativePath)
                 ? file.FileName
-                : Path.Combine(file.RelativePath, file.FileName).Replace('\\', '/');
+                : file.RelativePath).Replace('\\', '/');
 
             ImportItemStatus status;
             string? reason = null;


### PR DESCRIPTION
## Summary
- correct path key derivation during import validation conflict detection
- ensure existing files at matching relative paths are classified as conflicts

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69295ac434b48326a616873f3972e758)