### PR TITLE
Resolve VTP contract alias ambiguity in ExportPackageService

### DIFF
--- a/Veriado.Infrastructure/Storage/ExportPackageService.cs
+++ b/Veriado.Infrastructure/Storage/ExportPackageService.cs
@@ -10,7 +10,7 @@ using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Veriado.Application.Abstractions;
-using Veriado.Contracts.Storage;
+using Contracts = Veriado.Contracts.Storage;
 using AppVtpPackageInfo = Veriado.Application.Abstractions.VtpPackageInfo;
 using AppVtpPayloadType = Veriado.Application.Abstractions.VtpPayloadType;
 using Veriado.Infrastructure.Persistence;
@@ -276,7 +276,7 @@ public sealed class ExportPackageService : IExportPackageService
                 SourceInstanceName = request.SourceInstanceName,
             };
 
-        VtpPackageInfo vtpContract = vtpInfo.ToContract();
+        Contracts.VtpPackageInfo vtpContract = vtpInfo.ToContract();
 
         var manifest = new PackageJsonModel
         {


### PR DESCRIPTION
## Summary
- alias the storage contracts namespace to prevent VtpPackageInfo ambiguity
- explicitly use the contract VTP type when building export metadata

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b5c7032508326b297309922e2f617)