### PR TITLE
Add contracts dependency to infrastructure project

### DIFF
--- a/Veriado.Infrastructure/Veriado.Infrastructure.csproj
+++ b/Veriado.Infrastructure/Veriado.Infrastructure.csproj
@@ -32,5 +32,6 @@
   <ItemGroup>
     <ProjectReference Include="..\Veriado.Domain\Veriado.Domain.csproj" />
     <ProjectReference Include="..\Veriado.Application\Veriado.Appl.csproj" />
+    <ProjectReference Include="..\Veriado.Contracts\Veriado.Contracts.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- add missing project reference to Veriado.Contracts so infrastructure can access contract types

## Testing
- dotnet build (fails: dotnet not installed in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b393ac8ec8326be41cd046a0e98ea)