### PR TITLE
Add maintenance coordinator interface documentation

### DIFF
--- a/Veriado.Application/Abstractions/IApplicationMaintenanceCoordinator.cs
+++ b/Veriado.Application/Abstractions/IApplicationMaintenanceCoordinator.cs
@@ -3,11 +3,29 @@ using System.Threading.Tasks;
 
 namespace Veriado.Appl.Abstractions;
 
+/// <summary>
+/// Coordinates application-wide maintenance periods by pausing and resuming
+/// background processing so that long-running jobs can complete safely.
+/// </summary>
 public interface IApplicationMaintenanceCoordinator
 {
+    /// <summary>
+    /// Requests a pause of background work to allow maintenance to run without
+    /// contention.
+    /// </summary>
+    /// <param name="cancellationToken">Token to cancel the pause request.</param>
     Task PauseBackgroundWorkAsync(CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Signals that maintenance work has finished and background processing may
+    /// resume.
+    /// </summary>
+    /// <param name="cancellationToken">Token to cancel the resume request.</param>
     Task ResumeBackgroundWorkAsync(CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Waits until maintenance has completed and normal operations can continue.
+    /// </summary>
+    /// <param name="cancellationToken">Token to cancel the wait.</param>
     Task WaitForResumeAsync(CancellationToken cancellationToken = default);
 }


### PR DESCRIPTION
## Summary
- add XML documentation to IApplicationMaintenanceCoordinator to clarify maintenance pause/resume responsibilities

## Testing
- not run (dotnet SDK not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69344d3ea750832691953625e3d183e8)