### PR TITLE
Add VTP metadata support for storage packages

### DIFF
--- a/Veriado.Application/Abstractions/VtpModels.cs
+++ b/Veriado.Application/Abstractions/VtpModels.cs
@@ -1,0 +1,83 @@
+using System;
+using Contracts = Veriado.Contracts.Storage;
+
+namespace Veriado.Application.Abstractions;
+
+public enum VtpPayloadType
+{
+    Unknown = 0,
+    VpfPackage = 1,
+}
+
+public enum VtpImportItemStatus
+{
+    Unknown = 0,
+    Imported = 1,
+    Skipped = 2,
+    Conflicted = 3,
+}
+
+public enum VtpImportResultCode
+{
+    Unknown = 0,
+    Success = 1,
+    PartialSuccess = 2,
+    Failed = 3,
+}
+
+public sealed record VtpPackageInfo(
+    string Protocol,
+    string ProtocolVersion,
+    VtpPayloadType PayloadType,
+    Guid PackageId,
+    Guid CorrelationId,
+    Guid SourceInstanceId,
+    Guid TargetInstanceId)
+{
+    public static VtpPackageInfo Default(Guid? packageId = null, Guid? correlationId = null, Guid? sourceInstanceId = null, Guid? targetInstanceId = null)
+        => new(
+            "VTP",
+            "1.0",
+            VtpPayloadType.VpfPackage,
+            packageId ?? Guid.NewGuid(),
+            correlationId ?? Guid.NewGuid(),
+            sourceInstanceId ?? Guid.Empty,
+            targetInstanceId ?? Guid.Empty);
+}
+
+public static class VtpMappings
+{
+    public static VtpPackageInfo ToModel(this Contracts.VtpPackageInfo dto)
+        => new(
+            dto.Protocol,
+            dto.ProtocolVersion,
+            (VtpPayloadType)dto.PayloadType,
+            dto.PackageId,
+            dto.CorrelationId,
+            dto.SourceInstanceId,
+            dto.TargetInstanceId);
+
+    public static Contracts.VtpPackageInfo ToContract(this VtpPackageInfo model)
+        => new()
+        {
+            Protocol = model.Protocol,
+            ProtocolVersion = model.ProtocolVersion,
+            PayloadType = (Contracts.VtpPayloadType)model.PayloadType,
+            PackageId = model.PackageId,
+            CorrelationId = model.CorrelationId,
+            SourceInstanceId = model.SourceInstanceId,
+            TargetInstanceId = model.TargetInstanceId,
+        };
+
+    public static VtpImportItemStatus ToModel(this Contracts.VtpImportItemStatus status)
+        => (VtpImportItemStatus)status;
+
+    public static Contracts.VtpImportItemStatus ToContract(this VtpImportItemStatus status)
+        => (Contracts.VtpImportItemStatus)status;
+
+    public static VtpImportResultCode ToModel(this Contracts.VtpImportResultCode status)
+        => (VtpImportResultCode)status;
+
+    public static Contracts.VtpImportResultCode ToContract(this VtpImportResultCode status)
+        => (Contracts.VtpImportResultCode)status;
+}

--- a/Veriado.Contracts/Storage/VtpContracts.cs
+++ b/Veriado.Contracts/Storage/VtpContracts.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Text.Json.Serialization;
+
+namespace Veriado.Contracts.Storage;
+
+public enum VtpPayloadType
+{
+    Unknown = 0,
+    VpfPackage = 1,
+}
+
+public enum VtpImportItemStatus
+{
+    Unknown = 0,
+    Imported = 1,
+    Skipped = 2,
+    Conflicted = 3,
+}
+
+public enum VtpImportResultCode
+{
+    Unknown = 0,
+    Success = 1,
+    PartialSuccess = 2,
+    Failed = 3,
+}
+
+public sealed record VtpPackageInfo
+{
+    [JsonPropertyName("protocol")]
+    public string Protocol { get; init; } = "VTP";
+
+    [JsonPropertyName("protocolVersion")]
+    public string ProtocolVersion { get; init; } = "1.0";
+
+    [JsonPropertyName("payloadType")]
+    public VtpPayloadType PayloadType { get; init; } = VtpPayloadType.VpfPackage;
+
+    [JsonPropertyName("packageId")]
+    public Guid PackageId { get; init; } = Guid.NewGuid();
+
+    [JsonPropertyName("correlationId")]
+    public Guid CorrelationId { get; init; } = Guid.NewGuid();
+
+    [JsonPropertyName("sourceInstanceId")]
+    public Guid SourceInstanceId { get; init; } = Guid.Empty;
+
+    [JsonPropertyName("targetInstanceId")]
+    public Guid TargetInstanceId { get; init; } = Guid.Empty;
+}

--- a/Veriado.Infrastructure/Storage/ExportPackageService.cs
+++ b/Veriado.Infrastructure/Storage/ExportPackageService.cs
@@ -257,9 +257,21 @@ public sealed class ExportPackageService : IExportPackageService
             }
         }
 
+        var packageId = Guid.NewGuid();
+        var correlationId = Guid.NewGuid();
+
+        var vtpInfo = new VtpPackageInfo
+        {
+            PackageId = packageId,
+            CorrelationId = correlationId,
+            SourceInstanceId = request.SourceInstanceId ?? Guid.Empty,
+            TargetInstanceId = Guid.Empty,
+            PayloadType = VtpPayloadType.VpfPackage,
+        };
+
         var manifest = new PackageJsonModel
         {
-            PackageId = Guid.NewGuid(),
+            PackageId = packageId,
             Name = request.PackageName ?? "Veriado Package",
             Description = request.Description,
             CreatedAtUtc = DateTimeOffset.UtcNow,
@@ -267,6 +279,7 @@ public sealed class ExportPackageService : IExportPackageService
             SourceInstanceId = request.SourceInstanceId ?? Guid.Empty,
             SourceInstanceName = request.SourceInstanceName,
             ExportMode = "LogicalPerFile",
+            Vtp = vtpInfo,
         };
 
         var metadata = new MetadataJsonModel
@@ -280,6 +293,7 @@ public sealed class ExportPackageService : IExportPackageService
             TotalFilesBytes = totalBytes,
             HashAlgorithm = "SHA256",
             FileDescriptorSchemaVersion = 1,
+            Vtp = vtpInfo,
         };
 
         await WriteJsonAsync(Path.Combine(normalizedPackageRoot, VpfPackagePaths.PackageManifestFile), manifest, cancellationToken).ConfigureAwait(false);

--- a/Veriado.Infrastructure/Storage/Vpf/VpfLogicalModels.cs
+++ b/Veriado.Infrastructure/Storage/Vpf/VpfLogicalModels.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
+using Veriado.Contracts.Storage;
 
 namespace Veriado.Infrastructure.Storage.Vpf;
 
@@ -14,6 +15,9 @@ public sealed record PackageJsonModel
 
     [JsonPropertyName("specVersion")]
     public string SpecVersion { get; init; } = ExpectedSpecVersion;
+
+    [JsonPropertyName("vtp")]
+    public VtpPackageInfo Vtp { get; init; } = new();
 
     [JsonPropertyName("packageId")]
     public Guid PackageId { get; init; } = Guid.NewGuid();
@@ -51,6 +55,9 @@ public sealed record MetadataJsonModel
 
     [JsonPropertyName("applicationVersion")]
     public string ApplicationVersion { get; init; } = string.Empty;
+
+    [JsonPropertyName("vtp")]
+    public VtpPackageInfo Vtp { get; init; } = new();
 
     [JsonPropertyName("databaseSchemaVersion")]
     public string? DatabaseSchemaVersion { get; init; }


### PR DESCRIPTION
## Summary
- add VTP contract enums and package envelope definitions with application-layer mappings
- extend VPF package and metadata manifests to carry VTP information and populate it during export

## Testing
- Not run (dotnet not installed in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b2dcde0e88326a1be3a5eb4598420)