### PR TITLE
Set default localization to en-us and add Czech resources

### DIFF
--- a/Veriado.WinUI/Helpers/LocalizationHelper.cs
+++ b/Veriado.WinUI/Helpers/LocalizationHelper.cs
@@ -1,0 +1,12 @@
+using Microsoft.Windows.ApplicationModel.Resources;
+
+namespace Veriado.WinUI.Helpers;
+
+internal static class LocalizationHelper
+{
+    private static readonly ResourceLoader ResourceLoader = new();
+
+    public static string GetString(string key) => ResourceLoader.GetString(key);
+
+    public static string Format(string key, params object[] args) => string.Format(GetString(key), args);
+}

--- a/Veriado.WinUI/Package.appxmanifest
+++ b/Veriado.WinUI/Package.appxmanifest
@@ -15,8 +15,8 @@
   <mp:PhoneIdentity PhoneProductId="94356163-ff57-447b-86f1-67392cca0fcf" PhonePublisherId="00000000-0000-0000-0000-000000000000"/>
 
   <Properties>
-    <DisplayName>Veriado</DisplayName>
-    <PublisherDisplayName>AstraidLabs</PublisherDisplayName>
+    <DisplayName>ms-resource:AppDisplayName</DisplayName>
+    <PublisherDisplayName>ms-resource:PublisherDisplayName</PublisherDisplayName>
     <Logo>Assets\StoreLogo.png</Logo>
   </Properties>
 
@@ -26,7 +26,8 @@
   </Dependencies>
 
   <Resources>
-    <Resource Language="cs-CZ"/>
+    <Resource Language="en-us" />
+    <Resource Language="cs" />
   </Resources>
 
   <Applications>
@@ -34,8 +35,8 @@
       Executable="$targetnametoken$.exe"
       EntryPoint="$targetentrypoint$">
       <uap:VisualElements
-        DisplayName="Veriado"
-        Description="Veriado je desktopová aplikace pro firemní katalogizaci dokumentů, která kombinuje fulltextové vyhledávání s pečlivou správou metadat a platnosti. Je určena pro týmy, které potřebují mít důležité smlouvy, směrnice a záznamy okamžitě po ruce. Aplikace šetří čas díky rychlému vyhledávání a uloženým filtrům, hlídá platnost dokumentů a tím minimalizuje rizika. Díky lokálnímu provozu bez serveru přináší nízké provozní náklady a rychlé nasazení."
+        DisplayName="ms-resource:AppDisplayName"
+        Description="ms-resource:AppDescription"
         BackgroundColor="transparent"
         Square150x150Logo="Assets\Square150x150Logo.png"
         Square44x44Logo="Assets\Square44x44Logo.png">

--- a/Veriado.WinUI/Strings/cs/Resources.resw
+++ b/Veriado.WinUI/Strings/cs/Resources.resw
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="AppDisplayName" xml:space="preserve">
+    <value>Veriado</value>
+  </data>
+  <data name="PublisherDisplayName" xml:space="preserve">
+    <value>AstraidLabs</value>
+  </data>
+  <data name="AppDescription" xml:space="preserve">
+    <value>Veriado je desktopová aplikace pro firemní katalogizaci dokumentů, která kombinuje fulltextové vyhledávání s pečlivou správou metadat a platnosti. Je určena pro týmy, které potřebují mít důležité smlouvy, směrnice a záznamy okamžitě k dispozici. Aplikace šetří čas díky rychlému vyhledávání a uloženým filtrům, hlídá platnost dokumentů a tím minimalizuje rizika. Díky lokálnímu provozu bez serveru přináší nízké provozní náklady a rychlé nasazení.</value>
+  </data>
+</root>

--- a/Veriado.WinUI/Strings/en-us/Resources.resw
+++ b/Veriado.WinUI/Strings/en-us/Resources.resw
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="AppDisplayName" xml:space="preserve">
+    <value>Veriado</value>
+  </data>
+  <data name="PublisherDisplayName" xml:space="preserve">
+    <value>AstraidLabs</value>
+  </data>
+  <data name="AppDescription" xml:space="preserve">
+    <value>Veriado is a desktop application for corporate document cataloging that combines full-text search with careful metadata and validity management. It is built for teams that need important contracts, policies, and records at their fingertips. The app saves time with fast search and saved filters, monitors document validity to minimize risks, and thanks to local serverless operation offers low operating costs and quick deployment.</value>
+  </data>
+</root>

--- a/Veriado.WinUI/Veriado.csproj
+++ b/Veriado.WinUI/Veriado.csproj
@@ -87,6 +87,6 @@
     <HoursBetweenUpdateChecks>0</HoursBetweenUpdateChecks>
     <PackageIcon>pix3l_ai_Abstract_high-tech_vector_logo_for_a_corporate_DMS_s_3bc7159a-97e3-44d7-90e8-7eb36ebb4ff6_0.png</PackageIcon>
     <GenerateTemporaryStoreCertificate>False</GenerateTemporaryStoreCertificate>
-    <DefaultLanguage>cs-CZ</DefaultLanguage>
+    <DefaultLanguage>en-us</DefaultLanguage>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
## Summary
- set the WinUI project default language to en-us and prepare resource loader helper
- add en-us and cs resource files with localized app metadata for the manifest
- update the package manifest to reference resource-based display information and declare both supported languages

## Testing
- Not run (environment missing dotnet SDK)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b229c81b88326a6d5358679f0b260)