### PR TITLE
Complete VPF import commit pipeline

### DIFF
--- a/Veriado.Application/Abstractions/ImportModels.cs
+++ b/Veriado.Application/Abstractions/ImportModels.cs
@@ -41,10 +41,36 @@ public sealed record ValidatedImportFile(
     string ContentHash,
     long SizeBytes,
     string? MimeType,
+    string? Extension,
+    DateTimeOffset CreatedAtUtc,
+    string? CreatedBy,
     DateTimeOffset LastModifiedAtUtc,
+    string? LastModifiedBy,
     string StorageAlias,
     string LogicalPathHint,
-    Guid? OriginalInstanceId);
+    Guid? OriginalInstanceId,
+    bool IsReadOnly,
+    int Version,
+    string? Title,
+    string? Author,
+    ImportValidityInfo? Validity,
+    ImportSystemMetadataInfo? SystemMetadata,
+    string? PhysicalState);
+
+public sealed record ImportValidityInfo(
+    DateTimeOffset IssuedAtUtc,
+    DateTimeOffset ValidUntilUtc,
+    bool HasPhysicalCopy,
+    bool HasElectronicCopy);
+
+public sealed record ImportSystemMetadataInfo(
+    int Attributes,
+    DateTimeOffset CreatedUtc,
+    DateTimeOffset LastWriteUtc,
+    DateTimeOffset LastAccessUtc,
+    string? OwnerSid,
+    int? HardLinkCount,
+    int? AlternateDataStreamCount);
 
 public sealed record ImportItemPreview(
     Guid FileId,
@@ -97,4 +123,5 @@ public sealed record ImportCommitResult(
     IReadOnlyList<ImportValidationIssue> Issues,
     IReadOnlyList<ImportItemPreview> Items,
     VtpImportResultCode VtpResultCode,
-    Guid? CorrelationId);
+    Guid? CorrelationId,
+    IReadOnlyDictionary<Guid, Guid>? FileIdMap = null);

--- a/Veriado.Contracts/Storage/ImportContracts.cs
+++ b/Veriado.Contracts/Storage/ImportContracts.cs
@@ -101,11 +101,41 @@ public sealed record ValidatedImportFileDto
     public string ContentHash { get; init; } = string.Empty;
     public long SizeBytes { get; init; }
     public string? MimeType { get; init; }
+    public string? Extension { get; init; }
+    public DateTimeOffset CreatedAtUtc { get; init; }
+    public string? CreatedBy { get; init; }
     public DateTimeOffset LastModifiedAtUtc { get; init; }
+    public string? LastModifiedBy { get; init; }
     public string StorageAlias { get; init; } = "default";
     public string LogicalPathHint { get; init; } = string.Empty;
     public Guid? OriginalInstanceId { get; init; }
         = null;
+    public bool IsReadOnly { get; init; }
+    public int Version { get; init; }
+    public string? Title { get; init; }
+    public string? Author { get; init; }
+    public ImportValidityDto? Validity { get; init; }
+    public ImportSystemMetadataDto? SystemMetadata { get; init; }
+    public string? PhysicalState { get; init; }
+}
+
+public sealed record ImportValidityDto
+{
+    public DateTimeOffset IssuedAtUtc { get; init; }
+    public DateTimeOffset ValidUntilUtc { get; init; }
+    public bool HasPhysicalCopy { get; init; }
+    public bool HasElectronicCopy { get; init; }
+}
+
+public sealed record ImportSystemMetadataDto
+{
+    public int Attributes { get; init; }
+    public DateTimeOffset CreatedUtc { get; init; }
+    public DateTimeOffset LastWriteUtc { get; init; }
+    public DateTimeOffset LastAccessUtc { get; init; }
+    public string? OwnerSid { get; init; }
+    public int? HardLinkCount { get; init; }
+    public int? AlternateDataStreamCount { get; init; }
 }
 
 public sealed record ImportCommitResultDto
@@ -118,6 +148,7 @@ public sealed record ImportCommitResultDto
     public IReadOnlyList<ImportItemPreviewDto> Items { get; init; } = Array.Empty<ImportItemPreviewDto>();
     public VtpImportResultCode VtpResultCode { get; init; }
     public Guid? CorrelationId { get; init; }
+    public IReadOnlyDictionary<Guid, Guid>? FileIdMap { get; init; }
 }
 
 public sealed record ImportItemPreviewDto

--- a/Veriado.Infrastructure/Storage/Vpf/VpfPackageValidator.cs
+++ b/Veriado.Infrastructure/Storage/Vpf/VpfPackageValidator.cs
@@ -230,12 +230,38 @@ public sealed class VpfPackageValidator
                 descriptor.ContentHash,
                 descriptor.SizeBytes,
                 descriptor.MimeType,
+                descriptor.Extension,
+                descriptor.CreatedAtUtc,
+                descriptor.CreatedBy,
                 descriptor.LastModifiedAtUtc,
+                descriptor.LastModifiedBy,
                 descriptor.StorageAlias ?? "default",
                 string.IsNullOrWhiteSpace(descriptor.LogicalPathHint)
                     ? CombineRelative(relativePath)
                     : descriptor.LogicalPathHint,
-                descriptor.OriginalInstanceId));
+                descriptor.OriginalInstanceId,
+                descriptor.IsReadOnly,
+                descriptor.Version,
+                descriptor.Title,
+                descriptor.Author,
+                descriptor.Validity is null
+                    ? null
+                    : new ImportValidityInfo(
+                        descriptor.Validity.IssuedAtUtc,
+                        descriptor.Validity.ValidUntilUtc,
+                        descriptor.Validity.HasPhysicalCopy,
+                        descriptor.Validity.HasElectronicCopy),
+                descriptor.SystemMetadata is null
+                    ? null
+                    : new ImportSystemMetadataInfo(
+                        descriptor.SystemMetadata.Attributes,
+                        descriptor.SystemMetadata.CreatedUtc,
+                        descriptor.SystemMetadata.LastWriteUtc,
+                        descriptor.SystemMetadata.LastAccessUtc,
+                        descriptor.SystemMetadata.OwnerSid,
+                        descriptor.SystemMetadata.HardLinkCount,
+                        descriptor.SystemMetadata.AlternateDataStreamCount),
+                descriptor.PhysicalState));
         }
 
         foreach (var descriptorPath in Directory.EnumerateFiles(filesRoot, "*.json", SearchOption.AllDirectories))

--- a/Veriado.Services/Storage/StorageManagementService.cs
+++ b/Veriado.Services/Storage/StorageManagementService.cs
@@ -242,6 +242,7 @@ public sealed class StorageManagementService : IStorageManagementService
             Items = result.Items.Select(Map).ToArray(),
             VtpResultCode = result.VtpResultCode.ToContract(),
             CorrelationId = result.CorrelationId,
+            FileIdMap = result.FileIdMap,
         };
     }
 
@@ -264,10 +265,21 @@ public sealed class StorageManagementService : IStorageManagementService
             ContentHash = file.ContentHash,
             SizeBytes = file.SizeBytes,
             MimeType = file.MimeType,
+            Extension = file.Extension,
+            CreatedAtUtc = file.CreatedAtUtc,
+            CreatedBy = file.CreatedBy,
             LastModifiedAtUtc = file.LastModifiedAtUtc,
+            LastModifiedBy = file.LastModifiedBy,
             StorageAlias = file.StorageAlias,
             LogicalPathHint = file.LogicalPathHint,
             OriginalInstanceId = file.OriginalInstanceId,
+            IsReadOnly = file.IsReadOnly,
+            Version = file.Version,
+            Title = file.Title,
+            Author = file.Author,
+            Validity = Map(file.Validity),
+            SystemMetadata = Map(file.SystemMetadata),
+            PhysicalState = file.PhysicalState,
         };
 
     private static ImportItemPreviewDto Map(ImportItemPreview preview)
@@ -296,6 +308,41 @@ public sealed class StorageManagementService : IStorageManagementService
             VerifyDatabaseHash = dto.VerifyDatabaseHash,
             VerifyFilesByHash = dto.VerifyFilesByHash,
             VerifyFilesBySize = dto.VerifyFilesBySize,
+        };
+    }
+
+    private static ImportValidityDto? Map(ImportValidityInfo? validity)
+    {
+        if (validity is null)
+        {
+            return null;
+        }
+
+        return new ImportValidityDto
+        {
+            IssuedAtUtc = validity.IssuedAtUtc,
+            ValidUntilUtc = validity.ValidUntilUtc,
+            HasElectronicCopy = validity.HasElectronicCopy,
+            HasPhysicalCopy = validity.HasPhysicalCopy,
+        };
+    }
+
+    private static ImportSystemMetadataDto? Map(ImportSystemMetadataInfo? metadata)
+    {
+        if (metadata is null)
+        {
+            return null;
+        }
+
+        return new ImportSystemMetadataDto
+        {
+            Attributes = metadata.Attributes,
+            CreatedUtc = metadata.CreatedUtc,
+            LastWriteUtc = metadata.LastWriteUtc,
+            LastAccessUtc = metadata.LastAccessUtc,
+            OwnerSid = metadata.OwnerSid,
+            HardLinkCount = metadata.HardLinkCount,
+            AlternateDataStreamCount = metadata.AlternateDataStreamCount,
         };
     }
 

--- a/Veriado.WinUI/Views/Storage/StorageManagementPage.xaml
+++ b/Veriado.WinUI/Views/Storage/StorageManagementPage.xaml
@@ -145,6 +145,24 @@
                         <CheckBox Content="Ověřit po kopii" IsChecked="{Binding ImportVerifyAfterCopy, Mode=TwoWay}" />
                     </StackPanel>
 
+                    <StackPanel Orientation="Horizontal" Spacing="12" VerticalAlignment="Center">
+                        <TextBlock VerticalAlignment="Center" Text="Strategie konfliktů" />
+                        <ComboBox
+                            Width="220"
+                            ItemsSource="{Binding ImportStrategies}"
+                            SelectedItem="{Binding SelectedImportStrategy, Mode=TwoWay}" />
+                    </StackPanel>
+
+                    <StackPanel Spacing="4">
+                        <TextBlock Text="Přehled validace" FontWeight="SemiBold" />
+                        <TextBlock Text="{Binding ValidationSummary}" Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                    </StackPanel>
+
+                    <StackPanel Spacing="4">
+                        <TextBlock Text="Shrnutí importu" FontWeight="SemiBold" />
+                        <TextBlock Text="{Binding ImportSummary}" Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                    </StackPanel>
+
                     <Button Content="Spustit import" Command="{Binding RunImportCommand}" />
                 </StackPanel>
             </muxc:Expander>


### PR DESCRIPTION
## Summary
- extend VPF validation metadata and surface it via DTOs
- implement commit stage to copy files, persist domain aggregates, and report VTP status and id mapping
- add WinUI storage import controls for conflict strategy selection and preview/commit summaries

## Testing
- not run (dotnet CLI unavailable in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693556e668d8832692083f1f9bcc694e)