### PR TITLE
Handle missing source files before atomic copy

### DIFF
--- a/Veriado.Infrastructure/Storage/AtomicFileOperations.cs
+++ b/Veriado.Infrastructure/Storage/AtomicFileOperations.cs
@@ -19,6 +19,11 @@ internal static class AtomicFileOperations
 
         try
         {
+            if (!File.Exists(source))
+            {
+                throw new FileNotFoundException($"Source file not found: {source}", source);
+            }
+
             using var sourceStream = File.Open(source, FileMode.Open, FileAccess.Read, FileShare.Read);
             await using (var tempStream = File.Open(tempDestination, FileMode.Create, FileAccess.Write, FileShare.None))
             {


### PR DESCRIPTION
## Summary
- check for missing source files before starting atomic copy operations
- surface a consistent FileNotFoundException when the source path is absent

## Testing
- dotnet test *(fails: dotnet not available in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69343f2a542c832689a4e960ccb4a160)