### PR TITLE
Add max height to import log grid

### DIFF
--- a/Veriado.WinUI/Views/Import/ImportPage.xaml
+++ b/Veriado.WinUI/Views/Import/ImportPage.xaml
@@ -356,6 +356,7 @@
                     CanUserSortColumns="False"
                     HeadersVisibility="Column"
                     IsReadOnly="True"
+                    MaxHeight="420"
                     SelectionMode="Single"
                     GridLinesVisibility="All"
                     ScrollViewer.VerticalScrollBarVisibility="Auto"


### PR DESCRIPTION
## Summary
- add a maximum height to the import log grid to allow its built-in scrollbars to appear

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693dd17248e08326a2faeb90d1769e11)