### PR TITLE
Switch to WinUI tray icon implementation

### DIFF
--- a/Veriado.WinUI/Veriado.csproj
+++ b/Veriado.WinUI/Veriado.csproj
@@ -9,7 +9,6 @@
     <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
     <PublishProfile>win-$(Platform).pubxml</PublishProfile>
     <UseWinUI>true</UseWinUI>
-    <UseWindowsForms>true</UseWindowsForms>
     <EnableMsixTooling>true</EnableMsixTooling>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
@@ -53,6 +52,7 @@
     <PackageReference Include="CommunityToolkit.WinUI.Controls.SettingsControls" Version="8.2.250402" />
     <PackageReference Include="CommunityToolkit.WinUI.Controls.Sizers" Version="8.2.250402" />
     <PackageReference Include="CommunityToolkit.WinUI.Controls.TokenizingTextBox" Version="8.2.250402" />
+    <PackageReference Include="H.NotifyIcon.WinUI" Version="2.4.1" />
     <PackageReference Include="CommunityToolkit.WinUI.UI.Controls.DataGrid" Version="7.1.2" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.9" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.8.250916003" />


### PR DESCRIPTION
## Summary
- replace the Windows Forms tray icon with the H.NotifyIcon WinUI taskbar icon
- use WinUI menu flyout handlers for show, restart, and exit actions and ensure dispatcher access
- add the H.NotifyIcon.WinUI package reference and remove Windows Forms usage

## Testing
- not run (not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935b98695c88326a8628a5c2aa2ec75)