### PR TITLE
Implement VPack export/import pipeline

### DIFF
--- a/Veriado.Application/Abstractions/ExportModels.cs
+++ b/Veriado.Application/Abstractions/ExportModels.cs
@@ -1,0 +1,24 @@
+using System;
+
+namespace Veriado.Application.Abstractions;
+
+public sealed record ExportRequest
+{
+    public string DestinationPath { get; init; } = string.Empty;
+    public string? PackageName { get; init; }
+        = null;
+    public string? Description { get; init; }
+        = null;
+    public bool OverwriteExisting { get; init; }
+        = false;
+    public bool EncryptPayload { get; init; }
+        = false;
+    public string? Password { get; init; }
+        = null;
+    public bool SignPayload { get; init; }
+        = false;
+    public Guid? SourceInstanceId { get; init; }
+        = null;
+    public string? SourceInstanceName { get; init; }
+        = null;
+}

--- a/Veriado.Application/Abstractions/IStorageMigrationService.cs
+++ b/Veriado.Application/Abstractions/IStorageMigrationService.cs
@@ -43,6 +43,10 @@ public interface IExportPackageService
         string packageRoot,
         StorageExportOptions? options,
         CancellationToken cancellationToken);
+
+    Task<StorageOperationResult> ExportPackageAsync(
+        ExportRequest request,
+        CancellationToken cancellationToken);
 }
 
 /// <summary>Provides operations for importing a portable package into the current environment.</summary>
@@ -59,6 +63,15 @@ public interface IImportPackageService
         CancellationToken cancellationToken);
 
     Task<ImportCommitResult> CommitLogicalPackageAsync(
+        ImportRequest request,
+        ImportConflictStrategy conflictStrategy,
+        CancellationToken cancellationToken);
+
+    Task<ImportValidationResult> ValidateImportAsync(
+        ImportRequest request,
+        CancellationToken cancellationToken);
+
+    Task<ImportCommitResult> CommitImportAsync(
         ImportRequest request,
         ImportConflictStrategy conflictStrategy,
         CancellationToken cancellationToken);

--- a/Veriado.Application/Abstractions/ImportModels.cs
+++ b/Veriado.Application/Abstractions/ImportModels.cs
@@ -22,6 +22,9 @@ public sealed record ImportRequest
     /// <summary>Optional default conflict strategy to use for commit when caller does not pass one explicitly.</summary>
     public ImportConflictStrategy? DefaultConflictStrategy { get; init; }
         = null;
+
+    public string? Password { get; init; }
+        = null;
 }
 
 public sealed record ImportValidationIssue(
@@ -59,8 +62,10 @@ public sealed record ImportValidationResult(
     IReadOnlyList<ValidatedImportFile> ValidatedFiles,
     IReadOnlyList<ImportItemPreview> Items,
     int NewItems,
-    int UpdatableItems,
-    int SkippedItems)
+    int SameItems,
+    int NewerItems,
+    int OlderItems,
+    int ConflictItems)
 {
     public static ImportValidationResult FromIssues(IReadOnlyList<ImportValidationIssue> issues)
         => new(
@@ -71,6 +76,8 @@ public sealed record ImportValidationResult(
             0,
             Array.Empty<ValidatedImportFile>(),
             Array.Empty<ImportItemPreview>(),
+            0,
+            0,
             0,
             0,
             0);

--- a/Veriado.Contracts/Storage/ExportContracts.cs
+++ b/Veriado.Contracts/Storage/ExportContracts.cs
@@ -1,0 +1,33 @@
+using System;
+
+namespace Veriado.Contracts.Storage;
+
+public sealed record ExportRequestDto
+{
+    public string DestinationPath { get; init; } = string.Empty;
+    public string? PackageName { get; init; }
+        = null;
+    public string? Description { get; init; }
+        = null;
+    public bool OverwriteExisting { get; init; }
+        = false;
+    public bool EncryptPayload { get; init; }
+        = false;
+    public string? Password { get; init; }
+        = null;
+    public bool SignPayload { get; init; }
+        = false;
+    public Guid? SourceInstanceId { get; init; }
+        = null;
+    public string? SourceInstanceName { get; init; }
+        = null;
+}
+
+public sealed record ExportResultDto
+{
+    public StorageOperationResultDto Operation { get; init; } = new();
+    public string? PackageId { get; init; }
+        = null;
+    public string? FinalPath { get; init; }
+        = null;
+}

--- a/Veriado.Contracts/Storage/ImportContracts.cs
+++ b/Veriado.Contracts/Storage/ImportContracts.cs
@@ -38,10 +38,10 @@ public enum ImportIssueSeverity
 public enum ImportItemStatus
 {
     New,
-    DuplicateSameVersion,
-    DuplicateOlderInDb,
-    DuplicateNewerInDb,
-    ConflictOther,
+    Same,
+    NewerInPackage,
+    OlderInPackage,
+    Conflict,
 }
 
 public enum ImportCommitStatus
@@ -59,6 +59,8 @@ public sealed record ImportRequestDto
     public string? TargetStorageRoot { get; init; }
         = null;
     public ImportConflictStrategy? DefaultConflictStrategy { get; init; }
+        = null;
+    public string? Password { get; init; }
         = null;
 }
 
@@ -80,8 +82,10 @@ public sealed record ImportValidationResultDto
     public IReadOnlyList<ValidatedImportFileDto> ValidatedFiles { get; init; } = Array.Empty<ValidatedImportFileDto>();
     public IReadOnlyList<ImportItemPreviewDto> Items { get; init; } = Array.Empty<ImportItemPreviewDto>();
     public int NewItems { get; init; }
-    public int UpdatableItems { get; init; }
-    public int SkippedItems { get; init; }
+    public int SameItems { get; init; }
+    public int NewerItems { get; init; }
+    public int OlderItems { get; init; }
+    public int ConflictItems { get; init; }
 }
 
 public sealed record ValidatedImportFileDto

--- a/Veriado.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/Veriado.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
@@ -31,6 +31,7 @@ using Veriado.Infrastructure.Repositories;
 using Veriado.Infrastructure.Search;
 using Veriado.Infrastructure.Time;
 using Veriado.Infrastructure.Storage;
+using Veriado.Infrastructure.Storage.Vpack;
 using Veriado.Domain.Primitives;
 using Veriado.Domain.Search.Events;
 using Veriado.Appl.Pipeline.Idempotency;
@@ -204,6 +205,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IStorageMigrationService, StorageMigrationService>();
         services.AddScoped<IExportPackageService, ExportPackageService>();
         services.AddScoped<IImportPackageService, ImportPackageService>();
+        services.AddSingleton<IVPackContainerService, VPackContainerService>();
         services.AddSingleton<IStorageSpaceAnalyzer, StorageSpaceAnalyzer>();
         services.AddSingleton<IFileHashCalculator, FileHashCalculator>();
         services.AddSingleton<IFileSystemMonitoringService, FileSystemMonitoringService>();

--- a/Veriado.Infrastructure/Storage/Vpack/VPackContainerService.cs
+++ b/Veriado.Infrastructure/Storage/Vpack/VPackContainerService.cs
@@ -1,0 +1,274 @@
+using System;
+using System.IO;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Veriado.Infrastructure.Storage.Vpack;
+
+public interface IVPackContainerService
+{
+    Task CreateContainerAsync(Stream vpfPayload, Stream output, VPackCreateOptions options, CancellationToken cancellationToken);
+
+    Task<VPackOpenResult> OpenContainerAsync(Stream input, VPackOpenOptions options, CancellationToken cancellationToken);
+}
+
+public sealed record VPackCreateOptions
+{
+    public bool EncryptPayload { get; init; }
+        = false;
+
+    public string? Password { get; init; }
+        = null;
+
+    public bool SignPayload { get; init; }
+        = false;
+
+    public string PayloadFormat { get; init; } = "VPF-1.0";
+
+    public string PayloadEncoding { get; init; } = "zip";
+}
+
+public sealed record VPackOpenOptions
+{
+    public string? Password { get; init; }
+        = null;
+
+    public bool ValidateSignature { get; init; }
+        = false;
+}
+
+public sealed record VPackHeader
+{
+    public string ContainerSpec { get; init; } = "Veriado.VPack";
+
+    public int ContainerVersion { get; init; }
+        = 1;
+
+    public string PayloadFormat { get; init; } = "VPF-1.0";
+
+    public string PayloadEncoding { get; init; } = "zip";
+
+    public bool IsEncrypted { get; init; }
+        = false;
+
+    public EncryptionHeader? Encryption { get; init; }
+        = null;
+
+    public bool IsSigned { get; init; }
+        = false;
+
+    public string? SignatureAlgorithm { get; init; }
+        = null;
+
+    public string? Signature { get; init; }
+        = null;
+}
+
+public sealed record EncryptionHeader
+{
+    public string Algorithm { get; init; } = "AES-GCM";
+
+    public string KeyDerivation { get; init; } = "PBKDF2";
+
+    public int Iterations { get; init; }
+        = 150000;
+
+    public string Salt { get; init; } = string.Empty;
+
+    public string Nonce { get; init; } = string.Empty;
+}
+
+public sealed record VPackOpenResult
+{
+    public bool Success { get; init; }
+
+    public string? Error { get; init; }
+        = null;
+
+    public VPackHeader? Header { get; init; }
+        = null;
+
+    public Stream? PayloadStream { get; init; }
+        = null;
+}
+
+public sealed class VPackContainerService : IVPackContainerService
+{
+    private static readonly byte[] Magic = Encoding.ASCII.GetBytes("VPK1");
+
+    public async Task CreateContainerAsync(Stream vpfPayload, Stream output, VPackCreateOptions options, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(vpfPayload);
+        ArgumentNullException.ThrowIfNull(output);
+        ArgumentNullException.ThrowIfNull(options);
+
+        var payloadBytes = await ReadAllBytesAsync(vpfPayload, cancellationToken).ConfigureAwait(false);
+
+        byte[] sealedPayload;
+        EncryptionHeader? encryptionHeader = null;
+        if (options.EncryptPayload)
+        {
+            if (string.IsNullOrEmpty(options.Password))
+            {
+                throw new InvalidOperationException("Password is required when EncryptPayload is true.");
+            }
+
+            encryptionHeader = CreateEncryptionHeader();
+            sealedPayload = Encrypt(payloadBytes, options.Password!, encryptionHeader);
+        }
+        else
+        {
+            sealedPayload = payloadBytes;
+        }
+
+        var header = new VPackHeader
+        {
+            PayloadFormat = options.PayloadFormat,
+            PayloadEncoding = options.PayloadEncoding,
+            IsEncrypted = options.EncryptPayload,
+            Encryption = encryptionHeader,
+            IsSigned = options.SignPayload,
+        };
+
+        var headerJson = JsonSerializer.SerializeToUtf8Bytes(header, new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            WriteIndented = true,
+            DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
+        });
+
+        var headerLength = BitConverter.GetBytes(headerJson.Length);
+
+        await output.WriteAsync(Magic, cancellationToken).ConfigureAwait(false);
+        await output.WriteAsync(headerLength, cancellationToken).ConfigureAwait(false);
+        await output.WriteAsync(headerJson, cancellationToken).ConfigureAwait(false);
+        await output.WriteAsync(sealedPayload, cancellationToken).ConfigureAwait(false);
+        await output.FlushAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<VPackOpenResult> OpenContainerAsync(Stream input, VPackOpenOptions options, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(input);
+        ArgumentNullException.ThrowIfNull(options);
+
+        var magic = new byte[Magic.Length];
+        var readMagic = await input.ReadAsync(magic, cancellationToken).ConfigureAwait(false);
+        if (readMagic != Magic.Length || !Magic.AsSpan().SequenceEqual(magic))
+        {
+            return new VPackOpenResult { Success = false, Error = "Invalid VPack magic." };
+        }
+
+        var headerLenBuffer = new byte[sizeof(int)];
+        var readHeaderLen = await input.ReadAsync(headerLenBuffer, cancellationToken).ConfigureAwait(false);
+        if (readHeaderLen != sizeof(int))
+        {
+            return new VPackOpenResult { Success = false, Error = "Corrupted VPack header length." };
+        }
+
+        var headerLength = BitConverter.ToInt32(headerLenBuffer, 0);
+        var headerBuffer = new byte[headerLength];
+        var readHeader = await input.ReadAsync(headerBuffer, cancellationToken).ConfigureAwait(false);
+        if (readHeader != headerLength)
+        {
+            return new VPackOpenResult { Success = false, Error = "Corrupted VPack header." };
+        }
+
+        var header = JsonSerializer.Deserialize<VPackHeader>(headerBuffer, new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        });
+
+        if (header is null || !string.Equals(header.ContainerSpec, "Veriado.VPack", StringComparison.Ordinal))
+        {
+            return new VPackOpenResult { Success = false, Error = "Unsupported VPack container." };
+        }
+
+        using var payloadBuffer = new MemoryStream();
+        await input.CopyToAsync(payloadBuffer, cancellationToken).ConfigureAwait(false);
+        var payloadBytes = payloadBuffer.ToArray();
+
+        if (header.IsEncrypted)
+        {
+            if (string.IsNullOrEmpty(options.Password))
+            {
+                return new VPackOpenResult { Success = false, Error = "Password required for encrypted VPack." };
+            }
+
+            if (header.Encryption is null)
+            {
+                return new VPackOpenResult { Success = false, Error = "Encryption header missing." };
+            }
+
+            payloadBytes = Decrypt(payloadBytes, options.Password!, header.Encryption);
+        }
+
+        var payloadStream = new MemoryStream(payloadBytes, writable: false);
+        return new VPackOpenResult
+        {
+            Success = true,
+            Header = header,
+            PayloadStream = payloadStream,
+        };
+    }
+
+    private static async Task<byte[]> ReadAllBytesAsync(Stream stream, CancellationToken cancellationToken)
+    {
+        await using var buffer = new MemoryStream();
+        await stream.CopyToAsync(buffer, cancellationToken).ConfigureAwait(false);
+        return buffer.ToArray();
+    }
+
+    private static EncryptionHeader CreateEncryptionHeader()
+    {
+        Span<byte> salt = stackalloc byte[16];
+        Span<byte> nonce = stackalloc byte[12];
+        RandomNumberGenerator.Fill(salt);
+        RandomNumberGenerator.Fill(nonce);
+
+        return new EncryptionHeader
+        {
+            Salt = Convert.ToBase64String(salt),
+            Nonce = Convert.ToBase64String(nonce),
+        };
+    }
+
+    private static byte[] Encrypt(byte[] payload, string password, EncryptionHeader header)
+    {
+        var salt = Convert.FromBase64String(header.Salt);
+        var nonce = Convert.FromBase64String(header.Nonce);
+        using var derive = new Rfc2898DeriveBytes(password, salt, header.Iterations, HashAlgorithmName.SHA256);
+        var key = derive.GetBytes(32);
+
+        var cipher = new byte[payload.Length];
+        var tag = new byte[16];
+        using var aes = new AesGcm(key);
+        aes.Encrypt(nonce, payload, cipher, tag);
+
+        var sealedPayload = new byte[cipher.Length + tag.Length];
+        Buffer.BlockCopy(cipher, 0, sealedPayload, 0, cipher.Length);
+        Buffer.BlockCopy(tag, 0, sealedPayload, cipher.Length, tag.Length);
+        return sealedPayload;
+    }
+
+    private static byte[] Decrypt(byte[] sealedPayload, string password, EncryptionHeader header)
+    {
+        var salt = Convert.FromBase64String(header.Salt);
+        var nonce = Convert.FromBase64String(header.Nonce);
+        using var derive = new Rfc2898DeriveBytes(password, salt, header.Iterations, HashAlgorithmName.SHA256);
+        var key = derive.GetBytes(32);
+
+        var cipherLength = sealedPayload.Length - 16;
+        var cipher = new byte[cipherLength];
+        var tag = new byte[16];
+        Buffer.BlockCopy(sealedPayload, 0, cipher, 0, cipherLength);
+        Buffer.BlockCopy(sealedPayload, cipherLength, tag, 0, 16);
+
+        var plaintext = new byte[cipherLength];
+        using var aes = new AesGcm(key);
+        aes.Decrypt(nonce, cipher, tag, plaintext);
+        return plaintext;
+    }
+}

--- a/Veriado.Infrastructure/Storage/Vpf/VpfLogicalModels.cs
+++ b/Veriado.Infrastructure/Storage/Vpf/VpfLogicalModels.cs
@@ -1,0 +1,144 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace Veriado.Infrastructure.Storage.Vpf;
+
+public sealed record PackageJsonModel
+{
+    public const string ExpectedSpec = "Veriado.Package";
+    public const string ExpectedSpecVersion = "1.0";
+
+    [JsonPropertyName("spec")]
+    public string Spec { get; init; } = ExpectedSpec;
+
+    [JsonPropertyName("specVersion")]
+    public string SpecVersion { get; init; } = ExpectedSpecVersion;
+
+    [JsonPropertyName("packageId")]
+    public Guid PackageId { get; init; } = Guid.NewGuid();
+
+    [JsonPropertyName("name")]
+    public string? Name { get; init; }
+        = null;
+
+    [JsonPropertyName("description")]
+    public string? Description { get; init; }
+        = null;
+
+    [JsonPropertyName("createdAtUtc")]
+    public DateTimeOffset CreatedAtUtc { get; init; } = DateTimeOffset.UtcNow;
+
+    [JsonPropertyName("createdBy")]
+    public string? CreatedBy { get; init; }
+        = null;
+
+    [JsonPropertyName("sourceInstanceId")]
+    public Guid SourceInstanceId { get; init; } = Guid.Empty;
+
+    [JsonPropertyName("sourceInstanceName")]
+    public string? SourceInstanceName { get; init; }
+        = null;
+
+    [JsonPropertyName("exportMode")]
+    public string ExportMode { get; init; } = "LogicalPerFile";
+}
+
+public sealed record MetadataJsonModel
+{
+    [JsonPropertyName("formatVersion")]
+    public int FormatVersion { get; init; } = 1;
+
+    [JsonPropertyName("applicationVersion")]
+    public string ApplicationVersion { get; init; } = string.Empty;
+
+    [JsonPropertyName("databaseSchemaVersion")]
+    public string? DatabaseSchemaVersion { get; init; }
+        = string.Empty;
+
+    [JsonPropertyName("exportMode")]
+    public string ExportMode { get; init; } = "LogicalPerFile";
+
+    [JsonPropertyName("originalStorageRootPath")]
+    public string OriginalStorageRootPath { get; init; } = string.Empty;
+
+    [JsonPropertyName("totalFilesCount")]
+    public int TotalFilesCount { get; init; }
+        = 0;
+
+    [JsonPropertyName("totalFilesBytes")]
+    public long TotalFilesBytes { get; init; }
+        = 0;
+
+    [JsonPropertyName("hashAlgorithm")]
+    public string HashAlgorithm { get; init; } = "SHA256";
+
+    [JsonPropertyName("fileDescriptorSchemaVersion")]
+    public int FileDescriptorSchemaVersion { get; init; } = 1;
+
+    [JsonPropertyName("extensions")]
+    public IReadOnlyList<string> Extensions { get; init; } = Array.Empty<string>();
+}
+
+public sealed record ExportedFileDescriptor
+{
+    [JsonPropertyName("schema")]
+    public string Schema { get; init; } = "Veriado.FileDescriptor";
+
+    [JsonPropertyName("schemaVersion")]
+    public int SchemaVersion { get; init; } = 1;
+
+    [JsonPropertyName("fileId")]
+    public Guid FileId { get; init; }
+        = Guid.Empty;
+
+    [JsonPropertyName("originalInstanceId")]
+    public Guid OriginalInstanceId { get; init; }
+        = Guid.Empty;
+
+    [JsonPropertyName("relativePath")]
+    public string RelativePath { get; init; } = string.Empty;
+
+    [JsonPropertyName("fileName")]
+    public string FileName { get; init; } = string.Empty;
+
+    [JsonPropertyName("contentHash")]
+    public string ContentHash { get; init; } = string.Empty;
+
+    [JsonPropertyName("sizeBytes")]
+    public long SizeBytes { get; init; }
+        = 0;
+
+    [JsonPropertyName("mimeType")]
+    public string? MimeType { get; init; }
+        = string.Empty;
+
+    [JsonPropertyName("createdAtUtc")]
+    public DateTimeOffset CreatedAtUtc { get; init; } = DateTimeOffset.MinValue;
+
+    [JsonPropertyName("createdBy")]
+    public string? CreatedBy { get; init; }
+        = null;
+
+    [JsonPropertyName("lastModifiedAtUtc")]
+    public DateTimeOffset LastModifiedAtUtc { get; init; } = DateTimeOffset.MinValue;
+
+    [JsonPropertyName("lastModifiedBy")]
+    public string? LastModifiedBy { get; init; }
+        = null;
+
+    [JsonPropertyName("isReadOnly")]
+    public bool IsReadOnly { get; init; }
+        = false;
+
+    [JsonPropertyName("labels")]
+    public IReadOnlyList<string> Labels { get; init; } = Array.Empty<string>();
+
+    [JsonPropertyName("customMetadata")]
+    public IDictionary<string, object?> CustomMetadata { get; init; }
+        = new Dictionary<string, object?>();
+
+    [JsonPropertyName("extensions")]
+    public IDictionary<string, object?> Extensions { get; init; }
+        = new Dictionary<string, object?>();
+}

--- a/Veriado.Infrastructure/Storage/Vpf/VpfPackageValidator.cs
+++ b/Veriado.Infrastructure/Storage/Vpf/VpfPackageValidator.cs
@@ -57,13 +57,13 @@ public sealed class VpfPackageValidator
                 "Package is missing metadata.json."));
         }
 
-        VpfPackageManifest? manifest = null;
-        VpfTechnicalMetadata? metadata = null;
+        PackageJsonModel? manifest = null;
+        MetadataJsonModel? metadata = null;
 
         if (File.Exists(manifestPath))
         {
-            manifest = await DeserializeAsync<VpfPackageManifest>(manifestPath, cancellationToken).ConfigureAwait(false);
-            if (!string.Equals(manifest.Spec, VpfPackageManifest.ExpectedSpec, StringComparison.Ordinal))
+            manifest = await DeserializeAsync<PackageJsonModel>(manifestPath, cancellationToken).ConfigureAwait(false);
+            if (!string.Equals(manifest.Spec, PackageJsonModel.ExpectedSpec, StringComparison.Ordinal))
             {
                 issues.Add(new ImportValidationIssue(
                     ImportIssueType.ManifestUnsupported,
@@ -72,7 +72,7 @@ public sealed class VpfPackageValidator
                     $"Unsupported manifest spec '{manifest.Spec}'."));
             }
 
-            if (!string.Equals(manifest.SpecVersion, VpfPackageManifest.ExpectedSpecVersion, StringComparison.Ordinal))
+            if (!string.Equals(manifest.SpecVersion, PackageJsonModel.ExpectedSpecVersion, StringComparison.Ordinal))
             {
                 issues.Add(new ImportValidationIssue(
                     ImportIssueType.ManifestUnsupported,
@@ -84,7 +84,7 @@ public sealed class VpfPackageValidator
 
         if (File.Exists(metadataPath))
         {
-            metadata = await DeserializeAsync<VpfTechnicalMetadata>(metadataPath, cancellationToken).ConfigureAwait(false);
+            metadata = await DeserializeAsync<MetadataJsonModel>(metadataPath, cancellationToken).ConfigureAwait(false);
             if (metadata.FormatVersion != 1)
             {
                 issues.Add(new ImportValidationIssue(
@@ -113,7 +113,7 @@ public sealed class VpfPackageValidator
                 null,
                 "Package does not contain a files directory."));
 
-            return new ImportValidationResult(false, issues, 0, 0, 0, validatedFiles, Array.Empty<ImportItemPreview>(), 0, 0, 0);
+            return new ImportValidationResult(false, issues, 0, 0, 0, validatedFiles, Array.Empty<ImportItemPreview>(), 0, 0, 0, 0, 0);
         }
 
         var totalFiles = 0;
@@ -146,7 +146,7 @@ public sealed class VpfPackageValidator
             }
 
             descriptorCount++;
-            var descriptor = await DeserializeAsync<VpfFileDescriptor>(descriptorPath, cancellationToken).ConfigureAwait(false);
+            var descriptor = await DeserializeAsync<ExportedFileDescriptor>(descriptorPath, cancellationToken).ConfigureAwait(false);
             seenDescriptors.Add(descriptorPath);
 
             if (!string.Equals(descriptor.Schema, "Veriado.FileDescriptor", StringComparison.Ordinal))
@@ -252,7 +252,7 @@ public sealed class VpfPackageValidator
             }
         }
 
-        return new ImportValidationResult(issues.Count == 0, issues, totalFiles, descriptorCount, totalBytes, validatedFiles, Array.Empty<ImportItemPreview>(), 0, 0, 0);
+        return new ImportValidationResult(issues.Count == 0, issues, totalFiles, descriptorCount, totalBytes, validatedFiles, Array.Empty<ImportItemPreview>(), 0, 0, 0, 0, 0);
     }
 
     private static async Task<T> DeserializeAsync<T>(string path, CancellationToken cancellationToken)

--- a/Veriado.Services/Storage/IStorageManagementService.cs
+++ b/Veriado.Services/Storage/IStorageManagementService.cs
@@ -25,6 +25,10 @@ public interface IStorageManagementService
         StorageExportOptionsDto? options,
         CancellationToken cancellationToken);
 
+    Task<StorageOperationResultDto> ExportAsync(
+        ExportRequestDto request,
+        CancellationToken cancellationToken);
+
     Task<StorageOperationResultDto> ImportAsync(
         string packageRoot,
         string targetStorageRoot,

--- a/Veriado.Services/Storage/StorageManagementService.cs
+++ b/Veriado.Services/Storage/StorageManagementService.cs
@@ -60,6 +60,17 @@ public sealed class StorageManagementService : IStorageManagementService
         return Map(result);
     }
 
+    public async Task<StorageOperationResultDto> ExportAsync(
+        ExportRequestDto request,
+        CancellationToken cancellationToken)
+    {
+        var result = await _exportService
+            .ExportPackageAsync(Map(request), cancellationToken)
+            .ConfigureAwait(false);
+
+        return Map(result);
+    }
+
     public async Task<StorageOperationResultDto> ImportAsync(
         string packageRoot,
         string targetStorageRoot,
@@ -78,7 +89,7 @@ public sealed class StorageManagementService : IStorageManagementService
         CancellationToken cancellationToken)
     {
         var validation = await _importService
-            .ValidateLogicalPackageAsync(Map(request), cancellationToken)
+            .ValidateImportAsync(Map(request), cancellationToken)
             .ConfigureAwait(false);
 
         return Map(validation);
@@ -90,7 +101,7 @@ public sealed class StorageManagementService : IStorageManagementService
         CancellationToken cancellationToken)
     {
         var commit = await _importService
-            .CommitLogicalPackageAsync(Map(request), conflictStrategy, cancellationToken)
+            .CommitImportAsync(Map(request), conflictStrategy, cancellationToken)
             .ConfigureAwait(false);
 
         return Map(commit);
@@ -140,6 +151,20 @@ public sealed class StorageManagementService : IStorageManagementService
         };
     }
 
+    private static ExportRequest Map(ExportRequestDto dto)
+        => new()
+        {
+            DestinationPath = dto.DestinationPath,
+            PackageName = dto.PackageName,
+            Description = dto.Description,
+            OverwriteExisting = dto.OverwriteExisting,
+            EncryptPayload = dto.EncryptPayload,
+            Password = dto.Password,
+            SignPayload = dto.SignPayload,
+            SourceInstanceId = dto.SourceInstanceId,
+            SourceInstanceName = dto.SourceInstanceName,
+        };
+
     private static ImportRequest Map(ImportRequestDto dto)
         => new()
         {
@@ -147,6 +172,7 @@ public sealed class StorageManagementService : IStorageManagementService
             ScopeFilter = dto.ScopeFilter,
             TargetStorageRoot = dto.TargetStorageRoot,
             DefaultConflictStrategy = dto.DefaultConflictStrategy,
+            Password = dto.Password,
         };
 
     private static StorageOperationResultDto Map(StorageOperationResult result)
@@ -188,8 +214,10 @@ public sealed class StorageManagementService : IStorageManagementService
                 .Select(Map)
                 .ToArray(),
             NewItems = result.NewItems,
-            UpdatableItems = result.UpdatableItems,
-            SkippedItems = result.SkippedItems,
+            SameItems = result.SameItems,
+            NewerItems = result.NewerItems,
+            OlderItems = result.OlderItems,
+            ConflictItems = result.ConflictItems,
         };
     }
 


### PR DESCRIPTION
## Summary
- add VPF package models, descriptor validation updates, and new DTOs for export/import flows
- implement VPack container service with optional encryption and use it in the export pipeline built in temp locations
- extend import logic with VPack extraction, conflict-aware classification, and updated mappings across services

## Testing
- dotnet build Veriado.sln -v minimal *(fails: dotnet is not installed in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692a94ce04c88326821e9803eb93ee88)