### PR TITLE
Add initial localization resources for navigation and files UI

### DIFF
--- a/Veriado.WinUI/Strings/cs/Resources.resw
+++ b/Veriado.WinUI/Strings/cs/Resources.resw
@@ -21,4 +21,85 @@
   <data name="AppDescription" xml:space="preserve">
     <value>Veriado je desktopová aplikace pro firemní katalogizaci dokumentů, která kombinuje fulltextové vyhledávání s pečlivou správou metadat a platnosti. Je určena pro týmy, které potřebují mít důležité smlouvy, směrnice a záznamy okamžitě k dispozici. Aplikace šetří čas díky rychlému vyhledávání a uloženým filtrům, hlídá platnost dokumentů a tím minimalizuje rizika. Díky lokálnímu provozu bez serveru přináší nízké provozní náklady a rychlé nasazení.</value>
   </data>
+  <data name="DeleteAllCatalogDialog_Input.PlaceholderText" xml:space="preserve">
+    <value>Sem opište ověřovací kód</value>
+  </data>
+  <data name="DeleteAllCatalogDialog_Instructions.Text" xml:space="preserve">
+    <value>Pro potvrzení akce opište následující ověřovací kód:</value>
+  </data>
+  <data name="DeleteAllCatalogDialog_Title.Text" xml:space="preserve">
+    <value>Opravdu chcete smazat celý katalog?</value>
+  </data>
+  <data name="FileDetailDialog.PrimaryButtonText" xml:space="preserve">
+    <value>Uložit</value>
+  </data>
+  <data name="FileDetailDialog.SecondaryButtonText" xml:space="preserve">
+    <value>Zrušit</value>
+  </data>
+  <data name="FileDetailDialog.Title" xml:space="preserve">
+    <value>Detail souboru</value>
+  </data>
+  <data name="FilesPage_DeleteAllButtonText.Text" xml:space="preserve">
+    <value>Smazat katalog</value>
+  </data>
+  <data name="FilesPage_ErrorInfoBar.Message" xml:space="preserve">
+    <value>Nepodařilo se načíst výsledky.</value>
+  </data>
+  <data name="FilesPage_ErrorInfoBar.Title" xml:space="preserve">
+    <value>Chyba načítání</value>
+  </data>
+  <data name="FilesPage_HeaderSubtitle.Text" xml:space="preserve">
+    <value>Správa, validace a monitoring souborů</value>
+  </data>
+  <data name="FilesPage_HeaderTitle.Text" xml:space="preserve">
+    <value>Katalog dokumentů</value>
+  </data>
+  <data name="FilesPage_IndexingInfoBar.Title" xml:space="preserve">
+    <value>Probíhá indexace</value>
+  </data>
+  <data name="FilesPage_ItemDeleteButtonText.Text" xml:space="preserve">
+    <value>Smazat</value>
+  </data>
+  <data name="FilesPage_ItemDetailButtonText.Text" xml:space="preserve">
+    <value>Detail</value>
+  </data>
+  <data name="FilesPage_ItemOpenButtonText.Text" xml:space="preserve">
+    <value>Otevřít</value>
+  </data>
+  <data name="FilesPage_ItemShowInFolderButtonText.Text" xml:space="preserve">
+    <value>Ukázat ve složce</value>
+  </data>
+  <data name="FilesPage_ItemUpdateButtonText.Text" xml:space="preserve">
+    <value>Aktualizovat</value>
+  </data>
+  <data name="FilesPage_NextPageButton.Content" xml:space="preserve">
+    <value>Další</value>
+  </data>
+  <data name="FilesPage_PageNumberSeparator.Text" xml:space="preserve">
+    <value>/</value>
+  </data>
+  <data name="FilesPage_PageSizeLabel.Text" xml:space="preserve">
+    <value>Na stránce</value>
+  </data>
+  <data name="FilesPage_PreviousPageButton.Content" xml:space="preserve">
+    <value>Předchozí</value>
+  </data>
+  <data name="FilesPage_SearchBox.PlaceholderText" xml:space="preserve">
+    <value>Hledat soubory</value>
+  </data>
+  <data name="MainShell_FilesNavItem.Content" xml:space="preserve">
+    <value>Správa souborů</value>
+  </data>
+  <data name="MainShell_ImportNavItem.Content" xml:space="preserve">
+    <value>Nahrát soubory</value>
+  </data>
+  <data name="MainShell_SettingsNavItem.Content" xml:space="preserve">
+    <value>Nastavení</value>
+  </data>
+  <data name="MainShell_StorageNavItem.Content" xml:space="preserve">
+    <value>Migrace a balíčky</value>
+  </data>
+  <data name="StartupWindow_RetryButton.Content" xml:space="preserve">
+    <value>Zkusit znovu</value>
+  </data>
 </root>

--- a/Veriado.WinUI/Strings/en-us/Resources.resw
+++ b/Veriado.WinUI/Strings/en-us/Resources.resw
@@ -21,4 +21,85 @@
   <data name="AppDescription" xml:space="preserve">
     <value>Veriado is a desktop application for corporate document cataloging that combines full-text search with careful metadata and validity management. It is built for teams that need important contracts, policies, and records at their fingertips. The app saves time with fast search and saved filters, monitors document validity to minimize risks, and thanks to local serverless operation offers low operating costs and quick deployment.</value>
   </data>
+  <data name="DeleteAllCatalogDialog_Input.PlaceholderText" xml:space="preserve">
+    <value>Enter the verification code here</value>
+  </data>
+  <data name="DeleteAllCatalogDialog_Instructions.Text" xml:space="preserve">
+    <value>To confirm the action, type the following verification code:</value>
+  </data>
+  <data name="DeleteAllCatalogDialog_Title.Text" xml:space="preserve">
+    <value>Do you really want to delete the entire catalog?</value>
+  </data>
+  <data name="FileDetailDialog.PrimaryButtonText" xml:space="preserve">
+    <value>Save</value>
+  </data>
+  <data name="FileDetailDialog.SecondaryButtonText" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
+  <data name="FileDetailDialog.Title" xml:space="preserve">
+    <value>File detail</value>
+  </data>
+  <data name="FilesPage_DeleteAllButtonText.Text" xml:space="preserve">
+    <value>Delete catalog</value>
+  </data>
+  <data name="FilesPage_ErrorInfoBar.Message" xml:space="preserve">
+    <value>Unable to load results.</value>
+  </data>
+  <data name="FilesPage_ErrorInfoBar.Title" xml:space="preserve">
+    <value>Loading error</value>
+  </data>
+  <data name="FilesPage_HeaderSubtitle.Text" xml:space="preserve">
+    <value>Manage, validate, and monitor files</value>
+  </data>
+  <data name="FilesPage_HeaderTitle.Text" xml:space="preserve">
+    <value>Document catalog</value>
+  </data>
+  <data name="FilesPage_IndexingInfoBar.Title" xml:space="preserve">
+    <value>Indexing in progress</value>
+  </data>
+  <data name="FilesPage_ItemDeleteButtonText.Text" xml:space="preserve">
+    <value>Delete</value>
+  </data>
+  <data name="FilesPage_ItemDetailButtonText.Text" xml:space="preserve">
+    <value>Detail</value>
+  </data>
+  <data name="FilesPage_ItemOpenButtonText.Text" xml:space="preserve">
+    <value>Open</value>
+  </data>
+  <data name="FilesPage_ItemShowInFolderButtonText.Text" xml:space="preserve">
+    <value>Show in folder</value>
+  </data>
+  <data name="FilesPage_ItemUpdateButtonText.Text" xml:space="preserve">
+    <value>Update</value>
+  </data>
+  <data name="FilesPage_NextPageButton.Content" xml:space="preserve">
+    <value>Next</value>
+  </data>
+  <data name="FilesPage_PageNumberSeparator.Text" xml:space="preserve">
+    <value>/</value>
+  </data>
+  <data name="FilesPage_PageSizeLabel.Text" xml:space="preserve">
+    <value>Per page</value>
+  </data>
+  <data name="FilesPage_PreviousPageButton.Content" xml:space="preserve">
+    <value>Previous</value>
+  </data>
+  <data name="FilesPage_SearchBox.PlaceholderText" xml:space="preserve">
+    <value>Search files</value>
+  </data>
+  <data name="MainShell_FilesNavItem.Content" xml:space="preserve">
+    <value>File management</value>
+  </data>
+  <data name="MainShell_ImportNavItem.Content" xml:space="preserve">
+    <value>Upload files</value>
+  </data>
+  <data name="MainShell_SettingsNavItem.Content" xml:space="preserve">
+    <value>Settings</value>
+  </data>
+  <data name="MainShell_StorageNavItem.Content" xml:space="preserve">
+    <value>Migration and packages</value>
+  </data>
+  <data name="StartupWindow_RetryButton.Content" xml:space="preserve">
+    <value>Try again</value>
+  </data>
 </root>

--- a/Veriado.WinUI/Views/Files/DeleteAllCatalogDialogContent.xaml
+++ b/Veriado.WinUI/Views/Files/DeleteAllCatalogDialogContent.xaml
@@ -7,10 +7,10 @@
     mc:Ignorable="d">
 
     <StackPanel Spacing="8">
-        <TextBlock Text="Opravdu chcete smazat celý katalog?"
+        <TextBlock x:Uid="DeleteAllCatalogDialog_Title"
                    TextWrapping="Wrap" />
 
-        <TextBlock Text="Pro potvrzení akce opište následující ověřovací kód:"
+        <TextBlock x:Uid="DeleteAllCatalogDialog_Instructions"
                    TextWrapping="Wrap"
                    Margin="0,8,0,0"/>
 
@@ -23,7 +23,7 @@
                        FontWeight="SemiBold"/>
         </Border>
 
-        <TextBox Text="{Binding DeleteAllUserInput, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                 PlaceholderText="Sem opište ověřovací kód" />
+        <TextBox x:Uid="DeleteAllCatalogDialog_Input"
+                 Text="{Binding DeleteAllUserInput, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
     </StackPanel>
 </UserControl>

--- a/Veriado.WinUI/Views/Files/FileDetailDialog.xaml
+++ b/Veriado.WinUI/Views/Files/FileDetailDialog.xaml
@@ -7,11 +7,9 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d"
     x:Name="RootDialog"
+    x:Uid="FileDetailDialog"
     MinWidth="360"
     MaxWidth="920"
-    Title="Detail souboru"
-    PrimaryButtonText="Uložit"
-    SecondaryButtonText="Zrušit"
     DefaultButton="Primary"
     IsPrimaryButtonEnabled="{x:Bind ViewModel.CanSave, Mode=OneWay}">
     <ContentDialog.Resources>

--- a/Veriado.WinUI/Views/Files/FilesPage.xaml
+++ b/Veriado.WinUI/Views/Files/FilesPage.xaml
@@ -29,7 +29,7 @@
                     <FontIcon FontFamily="Segoe Fluent Icons"
                               Glyph="&#xE8A5;"
                               FontSize="28" />
-                    <TextBlock Text="Katalog dokumentů"
+                    <TextBlock x:Uid="FilesPage_HeaderTitle"
                                FontSize="28"
                                FontWeight="SemiBold" />
                 </StackPanel>
@@ -38,7 +38,7 @@
                            Fill="{ThemeResource SystemControlForegroundBaseLowBrush}"
                            Margin="0,6,0,6" />
 
-                <TextBlock Text="Správa, validace a monitoring souborů"
+                <TextBlock x:Uid="FilesPage_HeaderSubtitle"
                            FontSize="14"
                            Opacity="0.72"
                            Margin="2,0,0,12" />
@@ -47,7 +47,6 @@
                 <AutoSuggestBox
                     x:Name="SearchAutoSuggestBox"
                     x:Uid="FilesPage_SearchBox"
-                    PlaceholderText="Hledat soubory"
                     Text="{x:Bind ViewModel.SearchText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                     QuerySubmitted="OnSearchQuerySubmitted"
                     TextChanged="OnSearchTextChanged">
@@ -66,7 +65,6 @@
                 <StackPanel Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
                     <Button
                         x:Uid="FilesPage_PreviousPageButton"
-                        Content="Předchozí"
                         Command="{x:Bind ViewModel.PreviousPageCommand}" />
                     <StackPanel Orientation="Horizontal" Spacing="4" VerticalAlignment="Center">
                         <controls:NumberBox
@@ -77,16 +75,15 @@
                             Maximum="{x:Bind ViewModel.TargetPageMaximum, Mode=OneWay}"
                             SmallChange="1"
                             Value="{x:Bind ViewModel.TargetPage, Mode=TwoWay}" />
-                        <TextBlock Text="/" VerticalAlignment="Center" />
+                        <TextBlock x:Uid="FilesPage_PageNumberSeparator" VerticalAlignment="Center" />
                         <TextBlock Text="{x:Bind ViewModel.TotalPages, Mode=OneWay}" VerticalAlignment="Center" />
                     </StackPanel>
                     <Button
                         x:Uid="FilesPage_NextPageButton"
-                        Content="Další"
                         Command="{x:Bind ViewModel.NextPageCommand}" />
                 </StackPanel>
                 <StackPanel Orientation="Horizontal" Spacing="4" VerticalAlignment="Center">
-                    <TextBlock x:Uid="FilesPage_PageSizeLabel" VerticalAlignment="Center" Text="Na stránce" />
+                    <TextBlock x:Uid="FilesPage_PageSizeLabel" VerticalAlignment="Center" />
                     <ComboBox
                         x:Uid="FilesPage_PageSizeComboBox"
                         Width="90"
@@ -94,12 +91,12 @@
                         ItemsSource="{x:Bind ViewModel.PageSizeOptions, Mode=OneWay}"
                         SelectedItem="{x:Bind ViewModel.PageSize, Mode=TwoWay}" />
                 </StackPanel>
-                <Button HorizontalAlignment="Right"
+                <Button x:Uid="FilesPage_DeleteAllButton" HorizontalAlignment="Right"
                         Margin="8,0,0,0"
                         Command="{Binding DeleteAllCommand}">
                     <StackPanel Orientation="Horizontal" Spacing="4">
                         <FontIcon FontFamily="Segoe Fluent Icons" Glyph="&#xE74D;"/>
-                        <TextBlock Text="Smazat katalog"/>
+                        <TextBlock x:Uid="FilesPage_DeleteAllButtonText" />
                     </StackPanel>
                 </Button>
             </StackPanel>
@@ -108,15 +105,12 @@
                 IsClosable="False"
                 IsOpen="{x:Bind ViewModel.IsIndexingPending, Mode=OneWay}"
                 Severity="Warning"
-                Title="Probíhá indexace"
                 Message="{x:Bind ViewModel.IndexingWarningMessage, Mode=OneWay}" />
             <controls:InfoBar
                 x:Uid="FilesPage_ErrorInfoBar"
                 IsClosable="False"
                 IsOpen="{x:Bind ViewModel.HasError, Mode=OneWay}"
-                Severity="Error"
-                Title="Chyba načítání"
-                Message="Nepodařilo se načíst výsledky." />
+                Severity="Error" />
         </StackPanel>
 
         <controls:ItemsRepeaterScrollHost Grid.Row="1">
@@ -220,7 +214,7 @@
                                             CommandParameter="{x:Bind}">
                                             <StackPanel Orientation="Horizontal" Spacing="4">
                                                 <FontIcon FontFamily="Segoe Fluent Icons" Glyph="&#xE8E5;" />
-                                                <TextBlock Text="Otevřít" />
+                                                <TextBlock x:Uid="FilesPage_ItemOpenButtonText" />
                                             </StackPanel>
                                         </Button>
                                         <Button
@@ -230,7 +224,7 @@
                                             CommandParameter="{x:Bind}">
                                             <StackPanel Orientation="Horizontal" Spacing="4">
                                                 <FontIcon FontFamily="Segoe Fluent Icons" Glyph="&#xE8B7;" />
-                                                <TextBlock Text="Ukázat ve složce" />
+                                                <TextBlock x:Uid="FilesPage_ItemShowInFolderButtonText" />
                                             </StackPanel>
                                         </Button>
                                         <Button
@@ -239,7 +233,7 @@
                                             CommandParameter="{x:Bind}">
                                             <StackPanel Orientation="Horizontal" Spacing="4">
                                                 <FontIcon FontFamily="Segoe Fluent Icons" Glyph="&#xE72C;" />
-                                                <TextBlock Text="Aktualizovat" />
+                                                <TextBlock x:Uid="FilesPage_ItemUpdateButtonText" />
                                             </StackPanel>
                                         </Button>
                                         <Button
@@ -248,7 +242,7 @@
                                             CommandParameter="{x:Bind Dto}">
                                             <StackPanel Orientation="Horizontal" Spacing="4">
                                                 <FontIcon FontFamily="Segoe Fluent Icons" Glyph="&#xE946;" />
-                                                <TextBlock Text="Detail" />
+                                                <TextBlock x:Uid="FilesPage_ItemDetailButtonText" />
                                             </StackPanel>
                                         </Button>
                                         <Button
@@ -257,7 +251,7 @@
                                             CommandParameter="{x:Bind Dto}">
                                             <StackPanel Orientation="Horizontal" Spacing="4">
                                                 <FontIcon FontFamily="Segoe Fluent Icons" Glyph="&#xE74D;" />
-                                                <TextBlock Text="Smazat" />
+                                                <TextBlock x:Uid="FilesPage_ItemDeleteButtonText" />
                                             </StackPanel>
                                         </Button>
                                     </StackPanel>

--- a/Veriado.WinUI/Views/Shell/MainShell.xaml
+++ b/Veriado.WinUI/Views/Shell/MainShell.xaml
@@ -42,10 +42,10 @@
                 Color="{ThemeResource AppAccentColor}" />
         </controls:NavigationView.Resources>
         <controls:NavigationView.MenuItems>
-            <controls:NavigationViewItem Tag="files" Content="Správa souborů" Icon="Document" />
-            <controls:NavigationViewItem Tag="import" Content="Nahrát soubory" Icon="OpenFile" />
-            <controls:NavigationViewItem Tag="storage" Content="Migrace a balíčky" Icon="Sync" />
-            <controls:NavigationViewItem Tag="settings" Content="Nastavení" Icon="Setting" />
+            <controls:NavigationViewItem x:Uid="MainShell_FilesNavItem" Tag="files" Icon="Document" />
+            <controls:NavigationViewItem x:Uid="MainShell_ImportNavItem" Tag="import" Icon="OpenFile" />
+            <controls:NavigationViewItem x:Uid="MainShell_StorageNavItem" Tag="storage" Icon="Sync" />
+            <controls:NavigationViewItem x:Uid="MainShell_SettingsNavItem" Tag="settings" Icon="Setting" />
         </controls:NavigationView.MenuItems>
         <controls:NavigationView.Content>
             <Grid Background="{ThemeResource AppBackgroundBrush}">

--- a/Veriado.WinUI/Views/StartupWindow.xaml
+++ b/Veriado.WinUI/Views/StartupWindow.xaml
@@ -25,9 +25,9 @@
                 Foreground="{ThemeResource AppTextPrimaryBrush}"
                 Visibility="{Binding HasError, Converter={StaticResource BooleanToVisibilityConverter}}" />
             <Button
+                x:Uid="StartupWindow_RetryButton"
                 Width="160"
                 HorizontalAlignment="Center"
-                Content="Zkusit znovu"
                 Command="{Binding RetryCommand}"
                 Visibility="{Binding HasError, Converter={StaticResource BooleanToVisibilityConverter}}" />
         </StackPanel>


### PR DESCRIPTION
## Summary
- localize navigation menu, startup retry button, and files page labels using resource qualifiers
- add English and Czech resource entries for the updated UI elements and dialogs
- switch files dialog to resource-driven titles and buttons to enable localization

## Testing
- Not run (dotnet CLI not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b26f61e84832694c26e301bb74e2e)