### PR TITLE
Align maintenance coordinator abstractions namespace

### DIFF
--- a/Veriado.Application/Abstractions/IApplicationMaintenanceCoordinator.cs
+++ b/Veriado.Application/Abstractions/IApplicationMaintenanceCoordinator.cs
@@ -1,7 +1,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Veriado.Appl.Abstractions;
+namespace Veriado.Application.Abstractions;
 
 /// <summary>
 /// Coordinates application-wide maintenance periods by pausing and resuming

--- a/Veriado.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/Veriado.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
@@ -12,7 +12,7 @@ using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Logging;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
-using Veriado.Appl.Abstractions;
+using Veriado.Application.Abstractions;
 using Veriado.Application.Abstractions;
 using Veriado.Application.Import;
 using Veriado.Infrastructure.Events;

--- a/Veriado.Infrastructure/Idempotency/IdempotencyCleanupWorker.cs
+++ b/Veriado.Infrastructure/Idempotency/IdempotencyCleanupWorker.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using Veriado.Appl.Abstractions;
+using Veriado.Application.Abstractions;
 using Veriado.Infrastructure.Search;
 
 namespace Veriado.Infrastructure.Idempotency;

--- a/Veriado.Infrastructure/Integrity/IndexAuditBackgroundService.cs
+++ b/Veriado.Infrastructure/Integrity/IndexAuditBackgroundService.cs
@@ -5,7 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 
 using Microsoft.Extensions.Logging;
-using Veriado.Appl.Abstractions;
+using Veriado.Application.Abstractions;
 using Veriado.Infrastructure.Persistence.Options;
 
 namespace Veriado.Infrastructure.Integrity;

--- a/Veriado.Infrastructure/Maintenance/ApplicationMaintenanceCoordinator.cs
+++ b/Veriado.Infrastructure/Maintenance/ApplicationMaintenanceCoordinator.cs
@@ -1,6 +1,6 @@
 using System.Threading;
 using System.Threading.Tasks;
-using Veriado.Appl.Abstractions;
+using Veriado.Application.Abstractions;
 
 namespace Veriado.Infrastructure.Maintenance;
 

--- a/Veriado.Services/Files/CatalogMaintenanceService.cs
+++ b/Veriado.Services/Files/CatalogMaintenanceService.cs
@@ -2,7 +2,7 @@ using System.IO;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
-using Veriado.Appl.Abstractions;
+using Veriado.Application.Abstractions;
 using Veriado.Infrastructure.Persistence;
 using Veriado.Infrastructure.Persistence.Options;
 using Veriado.Infrastructure.Search;


### PR DESCRIPTION
## Summary
- move IApplicationMaintenanceCoordinator into the Veriado.Application.Abstractions namespace
- update implementations and consumers to use the corrected namespace
- register the coordinator with the updated namespace in dependency injection

## Testing
- not run (dotnet SDK unavailable in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6934507eb1448326a1fa8dd1e0d06500)