### PR TITLE
Use VTP factory when creating export package metadata

### DIFF
--- a/Veriado.Infrastructure/Storage/ExportPackageService.cs
+++ b/Veriado.Infrastructure/Storage/ExportPackageService.cs
@@ -269,16 +269,13 @@ public sealed class ExportPackageService : IExportPackageService
         var packageId = Guid.NewGuid();
         var correlationId = Guid.NewGuid();
 
-        var vtpInfo = new AppVtpPackageInfo(
-            "Veriado.Transfer",
-            "1.0",
-            AppVtpPayloadType.FullExport,
-            packageId,
-            correlationId,
-            request.SourceInstanceId ?? Guid.Empty,
-            request.SourceInstanceName,
-            Guid.Empty,
-            targetInstanceName: null);
+        var vtpInfo = AppVtpPackageInfo
+            .Default(packageId, correlationId, request.SourceInstanceId ?? Guid.Empty, targetInstanceId: Guid.Empty)
+            with
+            {
+                PayloadType = AppVtpPayloadType.FullExport,
+                SourceInstanceName = request.SourceInstanceName,
+            };
 
         var manifest = new PackageJsonModel
         {


### PR DESCRIPTION
## Summary
- build VTP package info via the default factory method when exporting packages
- explicitly set the payload type and source instance name on the generated metadata

## Testing
- not run (dotnet CLI unavailable in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b385dd56083268c35c5c56966a559)