### PR TITLE
Fix descriptor lookup dictionary creation

### DIFF
--- a/Veriado.Infrastructure/Storage/ImportPackageService.cs
+++ b/Veriado.Infrastructure/Storage/ImportPackageService.cs
@@ -146,8 +146,7 @@ public sealed class ImportPackageService : IImportPackageService
         var filesRoot = Path.Combine(Path.GetFullPath(request.PackagePath), VpfPackagePaths.FilesDirectory);
         var descriptorLookup = validation.ValidatedFiles.ToDictionary(
             f => f.FileId,
-            f => f,
-            StringComparer.OrdinalIgnoreCase);
+            f => f);
 
         await _pauseCoordinator.PauseAsync(cancellationToken).ConfigureAwait(false);
         try


### PR DESCRIPTION
## Summary
- remove inappropriate string comparer when building descriptor lookup keyed by Guid

## Testing
- dotnet test (fails: dotnet not available in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692a000fd6348326b4b34fa63cf89b0f)