### PR TITLE
Clarify maintenance coordinator interface

### DIFF
--- a/Veriado.Application/Abstractions/IApplicationMaintenanceCoordinator.cs
+++ b/Veriado.Application/Abstractions/IApplicationMaintenanceCoordinator.cs
@@ -6,12 +6,14 @@ namespace Veriado.Appl.Abstractions;
 /// <summary>
 /// Coordinates application-wide maintenance periods by pausing and resuming
 /// background processing so that long-running jobs can complete safely.
-///
-/// Implementations are expected to block background operations when
-/// <see cref="PauseBackgroundWorkAsync"/> is invoked, and release the block once
-/// <see cref="ResumeBackgroundWorkAsync"/> is called. Consumers can await
-/// <see cref="WaitForResumeAsync"/> to be notified when maintenance is over.
 /// </summary>
+/// <remarks>
+/// Implementations should block background operations when
+/// <see cref="PauseBackgroundWorkAsync"/> is invoked, unblock once
+/// <see cref="ResumeBackgroundWorkAsync"/> is called, and allow consumers to
+/// await <see cref="WaitForResumeAsync"/> to be notified when maintenance is
+/// over.
+/// </remarks>
 public interface IApplicationMaintenanceCoordinator
 {
     /// <summary>


### PR DESCRIPTION
## Summary
- clarify the documentation for IApplicationMaintenanceCoordinator
- move behavior guidance into remarks to highlight pause/resume expectations

## Testing
- not run (documentation-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69345409cf848326b8e19aeb678e0297)