### PR TITLE
Fix variable shadowing in import commit logic

### DIFF
--- a/Veriado.Infrastructure/Storage/ImportPackageService.cs
+++ b/Veriado.Infrastructure/Storage/ImportPackageService.cs
@@ -188,7 +188,10 @@ public sealed class ImportPackageService : IImportPackageService
         var validation = await ValidateLogicalPackageAsync(request, cancellationToken).ConfigureAwait(false);
         if (!validation.IsValid)
         {
-            var vtpResult = DetermineVtpImportResultCode(ImportCommitStatus.Failed, validation.Issues, validation.Items);
+            var failedVtpResult = DetermineVtpImportResultCode(
+                ImportCommitStatus.Failed,
+                validation.Issues,
+                validation.Items);
             return new ImportCommitResult(
                 ImportCommitStatus.Failed,
                 0,
@@ -196,7 +199,7 @@ public sealed class ImportPackageService : IImportPackageService
                 0,
                 validation.Issues,
                 validation.Items,
-                vtpResult,
+                failedVtpResult,
                 validation.Vtp?.CorrelationId);
         }
 


### PR DESCRIPTION
## Summary
- rename the temporary VTP result variable in `CommitLogicalPackageAsync` to avoid shadowing later usage

## Testing
- dotnet build Veriado.Infrastructure/Veriado.Infrastructure.csproj -v minimal *(fails: dotnet not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c89400f4083268cee39642360ec2c)