### PR TITLE
Align VTP protocol enums and import/export flow

### DIFF
--- a/Veriado.Application/Abstractions/IStorageMigrationService.cs
+++ b/Veriado.Application/Abstractions/IStorageMigrationService.cs
@@ -143,6 +143,8 @@ public sealed record StorageOperationResult
 
     public VtpPackageInfo? Vtp { get; init; }
 
+    public VtpImportResultCode? VtpResultCode { get; init; }
+
     public IReadOnlyList<string> MissingFiles { get; init; } = Array.Empty<string>();
 
     public IReadOnlyList<string> FailedFiles { get; init; } = Array.Empty<string>();

--- a/Veriado.Application/Abstractions/VtpModels.cs
+++ b/Veriado.Application/Abstractions/VtpModels.cs
@@ -7,20 +7,27 @@ public enum VtpPayloadType
 {
     Unknown = 0,
     VpfPackage = 1,
+    FullExport = 2,
+    DeltaExport = 3,
+    Backup = 4,
 }
 
 public enum VtpImportItemStatus
 {
     Unknown = 0,
-    Imported = 1,
-    Skipped = 2,
-    Conflicted = 3,
+    New = 1,
+    Same = 2,
+    Updated = 3,
+    SkippedOlder = 4,
+    Conflict = 5,
+    Failed = 6,
 }
 
 public enum VtpImportResultCode
 {
-    Unknown = 0,
-    Success = 1,
+    Unknown = -1,
+    Ok = 0,
+    OkWithWarnings = 1,
     PartialSuccess = 2,
     Failed = 3,
 }
@@ -32,17 +39,21 @@ public sealed record VtpPackageInfo(
     Guid PackageId,
     Guid CorrelationId,
     Guid SourceInstanceId,
-    Guid TargetInstanceId)
+    string? SourceInstanceName,
+    Guid TargetInstanceId,
+    string? TargetInstanceName)
 {
     public static VtpPackageInfo Default(Guid? packageId = null, Guid? correlationId = null, Guid? sourceInstanceId = null, Guid? targetInstanceId = null)
         => new(
-            "VTP",
+            "Veriado.Transfer",
             "1.0",
             VtpPayloadType.VpfPackage,
             packageId ?? Guid.NewGuid(),
             correlationId ?? Guid.NewGuid(),
             sourceInstanceId ?? Guid.Empty,
-            targetInstanceId ?? Guid.Empty);
+            null,
+            targetInstanceId ?? Guid.Empty,
+            null);
 }
 
 public static class VtpMappings
@@ -55,7 +66,9 @@ public static class VtpMappings
             dto.PackageId,
             dto.CorrelationId,
             dto.SourceInstanceId,
-            dto.TargetInstanceId);
+            dto.SourceInstanceName,
+            dto.TargetInstanceId,
+            dto.TargetInstanceName);
 
     public static Contracts.VtpPackageInfo ToContract(this VtpPackageInfo model)
         => new()
@@ -66,7 +79,9 @@ public static class VtpMappings
             PackageId = model.PackageId,
             CorrelationId = model.CorrelationId,
             SourceInstanceId = model.SourceInstanceId,
+            SourceInstanceName = model.SourceInstanceName,
             TargetInstanceId = model.TargetInstanceId,
+            TargetInstanceName = model.TargetInstanceName,
         };
 
     public static VtpImportItemStatus ToModel(this Contracts.VtpImportItemStatus status)

--- a/Veriado.Contracts/Storage/ImportContracts.cs
+++ b/Veriado.Contracts/Storage/ImportContracts.cs
@@ -37,11 +37,14 @@ public enum ImportIssueSeverity
 
 public enum ImportItemStatus
 {
-    New,
-    Same,
-    NewerInPackage,
-    OlderInPackage,
-    Conflict,
+    New = 0,
+    Same = 1,
+    Updated = 2,
+    NewerInPackage = Updated,
+    SkippedOlder = 3,
+    OlderInPackage = SkippedOlder,
+    Conflict = 4,
+    Failed = 5,
 }
 
 public enum ImportCommitStatus

--- a/Veriado.Contracts/Storage/StorageOperationResultDto.cs
+++ b/Veriado.Contracts/Storage/StorageOperationResultDto.cs
@@ -12,6 +12,8 @@ public sealed record StorageOperationResultDto
 
     public VtpPackageInfo? Vtp { get; init; }
 
+    public VtpImportResultCode? VtpResultCode { get; init; }
+
     public IReadOnlyList<string> MissingFiles { get; init; } = Array.Empty<string>();
 
     public IReadOnlyList<string> FailedFiles { get; init; } = Array.Empty<string>();

--- a/Veriado.Contracts/Storage/VtpContracts.cs
+++ b/Veriado.Contracts/Storage/VtpContracts.cs
@@ -7,20 +7,27 @@ public enum VtpPayloadType
 {
     Unknown = 0,
     VpfPackage = 1,
+    FullExport = 2,
+    DeltaExport = 3,
+    Backup = 4,
 }
 
 public enum VtpImportItemStatus
 {
     Unknown = 0,
-    Imported = 1,
-    Skipped = 2,
-    Conflicted = 3,
+    New = 1,
+    Same = 2,
+    Updated = 3,
+    SkippedOlder = 4,
+    Conflict = 5,
+    Failed = 6,
 }
 
 public enum VtpImportResultCode
 {
-    Unknown = 0,
-    Success = 1,
+    Unknown = -1,
+    Ok = 0,
+    OkWithWarnings = 1,
     PartialSuccess = 2,
     Failed = 3,
 }
@@ -28,7 +35,7 @@ public enum VtpImportResultCode
 public sealed record VtpPackageInfo
 {
     [JsonPropertyName("protocol")]
-    public string Protocol { get; init; } = "VTP";
+    public string Protocol { get; init; } = "Veriado.Transfer";
 
     [JsonPropertyName("protocolVersion")]
     public string ProtocolVersion { get; init; } = "1.0";
@@ -45,6 +52,14 @@ public sealed record VtpPackageInfo
     [JsonPropertyName("sourceInstanceId")]
     public Guid SourceInstanceId { get; init; } = Guid.Empty;
 
+    [JsonPropertyName("sourceInstanceName")]
+    public string? SourceInstanceName { get; init; }
+        = null;
+
     [JsonPropertyName("targetInstanceId")]
     public Guid TargetInstanceId { get; init; } = Guid.Empty;
+
+    [JsonPropertyName("targetInstanceName")]
+    public string? TargetInstanceName { get; init; }
+        = null;
 }

--- a/Veriado.Infrastructure/Storage/ExportPackageService.cs
+++ b/Veriado.Infrastructure/Storage/ExportPackageService.cs
@@ -269,11 +269,14 @@ public sealed class ExportPackageService : IExportPackageService
 
         var vtpInfo = new VtpPackageInfo
         {
+            Protocol = "Veriado.Transfer",
+            ProtocolVersion = "1.0",
             PackageId = packageId,
             CorrelationId = correlationId,
             SourceInstanceId = request.SourceInstanceId ?? Guid.Empty,
+            SourceInstanceName = request.SourceInstanceName,
             TargetInstanceId = Guid.Empty,
-            PayloadType = VtpPayloadType.VpfPackage,
+            PayloadType = VtpPayloadType.FullExport,
         };
 
         var manifest = new PackageJsonModel

--- a/Veriado.Infrastructure/Storage/Vpf/VpfPackageValidator.cs
+++ b/Veriado.Infrastructure/Storage/Vpf/VpfPackageValidator.cs
@@ -291,7 +291,7 @@ public sealed class VpfPackageValidator
         ImportIssueType issueType,
         ICollection<ImportValidationIssue> issues)
     {
-        if (!string.Equals(vtp.Protocol, "VTP", StringComparison.OrdinalIgnoreCase))
+        if (!string.Equals(vtp.Protocol, "Veriado.Transfer", StringComparison.OrdinalIgnoreCase))
         {
             issues.Add(new ImportValidationIssue(
                 issueType,
@@ -309,7 +309,7 @@ public sealed class VpfPackageValidator
                 $"{source} declares unsupported VTP protocolVersion '{vtp.ProtocolVersion}'."));
         }
 
-        if (vtp.PayloadType != VtpPayloadType.VpfPackage)
+        if (!IsSupportedPayload(vtp.PayloadType))
         {
             issues.Add(new ImportValidationIssue(
                 issueType,
@@ -318,6 +318,12 @@ public sealed class VpfPackageValidator
                 $"{source} payloadType '{vtp.PayloadType}' is not supported."));
         }
     }
+
+    private static bool IsSupportedPayload(VtpPayloadType payloadType)
+        => payloadType is VtpPayloadType.VpfPackage
+            or VtpPayloadType.FullExport
+            or VtpPayloadType.DeltaExport
+            or VtpPayloadType.Backup;
 
     private static async Task<T> DeserializeAsync<T>(string path, CancellationToken cancellationToken)
     {

--- a/Veriado.Services/Storage/StorageManagementService.cs
+++ b/Veriado.Services/Storage/StorageManagementService.cs
@@ -182,6 +182,7 @@ public sealed class StorageManagementService : IStorageManagementService
             Status = Map(result.Status),
             Message = result.Message,
             Vtp = result.Vtp?.ToContract(),
+            VtpResultCode = result.VtpResultCode?.ToContract(),
             MissingFiles = result.MissingFiles,
             FailedFiles = result.FailedFiles,
             Warnings = result.Warnings,


### PR DESCRIPTION
## Summary
- expand VTP contracts with protocol fields, payload types, and detailed import codes
- update import/export services and validators to honor the new VTP metadata and result mapping
- surface VTP import result codes through storage operation results and API mappings

## Testing
- ⚠️ `dotnet test -q` *(dotnet SDK unavailable in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b3555d31c8326a3165ff968a7f907)