### PR TITLE
Remove duplicate PathMapping model

### DIFF
--- a/Veriado.Infrastructure/Storage/Vpf/VpfPackageModels.cs
+++ b/Veriado.Infrastructure/Storage/Vpf/VpfPackageModels.cs
@@ -63,15 +63,6 @@ public sealed record VpfPackageManifest
     public string ExportMode { get; init; } = "LogicalPerFile";
 }
 
-public sealed record PathMapping
-{
-    [JsonPropertyName("storageAlias")]
-    public string StorageAlias { get; init; } = "default";
-
-    [JsonPropertyName("relativeRoot")]
-    public string RelativeRoot { get; init; } = string.Empty;
-}
-
 /// <summary>
 /// Technical metadata describing application and schema versions captured during export.
 /// </summary>


### PR DESCRIPTION
## Summary
- removed duplicate PathMapping record from VpfPackageModels to avoid namespace conflict

## Testing
- not run (dotnet SDK not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69343476f29c83268532e453491c525c)