### PR TITLE
Add VTP mappings to import results

### DIFF
--- a/Veriado.Application/Abstractions/ImportModels.cs
+++ b/Veriado.Application/Abstractions/ImportModels.cs
@@ -92,4 +92,6 @@ public sealed record ImportCommitResult(
     int SkippedFiles,
     int ConflictedFiles,
     IReadOnlyList<ImportValidationIssue> Issues,
-    IReadOnlyList<ImportItemPreview> Items);
+    IReadOnlyList<ImportItemPreview> Items,
+    VtpImportResultCode VtpResultCode,
+    Guid? CorrelationId);

--- a/Veriado.Contracts/Storage/ImportContracts.cs
+++ b/Veriado.Contracts/Storage/ImportContracts.cs
@@ -109,6 +109,8 @@ public sealed record ImportCommitResultDto
     public int ConflictedFiles { get; init; }
     public IReadOnlyList<ImportValidationIssueDto> Issues { get; init; } = Array.Empty<ImportValidationIssueDto>();
     public IReadOnlyList<ImportItemPreviewDto> Items { get; init; } = Array.Empty<ImportItemPreviewDto>();
+    public VtpImportResultCode VtpResultCode { get; init; }
+    public Guid? CorrelationId { get; init; }
 }
 
 public sealed record ImportItemPreviewDto

--- a/Veriado.Services/Storage/StorageManagementService.cs
+++ b/Veriado.Services/Storage/StorageManagementService.cs
@@ -237,6 +237,8 @@ public sealed class StorageManagementService : IStorageManagementService
             ConflictedFiles = result.ConflictedFiles,
             Issues = result.Issues.Select(Map).ToArray(),
             Items = result.Items.Select(Map).ToArray(),
+            VtpResultCode = result.VtpResultCode.ToContract(),
+            CorrelationId = result.CorrelationId,
         };
     }
 


### PR DESCRIPTION
## Summary
- map import item statuses to VTP import statuses and track outcomes during commit
- surface VTP import result codes and correlation IDs in commit results and DTO mappings

## Testing
- dotnet test *(fails: command not found)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b31d3916883269eea8980d2a7061f)