### PR TITLE
Move storage import/export enums to contracts

### DIFF
--- a/Veriado.Application/Abstractions/IStorageMigrationService.cs
+++ b/Veriado.Application/Abstractions/IStorageMigrationService.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Veriado.Contracts.Storage;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -98,12 +99,6 @@ public sealed record StorageExportOptions
 
     /// <summary>Defines the logical export mode used for the package.</summary>
     public StorageExportMode ExportMode { get; init; } = StorageExportMode.LogicalPerFile;
-}
-
-public enum StorageExportMode
-{
-    PhysicalWithDatabase,
-    LogicalPerFile,
 }
 
 /// <summary>Options controlling import behaviour.</summary>

--- a/Veriado.Application/Abstractions/ImportModels.cs
+++ b/Veriado.Application/Abstractions/ImportModels.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Veriado.Contracts.Storage;
 
 namespace Veriado.Application.Abstractions;
 
@@ -19,38 +20,6 @@ public sealed record ImportRequest
         = null;
 }
 
-public enum ImportConflictStrategy
-{
-    SkipIfExists,
-    UpdateIfNewer,
-    AlwaysOverwrite,
-    CreateDuplicate,
-}
-
-public enum ImportIssueType
-{
-    PackageMissing,
-    ManifestMissing,
-    ManifestUnsupported,
-    MetadataMissing,
-    MetadataUnsupported,
-    FilesRootMissing,
-    MissingDescriptor,
-    MissingFile,
-    SizeMismatch,
-    HashMismatch,
-    SchemaUnsupported,
-    FileCountMismatch,
-    FileBytesMismatch,
-    ConflictExistingFile,
-}
-
-public enum ImportIssueSeverity
-{
-    Warning,
-    Error,
-}
-
 public sealed record ImportValidationIssue(
     ImportIssueType Type,
     ImportIssueSeverity Severity,
@@ -66,15 +35,6 @@ public sealed record ValidatedImportFile(
     long SizeBytes,
     string? MimeType,
     DateTimeOffset LastModifiedAtUtc);
-
-public enum ImportItemStatus
-{
-    New,
-    DuplicateSameVersion,
-    DuplicateOlderInDb,
-    DuplicateNewerInDb,
-    ConflictOther,
-}
 
 public sealed record ImportItemPreview(
     Guid FileId,
@@ -110,13 +70,6 @@ public sealed record ImportValidationResult(
             0,
             0,
             0);
-}
-
-public enum ImportCommitStatus
-{
-    Success,
-    PartialSuccess,
-    Failed,
 }
 
 public sealed record ImportCommitResult(

--- a/Veriado.Contracts/Storage/ImportContracts.cs
+++ b/Veriado.Contracts/Storage/ImportContracts.cs
@@ -1,8 +1,55 @@
 using System;
 using System.Collections.Generic;
-using Veriado.Application.Abstractions;
 
 namespace Veriado.Contracts.Storage;
+
+public enum ImportConflictStrategy
+{
+    SkipIfExists,
+    UpdateIfNewer,
+    AlwaysOverwrite,
+    CreateDuplicate,
+}
+
+public enum ImportIssueType
+{
+    PackageMissing,
+    ManifestMissing,
+    ManifestUnsupported,
+    MetadataMissing,
+    MetadataUnsupported,
+    FilesRootMissing,
+    MissingDescriptor,
+    MissingFile,
+    SizeMismatch,
+    HashMismatch,
+    SchemaUnsupported,
+    FileCountMismatch,
+    FileBytesMismatch,
+    ConflictExistingFile,
+}
+
+public enum ImportIssueSeverity
+{
+    Warning,
+    Error,
+}
+
+public enum ImportItemStatus
+{
+    New,
+    DuplicateSameVersion,
+    DuplicateOlderInDb,
+    DuplicateNewerInDb,
+    ConflictOther,
+}
+
+public enum ImportCommitStatus
+{
+    Success,
+    PartialSuccess,
+    Failed,
+}
 
 public sealed record ImportRequestDto
 {

--- a/Veriado.Contracts/Storage/StorageExportOptionsDto.cs
+++ b/Veriado.Contracts/Storage/StorageExportOptionsDto.cs
@@ -4,6 +4,15 @@ using Veriado.Application.Abstractions;
 namespace Veriado.Contracts.Storage;
 
 /// <summary>
+/// Defines the logical export mode used for the package.
+/// </summary>
+public enum StorageExportMode
+{
+    PhysicalWithDatabase,
+    LogicalPerFile,
+}
+
+/// <summary>
 /// Options controlling export behaviour.
 /// </summary>
 public sealed record StorageExportOptionsDto

--- a/Veriado.Infrastructure/Storage/ExportPackageService.cs
+++ b/Veriado.Infrastructure/Storage/ExportPackageService.cs
@@ -10,6 +10,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Veriado.Appl.Abstractions;
 using Veriado.Application.Abstractions;
+using Veriado.Contracts.Storage;
 using Veriado.Infrastructure.Persistence;
 using Veriado.Infrastructure.Persistence.Connections;
 using Veriado.Infrastructure.Storage.Vpf;

--- a/Veriado.Infrastructure/Storage/ImportPackageService.cs
+++ b/Veriado.Infrastructure/Storage/ImportPackageService.cs
@@ -9,6 +9,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Veriado.Appl.Abstractions;
 using Veriado.Application.Abstractions;
+using Veriado.Contracts.Storage;
 using Veriado.Infrastructure.FileSystem;
 using Veriado.Infrastructure.Persistence;
 using Veriado.Infrastructure.Persistence.Connections;

--- a/Veriado.Infrastructure/Storage/Vpf/VpfPackageValidator.cs
+++ b/Veriado.Infrastructure/Storage/Vpf/VpfPackageValidator.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Veriado.Application.Abstractions;
+using Veriado.Contracts.Storage;
 
 namespace Veriado.Infrastructure.Storage.Vpf;
 


### PR DESCRIPTION
## Summary
- move shared import/export enums into the Contracts project to avoid missing references
- update application and infrastructure layers to consume the shared contract enums
- add necessary namespace imports for storage validation and export services

## Testing
- not run (tooling unavailable in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929f0090a7c8326b62bc7f1998542bf)