### PR TITLE
Add tray icon and keep app alive when hidden

### DIFF
--- a/Veriado.WinUI/Veriado.csproj
+++ b/Veriado.WinUI/Veriado.csproj
@@ -9,6 +9,7 @@
     <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
     <PublishProfile>win-$(Platform).pubxml</PublishProfile>
     <UseWinUI>true</UseWinUI>
+    <UseWindowsForms>true</UseWindowsForms>
     <EnableMsixTooling>true</EnableMsixTooling>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>


### PR DESCRIPTION
## Summary
- keep the main window alive by hiding it on close so background work continues
- add a Windows Forms notify icon with Open, Restart, and Exit actions plus double-click activation
- register app notifications during startup to ensure toast delivery when the window is hidden

## Testing
- not run (dotnet CLI unavailable in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935b16f52cc8326a4df14fafc825733)