### PR TITLE
Validate VTP metadata during import

### DIFF
--- a/Veriado.Application/Abstractions/ImportModels.cs
+++ b/Veriado.Application/Abstractions/ImportModels.cs
@@ -51,6 +51,7 @@ public sealed record ImportItemPreview(
     long SizeBytes,
     DateTimeOffset LastModifiedAtUtc,
     ImportItemStatus Status,
+    VtpImportItemStatus VtpStatus,
     string? ConflictReason);
 
 public sealed record ImportValidationResult(
@@ -65,7 +66,8 @@ public sealed record ImportValidationResult(
     int SameItems,
     int NewerItems,
     int OlderItems,
-    int ConflictItems)
+    int ConflictItems,
+    VtpPackageInfo? Vtp)
 {
     public static ImportValidationResult FromIssues(IReadOnlyList<ImportValidationIssue> issues)
         => new(
@@ -80,7 +82,8 @@ public sealed record ImportValidationResult(
             0,
             0,
             0,
-            0);
+            0,
+            null);
 }
 
 public sealed record ImportCommitResult(

--- a/Veriado.Contracts/Storage/ImportContracts.cs
+++ b/Veriado.Contracts/Storage/ImportContracts.cs
@@ -86,6 +86,7 @@ public sealed record ImportValidationResultDto
     public int NewerItems { get; init; }
     public int OlderItems { get; init; }
     public int ConflictItems { get; init; }
+    public VtpPackageInfo? Vtp { get; init; }
 }
 
 public sealed record ValidatedImportFileDto
@@ -119,5 +120,6 @@ public sealed record ImportItemPreviewDto
     public long SizeBytes { get; init; }
     public DateTimeOffset LastModifiedAtUtc { get; init; }
     public ImportItemStatus Status { get; init; }
+    public VtpImportItemStatus VtpStatus { get; init; }
     public string? ConflictReason { get; init; }
 }

--- a/Veriado.Services/Storage/StorageManagementService.cs
+++ b/Veriado.Services/Storage/StorageManagementService.cs
@@ -209,6 +209,7 @@ public sealed class StorageManagementService : IStorageManagementService
             DiscoveredDescriptors = result.DiscoveredDescriptors,
             DiscoveredFiles = result.DiscoveredFiles,
             TotalBytes = result.TotalBytes,
+            Vtp = result.Vtp?.ToContract(),
             Issues = result.Issues
                 .Select(Map)
                 .ToArray(),
@@ -271,6 +272,7 @@ public sealed class StorageManagementService : IStorageManagementService
             SizeBytes = preview.SizeBytes,
             LastModifiedAtUtc = preview.LastModifiedAtUtc,
             Status = preview.Status,
+            VtpStatus = preview.VtpStatus.ToContract(),
             ConflictReason = preview.ConflictReason,
         };
 


### PR DESCRIPTION
## Summary
- validate VTP metadata from package.json/metadata.json and VPack headers, enforcing protocol version and payload type expectations
- expose VTP package info and per-item VTP import statuses in import validation results

## Testing
- `dotnet test Veriado.sln` *(fails: `dotnet` command not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b307e74d88326b427cf1e24f7a5ae)