### PR TITLE
Fix VTP contract namespace usage in export service

### DIFF
--- a/Veriado.Infrastructure/Storage/ExportPackageService.cs
+++ b/Veriado.Infrastructure/Storage/ExportPackageService.cs
@@ -9,9 +9,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
-using Veriado.Appl.Abstractions;
 using Veriado.Application.Abstractions;
-using Contracts = Veriado.Contracts.Storage;
+using Veriado.Contracts.Storage;
 using AppVtpPackageInfo = Veriado.Application.Abstractions.VtpPackageInfo;
 using AppVtpPayloadType = Veriado.Application.Abstractions.VtpPayloadType;
 using Veriado.Infrastructure.Persistence;
@@ -277,7 +276,7 @@ public sealed class ExportPackageService : IExportPackageService
                 SourceInstanceName = request.SourceInstanceName,
             };
 
-        Contracts.VtpPackageInfo vtpContract = vtpInfo.ToContract();
+        VtpPackageInfo vtpContract = vtpInfo.ToContract();
 
         var manifest = new PackageJsonModel
         {


### PR DESCRIPTION
## Summary
- switch ExportPackageService to import VTP contract types from the Storage namespace directly
- simplify VTP package conversion to use the imported contract type

## Testing
- not run (not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b5855faa0832687c0038632703f5e)