### PR TITLE
Make StorageOperationResult a record

### DIFF
--- a/Veriado.Application/Abstractions/IStorageMigrationService.cs
+++ b/Veriado.Application/Abstractions/IStorageMigrationService.cs
@@ -135,7 +135,7 @@ public enum StorageOperationStatus
     PendingMigrations,
 }
 
-public sealed class StorageOperationResult
+public sealed record StorageOperationResult
 {
     public StorageOperationStatus Status { get; init; }
 


### PR DESCRIPTION
## Summary
- convert StorageOperationResult to a record so it can be used with C# with-expressions

## Testing
- dotnet build Veriado.sln *(fails: dotnet CLI not available in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b15ff296c832681db66406e52d3db)