### PR TITLE
Add slider to control import log size

### DIFF
--- a/Veriado.WinUI/ViewModels/Import/ImportPageViewModel.cs
+++ b/Veriado.WinUI/ViewModels/Import/ImportPageViewModel.cs
@@ -16,7 +16,7 @@ namespace Veriado.WinUI.ViewModels.Import;
 
 public partial class ImportPageViewModel : ViewModelBase
 {
-    private const int MaxLogEntries = 250;
+    private const int DefaultMaxLogEntries = 250;
 
     private readonly IImportService _importService;
     private readonly IHotStateService? _hotStateService;
@@ -111,6 +111,9 @@ public partial class ImportPageViewModel : ViewModelBase
 
     [ObservableProperty]
     private bool _autoExportLog;
+
+    [ObservableProperty]
+    private int _maxLogEntries = DefaultMaxLogEntries;
 
     [ObservableProperty]
     private bool _isImporting;
@@ -1631,6 +1634,17 @@ public partial class ImportPageViewModel : ViewModelBase
         {
             _hotStateService.ImportAutoExportLog = value;
         }
+    }
+
+    partial void OnMaxLogEntriesChanged(int value)
+    {
+        if (value < 1)
+        {
+            MaxLogEntries = 1;
+            return;
+        }
+
+        TrimLog();
     }
 
     partial void OnSelectedErrorFilterChanged(ImportErrorSeverity value)

--- a/Veriado.WinUI/Views/Import/ImportPage.xaml
+++ b/Veriado.WinUI/Views/Import/ImportPage.xaml
@@ -330,6 +330,16 @@
                 <Button Content="Vymazat výsledky" Command="{Binding ClearResultsCommand}" />
                 <Button Content="Exportovat protokol" Command="{Binding ExportLogCommand}" />
             </StackPanel>
+            <StackPanel Orientation="Horizontal" Spacing="8">
+                <TextBlock VerticalAlignment="Center" Text="Max. záznamů:" />
+                <Slider
+                    Width="220"
+                    Minimum="50"
+                    Maximum="1000"
+                    StepFrequency="50"
+                    Value="{Binding MaxLogEntries, Mode=TwoWay}" />
+                <TextBlock VerticalAlignment="Center" Text="{Binding MaxLogEntries}" />
+            </StackPanel>
             <Grid RowSpacing="12">
                 <Grid.RowDefinitions>
                     <RowDefinition Height="*" />


### PR DESCRIPTION
## Summary
- add a slider to the import log section to let users set how many entries are kept
- expose the maximum log entry count in the view model and trim the log when the value changes

## Testing
- dotnet build Veriado.sln (fails: dotnet not available in the environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693dcf3d3c308326b67ad1454c95b98f)