### PR TITLE
Fix export package metadata conversions

### DIFF
--- a/Veriado.Infrastructure/Storage/ExportPackageService.cs
+++ b/Veriado.Infrastructure/Storage/ExportPackageService.cs
@@ -266,8 +266,8 @@ public sealed class ExportPackageService : IExportPackageService
                     LastWriteUtc = file.SystemMetadata.LastWriteUtc.ToDateTimeOffset(),
                     LastAccessUtc = file.SystemMetadata.LastAccessUtc.ToDateTimeOffset(),
                     OwnerSid = file.SystemMetadata.OwnerSid,
-                    HardLinkCount = file.SystemMetadata.HardLinkCount,
-                    AlternateDataStreamCount = file.SystemMetadata.AlternateDataStreamCount,
+                    HardLinkCount = (int?)file.SystemMetadata.HardLinkCount,
+                    AlternateDataStreamCount = (int?)file.SystemMetadata.AlternateDataStreamCount,
                 };
 
                 var descriptor = new ExportedFileDescriptor
@@ -288,7 +288,7 @@ public sealed class ExportPackageService : IExportPackageService
                     LastModifiedAtUtc = file.LastModifiedUtc.ToDateTimeOffset(),
                     LastModifiedBy = file.Author,
                     IsReadOnly = file.IsReadOnly,
-                    Title = file.Title?.Value,
+                    Title = file.Title,
                     Author = file.Author,
                     Validity = validity,
                     SystemMetadata = systemMetadata,


### PR DESCRIPTION
## Summary
- fix nullable conversions for system metadata counts during export
- use file title string directly instead of accessing a nonexistent value property

## Testing
- dotnet build Veriado.sln (fails: dotnet command not available in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6934354eebac8326853d51c7d1a559cb)