### PR TITLE
Replace unsupported WrapPanel spacing property

### DIFF
--- a/Veriado.WinUI/Views/Files/FilesPage.xaml
+++ b/Veriado.WinUI/Views/Files/FilesPage.xaml
@@ -57,17 +57,19 @@
                 </AutoSuggestBox>
             </Grid>
 
-        <toolkit:WrapPanel Spacing="8" VerticalAlignment="Center">
-            <ProgressRing Width="20" Height="20" IsActive="{x:Bind ViewModel.IsBusy}" />
+        <toolkit:WrapPanel VerticalAlignment="Center">
+            <ProgressRing Width="20" Height="20" IsActive="{x:Bind ViewModel.IsBusy}" Margin="0,0,8,0" />
             <TextBlock
                 x:Uid="FilesPage_StatusText"
                 VerticalAlignment="Center"
+                Margin="0,0,8,0"
                 Text="{x:Bind ViewModel.StatusText, Mode=OneWay}" />
-            <toolkit:WrapPanel Spacing="8" VerticalAlignment="Center">
+            <toolkit:WrapPanel VerticalAlignment="Center">
                 <Button
                     x:Uid="FilesPage_PreviousPageButton"
-                    Command="{x:Bind ViewModel.PreviousPageCommand}" />
-                <StackPanel Orientation="Horizontal" Spacing="4" VerticalAlignment="Center">
+                    Command="{x:Bind ViewModel.PreviousPageCommand}"
+                    Margin="0,0,8,0" />
+                <StackPanel Orientation="Horizontal" Spacing="4" VerticalAlignment="Center" Margin="0,0,8,0">
                     <controls:NumberBox
                             x:Uid="FilesPage_PageNumberBox"
                             Width="80"
@@ -81,16 +83,18 @@
                     </StackPanel>
                     <Button
                         x:Uid="FilesPage_NextPageButton"
-                        Command="{x:Bind ViewModel.NextPageCommand}" />
+                        Command="{x:Bind ViewModel.NextPageCommand}"
+                        Margin="0,0,8,0" />
             </toolkit:WrapPanel>
-            <toolkit:WrapPanel Spacing="4" VerticalAlignment="Center">
-                <TextBlock x:Uid="FilesPage_PageSizeLabel" VerticalAlignment="Center" />
+            <toolkit:WrapPanel VerticalAlignment="Center">
+                <TextBlock x:Uid="FilesPage_PageSizeLabel" VerticalAlignment="Center" Margin="0,0,4,0" />
                 <ComboBox
                     x:Uid="FilesPage_PageSizeComboBox"
                     Width="90"
                     HorizontalAlignment="Left"
                     ItemsSource="{x:Bind ViewModel.PageSizeOptions, Mode=OneWay}"
-                    SelectedItem="{x:Bind ViewModel.PageSize, Mode=TwoWay}" />
+                    SelectedItem="{x:Bind ViewModel.PageSize, Mode=TwoWay}"
+                    Margin="0,0,4,0" />
             </toolkit:WrapPanel>
             <Button x:Uid="FilesPage_DeleteAllButton" HorizontalAlignment="Right"
                     Margin="8,0,0,0"

--- a/Veriado.WinUI/Views/Import/ImportPage.xaml
+++ b/Veriado.WinUI/Views/Import/ImportPage.xaml
@@ -111,8 +111,8 @@
                 </Grid.ColumnDefinitions>
 
                 <!-- Tlačítka vlevo -->
-                <toolkit:WrapPanel Spacing="12">
-                    <Button Command="{Binding RunImportCommand}">
+                <toolkit:WrapPanel>
+                    <Button Command="{Binding RunImportCommand}" Margin="0,0,12,0">
                         <StackPanel Orientation="Horizontal" Spacing="8">
                             <FontIcon FontFamily="Segoe Fluent Icons" Glyph="&#xE898;" FontSize="16" />
                                 <TextBlock Text="Nahrát" />
@@ -120,7 +120,7 @@
                     </Button>
 
                     <Button Command="{Binding StopImportCommand}"
-                IsEnabled="{Binding IsImporting}">
+                IsEnabled="{Binding IsImporting}" Margin="0,0,12,0">
                         <StackPanel Orientation="Horizontal" Spacing="8">
                             <FontIcon FontFamily="Segoe Fluent Icons" Glyph="&#xE71A;" FontSize="16" />
                                 <TextBlock Text="Zastavit nahrávání" />

--- a/Veriado.WinUI/Views/Settings/SettingsPage.xaml
+++ b/Veriado.WinUI/Views/Settings/SettingsPage.xaml
@@ -80,20 +80,23 @@
                            TextTrimming="CharacterEllipsis"
                            MaxWidth="600" />
 
-                <toolkit:WrapPanel Spacing="8" Margin="0,8,0,0">
+                <toolkit:WrapPanel Margin="0,8,0,0">
                     <TextBox
                         MinWidth="240"
                         MaxWidth="600"
                         IsReadOnly="True"
+                        Margin="0,0,8,0"
                         Text="{Binding NewStorageRootCandidate, Mode=OneWay}" />
 
                     <Button Content="Změnit složku"
                             Command="{Binding BrowseStorageRootCommand}"
-                            IsEnabled="{Binding CanChangeStorageRoot}" />
+                            IsEnabled="{Binding CanChangeStorageRoot}"
+                            Margin="0,0,8,0" />
 
                     <Button Content="Uložit"
                             Command="{Binding SaveStorageRootCommand}"
-                            IsEnabled="{Binding CanChangeStorageRoot}" />
+                            IsEnabled="{Binding CanChangeStorageRoot}"
+                            Margin="0,0,8,0" />
                 </toolkit:WrapPanel>
 
                 <TextBlock Text="{Binding StorageChangeMessage}"


### PR DESCRIPTION
## Summary
- remove unsupported Spacing attribute from toolkit WrapPanel controls
- add margins to preserve layout spacing on Files, Import, and Settings pages

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693dcdc09bfc8326b7ded56b0d756fe4)