### PR TITLE
Add legacy DPI awareness fallback

### DIFF
--- a/Veriado.WinUI/app.manifest
+++ b/Veriado.WinUI/app.manifest
@@ -13,6 +13,7 @@
   
   <application xmlns="urn:schemas-microsoft-com:asm.v3">
     <windowsSettings>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/pm</dpiAware>
       <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
     </windowsSettings>
   </application>


### PR DESCRIPTION
## Summary
- add a legacy dpiAware declaration alongside PerMonitorV2 to improve compatibility with common scaling configurations

## Testing
- dotnet build Veriado.sln *(fails: dotnet not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c6aa6c8d08326a1c8ceb0efab42bf)