### PR TITLE
Ensure audit filesystem table created during SQLite initialization

### DIFF
--- a/Veriado.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/Veriado.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
@@ -305,6 +305,25 @@ public static class ServiceCollectionExtensions
 
             if (dbContext.Database.IsSqlite())
             {
+                const string createAuditFilesystemTableSql = """
+                    CREATE TABLE IF NOT EXISTS "audit_filesystem" (
+                        "filesystem_id" BLOB NOT NULL,
+                        "action" TEXT NOT NULL,
+                        "path" TEXT,
+                        "hash" TEXT,
+                        "size" INTEGER,
+                        "mime" TEXT,
+                        "attrs" INTEGER,
+                        "owner_sid" TEXT,
+                        "is_encrypted" INTEGER,
+                        "occurred_utc" TEXT NOT NULL,
+                        CONSTRAINT "PK_audit_filesystem" PRIMARY KEY ("filesystem_id", "occurred_utc")
+                    );
+                    """;
+
+                await dbContext.Database.ExecuteSqlRawAsync(createAuditFilesystemTableSql, cancellationToken)
+                    .ConfigureAwait(false);
+
                 await using (var connection = connectionProvider.CreateConnection())
                 {
                     await connection.OpenAsync(cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
## Summary
- ensure SQLite initialization creates the audit_filesystem table if it is missing

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69343df625a0832683fe6a278b003d5b)