### PR TITLE
Fix VTP package validation issues

### DIFF
--- a/Veriado.Infrastructure/Storage/ImportPackageService.cs
+++ b/Veriado.Infrastructure/Storage/ImportPackageService.cs
@@ -161,7 +161,7 @@ public sealed class ImportPackageService : IImportPackageService
             var manifest = await JsonSerializer
                 .DeserializeAsync<PackageJsonModel>(stream, VpfSerialization.Options, cancellationToken)
                 .ConfigureAwait(false);
-            return manifest?.Vtp;
+            return manifest?.Vtp.ToModel();
         }
         catch
         {
@@ -443,12 +443,10 @@ public sealed class ImportPackageService : IImportPackageService
                 case ImportItemStatus.Same:
                     sameItems++;
                     break;
-                case ImportItemStatus.Updated:
-                case ImportItemStatus.NewerInPackage:
+                case ImportItemStatus.Updated or ImportItemStatus.NewerInPackage:
                     newerItems++;
                     break;
-                case ImportItemStatus.SkippedOlder:
-                case ImportItemStatus.OlderInPackage:
+                case ImportItemStatus.SkippedOlder or ImportItemStatus.OlderInPackage:
                     olderItems++;
                     break;
                 case ImportItemStatus.Failed:
@@ -706,13 +704,11 @@ public sealed class ImportPackageService : IImportPackageService
                 return true;
             case ImportItemStatus.Same:
                 return strategy is ImportConflictStrategy.AlwaysOverwrite or ImportConflictStrategy.CreateDuplicate;
-            case ImportItemStatus.Updated:
-            case ImportItemStatus.NewerInPackage:
+            case ImportItemStatus.Updated or ImportItemStatus.NewerInPackage:
                 return strategy is ImportConflictStrategy.UpdateIfNewer
                     or ImportConflictStrategy.AlwaysOverwrite
                     or ImportConflictStrategy.CreateDuplicate;
-            case ImportItemStatus.SkippedOlder:
-            case ImportItemStatus.OlderInPackage:
+            case ImportItemStatus.SkippedOlder or ImportItemStatus.OlderInPackage:
                 if (strategy is ImportConflictStrategy.AlwaysOverwrite or ImportConflictStrategy.CreateDuplicate)
                 {
                     return true;

--- a/Veriado.Infrastructure/Storage/Vpf/VpfPackageModels.cs
+++ b/Veriado.Infrastructure/Storage/Vpf/VpfPackageModels.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using VtpPackageInfo = Veriado.Application.Abstractions.VtpPackageInfo;
+using VtpPackageInfo = Veriado.Contracts.Storage.VtpPackageInfo;
 
 namespace Veriado.Infrastructure.Storage.Vpf;
 

--- a/Veriado.Infrastructure/Storage/Vpf/VpfPackageValidator.cs
+++ b/Veriado.Infrastructure/Storage/Vpf/VpfPackageValidator.cs
@@ -6,8 +6,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using Veriado.Application.Abstractions;
 using Veriado.Contracts.Storage;
-using VtpPackageInfo = Veriado.Application.Abstractions.VtpPackageInfo;
-using VtpPayloadType = Veriado.Application.Abstractions.VtpPayloadType;
+using AppVtpPackageInfo = Veriado.Application.Abstractions.VtpPackageInfo;
+using AppVtpPayloadType = Veriado.Application.Abstractions.VtpPayloadType;
 
 namespace Veriado.Infrastructure.Storage.Vpf;
 
@@ -61,7 +61,7 @@ public sealed class VpfPackageValidator
 
         PackageJsonModel? manifest = null;
         MetadataJsonModel? metadata = null;
-        VtpPackageInfo? vtp = null;
+        AppVtpPackageInfo? vtp = null;
 
         if (File.Exists(manifestPath))
         {
@@ -84,7 +84,7 @@ public sealed class VpfPackageValidator
                 $"Unsupported manifest specVersion '{manifest.SpecVersion}'."));
             }
 
-            ValidateVtp(manifest.Vtp, "package.json", ImportIssueType.ManifestUnsupported, issues);
+            ValidateVtp(manifest.Vtp.ToModel(), "package.json", ImportIssueType.ManifestUnsupported, issues);
         }
 
         if (File.Exists(metadataPath))
@@ -108,11 +108,11 @@ public sealed class VpfPackageValidator
                 "Only SHA256 hashAlgorithm is supported."));
             }
 
-            ValidateVtp(metadata.Vtp, "metadata.json", ImportIssueType.MetadataUnsupported, issues);
+            ValidateVtp(metadata.Vtp.ToModel(), "metadata.json", ImportIssueType.MetadataUnsupported, issues);
         }
 
-        var manifestVtp = manifest?.Vtp;
-        var metadataVtp = metadata?.Vtp;
+        var manifestVtp = manifest?.Vtp.ToModel();
+        var metadataVtp = metadata?.Vtp.ToModel();
         if (manifestVtp is not null && metadataVtp is not null)
         {
             if (!string.Equals(manifestVtp.ProtocolVersion, metadataVtp.ProtocolVersion, StringComparison.Ordinal))
@@ -288,7 +288,7 @@ public sealed class VpfPackageValidator
     }
 
     private static void ValidateVtp(
-        VtpPackageInfo vtp,
+        AppVtpPackageInfo vtp,
         string source,
         ImportIssueType issueType,
         ICollection<ImportValidationIssue> issues)
@@ -321,11 +321,11 @@ public sealed class VpfPackageValidator
         }
     }
 
-    private static bool IsSupportedPayload(VtpPayloadType payloadType)
-        => payloadType is VtpPayloadType.VpfPackage
-            or VtpPayloadType.FullExport
-            or VtpPayloadType.DeltaExport
-            or VtpPayloadType.Backup;
+    private static bool IsSupportedPayload(AppVtpPayloadType payloadType)
+        => payloadType is AppVtpPayloadType.VpfPackage
+            or AppVtpPayloadType.FullExport
+            or AppVtpPayloadType.DeltaExport
+            or AppVtpPayloadType.Backup;
 
     private static async Task<T> DeserializeAsync<T>(string path, CancellationToken cancellationToken)
     {


### PR DESCRIPTION
## Summary
- convert VPF manifest metadata to use contract VTP info and map to application models
- adjust import classification switches to merge overlapping enum values
- update VTP validation to handle mapped types

## Testing
- dotnet build Veriado.sln *(fails: dotnet not installed in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c8849b14083268b64bbd33e3a758d)