### PR TITLE
Improve layout wrapping for high DPI displays

### DIFF
--- a/Veriado.WinUI/Views/Files/FilesPage.xaml
+++ b/Veriado.WinUI/Views/Files/FilesPage.xaml
@@ -7,6 +7,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:controls="using:Microsoft.UI.Xaml.Controls"
     xmlns:views="using:Veriado.WinUI.Views.Files"
+    xmlns:toolkit="using:CommunityToolkit.WinUI.Controls"
     xmlns:converters="using:Veriado.WinUI.Converters"
     xmlns:viewModels="using:Veriado.WinUI.ViewModels.Files"
     mc:Ignorable="d">
@@ -56,18 +57,18 @@
                 </AutoSuggestBox>
             </Grid>
 
-            <StackPanel Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
-                <ProgressRing Width="20" Height="20" IsActive="{x:Bind ViewModel.IsBusy}" />
-                <TextBlock
-                    x:Uid="FilesPage_StatusText"
-                    VerticalAlignment="Center"
-                    Text="{x:Bind ViewModel.StatusText, Mode=OneWay}" />
-                <StackPanel Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
-                    <Button
-                        x:Uid="FilesPage_PreviousPageButton"
-                        Command="{x:Bind ViewModel.PreviousPageCommand}" />
-                    <StackPanel Orientation="Horizontal" Spacing="4" VerticalAlignment="Center">
-                        <controls:NumberBox
+        <toolkit:WrapPanel Spacing="8" VerticalAlignment="Center">
+            <ProgressRing Width="20" Height="20" IsActive="{x:Bind ViewModel.IsBusy}" />
+            <TextBlock
+                x:Uid="FilesPage_StatusText"
+                VerticalAlignment="Center"
+                Text="{x:Bind ViewModel.StatusText, Mode=OneWay}" />
+            <toolkit:WrapPanel Spacing="8" VerticalAlignment="Center">
+                <Button
+                    x:Uid="FilesPage_PreviousPageButton"
+                    Command="{x:Bind ViewModel.PreviousPageCommand}" />
+                <StackPanel Orientation="Horizontal" Spacing="4" VerticalAlignment="Center">
+                    <controls:NumberBox
                             x:Uid="FilesPage_PageNumberBox"
                             Width="80"
                             HorizontalAlignment="Left"
@@ -81,25 +82,25 @@
                     <Button
                         x:Uid="FilesPage_NextPageButton"
                         Command="{x:Bind ViewModel.NextPageCommand}" />
+            </toolkit:WrapPanel>
+            <toolkit:WrapPanel Spacing="4" VerticalAlignment="Center">
+                <TextBlock x:Uid="FilesPage_PageSizeLabel" VerticalAlignment="Center" />
+                <ComboBox
+                    x:Uid="FilesPage_PageSizeComboBox"
+                    Width="90"
+                    HorizontalAlignment="Left"
+                    ItemsSource="{x:Bind ViewModel.PageSizeOptions, Mode=OneWay}"
+                    SelectedItem="{x:Bind ViewModel.PageSize, Mode=TwoWay}" />
+            </toolkit:WrapPanel>
+            <Button x:Uid="FilesPage_DeleteAllButton" HorizontalAlignment="Right"
+                    Margin="8,0,0,0"
+                    Command="{Binding DeleteAllCommand}">
+                <StackPanel Orientation="Horizontal" Spacing="4">
+                    <FontIcon FontFamily="Segoe Fluent Icons" Glyph="&#xE74D;"/>
+                    <TextBlock x:Uid="FilesPage_DeleteAllButtonText" />
                 </StackPanel>
-                <StackPanel Orientation="Horizontal" Spacing="4" VerticalAlignment="Center">
-                    <TextBlock x:Uid="FilesPage_PageSizeLabel" VerticalAlignment="Center" />
-                    <ComboBox
-                        x:Uid="FilesPage_PageSizeComboBox"
-                        Width="90"
-                        HorizontalAlignment="Left"
-                        ItemsSource="{x:Bind ViewModel.PageSizeOptions, Mode=OneWay}"
-                        SelectedItem="{x:Bind ViewModel.PageSize, Mode=TwoWay}" />
-                </StackPanel>
-                <Button x:Uid="FilesPage_DeleteAllButton" HorizontalAlignment="Right"
-                        Margin="8,0,0,0"
-                        Command="{Binding DeleteAllCommand}">
-                    <StackPanel Orientation="Horizontal" Spacing="4">
-                        <FontIcon FontFamily="Segoe Fluent Icons" Glyph="&#xE74D;"/>
-                        <TextBlock x:Uid="FilesPage_DeleteAllButtonText" />
-                    </StackPanel>
-                </Button>
-            </StackPanel>
+            </Button>
+        </toolkit:WrapPanel>
             <controls:InfoBar
                 x:Uid="FilesPage_IndexingInfoBar"
                 IsClosable="False"

--- a/Veriado.WinUI/Views/Import/ImportPage.xaml
+++ b/Veriado.WinUI/Views/Import/ImportPage.xaml
@@ -111,7 +111,7 @@
                 </Grid.ColumnDefinitions>
 
                 <!-- Tlačítka vlevo -->
-                <StackPanel Orientation="Horizontal" Spacing="12">
+                <toolkit:WrapPanel Spacing="12">
                     <Button Command="{Binding RunImportCommand}">
                         <StackPanel Orientation="Horizontal" Spacing="8">
                             <FontIcon FontFamily="Segoe Fluent Icons" Glyph="&#xE898;" FontSize="16" />
@@ -126,7 +126,7 @@
                                 <TextBlock Text="Zastavit nahrávání" />
                         </StackPanel>
                     </Button>
-                </StackPanel>
+                </toolkit:WrapPanel>
             </Grid>
 
             <!-- Progres přes celou šířku -->

--- a/Veriado.WinUI/Views/Settings/SettingsPage.xaml
+++ b/Veriado.WinUI/Views/Settings/SettingsPage.xaml
@@ -5,96 +5,104 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:controls="using:Microsoft.UI.Xaml.Controls"
+    xmlns:toolkit="using:CommunityToolkit.WinUI.Controls"
     mc:Ignorable="d">
-    <StackPanel Padding="24" Spacing="12">
-        <TextBlock Text="Nastavení" FontSize="20" FontWeight="SemiBold" />
+    <ScrollViewer
+        Padding="24"
+        HorizontalScrollBarVisibility="Auto"
+        VerticalScrollBarVisibility="Auto">
+        <StackPanel Spacing="12">
+            <TextBlock Text="Nastavení" FontSize="20" FontWeight="SemiBold" />
 
-        <ComboBox
-            Header="Motiv aplikace"
-            ItemsSource="{Binding ThemeOptions}"
-            SelectedItem="{Binding ThemeMode, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+            <ComboBox
+                Header="Motiv aplikace"
+                ItemsSource="{Binding ThemeOptions}"
+                SelectedItem="{Binding ThemeMode, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
 
-        <controls:NumberBox
-            Header="Velikost stránky"
-            Minimum="1"
-            SmallChange="1"
-            Value="{Binding PageSize, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+            <controls:NumberBox
+                Header="Velikost stránky"
+                Minimum="1"
+                SmallChange="1"
+                Value="{Binding PageSize, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
 
-        <TextBox
-            Header="Poslední složka"
-            PlaceholderText="Cesta ke složce"
-            Text="{Binding LastFolder, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+            <TextBox
+                Header="Poslední složka"
+                PlaceholderText="Cesta ke složce"
+                Text="{Binding LastFolder, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
 
-        <TextBlock Text="Platnost dokumentů" FontSize="16" FontWeight="SemiBold" Margin="0,12,0,0" />
+            <TextBlock Text="Platnost dokumentů" FontSize="16" FontWeight="SemiBold" Margin="0,12,0,0" />
 
-        <controls:NumberBox
-            Header="Červený odznak (dní)"
-            Minimum="0"
-            SmallChange="1"
-            SpinButtonPlacementMode="Compact"
-            Value="{Binding ValidityRedThreshold, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+            <controls:NumberBox
+                Header="Červený odznak (dní)"
+                Minimum="0"
+                SmallChange="1"
+                SpinButtonPlacementMode="Compact"
+                Value="{Binding ValidityRedThreshold, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
 
-        <controls:NumberBox
-            Header="Oranžový odznak (dní)"
-            Minimum="0"
-            SmallChange="1"
-            SpinButtonPlacementMode="Compact"
-            Value="{Binding ValidityOrangeThreshold, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+            <controls:NumberBox
+                Header="Oranžový odznak (dní)"
+                Minimum="0"
+                SmallChange="1"
+                SpinButtonPlacementMode="Compact"
+                Value="{Binding ValidityOrangeThreshold, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
 
-        <controls:NumberBox
-            Header="Zelený odznak (dní)"
-            Minimum="0"
-            SmallChange="1"
-            SpinButtonPlacementMode="Compact"
-            Value="{Binding ValidityGreenThreshold, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+            <controls:NumberBox
+                Header="Zelený odznak (dní)"
+                Minimum="0"
+                SmallChange="1"
+                SpinButtonPlacementMode="Compact"
+                Value="{Binding ValidityGreenThreshold, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
 
-        <StackPanel Orientation="Vertical" Spacing="12" Margin="0,16,0,4">
-            <StackPanel Orientation="Vertical" Spacing="4">
-                <StackPanel Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
-                    <FontIcon FontFamily="Segoe Fluent Icons"
-                              Glyph="&#xE8B7;"
-                              FontSize="24" />
-                    <TextBlock Text="Uložiště dokumentů"
-                               FontSize="24"
-                               FontWeight="SemiBold" />
+            <StackPanel Orientation="Vertical" Spacing="12" Margin="0,16,0,4">
+                <StackPanel Orientation="Vertical" Spacing="4">
+                    <StackPanel Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
+                        <FontIcon FontFamily="Segoe Fluent Icons"
+                                  Glyph="&#xE8B7;"
+                                  FontSize="24" />
+                        <TextBlock Text="Uložiště dokumentů"
+                                   FontSize="24"
+                                   FontWeight="SemiBold" />
+                    </StackPanel>
+
+                    <Rectangle Height="1"
+                               Fill="{ThemeResource SystemControlForegroundBaseLowBrush}"
+                               Margin="0,6,0,6" />
+
+                    <TextBlock Text="Konfigurace cesty k úložišti dokumentů"
+                               FontSize="14"
+                               Opacity="0.72"
+                               Margin="2,0,0,4" />
                 </StackPanel>
 
-                <Rectangle Height="1"
-                           Fill="{ThemeResource SystemControlForegroundBaseLowBrush}"
-                           Margin="0,6,0,6" />
+                <TextBlock Text="Aktuální složka úložiště:"
+                           FontWeight="SemiBold" />
+                <TextBlock Text="{Binding CurrentStorageRoot}"
+                           TextTrimming="CharacterEllipsis"
+                           MaxWidth="600" />
 
-                <TextBlock Text="Konfigurace cesty k úložišti dokumentů"
-                           FontSize="14"
-                           Opacity="0.72"
-                           Margin="2,0,0,4" />
+                <toolkit:WrapPanel Spacing="8" Margin="0,8,0,0">
+                    <TextBox
+                        MinWidth="240"
+                        MaxWidth="600"
+                        IsReadOnly="True"
+                        Text="{Binding NewStorageRootCandidate, Mode=OneWay}" />
+
+                    <Button Content="Změnit složku"
+                            Command="{Binding BrowseStorageRootCommand}"
+                            IsEnabled="{Binding CanChangeStorageRoot}" />
+
+                    <Button Content="Uložit"
+                            Command="{Binding SaveStorageRootCommand}"
+                            IsEnabled="{Binding CanChangeStorageRoot}" />
+                </toolkit:WrapPanel>
+
+                <TextBlock Text="{Binding StorageChangeMessage}"
+                           TextWrapping="Wrap"
+                           Foreground="{ThemeResource SystemControlForegroundBaseMediumBrush}"
+                           Margin="0,4,0,0" />
             </StackPanel>
 
-            <TextBlock Text="Aktuální složka úložiště:"
-                       FontWeight="SemiBold" />
-            <TextBlock Text="{Binding CurrentStorageRoot}"
-                       TextTrimming="CharacterEllipsis"
-                       MaxWidth="600" />
-
-            <StackPanel Orientation="Horizontal" Spacing="8" Margin="0,8,0,0">
-                <TextBox Width="400"
-                         IsReadOnly="True"
-                         Text="{Binding NewStorageRootCandidate, Mode=OneWay}" />
-
-                <Button Content="Změnit složku"
-                        Command="{Binding BrowseStorageRootCommand}"
-                        IsEnabled="{Binding CanChangeStorageRoot}" />
-
-                <Button Content="Uložit"
-                        Command="{Binding SaveStorageRootCommand}"
-                        IsEnabled="{Binding CanChangeStorageRoot}" />
-            </StackPanel>
-
-            <TextBlock Text="{Binding StorageChangeMessage}"
-                       TextWrapping="Wrap"
-                       Foreground="{ThemeResource SystemControlForegroundBaseMediumBrush}"
-                       Margin="0,4,0,0" />
+            <Button Content="Použít motiv" Command="{Binding ApplyThemeCommand}" />
         </StackPanel>
-
-        <Button Content="Použít motiv" Command="{Binding ApplyThemeCommand}" />
-    </StackPanel>
+    </ScrollViewer>
 </Page>


### PR DESCRIPTION
## Summary
- allow Files page toolbar controls to wrap when screen space is limited by high DPI scaling
- wrap import action buttons to avoid clipping on smaller scaled displays
- add scroll and wrapping to Settings page storage controls for better accessibility at 150% scaling

## Testing
- Not run (dotnet CLI is not available in the container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693dcaf4c0e48326997643390ce124ad)